### PR TITLE
bugfix for get-text with extent=screen

### DIFF
--- a/kitty/cmds.py
+++ b/kitty/cmds.py
@@ -530,7 +530,7 @@ def get_text(boss, window, payload):
     if payload['extent'] == 'selection':
         ans = window.text_for_selection()
     else:
-        ans = window.as_text(as_ansi=bool(payload['ansi']), add_history=True)
+        ans = window.as_text(as_ansi=bool(payload['ansi']), add_history=(payload['extent']=='all'))
     return ans
 # }}}
 


### PR DESCRIPTION
Currently, the `get-text` command only checks if the argument `extent` is equal to `selection`, but if it isn't, always the history is appended, while this should only be the case, if `extent` is set to `all`