### PR TITLE
Enable subpixel quantization and positioning

### DIFF
--- a/kitty/core_text.m
+++ b/kitty/core_text.m
@@ -245,6 +245,8 @@ render_char(Face *self, PyObject *args) {
     if (ctx == NULL) { PyErr_SetString(PyExc_ValueError, "Failed to create bitmap context"); goto end; }
     CGContextSetShouldAntialias(ctx, true);
     CGContextSetShouldSmoothFonts(ctx, true);  // sub-pixel antialias
+    CGContextSetShouldSubpixelQuantizeFonts(ctx, true);
+    CGContextSetShouldSubpixelPositionFonts(ctx, true);
     CGContextSetRGBFillColor(ctx, 1, 1, 1, 1); // white glyphs
     CGAffineTransform transform = CGAffineTransformIdentity;
     CGContextSetTextDrawingMode(ctx, kCGTextFill);


### PR DESCRIPTION
Improves font appearance on macOS, using same mechanisms as alacritty and iTerm2.