### PR TITLE
Calculate pixel ratio in cursor_pos_callback

### DIFF
--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -74,7 +74,14 @@ scroll_callback(GLFWwindow *w, double xoffset, double yoffset) {
 
 static void 
 cursor_pos_callback(GLFWwindow *w, double x, double y) {
-    WINDOW_CALLBACK(cursor_pos_callback, "dd", x, y);
+    int framebufferWidth, framebufferHeight;
+    int windowWidth, windowHeight;
+    float ratioX, ratioY;
+    glfwGetFramebufferSize(w, &framebufferWidth, &framebufferHeight);
+    glfwGetWindowSize(w, &windowWidth, &windowHeight);
+    ratioX = (float)framebufferWidth / (float)windowWidth;
+    ratioY = (float)framebufferHeight / (float)windowHeight;
+    WINDOW_CALLBACK(cursor_pos_callback, "dd", x*ratioX, y*ratioY);
 }
 
 static void 


### PR DESCRIPTION
On my Retina MacBook Pro when dragging to make a selection or when trying to click a link, the x and y coordinates were off. This calculates the ratio before calling the callback. Can't test on a non-Retina screen but it should work correctly.