### PR TITLE
Fix build on FreeBSD 11

### DIFF
--- a/glfw/source-info.json
+++ b/glfw/source-info.json
@@ -113,8 +113,7 @@
       "posix_thread.h", 
       "glx_context.h", 
       "egl_context.h", 
-      "osmesa_context.h", 
-      "linux_joystick.h"
+      "osmesa_context.h"
     ], 
     "sources": [
       "x11_init.c", 
@@ -125,8 +124,7 @@
       "posix_thread.c", 
       "glx_context.c", 
       "egl_context.c", 
-      "osmesa_context.c", 
-      "linux_joystick.c"
+      "osmesa_context.c"
     ]
   }
 }

--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -5,8 +5,8 @@
  * Distributed under terms of the GPL3 license.
  */
 
-#include "threading.h"
 #include "state.h"
+#include "threading.h"
 #include "screen.h"
 #include "fonts.h"
 #include <termios.h>

--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -7,13 +7,12 @@
 
 #pragma once
 
-
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <poll.h>
 #include <pthread.h>
-#define PY_SSIZE_T_CLEAN
-#include <Python.h>
 // Required minimum OpenGL version
 #define OPENGL_REQUIRED_VERSION_MAJOR 3
 #define OPENGL_REQUIRED_VERSION_MINOR 3

--- a/kitty/glfw-wrapper.c
+++ b/kitty/glfw-wrapper.c
@@ -1,7 +1,7 @@
 
-#include <dlfcn.h>
 #include "data-types.h"
 #include "glfw-wrapper.h"
+#include <dlfcn.h>
 
 static void* handle = NULL;
 

--- a/kitty/keys.c
+++ b/kitty/keys.c
@@ -5,8 +5,8 @@
  * Distributed under terms of the GPL3 license.
  */
 
-#include "keys.h"
 #include "state.h"
+#include "keys.h"
 #include "screen.h"
 #include "glfw-wrapper.h"
 #include "control-codes.h"

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -5,8 +5,8 @@
  * Distributed under terms of the GPL3 license.
  */
 
-#include "gl.h"
 #include "fonts.h"
+#include "gl.h"
 
 enum { CELL_PROGRAM, CELL_BG_PROGRAM, CELL_SPECIAL_PROGRAM, CELL_FG_PROGRAM, CURSOR_PROGRAM, BORDERS_PROGRAM, GRAPHICS_PROGRAM, GRAPHICS_PREMULT_PROGRAM, BLIT_PROGRAM, NUM_PROGRAMS };
 enum { SPRITE_MAP_UNIT, GRAPHICS_UNIT, BLIT_UNIT };

--- a/kitty/threading.h
+++ b/kitty/threading.h
@@ -12,17 +12,25 @@
 // I cant figure out how to get pthread.h to include this definition on macOS. MACOSX_DEPLOYMENT_TARGET does not work.
 extern int pthread_setname_np(const char *name);
 #else
+#ifdef __FreeBSD__
+void pthread_set_name_np(pthread_t tid, const char *name);
+#else 
 // Need _GNU_SOURCE for pthread_setname_np on linux and that causes other issues on systems with old glibc
 extern int pthread_setname_np(pthread_t, const char *name);
+#endif
 #endif
 
 static inline void
 set_thread_name(const char *name) {
     int ret = 0;
 #ifdef __APPLE__
-    ret = pthread_setname_np(name);
+    ret = pthreadset_name_np(name);
+#else
+#ifdef __FreeBSD__
+    pthread_set_name_np(pthread_self(), name);
 #else
     ret = pthread_setname_np(pthread_self(), name);
+#endif
 #endif
     if (ret != 0) perror("Failed to set thread name");
 }

--- a/kitty/threading.h
+++ b/kitty/threading.h
@@ -8,29 +8,26 @@
 
 #include <stdio.h>
 #include <pthread.h>
-#ifdef __APPLE__
+#if defined(__APPLE__)
 // I cant figure out how to get pthread.h to include this definition on macOS. MACOSX_DEPLOYMENT_TARGET does not work.
 extern int pthread_setname_np(const char *name);
-#else
-#ifdef __FreeBSD__
+#elif defined(__FreeBSD__)
+// Function has a different name on FreeBSD
 void pthread_set_name_np(pthread_t tid, const char *name);
 #else 
 // Need _GNU_SOURCE for pthread_setname_np on linux and that causes other issues on systems with old glibc
 extern int pthread_setname_np(pthread_t, const char *name);
 #endif
-#endif
 
 static inline void
 set_thread_name(const char *name) {
     int ret = 0;
-#ifdef __APPLE__
+#if defined(__APPLE__)
     ret = pthreadset_name_np(name);
-#else
-#ifdef __FreeBSD__
+#elif defined(__FreeBSD__)
     pthread_set_name_np(pthread_self(), name);
 #else
     ret = pthread_setname_np(pthread_self(), name);
-#endif
 #endif
     if (ret != 0) perror("Failed to set thread name");
 }


### PR DESCRIPTION
This set of patches fixes the build on FreeBSD 11: it fixes errors resulting from the ordering of `#include`s, builds the correct (`null`) joystick driver for `glfw`, and deals with a `pthread` function naming issue.

I checked to make sure that these patches don't break the build in Linux (recent Arch) 