### PR TITLE
Fix packaging trying to modify unrelated files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -516,8 +516,8 @@ def package(args, for_bundle=False, sh_launcher=False):  # {{{
     shutil.copytree('kitty', os.path.join(libdir, 'kitty'), ignore=src_ignore)
     shutil.copytree('kittens', os.path.join(libdir, 'kittens'), ignore=src_ignore)
     import compileall
-    compileall.compile_dir(ddir, quiet=1, workers=4)
-    for root, dirs, files in os.walk(ddir):
+    compileall.compile_dir(libdir, quiet=1, workers=4)
+    for root, dirs, files in os.walk(libdir):
         for f in files:
             path = os.path.join(root, f)
             os.chmod(path, 0o755 if f.endswith('.so') else 0o644)


### PR DESCRIPTION
`package()` method in `setup.py` tries to compile and chmod all files under the directory given by `--prefix PREFIX`.

If `PREFIX` is a directory containing other distributions (like `/usr/local` or `$HOME/.local`), then it would try to compile - using possibly the wrong python version - and chmod files within `PREFIX`.