### PR TITLE
Fix deprecation warning on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -680,7 +680,8 @@ Categories=System;TerminalEmulator;
             LSApplicationCategoryType='public.app-category.utilities',
             LSEnvironment={'KITTY_LAUNCHED_BY_LAUNCH_SERVICES': '1'},
         )
-        plistlib.writePlist(pl, 'Info.plist')
+        with open('Info.plist', 'wb') as fp:
+            plistlib.dump(pl, fp)
         os.rename('../share', 'Resources')
         os.rename('../bin', 'MacOS')
         os.rename('../lib', 'Frameworks')


### PR DESCRIPTION
When compiling kitty on macOS, I get the following warning:
`setup.py:683: DeprecationWarning: The writePlist function is deprecated, use dump() instead
  plistlib.writePlist(pl, 'Info.plist')`
This pull request replaces `writePlist()` with `dump()` as suggested in the warning.
Does this have any implications for compatibility with older systems?