### PR TITLE
Replace "control" in the docs by "ctrl"

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -124,8 +124,8 @@ Action                      Shortcut
 ========================    =======================
 New tab                     :sc:`new_tab`
 Close tab                   :sc:`close_tab`
-Next tab                    :sc:`next_tab` (also :kbd:`control+tab` on macOS)
-Previous tab                :sc:`previous_tab` (also :kbd:`control+shift+tab` on macOS)
+Next tab                    :sc:`next_tab` (also :kbd:`ctrl+tab` on macOS)
+Previous tab                :sc:`previous_tab` (also :kbd:`ctrl+shift+tab` on macOS)
 Next layout                 :sc:`next_layout`
 Move tab forward            :sc:`move_tab_forward`
 Move tab backward           :sc:`move_tab_backward`


### PR DESCRIPTION
Shouldn't `control` here be `ctrl` or did you deliberately write `control`?