### PR TITLE
Fix iconset build flow for macOS

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -431,7 +431,12 @@ the approach using ligatures.
 
 === How do I build kitty.app on macOS?
 
-Run:
+At first, install `optipng` command via:
+```
+brew install optipng
+```
+
+And run:
 ```
 logo/make.py
 ./setup.py kitty.app

--- a/logo/make.py
+++ b/logo/make.py
@@ -23,7 +23,7 @@ if os.path.exists(iconset):
     shutil.rmtree(iconset)
 os.mkdir(iconset)
 os.chdir(iconset)
-for sz in (16, 32, 128, 256, 512, 1024):
+for sz in (16, 32, 64, 128, 256, 512, 1024):
     iname = 'icon_{0}x{0}.png'.format(sz)
     iname2x = 'icon_{0}x{0}@2x.png'.format(sz // 2)
     render(iname, sz)


### PR DESCRIPTION
Fix macOS build flow.

- Add install 'optipng' description because logo/make.py depends 'optipng'
- Add missing 64 size because doesn't create icon_32x32@2x.png