### PR TITLE
Fix/string operations on bytecode (kitten/diff)

### DIFF
--- a/kittens/diff/collect.py
+++ b/kittens/diff/collect.py
@@ -139,7 +139,7 @@ def is_image(path):
 @lru_cache(maxsize=1024)
 def data_for_path(path):
     ans = raw_data_for_path(path)
-    if not is_image(path):
+    if not is_image(path) and not os.path.samefile(path, os.devnull):
         try:
             ans = ans.decode('utf-8')
         except UnicodeDecodeError:

--- a/kittens/diff/collect.py
+++ b/kittens/diff/collect.py
@@ -139,7 +139,7 @@ def is_image(path):
 @lru_cache(maxsize=1024)
 def data_for_path(path):
     ans = raw_data_for_path(path)
-    if not is_image(path) and not os.path.samefile(path, os.devnull):
+    if not is_image(path):
         try:
             ans = ans.decode('utf-8')
         except UnicodeDecodeError:
@@ -149,6 +149,9 @@ def data_for_path(path):
 
 @lru_cache(maxsize=1024)
 def lines_for_path(path):
+    if os.path.samefile(path, os.devnull):
+        return ''
+
     data = data_for_path(path).replace('\t', lines_for_path.replace_tab_by)
     return tuple(sanitize(data).splitlines())
 


### PR DESCRIPTION
Had a repo with a bunch of deleted files that kept generating TypeError must be a str not bytecode error when using kitten diff, Tracked it down to /dev/null file never getting decoded.

I don't know how you want to handle this - but I image if it's a devnull we don't even want to do any string operations on it.