### PR TITLE
Made window size caching and initial dimensions configurable

### DIFF
--- a/kitty/config.py
+++ b/kitty/config.py
@@ -110,6 +110,9 @@ type_map = {
     'cursor_blink_interval': float,
     'cursor_stop_blinking_after': float,
     'enabled_layouts': to_layout_names,
+    'cache_window_size': to_bool,
+    'initial_window_width': int,
+    'initial_window_height': int,
     'use_system_wcwidth': to_bool,
 }
 

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -66,6 +66,13 @@ mouse_hide_wait 3.0
 # For a list of available layouts, see the file layouts.py
 enabled_layouts *
 
+# If enabled, the window size will be cached so that new instances of kitty will have the same
+# size as the previous instance. If disabled, the window will initially have size configured
+# by initial_window_width/height, in pixels.
+cache_window_size      yes
+initial_window_width   640
+initial_window_height  400
+
 # Delay (in milliseconds) between screen updates. Decreasing it, increases fps
 # at the cost of more CPU usage. The default value yields ~100fps which is more
 # that sufficient for most uses.
@@ -145,7 +152,7 @@ color15  #ffffff
 # For a list of key names, see: http://www.glfw.org/docs/latest/group__keys.html
 # For a list of modifier names, see: http://www.glfw.org/docs/latest/group__mods.html
 # You can use the special action no_op to unmap a keyboard shortcut that is
-# assigned in the default configuration. 
+# assigned in the default configuration.
 
 # Clipboard
 map ctrl+shift+v        paste_from_clipboard

--- a/kitty/main.py
+++ b/kitty/main.py
@@ -89,7 +89,7 @@ def dispatch_pending_calls(boss):
 def run_app(opts, args):
     setup_opengl()
     load_cached_values()
-    if 'window-size' in cached_values:
+    if 'window-size' in cached_values and opts.cache_window_size:
         ws = cached_values['window-size']
         try:
             viewport_size.width, viewport_size.height = map(int, ws)
@@ -97,6 +97,9 @@ def run_app(opts, args):
             safe_print('Invalid cached window size, ignoring', file=sys.stderr)
         viewport_size.width = max(100, viewport_size.width)
         viewport_size.height = max(80, viewport_size.height)
+    else:
+        viewport_size.width = opts.initial_window_width
+        viewport_size.height = opts.initial_window_height
     window = Window(
         viewport_size.width, viewport_size.height, args.cls)
     window.set_title(appname)


### PR DESCRIPTION
I was personally not a fan of the window size caching, so I made it configurable.
Currently it still writes the previous window dimensions to cached.json even when disabled.