### PR TITLE
Reduce icon set size to fit iconutil limits

### DIFF
--- a/logo/make.py
+++ b/logo/make.py
@@ -34,7 +34,7 @@ for sz in (16, 32, 64, 128, 256, 512, 1024):
     iname = 'icon_{0}x{0}.png'.format(sz)
     iname2x = 'icon_{0}x{0}@2x.png'.format(sz // 2)
     render(iname, sz)
-    if sz > 16:
+    if sz > 16 and sz != 128:
         shutil.copy2(iname, iname2x)
-    if sz > 512:
+    if sz in (64, 1024):
         os.remove(iname)


### PR DESCRIPTION
The existing iconset generation code leads to the following error and the lack of an icon for the OS X app:

> Mar 30 22:58:36 OXY4776M iconutil[63748] <Error>: ImageIO: _CGImageDestinationCreateWithWriter capacity parameter (12) is too large for this file format (max is 10)

`icon_64x64.png` and `icon_64x64@2x.png` is [unnecessary](https://developer.apple.com/library/content/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Optimizing/Optimizing.html). This PR prevents them from being created.