### PR TITLE
Support "-T" as an alias for "--title".

### DIFF
--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -44,7 +44,7 @@ condition=not is_macos
 Set the name part of the :italic:`WM_CLASS` property (defaults to using the value from :option:`{appname} --class`)
 
 
---title
+--title -T
 Set the window title. This will override any title set by the program running inside kitty. So
 only use this if you are running a program that does not set titles.
 


### PR DESCRIPTION
Thank you for developing Kitty.

Currently kitty is not available on the list of "alternatives" for a
terminal emulator on Debian GNU/Linux and derivatives. This is because
Debian Policy states that packages that provide a terminal emulator must
provide, inter alia, support the command-line option -T title, which
creates a new terminal window with the specified window title [0].

This PR therefore adds -T as an alias for --title, thus bringing kitty into
compliance and allowing cleaner integration into the Debian desktop.

This issue was originally filed as #900704.

  [0] https://www.debian.org/doc/debian-policy/#packages-providing-a-terminal-emulator
  [1] https://bugs.debian.org/900704