### PR TITLE
Correct types for various PyArg_ParseTuple/Py_BuildValue calls

### DIFF
--- a/kitty/data-types.c
+++ b/kitty/data-types.c
@@ -194,7 +194,7 @@ PyInit_fast_data_types(void) {
         if (!init_fonts(m)) return NULL;
 
 #define OOF(n) #n, offsetof(Cell, n)
-        if (PyModule_AddObject(m, "CELL", Py_BuildValue("{sI sI sI sI sI sI sI sI sI}",
+        if (PyModule_AddObject(m, "CELL", Py_BuildValue("{sI sI sI sI sI sH sH sH sI}",
                     OOF(ch), OOF(fg), OOF(bg), OOF(decoration_fg), OOF(cc_idx), OOF(sprite_x), OOF(sprite_y), OOF(sprite_z), "size", sizeof(Cell))) != 0) return NULL;
 #undef OOF
         PyModule_AddIntConstant(m, "BOLD", BOLD_SHIFT);

--- a/kitty/fonts.c
+++ b/kitty/fonts.c
@@ -852,7 +852,7 @@ test_shape(PyObject UNUSED *self, PyObject *args) {
 
         PyObject *eg = PyTuple_New(MAX_NUM_EXTRA_GLYPHS);
         for (size_t g = 0; g < MAX_NUM_EXTRA_GLYPHS; g++) PyTuple_SET_ITEM(eg, g, Py_BuildValue("H", g + 1 < group->num_glyphs ? G(info)[group->first_glyph_idx + g].codepoint : 0));
-        PyList_Append(ans, Py_BuildValue("IIIN", group->num_cells, group->num_glyphs, first_glyph, eg));
+        PyList_Append(ans, Py_BuildValue("IIHN", group->num_cells, group->num_glyphs, first_glyph, eg));
         idx++;
     }
     if (face) { Py_CLEAR(face); free(font); }
@@ -988,7 +988,7 @@ static PyObject*
 test_sprite_position_for(PyObject UNUSED *self, PyObject *args) {
     glyph_index glyph;
     ExtraGlyphs extra_glyphs = {{0}};
-    if (!PyArg_ParseTuple(args, "H|I", &glyph, &extra_glyphs.data)) return NULL;
+    if (!PyArg_ParseTuple(args, "H|H", &glyph, &extra_glyphs.data)) return NULL;
     int error;
     SpritePosition *pos = sprite_position_for(&fonts.fonts[fonts.medium_font_idx], glyph, &extra_glyphs, 0, &error);
     if (pos == NULL) { sprite_map_set_error(error); return NULL; }

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -321,7 +321,7 @@ create_os_window(PyObject UNUSED *self, PyObject *args) {
     int width, height, x = -1, y = -1;
     char *title, *wm_class_class, *wm_class_name;
     PyObject *load_programs = NULL;
-    if (!PyArg_ParseTuple(args, "iisss|Oiii", &width, &height, &title, &wm_class_name, &wm_class_class, &load_programs, &x, &y)) return NULL;
+    if (!PyArg_ParseTuple(args, "iisss|Oii", &width, &height, &title, &wm_class_name, &wm_class_class, &load_programs, &x, &y)) return NULL;
 
     if (is_first_window) {
         glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);

--- a/kitty/graphics.c
+++ b/kitty/graphics.c
@@ -873,9 +873,10 @@ new(PyTypeObject UNUSED *type, PyObject UNUSED *args, PyObject UNUSED *kwds) {
 static inline PyObject*
 image_as_dict(Image *img) {
 #define U(x) #x, img->x
-    return Py_BuildValue("{sI sI sI sI sI sI sH sH sN}",
-        U(texture_id), U(client_id), U(width), U(height), U(internal_id), U(refcnt), U(data_loaded),
-        "is_4byte_aligned", img->load_data.is_4byte_aligned,
+    return Py_BuildValue("{sI sI sI sI sI sI sO sO sN}",
+        U(texture_id), U(client_id), U(width), U(height), U(internal_id), U(refcnt),
+        "data_loaded", img->data_loaded ? Py_True : Py_False,
+        "is_4byte_aligned", img->load_data.is_4byte_aligned ? Py_True : Py_False,
         "data", Py_BuildValue("y#", img->load_data.data, img->load_data.data_sz)
     );
 #undef U


### PR DESCRIPTION
Debian's [mips] build failed one of the font tests:

    FAIL: test_sprite_map (kitty_tests.fonts.Rendering)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/<<PKGBUILDDIR>>/kitty_tests/fonts.py", line 48, in test_sprite_map
        self.ae(test_sprite_position_for(0, 1), (0, 1, 1))
        self = <kitty_tests.fonts.Rendering testMethod=test_sprite_map>
    AssertionError: Tuples differ: (0, 0, 0) != (0, 1, 1)

    First differing element 1:
    0
    1

    - (0, 0, 0)
    ?     ^  ^

    + (0, 1, 1)
    ?     ^  ^

This was due to test_sprite_position_for() using the "I" code to parse
into an unsigned short.  Since mips is big endian, the "wrong" byte was
stored into extra_glyphs.data.

This commit changes all similar data type mismatches that were found
from auditing calls to PyArg_ParseTuple/Py_BuildValue.

[mips]: https://buildd.debian.org/status/fetch.php?pkg=kitty&arch=mips&ver=0.9.0-1&stamp=1524126606&raw=0