### PR TITLE
More robustly strip bracketed paste termination sequence

### DIFF
--- a/kitty/window.py
+++ b/kitty/window.py
@@ -431,7 +431,11 @@ class Window:
             if isinstance(text, str):
                 text = text.encode('utf-8')
             if self.screen.in_bracketed_paste_mode:
-                text = text.replace(b'\033[201~', b'').replace(b'\x9b201~', b'')
+                while True:
+                    new_text = text.replace(b'\033[201~', b'').replace(b'\x9b201~', b'')
+                    if text == new_text:
+                        break
+                    text = new_text
             self.screen.paste(text)
 
     def copy_to_clipboard(self):


### PR DESCRIPTION
The previous code performed only one replacement on the bracketed
paste content. This procedure didn't stop someone embedding the
terminating sequence anyway. POC:

1) $ x=$'\033[201~'; printf '%s%s%s\necho hello world\n' "${x:0:1}" "$x" "${x:1}" | xclip
2) paste into kitty
3) see the shell execute a command!

This patch closes this hole.