### PR TITLE
Added keyboard-mapping based on symbol (use "mapsym" in config)

### DIFF
--- a/kitty/config.py
+++ b/kitty/config.py
@@ -36,6 +36,7 @@ named_syms = {
     "space": " ",
 }
 
+
 def parse_shortcut(sc, is_sym):
     parts = sc.split('+')
     mods = parse_mods(parts[:-1], sc)
@@ -275,7 +276,7 @@ defaults = None
 
 
 def parse_config(lines, check_keys=True):
-    ans = {'symbol_map': {}, 'keymap': {}, 'keymap_sym': {}, 'sequence_map': {}, 'sequence_map_sym':{}, 'key_definitions': []}
+    ans = {'symbol_map': {}, 'keymap': {}, 'keymap_sym': {}, 'sequence_map': {}, 'sequence_map_sym': {}, 'key_definitions': []}
     parse_config_base(
         lines,
         defaults,

--- a/kitty/config.py
+++ b/kitty/config.py
@@ -34,6 +34,7 @@ named_keys = {
 
 named_syms = {
     "space": " ",
+    "plus": "+"
 }
 
 

--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -287,6 +287,7 @@ void wakeup_io_loop(bool);
 void scroll_event(double, double);
 void fake_scroll(int, bool);
 void set_special_key_combo(int glfw_key, int mods);
+void set_special_key_sym_combo(const char* sym_text, int mods);
 void on_key_input(int key, int scancode, int action, int mods, const char*, int);
 void request_window_attention(id_type, bool);
 SPRITE_MAP_HANDLE alloc_sprite_map(unsigned int, unsigned int);

--- a/kitty/keys.c
+++ b/kitty/keys.c
@@ -117,13 +117,10 @@ on_key_input(int key, int scancode, int action, int mods, const char* text, int 
     if (action == GLFW_PRESS || action == GLFW_REPEAT) {
         uint16_t qkey = (0 <= key && key < (ssize_t)arraysz(key_map)) ? key_map[key] : UINT8_MAX;
         bool special = false;
-        if (qkey != UINT8_MAX) {
-            qkey = SPECIAL_INDEX(qkey);
-            special = needs_special_handling[qkey];
-        }
-        /* printf("key: %s mods: %d special: %d\n", key_name(lkey), mods, special); */
+
+        special = needs_special_sym_handling[SPECIAL_SYM_INDEX(text, mods)];
         if (special) {
-            PyObject *ret = PyObject_CallMethod(global_state.boss, "dispatch_special_key", "iiii", key, scancode, action, mods);
+            PyObject *ret = PyObject_CallMethod(global_state.boss, "dispatch_special_key_sym", "iiiis", key, scancode, action, mods, text);
             if (ret == NULL) { PyErr_Print(); }
             else {
                 bool consumed = ret == Py_True;
@@ -131,9 +128,14 @@ on_key_input(int key, int scancode, int action, int mods, const char* text, int 
                 if (consumed) return;
             }
         }
-        special = needs_special_sym_handling[SPECIAL_SYM_INDEX(text, mods)];
+
+        if (qkey != UINT8_MAX) {
+            qkey = SPECIAL_INDEX(qkey);
+            special = needs_special_handling[qkey];
+        }
+        /* printf("key: %s mods: %d special: %d\n", key_name(lkey), mods, special); */
         if (special) {
-            PyObject *ret = PyObject_CallMethod(global_state.boss, "dispatch_special_key_sym", "iiiis", key, scancode, action, mods, text);
+            PyObject *ret = PyObject_CallMethod(global_state.boss, "dispatch_special_key", "iiii", key, scancode, action, mods);
             if (ret == NULL) { PyErr_Print(); }
             else {
                 bool consumed = ret == Py_True;

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -330,6 +330,16 @@ set_special_keys(PyObject *dict) {
     }}
 }
 
+static inline void
+set_special_keys_sym(PyObject *dict) {
+    dict_iter(dict) {
+        if (!PyTuple_Check(key)) { PyErr_SetString(PyExc_TypeError, "dict keys for special keys must be tuples"); return; }
+        int mods = PyLong_AsLong(PyTuple_GET_ITEM(key, 0));
+        const char* sym_text = PyUnicode_AS_DATA(PyTuple_GET_ITEM(key, 1));
+        set_special_key_sym_combo(sym_text, mods);
+    }}
+}
+
 PYWRAP0(next_window_id) {
     return PyLong_FromUnsignedLongLong(global_state.window_id_counter + 1);
 }
@@ -400,6 +410,11 @@ PYWRAP1(set_options) {
     GA(keymap); set_special_keys(ret);
     Py_DECREF(ret); if (PyErr_Occurred()) return NULL;
     GA(sequence_map); set_special_keys(ret);
+    Py_DECREF(ret); if (PyErr_Occurred()) return NULL;
+
+    GA(keymap_sym); set_special_keys_sym(ret);
+    Py_DECREF(ret); if (PyErr_Occurred()) return NULL;
+    GA(sequence_map_sym); set_special_keys_sym(ret);
     Py_DECREF(ret); if (PyErr_Occurred()) return NULL;
 
 #define read_adjust(name) { \


### PR DESCRIPTION
This pull-request adds the option to add keyboard shortcuts based on symbols instead of GLFW-keys.
The necessity of using GLFW-keys is quite annoying to any user of non-English keyboards, since some keys can simply not be mapped (see #643).
In order to not break with the current mappings, it adds a new identifier to the config: `mapsym`.
e.g.: `mapsym kitty_mod+* change_font_size all +2.0`
can be used on a german keyboard to map the "+"-key (which becomes a "*", when pressed together with shift). It is important to always specify the symbol with modifiers applied, (i.e. mapping shift+x will not work, since there is usually no way to get a lower-case x at the same time as shift -> use shift+X) when mapping.

Technical details:
Keybindings are stored and processed in python, just like ordinary key-presses.
In C, there is the array `needs_special_sym_handling`, which takes the utf-8-encoded symbol as the index mangled with the mod-keys for early decisions whether a mapping should be sent to python (much like the `needs_special_handling`-array). Note that this is only an early detection, whether the pressed keys might need special treatment, since the actual decision, whether to treat it in a special manner is taken in Python. For that reason, it is not necessary for the `needs_special_sym_handling`-table to uniquely map each symbol to a different entry and thus, it does not have to be big enough to store every symbol/mod-combination.

The symbols that are used are are given by `xkb_state_key_get_utf8`. There is one downside to that function: When using Ctrl+Shift, it does not generate any symbols. My proposal here is to simply ignore the Ctrl while resolving the symbol, if Shift is pressed, as well.
The current implementation otherwise explicitly does not generate the symbol-text, if either Ctrl, Alt, or Super are pressed. For this purpose, however, I changed that behaviour, which is not really necessary in my opinion. (i.e. formerly pressing Ctrl+Shift+Z would simply enter nothing, if that was not bound to any combination while with the change it enters a capital Z.)
