### PR TITLE
Add option to open URLs without modifiers. Fixes #371

### DIFF
--- a/kitty/config.py
+++ b/kitty/config.py
@@ -60,7 +60,8 @@ def parse_mods(parts, sc):
         try:
             mods |= getattr(defines, 'GLFW_MOD_' + map_mod(m.upper()))
         except AttributeError:
-            log_error('Shortcut: {} has unknown modifier, ignoring'.format(sc))
+            if 'none' not in m.lower():
+                log_error('Shortcut: {} has unknown modifier, ignoring'.format(sc))
             return
 
     return mods

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -100,7 +100,8 @@ wheel_scroll_multiplier 5.0
 url_color #0087BD
 url_style curly
 
-# The modifier keys to press when clicking with the mouse on URLs to open the URL
+# The modifier keys to press when clicking with the mouse on URLs to open the URL. Set to
+# none to allow direct clicks without modifiers.
 open_url_modifiers kitty_mod
 
 # The program with which to open URLs that are clicked on. The special value "default" means to

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -320,8 +320,8 @@ HANDLER(handle_button_event) {
         switch(button) {
             case GLFW_MOUSE_BUTTON_LEFT:
                 update_drag(true, w, is_release, modifiers);
-                if (is_release) {
-                    if (modifiers == (int)OPT(open_url_modifiers)) open_url(w);
+                if (is_release && !screen_has_selection(w->render_data.screen)) {
+                    if (!OPT(open_url_modifiers) || modifiers == (int)OPT(open_url_modifiers)) open_url(w);
                 } else add_click(w, button, modifiers, window_idx);
                 break;
             case GLFW_MOUSE_BUTTON_MIDDLE:


### PR DESCRIPTION
This will allow urls to be clicked without holding a modifier, it is enabled by setting "open_url_modifiers" to "none".

The reason for the check for "!screen_has_selection(w->render_data.screen)" is because it would otherwise trigger opening the url when highlighting.