### PR TITLE
Make slow scrolling possible on some operating systems

### DIFF
--- a/kitty/state.h
+++ b/kitty/state.h
@@ -69,6 +69,7 @@ typedef struct {
     WindowGeometry geometry;
     ClickQueue click_queue;
     double last_drag_scroll_at;
+    double yoffset_remaining;
 } Window;
 
 typedef struct {


### PR DESCRIPTION
On macOS the `yoffset` in `scroll_event()` in mouse.c can be as small as 0.1 (in my testing) when scrolling slowly enough. Since the code is multiplying `yoffset` with `OPT(wheel_scroll_multiplier)` and then rounding it to the nearest integer, the resulting integer can be equal to zero when scrolling slowly enough or when `wheel_scroll_multiplier ` is set to a small value. This pull request attempts to fix this by storing the difference between the precise and the rounded value and adding it to the next `yoffset`. This makes it possible to scroll arbitrarily slowly in macOS.
I'm not sure if state.h is the right place to store `yoffset_remaining`, please let me know it it belongs somewhere else.
One possible issue I can think of with this pull request might be the following situation:
Suppose someone has a mouse with low scrolling resolution and the `wheel_scroll_multiplier` setting is set to 1. On every change of the scroll wheel kitty might get a `yoffset ` of 1.5. The "old" behaviour will cause kitty to scroll two lines per scroll wheel change (I think) because the value will get rounded up. The "new" behaviour will cause kitty to alternate between scrolling by one line and scrolling by two lines. This motion might be perceived more irregular and unpredictable than before. It may be a good idea to make this behaviour optional or to detect the resolution of the mouse or touchpad somehow and change behaviour based on that.