### PR TITLE
ssh kitten: pass through extra params to ssh process

### DIFF
--- a/kittens/ssh/main.py
+++ b/kittens/ssh/main.py
@@ -42,7 +42,7 @@ def main(args):
     server = args[1]
     terminfo = subprocess.check_output(['infocmp']).decode('utf-8')
     sh_script = SHELL_SCRIPT.replace('TERMINFO', terminfo, 1)
-    cmd = ['ssh', '-t', server, sh_script]
+    cmd = ['ssh'] + args[2:] + ['-t', server, sh_script]
     p = subprocess.Popen(cmd)
     raise SystemExit(p.wait())
 


### PR DESCRIPTION
The idea is to allow `kitty +kitten ssh server -v`, which should pass `-v` to `ssh` process. 