### PR TITLE
kittens config parser not handling spaces in front of action

### DIFF
--- a/kitty/conf/utils.py
+++ b/kitty/conf/utils.py
@@ -228,19 +228,28 @@ def parse_kittens_shortcut(sc):
 
 
 def parse_kittens_func_args(action, args_funcs):
-    parts = action.split(' ', 1)
+    parts = action.strip().split(' ', 1)
     func = parts[0]
     if len(parts) == 1:
         return func, ()
     rest = parts[1]
-    parser = args_funcs.get(func)
-    if parser is not None:
-        try:
-            func, args = parser(func, rest)
-        except Exception:
-            raise ValueError('Unknown key action: {}'.format(action))
+
+    try:
+        parser = args_funcs[func]
+    except KeyError:
+        raise KeyError(
+            "Couldn't get valid key from {}. Check if input action: "
+            "{} is valid".format(parts, action)
+        )
+
+    try:
+        func, args = parser(func, rest)
+    except Exception:
+        raise ValueError('Unknown key action: {}'.format(action))
+
     if not isinstance(args, (list, tuple)):
         args = (args,)
+
     return func, tuple(args)
 
 


### PR DESCRIPTION
I encountered this problem when I was trying to use kitten diff with the 
provided example file, It generated an UnboundLocalError in the
`kitty.conf.utils.parse_kittens_func_args`.

The bug was related to trying to split a string with prefix spaces in
the action parameter which resulted in `func` being empty which in turn 
raised the UnboundLocalError as `parser` was None . The fix is twofold,
it makes sure that we raise the keyerror if we're trying to grab a non
existing key and we're stripping the spaces from the action before
splitting.

This should fix both the unbound error and the not being able to resolve
correct actions. 