### PR TITLE
create_session: handle args=None

### DIFF
--- a/kitty/session.py
+++ b/kitty/session.py
@@ -124,7 +124,7 @@ def create_session(opts, args=None, special_window=None, cwd_from=None, respect_
     ans.tabs[-1].layout = current_layout
     if special_window is None:
         cmd = args.args if args and args.args else resolved_shell(opts)
-        if args.hold:
+        if args and args.hold:
             cmd = [kitty_exe(), '+hold'] + cmd
         from kitty.tabs import SpecialWindow
         k = {'cwd_from': cwd_from}


### PR DESCRIPTION
Fixes `new_os_window`:

    scancode: 0x39 release: 0 clean_sym: n composed_sym: N mods: ctrl+shift glfw_key: N
    Traceback (most recent call last):
      File "…/Vcs/kitty/kitty/boss.py", line 431, in dispatch_special_key
        return self.dispatch_action(key_action)
      File "…/Vcs/kitty/kitty/boss.py", line 487, in dispatch_action
        passthrough = f(*key_action.args)
      File "…/Vcs/kitty/kitty/boss.py", line 199, in new_os_window
        self._new_os_window(args)
      File "…/Vcs/kitty/kitty/boss.py", line 195, in _new_os_window
        startup_session = create_session(self.opts, special_window=sw, cwd_from=cwd_from)
      File "…/Vcs/kitty/kitty/session.py", line 127, in create_session
        if args.hold:
    AttributeError: 'NoneType' object has no attribute 'hold'

Regressed/added via #667.
