### PR TITLE
Ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__
 glfw/wayland-*-client-protocol.[ch]
 docs/_build
 docs/generated
+.DS_Store


### PR DESCRIPTION
macOS will often create hidden files named .DS_Store, which can be a bit annoying for contributors working on macOS. Ignoring these files would be nice and simplify things a little.