### PR TITLE
Add `+` to named_keys, #190 related

### DIFF
--- a/kitty/config.py
+++ b/kitty/config.py
@@ -71,6 +71,7 @@ def parse_mods(parts):
 named_keys = {
     "'": 'APOSTROPHE',
     ',': 'COMMA',
+    '+': 'PLUS',
     '-': 'MINUS',
     '.': 'PERIOD',
     '/': 'SLASH',


### PR DESCRIPTION
I tried to change the hotkeys for changing font size to the ones used by every other application I use

```
# map ctrl+shift+equal    increase_font_size
# map ctrl+shift+minus    decrease_font_size
# map ctrl+shift+backspace restore_font_size
map ctrl+plus increase_font_size
map ctrl+minus decrease_font_size
map ctrl+0 restore_font_size
```

I get `Shortcut: ctrl+plus increase_font_size has an unknown key, ignoring` when starting. 

In issue #190 the following was said: 
> \+ is not a key on most keyboards (leaving aside the numeric keyboard). The default shortcut is ctrl+shift+=

Maybe it's not a key on most keyboards, but there's a "few" million keyboards out there where it is. Like mine. I don't have a dedicated <kbd>=</kbd>, but I do have a <kbd>+</kbd> key. 

Can we define our own named keys in the config so these kinds of PRs would be unnecessary? It wasn't apparent from the README or the 60 lines of source I "read". There are hundreds of keyboard layouts, it's not possible to have the right config for everyone. 