### PR TITLE
 Add support for sha1 hashes to the hint kitten 

### DIFF
--- a/kittens/hints/main.py
+++ b/kittens/hints/main.py
@@ -244,8 +244,8 @@ def functions_for(args):
         post_processors.extend((brackets, quotes))
     elif args.type == 'line':
         pattern = '(?m)^\\s*(.+)[\\s\0]*$'
-    elif args.type == 'sha1':
-        pattern = '[0-9a-f]{7,40}'
+    elif args.type == 'hash':
+        pattern = '[0-9a-f]{7,128}'
     elif args.type == 'word':
         chars = args.word_characters
         if chars is None:
@@ -315,7 +315,7 @@ terminal window instead. A value of :file:`@` will copy the match to the clipboa
 
 --type
 default=url
-choices=url,regex,path,line,sha1,word
+choices=url,regex,path,line,hash,word
 The type of text to search for.
 
 

--- a/kittens/hints/main.py
+++ b/kittens/hints/main.py
@@ -333,7 +333,7 @@ Comma separated list of recognized URL prefixes.
 
 
 --word-characters
-Csha1,haracters to consider as part of a word. In addition, all characters marked as
+Characters to consider as part of a word. In addition, all characters marked as
 alpha-numeric in the unicode database will be considered as word characters.
 Defaults to the select_by_word_characters setting from kitty.conf.
 

--- a/kittens/hints/main.py
+++ b/kittens/hints/main.py
@@ -244,6 +244,8 @@ def functions_for(args):
         post_processors.extend((brackets, quotes))
     elif args.type == 'line':
         pattern = '(?m)^\\s*(.+)[\\s\0]*$'
+    elif args.type == 'sha1':
+        pattern = '[0-9a-f]{7,40}'
     elif args.type == 'word':
         chars = args.word_characters
         if chars is None:
@@ -313,7 +315,7 @@ terminal window instead. A value of :file:`@` will copy the match to the clipboa
 
 --type
 default=url
-choices=url,regex,path,line,word
+choices=url,regex,path,line,sha1,word
 The type of text to search for.
 
 
@@ -331,7 +333,7 @@ Comma separated list of recognized URL prefixes.
 
 
 --word-characters
-Characters to consider as part of a word. In addition, all characters marked as
+Csha1,haracters to consider as part of a word. In addition, all characters marked as
 alpha-numeric in the unicode database will be considered as word characters.
 Defaults to the select_by_word_characters setting from kitty.conf.
 

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -490,6 +490,10 @@ map kitty_mod+e         kitten hints
 # run git commands on a filename output from a previous git command.
 map kitty_mod+p>f       kitten hints --type path --program -
 
+# Select something that looks like a SHA1 hash and insert it into the terminal.
+# Useful with git, which uses sha1 hashes to identify commits
+map kitty_mod+p>s       kitten hints --type sha1 --program -
+
 # Select a path/filename and open it with the default open program.
 map kitty_mod+p>shift+f kitten hints --type path
 

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -490,9 +490,9 @@ map kitty_mod+e         kitten hints
 # run git commands on a filename output from a previous git command.
 map kitty_mod+p>f       kitten hints --type path --program -
 
-# Select something that looks like a SHA1 hash and insert it into the terminal.
+# Select something that looks like a hash and insert it into the terminal.
 # Useful with git, which uses sha1 hashes to identify commits
-map kitty_mod+p>s       kitten hints --type sha1 --program -
+map kitty_mod+p>h       kitten hints --type hash --program -
 
 # Select a path/filename and open it with the default open program.
 map kitty_mod+p>shift+f kitten hints --type path


### PR DESCRIPTION
This is specifically intended for git commit hashes, so it allows for
hashes as short as 7 characters (git's default length for abbreviated
hashes) up to the full 40 characters