### PR TITLE
osx: focus for keyboard input follows mouse

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -695,6 +695,8 @@ static GLFWapplicationshouldhandlereopenfun handle_reopen_callback = NULL;
     if (window->cursorMode == GLFW_CURSOR_HIDDEN)
         hideCursor(window);
 
+    [[self window] makeKeyWindow];
+
     _glfwInputCursorEnter(window, GLFW_TRUE);
 }
 
@@ -743,6 +745,7 @@ static GLFWapplicationshouldhandlereopenfun handle_reopen_callback = NULL;
                                           NSTrackingEnabledDuringMouseDrag |
                                           NSTrackingCursorUpdate |
                                           NSTrackingInVisibleRect |
+                                          NSTrackingActiveAlways |
                                           NSTrackingAssumeInside;
 
     trackingArea = [[NSTrackingArea alloc] initWithRect:[self bounds]


### PR DESCRIPTION
This patch adds (unconditional on preferences) focus follows mouse for
kitty windows on macOS. It doesn't bring moused-over windows to the
foreground - it only changes where keypresses are sent.

Closes #754.

Here's a GFYCat showing the behavior: https://gfycat.com/gifs/detail/RemarkableEachFlea