### PR TITLE
Typo in kitty.conf

### DIFF
--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -76,7 +76,7 @@ cursor_shape     block
 cursor_blink_interval     0.5
 
 # Stop blinking cursor after the specified number of seconds of keyboard inactivity. Set to
-# zero to never stop blinking.
+# zero to stop blinking.
 cursor_stop_blinking_after 15.0
 # }}}
 


### PR DESCRIPTION
My previous issue I opened up was opened because of what the description for the stop blinking option said.  I have fixed the typo.  

I apologize for the unformatted description for this PR.  I am doing this through my mobile device.  