### PR TITLE
Use uint64_t to detect out of range graphics command id

### DIFF
--- a/kitty/parser.c
+++ b/kitty/parser.c
@@ -816,7 +816,7 @@ parse_graphics_code(Screen *screen, PyObject UNUSED *dump_callback) {
     enum KEYS key = 'a';
     static GraphicsCommand g;
     unsigned int i, code;
-    unsigned long lcode;
+    uint64_t lcode;
     bool is_negative;
     memset(&g, 0, sizeof(g));
     static uint8_t payload[4096];


### PR DESCRIPTION
parse_graphics_code() uses an unsigned long to detect if the id is
"> UINT32_MAX", however sizeof(long) == sizeof(void *) on Linux systems.
So this condition will be impossible on any 32-bit system.