### PR TITLE
Fixed where output of '--debug-config' would not be aligned if an opt…

### DIFF
--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -555,12 +555,15 @@ def flatten_sequence_map(m):
 def compare_opts(opts):
     print('\nConfig options different from defaults:')
     default_opts = load_config()
+    l = ('key_definitions', 'keymap', 'sequence_map')
+    fmt = '{{:{:d}s}}'.format(max(len(k) for k in opts
+        if getattr(opts, k) != getattr(defaults, k) and k not in l))
 
     for f in sorted(defaults._fields):
         if getattr(opts, f) != getattr(defaults, f):
-            if f in ('key_definitions', 'keymap', 'sequence_map'):
+            if f in l:
                 continue
-            print(title('{:20s}'.format(f)), getattr(opts, f))
+            print(title(fmt.format(f)), getattr(opts, f))
 
     final, initial = opts.keymap, default_opts.keymap
     final = {(k,): v for k, v in final.items()}


### PR DESCRIPTION
### Reason for PR
When doing a test for an issue that I ran into <sup>*Haven't opened the issue yet*</sup>, I noticed that the output of `--debug-config` was not aligned if the length of one **option** `key` *(Given that the corresponding **option** `value` was different from the default **option** `value`)* was longer than 20 characters.

### Description of PR
This is a rather simple fix, and I may have went a bit far with this because instead of just changing the **format** in `print(title('{:20s}'.format(f)), getattr(opts, f))` to a higher **specification**, I made it so that the **format specification** is set to the length of the highest *Valid* **option** `key`, rather than the length of the highest **option** `key` available.  I did this because at the time of testing, the length of the highest **option** `key` was 26 characters, and if in `kitty.conf`, the only **options** that are different from *default* are of a small length, it would look rather funny with all that extra white space between the **option** `key` and changed **option** `value`.

### Extra Information - Future Proof
With this approach, it will *adapt* to any other **options** that get added in the future, and will not require any further modifications.