### PR TITLE
Fix hiding window decorations under X11/Wayland

### DIFF
--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -397,7 +397,7 @@ create_os_window(PyObject UNUSED *self, PyObject *args) {
     glfwWindowHintString(GLFW_X11_INSTANCE_NAME, wm_class_name);
     glfwWindowHintString(GLFW_X11_CLASS_NAME, wm_class_class);
     if (OPT(x11_hide_window_decorations)) {
-        glfwWindowHint(GLFW_DECORATED, GLFW_TRUE);
+        glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);
     }
 #endif
 


### PR DESCRIPTION
When the `x11_hide_window_decorations` property is true, the `GLFW_DECORATED` window hint should be set to false.
