### PR TITLE
Add macos_hide_from_tasks option

### DIFF
--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -228,10 +228,9 @@ macos_change_titlebar_color(PyObject *self UNUSED, PyObject *val) {
     Py_RETURN_NONE;
 }
 
-static PyObject*
-macos_set_hide_from_tasks(PyObject *self UNUSED, PyObject *val UNUSED) {
+void
+cocoa_set_hide_from_tasks(void) {
     [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
-    Py_RETURN_NONE;
 }
 
 void
@@ -266,7 +265,6 @@ static PyMethodDef module_methods[] = {
     {"cocoa_get_lang", (PyCFunction)cocoa_get_lang, METH_NOARGS, ""},
     {"cwd_of_process", (PyCFunction)cwd_of_process, METH_O, ""},
     {"macos_change_titlebar_color", (PyCFunction)macos_change_titlebar_color, METH_O, ""},
-    {"macos_set_hide_from_tasks", (PyCFunction)macos_set_hide_from_tasks, METH_NOARGS, ""},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -228,6 +228,12 @@ macos_change_titlebar_color(PyObject *self UNUSED, PyObject *val) {
     Py_RETURN_NONE;
 }
 
+static PyObject*
+macos_set_hide_from_tasks(PyObject *self UNUSED, PyObject *val UNUSED) {
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+    Py_RETURN_NONE;
+}
+
 void
 cocoa_set_titlebar_color(void *w)
 {
@@ -260,6 +266,7 @@ static PyMethodDef module_methods[] = {
     {"cocoa_get_lang", (PyCFunction)cocoa_get_lang, METH_NOARGS, ""},
     {"cwd_of_process", (PyCFunction)cwd_of_process, METH_O, ""},
     {"macos_change_titlebar_color", (PyCFunction)macos_change_titlebar_color, METH_O, ""},
+    {"macos_set_hide_from_tasks", (PyCFunction)macos_set_hide_from_tasks, METH_NOARGS, ""},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/kitty/config.py
+++ b/kitty/config.py
@@ -318,6 +318,7 @@ type_map = {
     'initial_window_width': positive_int,
     'initial_window_height': positive_int,
     'macos_hide_titlebar': to_bool,
+    'macos_hide_from_tasks': to_bool,
     'macos_option_as_alt': to_bool,
     'macos_titlebar_color': macos_titlebar_color,
     'box_drawing_scale': box_drawing_scale,

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -9,6 +9,7 @@
 #include "glfw-wrapper.h"
 extern bool cocoa_make_window_resizable(void *w);
 extern void cocoa_create_global_menu(void);
+extern void cocoa_set_hide_from_tasks(void);
 extern void cocoa_set_titlebar_color(void *w);
 
 #if GLFW_KEY_LAST >= MAX_KEY_COUNT
@@ -375,6 +376,8 @@ create_os_window(PyObject UNUSED *self, PyObject *args) {
 #ifdef __APPLE__
         cocoa_create_global_menu();
         if (OPT(macos_option_as_alt)) glfwSetCocoaTextInputFilter(glfw_window, filter_option);
+        // This needs to be done only after the first window has been created, because glfw only sets the activation policy once upon initialization.
+        if (OPT(macos_hide_from_tasks)) cocoa_set_hide_from_tasks();
 #endif
         is_first_window = false;
     }

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -501,5 +501,5 @@ macos_hide_titlebar no
 macos_option_as_alt yes
 
 # Hide the kitty window from running tasks (alt-tab) on macOS.
-macos_hide_from_tasks yes
+macos_hide_from_tasks no
 # }}}

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -499,4 +499,7 @@ macos_hide_titlebar no
 # break any Alt+key keyboard shortcuts in your terminal programs, but you
 # can use the macOS unicode input technique.
 macos_option_as_alt yes
+
+# Hide the kitty window from running tasks (alt-tab) on macOS.
+macos_hide_from_tasks yes
 # }}}

--- a/kitty/main.py
+++ b/kitty/main.py
@@ -45,10 +45,6 @@ def run_app(opts, args):
     with cached_values_for('main') as cached_values:
         w, h = initial_window_size(opts, cached_values)
         window_id = create_os_window(w, h, appname, args.name or args.cls or appname, args.cls or appname, load_all_shaders)
-        if is_macos and opts.macos_hide_from_tasks:
-            from .fast_data_types import macos_set_hide_from_tasks
-            # This needs to be done after creating the OS window as glfw sets the activation policy as well.
-            macos_set_hide_from_tasks()
         startup_ctx = init_startup_notification(window_id)
         show_window(window_id)
         if not is_wayland and not is_macos:  # no window icons on wayland

--- a/kitty/main.py
+++ b/kitty/main.py
@@ -45,6 +45,10 @@ def run_app(opts, args):
     with cached_values_for('main') as cached_values:
         w, h = initial_window_size(opts, cached_values)
         window_id = create_os_window(w, h, appname, args.name or args.cls or appname, args.cls or appname, load_all_shaders)
+        if is_macos and opts.macos_hide_from_tasks:
+            from .fast_data_types import macos_set_hide_from_tasks
+            # This needs to be done after creating the OS window as glfw sets the activation policy as well.
+            macos_set_hide_from_tasks()
         startup_ctx = init_startup_notification(window_id)
         show_window(window_id)
         if not is_wayland and not is_macos:  # no window icons on wayland

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -358,6 +358,7 @@ PYWRAP1(set_options) {
     S(close_on_child_death, PyObject_IsTrue);
     S(macos_option_as_alt, PyObject_IsTrue);
     S(macos_hide_titlebar, PyObject_IsTrue);
+    S(macos_hide_from_tasks, PyObject_IsTrue);
 
     PyObject *chars = PyObject_GetAttrString(opts, "select_by_word_characters");
     if (chars == NULL) return NULL;

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -23,7 +23,7 @@ typedef struct {
     color_type url_color, background, active_border_color, inactive_border_color;
     double repaint_delay, input_delay;
     bool focus_follows_mouse;
-    bool macos_option_as_alt, macos_hide_titlebar;
+    bool macos_option_as_alt, macos_hide_titlebar, macos_hide_from_tasks;
     int adjust_line_height_px, adjust_column_width_px;
     float adjust_line_height_frac, adjust_column_width_frac;
     float background_opacity;


### PR DESCRIPTION
Adds option for macOS to hide from tasks list. This is useful if you have kitty configured with a global hotkey and don't need to see it when alt tabbing.

