### PR TITLE
Make ctrl+shift+tab previous_tab by default on macOS

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -125,7 +125,7 @@ Action                      Shortcut
 New tab                     :sc:`new_tab`
 Close tab                   :sc:`close_tab`
 Next tab                    :sc:`next_tab` (also :kbd:`control+tab` on macOS)
-Previous tab                :sc:`previous_tab`
+Previous tab                :sc:`previous_tab` (also :kbd:`control+shift+tab` on macOS)
 Next layout                 :sc:`next_layout`
 Move tab forward            :sc:`move_tab_forward`
 Move tab backward           :sc:`move_tab_backward`

--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -875,6 +875,8 @@ g('shortcuts.tab')  # {{{
 if is_macos:
     k('next_tab', 'ctrl+tab', 'next_tab', _('Next tab'))
 k('next_tab', 'kitty_mod+right', 'next_tab', _('Next tab'))
+if is_macos:
+    k('previous_tab', 'ctrl+shift+tab', 'previous_tab', _('Previous tab'))
 k('previous_tab', 'kitty_mod+left', 'previous_tab', _('Previous tab'))
 k('new_tab', 'kitty_mod+t', 'new_tab', _('New tab'))
 k('close_tab', 'kitty_mod+q', 'close_tab', _('Close tab'))


### PR DESCRIPTION
Like ea8b17565d71a9efdf5a5b3efa32b580dc2c0513 but for `previous_tab`.