### PR TITLE
Wrong indent level

### DIFF
--- a/kitty/utils.py
+++ b/kitty/utils.py
@@ -120,7 +120,7 @@ def get_logical_dpi():
                     xdpi, ydpi = glfw_get_physical_dpi()
             else:
                 xdpi, ydpi = xscale * 96.0, yscale * 96.0
-        get_logical_dpi.ans = xdpi, ydpi
+            get_logical_dpi.ans = xdpi, ydpi
     return get_logical_dpi.ans
 
 


### PR DESCRIPTION
Wrong indent level causes macOS to reference undefined "xdpi". 

 File "./__main__.py", line 13, in <module>
  File "./kitty/main.py", line 292, in main
  File "./kitty/main.py", line 202, in run_app
  File "./kitty/main.py", line 156, in initialize_window
  File "./kitty/utils.py", line 123, in get_logical_dpi
UnboundLocalError: local variable 'xdpi' referenced before assignment
[glfw error 65537]: The GLFW library is not initialized