### PR TITLE
docs: improve generation of default config files

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -500,35 +500,30 @@ def write_conf_docs(app, all_kitten_names):
     sc_role.warn_dangling = True
     sc_role.process_link = process_shortcut_link
 
-    def generate(all_options, name='kitty'):
+    def generate_default_config(all_options, name):
         from kitty.conf.definition import as_conf_file
-        from textwrap import indent
         with open(f'generated/conf-{name}.rst', 'w', encoding='utf-8') as f:
             print('.. highlight:: conf\n', file=f)
             f.write(render_conf(name, all_options.values()))
 
-        with open(f'generated/conf-{name}-literal.rst', 'w', encoding='utf-8') as f:
-            print('.. code-block:: conf\n', file=f)
+        conf_name = re.sub(r'^kitten-', '', name) + '.conf'
+        with open(f'generated/conf/{conf_name}', 'w', encoding='utf-8') as f:
             text = '\n'.join(as_conf_file(all_options.values()))
-            text = indent(text, '    ', lambda l: True)
             print(text, file=f)
 
     from kitty.config_data import all_options
-    generate(all_options)
+    generate_default_config(all_options, 'kitty')
 
     from kittens.runner import get_kitten_conf_docs
     for kitten in all_kitten_names:
         all_options = get_kitten_conf_docs(kitten)
         if all_options:
-            generate(all_options, f'kitten-{kitten}')
+            generate_default_config(all_options, f'kitten-{kitten}')
 # }}}
 
 
 def setup(app):
-    try:
-        os.mkdir('generated')
-    except FileExistsError:
-        pass
+    os.makedirs('generated/conf', exist_ok=True)
     from kittens.runner import all_kitten_names
     all_kitten_names = all_kitten_names()
     write_cli_docs(all_kitten_names)

--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -35,6 +35,7 @@ expanded, so :code:`${USER}.conf` becomes :file:`name.conf` if
 Sample kitty.conf
 ^^^^^^^^^^^^^^^^^^^^^
 
-Below is a sample :file:`kitty.conf` with all default settings.
+Below is a sample :download:`kitty.conf </generated/conf/kitty.conf>` with all default settings.
 
-.. include:: /generated/conf-kitty-literal.rst
+.. literalinclude:: /generated/conf/kitty.conf
+   :language: conf

--- a/docs/kittens/diff.rst
+++ b/docs/kittens/diff.rst
@@ -152,6 +152,7 @@ Command Line Interface
 Sample diff.conf
 -----------------
 
-Below is a sample :file:`diff.conf` with all default settings.
+Below is a sample :download:`diff.conf </generated/conf/diff.conf>` with all default settings.
 
-.. include:: /generated/conf-kitten-diff-literal.rst
+.. literalinclude:: /generated/conf/diff.conf
+   :language: conf


### PR DESCRIPTION
- config files are placed into `docs/generated/conf/`, using the
  expected name, and without any indentation
- `literalinclude::` is used instead of `include::`
- uses `:download:` instead of `:file:` to allow for downloading the
  generated files easily