### PR TITLE
Silence tic warnings during compilation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -598,7 +598,7 @@ def package(args, for_bundle=False, sh_launcher=False):
     for x in (libdir, os.path.join(ddir, 'share')):
         odir = os.path.join(x, 'terminfo')
         safe_makedirs(odir)
-        subprocess.check_call(['tic', '-x', '-o' + odir, 'terminfo/kitty.terminfo'])
+        subprocess.check_call(['tic', '-x', '-o' + odir, 'terminfo/kitty.terminfo'], stderr=subprocess.DEVNULL)
         if not glob.glob(os.path.join(odir, '*/xterm-kitty')):
             raise SystemExit('tic failed to output the compiled kitty terminfo file')
     shutil.copy2('__main__.py', libdir)


### PR DESCRIPTION
This pull request redirects stderr of tic to `/dev/null` to ignore the annoying `"terminfo/kitty.terminfo", line 1, col 22, terminal 'xterm-kitty': older tic versions may treat the description field as an alias` warning.
According to https://docs.python.org/3/library/subprocess.html#subprocess.DEVNULL, `subprocess.DEVNULL` is only available since python 3.3. Does kitty need to support older python versions? If so, `/dev/null` can be manually opened as a file.
Could there be other errors or warnings that we might miss if we ignore stderr or is the check in the next line for the existence of the file enough?