### PR TITLE
Adds close_on_child_death option for disowned processes.

### DIFF
--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -980,7 +980,7 @@ io_loop(void *data) {
                 bool kill_signal = false, child_died = false;
                 read_signals(fds[1].fd, &kill_signal, &child_died);
                 if (kill_signal) { children_mutex(lock); kill_signal_received = true; children_mutex(unlock); }
-                if (child_died) reap_children(self, false);
+                if (child_died) reap_children(self, OPT(close_on_child_death));
             }
             for (i = 0; i < self->count; i++) {
                 if (fds[EXTRA_FDS + i].revents & (POLLIN | POLLHUP)) {

--- a/kitty/config.py
+++ b/kitty/config.py
@@ -272,6 +272,7 @@ type_map = {
     'repaint_delay': positive_int,
     'input_delay': positive_int,
     'sync_to_monitor': to_bool,
+    'close_on_child_death': to_bool,
     'window_border_width': positive_float,
     'window_margin_width': positive_float,
     'window_padding_width': positive_float,

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -149,6 +149,12 @@ input_delay 3
 # If so, set this to no.
 sync_to_monitor yes
 
+# Close the terminal when the child process (shell) exits. If no, the terminal
+# will remain open when the shell exits if processes are still outputting to
+# the terminal. If yes, the terminal will close as soon as the child process
+# exits regardless of processes outputting to the terminal. 
+close_on_child_death no
+
 # Visual bell duration. Flash the screen when a bell occurs for the specified number of
 # seconds. Set to zero to disable.
 visual_bell_duration 0.0

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -352,6 +352,7 @@ PYWRAP1(set_options) {
     S(repaint_delay, repaint_delay);
     S(input_delay, repaint_delay);
     S(sync_to_monitor, PyObject_IsTrue);
+    S(close_on_child_death, PyObject_IsTrue);
     S(macos_option_as_alt, PyObject_IsTrue);
     S(macos_hide_titlebar, PyObject_IsTrue);
 

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -31,6 +31,7 @@ typedef struct {
     float inactive_text_alpha;
     Edge tab_bar_edge;
     bool sync_to_monitor;
+    bool close_on_child_death;
 } Options;
 
 typedef struct {


### PR DESCRIPTION
This adds the close_on_child_death option to kitty's configuration, with the default being the current behaviour. (close_on_child_death no).

You kindly refactored the code to make this easy as a result of issue #378, and pointed me in the right direction to alter it. I know you're not keen on this addition, but as I've got the code written I thought it would be polite to send a pull request. No offence if you don't want to merge; I'll just maintain the fork in sync.

Thanks again for kitty, and for taking the time to help with this.