### PR TITLE
Track mouse events outside the window

### DIFF
--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -197,6 +197,7 @@ push_focus_history(OSWindow *w) {
 
 static void
 window_focus_callback(GLFWwindow *w, int focused) {
+    global_state.drag_start_window = NULL;
     if (!set_callback_window(w)) return;
     global_state.callback_os_window->is_focused = focused ? true : false;
     if (focused) {

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -128,6 +128,10 @@ cell_for_pos(Window *w, unsigned int *x, unsigned int *y, OSWindow *os_window) {
     double mouse_x = global_state.callback_os_window->mouse_x;
     double mouse_y = global_state.callback_os_window->mouse_y;
     double left = window_left(w, os_window), top = window_top(w, os_window), right = window_right(w, os_window), bottom = window_bottom(w, os_window);
+	if (global_state.drag_start_window) {
+		mouse_x = MIN(MAX(mouse_x, left), right);
+		mouse_y = MIN(MAX(mouse_y, top), bottom);
+	}
     if (mouse_x < left || mouse_y < top || mouse_x > right || mouse_y > bottom) return false;
     if (mouse_x >= g->right) qx = screen->columns - 1;
     else if (mouse_x >= g->left) qx = (unsigned int)((double)(mouse_x - g->left) / os_window->fonts_data->cell_width);
@@ -229,7 +233,9 @@ HANDLER(handle_move_event) {
             call_boss(switch_focus_to, "I", window_idx);
         }
     }
-    if (!cell_for_pos(w, &x, &y, global_state.callback_os_window)) return;
+    if (!cell_for_pos(w, &x, &y, global_state.callback_os_window)) {
+		return;
+	}
     Screen *screen = w->render_data.screen;
     detect_url(screen, x, y);
     bool mouse_cell_changed = x != w->mouse_cell_x || y != w->mouse_cell_y;
@@ -370,7 +376,18 @@ mouse_in_region(Region *r) {
 }
 
 static inline Window*
-window_for_event(unsigned int *window_idx, bool *in_tab_bar) {
+window_for_event(int button, unsigned int *window_idx, bool *in_tab_bar) {
+	bool is_press = button >= 0 && global_state.callback_os_window->mouse_button_pressed[button];
+	bool is_release = button >= 0 && !global_state.callback_os_window->mouse_button_pressed[button];
+
+	if (is_release || button >= 1)
+		global_state.drag_start_window = NULL;
+	if (global_state.drag_start_window) {
+		*in_tab_bar = global_state.drag_start_in_tab_bar;
+		*window_idx = global_state.drag_start_window_idx;
+		return global_state.drag_start_window;
+	}
+
     Region central, tab_bar;
 	os_window_regions(global_state.callback_os_window, &central, &tab_bar);
 	*in_tab_bar = mouse_in_region(&tab_bar);
@@ -378,6 +395,11 @@ window_for_event(unsigned int *window_idx, bool *in_tab_bar) {
         Tab *t = global_state.callback_os_window->tabs + global_state.callback_os_window->active_tab;
         for (unsigned int i = 0; i < t->num_windows; i++) {
             if (contains_mouse(t->windows + i, global_state.callback_os_window) && t->windows[i].render_data.screen) {
+				if (is_press && button == 0) {
+					global_state.drag_start_window_idx = i;
+					global_state.drag_start_window = t->windows + i;
+					global_state.drag_start_in_tab_bar = *in_tab_bar;
+				}
                 *window_idx = i; return t->windows + i;
             }
         }
@@ -393,7 +415,7 @@ focus_in_event() {
     unsigned int window_idx = 0;
     mouse_cursor_shape = BEAM;
     set_mouse_cursor(BEAM);
-    Window *w = window_for_event(&window_idx, &in_tab_bar);
+    Window *w = window_for_event(-1, &window_idx, &in_tab_bar);
     if (w && w->render_data.screen) screen_mark_url(w->render_data.screen, 0, 0, 0, 0);
 }
 
@@ -402,7 +424,7 @@ mouse_event(int button, int modifiers) {
     MouseShape old_cursor = mouse_cursor_shape;
     bool in_tab_bar;
     unsigned int window_idx = 0;
-    Window *w = window_for_event(&window_idx, &in_tab_bar);
+    Window *w = window_for_event(button, &window_idx, &in_tab_bar);
     if (in_tab_bar) {
         mouse_cursor_shape = HAND;
         handle_tab_bar_mouse(button, modifiers);
@@ -424,7 +446,7 @@ scroll_event(double UNUSED xoffset, double yoffset) {
     bool upwards = s > 0;
     bool in_tab_bar;
     unsigned int window_idx = 0;
-    Window *w = window_for_event(&window_idx, &in_tab_bar);
+    Window *w = window_for_event(-1, &window_idx, &in_tab_bar);
     if (w) {
         Screen *screen = w->render_data.screen;
         if (screen->linebuf == screen->main_linebuf) {

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -143,6 +143,7 @@ remove_window_inner(Tab *tab, id_type id) {
 
 static inline void
 remove_window(id_type os_window_id, id_type tab_id, id_type id) {
+    global_state.drag_start_window = NULL;
     WITH_TAB(os_window_id, tab_id);
         make_os_window_context_current(osw);
         remove_window_inner(tab, id);
@@ -151,6 +152,7 @@ remove_window(id_type os_window_id, id_type tab_id, id_type id) {
 
 static inline void
 destroy_tab(Tab *tab) {
+    global_state.drag_start_window = NULL;
     for (size_t i = tab->num_windows; i > 0; i--) remove_window_inner(tab, tab->windows[i - 1].id);
     remove_vao(tab->border_rects.vao_idx);
     free(tab->border_rects.rect_buf); tab->border_rects.rect_buf = NULL;

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -134,6 +134,9 @@ typedef struct {
     OSWindow *os_windows;
     size_t num_os_windows, capacity;
     OSWindow *callback_os_window;
+    Window *drag_start_window;
+    bool drag_start_in_tab_bar;
+    int drag_start_window_idx;
     bool close_all_windows;
     bool is_wayland;
     bool debug_gl, debug_font_fallback;


### PR DESCRIPTION
On mouse down, there's an "implicit grab" made by the window system
which ensures that mouse events are delivered to the window that
received the mouse-down even if the cursor strays outside the original
window before mouse-up. Kitty has been filtering out these
outside-window events and ignoring them, creating behavior that
differs from most other applications.

This change remembers the window bound to the mouse-down event and
uses it until mouse up, implementing more conventional moues behavior.