### PR TITLE
Add support for embedded bitmap glyphs

### DIFF
--- a/kitty/freetype.c
+++ b/kitty/freetype.c
@@ -236,7 +236,7 @@ load_glyph(Face *self, int glyph_index, int load_type) {
     // Embedded bitmap glyph?
     if(self->face->glyph->bitmap.pixel_mode == FT_PIXEL_MODE_MONO) {
         FT_Bitmap bitmap;
-        FT_Bitmap_Init(&bitmap);
+        FT_Bitmap_New(&bitmap);
 
         // This also sets pixel_mode to FT_PIXEL_MODE_GRAY so we don't have to
         error = FT_Bitmap_Convert(library, &self->face->glyph->bitmap, &bitmap, 1);

--- a/kitty/freetype.c
+++ b/kitty/freetype.c
@@ -17,6 +17,7 @@
 #endif
 
 #include FT_FREETYPE_H
+#include FT_BITMAP_H
 typedef struct {
     PyObject_HEAD
 
@@ -231,6 +232,30 @@ load_glyph(Face *self, int glyph_index, int load_type) {
     int flags = get_load_flags(self->hinting, self->hintstyle, load_type);
     int error = FT_Load_Glyph(self->face, glyph_index, flags);
     if (error) { set_freetype_error("Failed to load glyph, with error:", error); return false; }
+
+    // Embedded bitmap glyph?
+    if(self->face->glyph->bitmap.pixel_mode == FT_PIXEL_MODE_MONO) {
+        FT_Bitmap bitmap;
+        FT_Bitmap_Init(&bitmap);
+
+        // This also sets pixel_mode to FT_PIXEL_MODE_GRAY so we don't have to
+        error = FT_Bitmap_Convert(library, &self->face->glyph->bitmap, &bitmap, 1);
+        if (error) { set_freetype_error("Failed to convert bitmap, with error:", error); return false; }
+
+        // Normalize gray levels to the range [0..255]
+        bitmap.num_grays = 256;
+        for (uint i = 0; i < bitmap.rows; ++i) {
+            for (uint j = 0; j < bitmap.width; ++j)
+            {
+                unsigned char *p = &bitmap.buffer[i*bitmap.width+j];
+                // We only have 2 levels
+                *p = *p ? 255 : 0;
+            }
+        }
+        error = FT_Bitmap_Copy(library, &bitmap, &self->face->glyph->bitmap);
+        if (error) { set_freetype_error("Failed to copy bitmap, with error:", error); return false; }
+        FT_Bitmap_Done(library, &bitmap);
+    }
     return true;
 }
 


### PR DESCRIPTION
 Tested with [Terminus (TTF) ](https://files.ax86.net/terminus-ttf/) using the recommended font sizes, seems to fix issues mentioned in #106.
This _doesn't_ add support for bitmap fonts.