### PR TITLE
fixed error when loading json due to binary mode

### DIFF
--- a/kitty/config.py
+++ b/kitty/config.py
@@ -189,7 +189,7 @@ cached_path = os.path.join(config_dir, 'cached.json')
 def load_cached_values():
     cached_values.clear()
     try:
-        with open(cached_path, 'rb') as f:
+        with open(cached_path,'r', encoding='utf-8') as f:
             cached_values.update(json.loads(f.read()))
     except FileNotFoundError:
         pass


### PR DESCRIPTION
When I tested the new feature I got the error:

Failed to load cached value with error: the JSON object must be str not 'bytes'