### PR TITLE
add the enter key on the numpad to the key map

### DIFF
--- a/kitty/keys.py
+++ b/kitty/keys.py
@@ -24,6 +24,7 @@ del f
 
 key_map[defines.GLFW_KEY_ESCAPE] = b'\033'
 key_map[defines.GLFW_KEY_ENTER] = b'\r'
+key_map[defines.GLFW_KEY_KP_ENTER] = b'\r'
 key_map[defines.GLFW_KEY_BACKSPACE] = key_as_bytes('kbs')
 key_map[defines.GLFW_KEY_TAB] = b'\t'
 


### PR DESCRIPTION
Before the enter key on the numpad did not work, now it does.