### PR TITLE
Stop setting title to ";" when 0-length OSC 2 is received

### DIFF
--- a/kitty/parser.c
+++ b/kitty/parser.c
@@ -310,7 +310,7 @@ dispatch_osc(Screen *screen, PyObject DUMP_UNUSED *dump_callback) {
     }
     if (i > 0) {
         code = utoi(screen->parser_buf, i);
-        if (i < limit - 1 && screen->parser_buf[i] == ';') i++;
+        if (i < limit && screen->parser_buf[i] == ';') i++;
     }
     PyObject *string = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, screen->parser_buf + i, limit - i);
     if (string != NULL) {

--- a/kitty_tests/parser.py
+++ b/kitty_tests/parser.py
@@ -182,6 +182,9 @@ class TestParser(BaseTest):
         c.clear()
         pb('\033]2;;;;\x07', ('set_title', ';;;'))
         self.ae(c.titlebuf, ';;;')
+        c.clear()
+        pb('\033]2;\x07', ('set_title', ''))
+        self.ae(c.titlebuf, '')
         pb('\033]110\x07', ('set_dynamic_color', 110, ''))
         self.ae(c.colorbuf, '')
 


### PR DESCRIPTION
Various programs send a 0-length title if no title is configured (e.g.,
(n)vim with 'title' unset, or mutt without ts_enabled).  When this
happens, kitty is mis-parsing the data and setting the title to ";".