### PR TITLE
Mouse selection based on edges

### DIFF
--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -130,11 +130,11 @@ distance_to_window(Window *w, OSWindow *os_window) {
 static bool clamp_to_window = false;
 
 static inline bool
-cell_for_pos(Window *w, unsigned int *x, unsigned int *y, OSWindow *os_window) {
+cell_for_pos(Window *w, unsigned int *x, unsigned int *y, unsigned int *edge_x, unsigned int *edge_y, OSWindow *os_window) {
     WindowGeometry *g = &w->geometry;
     Screen *screen = w->render_data.screen;
     if (!screen) return false;
-    unsigned int qx = 0, qy = 0;
+    double qx = 0, qy = 0;
     double mouse_x = global_state.callback_os_window->mouse_x;
     double mouse_y = global_state.callback_os_window->mouse_y;
     double left = window_left(w, os_window), top = window_top(w, os_window), right = window_right(w, os_window), bottom = window_bottom(w, os_window);
@@ -143,12 +143,15 @@ cell_for_pos(Window *w, unsigned int *x, unsigned int *y, OSWindow *os_window) {
         mouse_y = MIN(MAX(mouse_y, top), bottom);
     }
     if (mouse_x < left || mouse_y < top || mouse_x > right || mouse_y > bottom) return false;
-    if (mouse_x >= g->right) qx = screen->columns - 1;
-    else if (mouse_x >= g->left) qx = (unsigned int)((double)(mouse_x - g->left) / os_window->fonts_data->cell_width);
-    if (mouse_y >= g->bottom) qy = screen->lines - 1;
-    else if (mouse_y >= g->top) qy = (unsigned int)((double)(mouse_y - g->top) / os_window->fonts_data->cell_height);
+    if (mouse_x >= g->right) qx = screen->columns - 0.5;
+    else if (mouse_x >= g->left) qx = ((double)(mouse_x - g->left) / os_window->fonts_data->cell_width);
+    if (mouse_y >= g->bottom) qy = screen->lines - 0.5;
+    else if (mouse_y >= g->top) qy = ((double)(mouse_y - g->top) / os_window->fonts_data->cell_height);
     if (qx < screen->columns && qy < screen->lines) {
-        *x = qx; *y = qy;
+        *x = (unsigned int)qx;
+        *y = (unsigned int)qy;
+        *edge_x = (unsigned int)(qx + 0.5);
+        *edge_y = (unsigned int)(qy + 0.5);
         return true;
     }
     return false;
@@ -164,14 +167,15 @@ update_drag(bool from_button, Window *w, bool is_release, int modifiers) {
             global_state.active_drag_in_window = 0;
             w->last_drag_scroll_at = 0;
             if (screen->selection.in_progress)
-                screen_update_selection(screen, w->mouse_cell_x, w->mouse_cell_y, true);
+                screen_update_selection(screen, w->mouse_edge_x, screen->selection.rectangle_select ? w->mouse_edge_y : w->mouse_cell_y, true);
         }
         else {
+            bool rectangle_select = modifiers == (int)OPT(rectangle_select_modifiers) || modifiers == ((int)OPT(rectangle_select_modifiers) | GLFW_MOD_SHIFT);
             global_state.active_drag_in_window = w->id;
-            screen_start_selection(screen, w->mouse_cell_x, w->mouse_cell_y, modifiers == (int)OPT(rectangle_select_modifiers) || modifiers == ((int)OPT(rectangle_select_modifiers) | GLFW_MOD_SHIFT), EXTEND_CELL);
+            screen_start_selection(screen, w->mouse_edge_x, rectangle_select ? w->mouse_edge_y : w->mouse_cell_y, rectangle_select, EXTEND_CELL);
         }
     } else if (screen->selection.in_progress) {
-        screen_update_selection(screen, w->mouse_cell_x, w->mouse_cell_y, false);
+        screen_update_selection(screen, w->mouse_edge_x, screen->selection.rectangle_select ? w->mouse_edge_y : w->mouse_cell_y, false);
     }
 }
 
@@ -266,18 +270,21 @@ detect_url(Screen *screen, unsigned int x, unsigned int y) {
 
 
 HANDLER(handle_move_event) {
-    unsigned int x = 0, y = 0;
+    unsigned int x = 0, y = 0, edge_x = 0, edge_y = 0;
     if (OPT(focus_follows_mouse)) {
         Tab *t = global_state.callback_os_window->tabs + global_state.callback_os_window->active_tab;
         if (window_idx != t->active_window) {
             call_boss(switch_focus_to, "I", window_idx);
         }
     }
-    if (!cell_for_pos(w, &x, &y, global_state.callback_os_window)) return;
+    if (!cell_for_pos(w, &x, &y, &edge_x, &edge_y, global_state.callback_os_window)) return;
+
     Screen *screen = w->render_data.screen;
     detect_url(screen, x, y);
     bool mouse_cell_changed = x != w->mouse_cell_x || y != w->mouse_cell_y;
+    bool mouse_edge_changed = edge_x != w->mouse_edge_x || edge_y != w->mouse_edge_y;
     w->mouse_cell_x = x; w->mouse_cell_y = y;
+    w->mouse_edge_x = edge_x; w->mouse_edge_y = edge_y;
     bool handle_in_kitty = (
             (screen->modes.mouse_tracking_mode == ANY_MODE ||
             (screen->modes.mouse_tracking_mode == MOTION_MODE && button >= 0)) &&
@@ -286,7 +293,7 @@ HANDLER(handle_move_event) {
     if (handle_in_kitty) {
         if (screen->selection.in_progress && button == GLFW_MOUSE_BUTTON_LEFT) {
             double now = monotonic();
-            if ((now - w->last_drag_scroll_at) >= 0.02 || mouse_cell_changed) {
+            if ((now - w->last_drag_scroll_at) >= 0.02 || mouse_edge_changed || mouse_cell_changed) {
                 update_drag(false, w, false, 0);
                 w->last_drag_scroll_at = monotonic();
             }

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -335,7 +335,7 @@ move_widened_char(Screen *self, CPUCell* cpu_cell, GPUCell *gpu_cell, index_type
 
 static inline bool
 selection_has_screen_line(Selection *s, int y) {
-    if (s->start_scrolled_by == s->end_scrolled_by && s->start_x == s->end_x && s->start_y == s->end_y) return false;
+    if (s->start_scrolled_by == s->end_scrolled_by && s->start_x == UINT_MAX) return false;
     int top = (int)s->start_y - s->start_scrolled_by;
     int bottom = (int)s->end_y - s->end_scrolled_by;
     return top <= y && y <= bottom;
@@ -810,7 +810,7 @@ screen_cursor_to_column(Screen *self, unsigned int column) {
 
 static inline void
 index_selection(Screen *self, Selection *s, bool up) {
-    if (s->start_scrolled_by == s->end_scrolled_by && s->start_x == s->end_x && s->start_y == s->end_y) return;
+    if (s->start_scrolled_by == s->end_scrolled_by && s->start_x == UINT_MAX) return;
     if (up) {
         if (s->start_y == 0) s->start_scrolled_by += 1;
         else s->start_y--;
@@ -1495,7 +1495,9 @@ is_selection_empty(Screen *self, unsigned int start_x, unsigned int start_y, uns
 
 static inline void
 selection_coord(Screen *self, unsigned int x, unsigned int y, unsigned int ydelta, SelectionBoundary *ans) {
-    if (y + self->scrolled_by < ydelta) {
+    if (x == UINT_MAX) {
+        ans->x = UINT_MAX; ans->y = UINT_MAX;
+    } else if (y + self->scrolled_by < ydelta) {
         ans->x = 0; ans->y = 0;
     } else {
         y = y - ydelta + self->scrolled_by;
@@ -1912,7 +1914,7 @@ text_for_selection(Screen *self, PyObject *a UNUSED) {
     FullSelectionBoundary start, end;
     full_selection_limits_(selection, &start, &end);
     PyObject *ans = NULL;
-    if (start.y == end.y && start.x == end.x) ans = PyTuple_New(0);
+    if (start.x == UINT_MAX) ans = PyTuple_New(0);
     else text_for_range(ans, start, end, self->selection.rectangle_select, true, range_line_, int);
     return ans;
 }

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -1490,7 +1490,7 @@ screen_update_cell_data(Screen *self, void *address, FONTS_DATA_HANDLE fonts_dat
 
 static inline bool
 is_selection_empty(Screen *self, unsigned int start_x, unsigned int start_y, unsigned int end_x, unsigned int end_y) {
-    return (start_x >= self->columns || start_y >= self->lines || end_x >= self->columns || end_y >= self->lines || (start_x == end_x && start_y == end_y)) ? true : false;
+    return start_x >= self->columns || start_y >= self->lines || end_x >= self->columns || end_y >= self->lines;
 }
 
 static inline void
@@ -2019,7 +2019,14 @@ screen_is_selection_dirty(Screen *self) {
 void
 screen_start_selection(Screen *self, index_type x, index_type y, bool rectangle_select, SelectionExtendMode extend_mode) {
 #define A(attr, val) self->selection.attr = val;
-    A(start_x, x); A(end_x, x); A(start_y, y); A(end_y, y); A(start_scrolled_by, self->scrolled_by); A(end_scrolled_by, self->scrolled_by);
+    A(anchor_x, x);
+    A(anchor_y, y);
+    A(start_x, UINT_MAX);
+    A(start_y, UINT_MAX);
+    A(end_x, UINT_MAX);
+    A(end_y, UINT_MAX);
+    A(start_scrolled_by, self->scrolled_by);
+    A(end_scrolled_by, self->scrolled_by);
     A(in_progress, true); A(rectangle_select, rectangle_select); A(extend_mode, extend_mode);
 #undef A
 }
@@ -2033,27 +2040,55 @@ screen_mark_url(Screen *self, index_type start_x, index_type start_y, index_type
 
 void
 screen_update_selection(Screen *self, index_type x, index_type y, bool ended) {
-    self->selection.end_x = x; self->selection.end_y = y; self->selection.end_scrolled_by = self->scrolled_by;
     if (ended) self->selection.in_progress = false;
-    index_type start, end;
-    bool found = false;
-    bool extending_leftwards = self->selection.end_y < self->selection.start_y || (self->selection.end_y == self->selection.start_y && self->selection.end_x < self->selection.start_x);
-    switch(self->selection.extend_mode) {
+    bool empty = false;
+    bool extending_leftwards = y < self->selection.anchor_y || (y == self->selection.anchor_y && x <= self->selection.anchor_x);
+    if (self->selection.rectangle_select) {
+        if (x == self->selection.anchor_x || y == self->selection.anchor_y) {
+            empty = true;
+        } else {
+            self->selection.start_x = MIN(self->selection.anchor_x, x);
+            self->selection.end_x = MAX(self->selection.anchor_x, x) - 1;
+            self->selection.start_y = MIN(self->selection.anchor_y, y);
+            self->selection.end_y = MAX(self->selection.anchor_y, y) - 1;
+        }
+    } else {
+        if (self->selection.extend_mode == EXTEND_CELL && x == self->selection.anchor_x && y == self->selection.anchor_y) {
+            empty = true;
+        } else if (extending_leftwards) {
+            self->selection.start_x = x;
+            self->selection.start_y = y;
+            self->selection.end_x = self->selection.anchor_x - 1;
+            self->selection.end_y = self->selection.anchor_y;
+        } else {
+            self->selection.start_x = self->selection.anchor_x;
+            self->selection.start_y = self->selection.anchor_y;
+            self->selection.end_x = x - 1;
+            self->selection.end_y = y;
+        }
+    }
+
+    if (empty) {
+        self->selection.start_x = self->selection.start_y = self->selection.end_x = self->selection.end_y = UINT_MAX;
+    } else {
+        index_type start, end;
+        bool found = false;
+        switch(self->selection.extend_mode) {
         case EXTEND_WORD: {
             index_type y1 = y, y2;
-            found = screen_selection_range_for_word(self, x, &y1, &y2, &start, &end);
+            found = screen_selection_range_for_word(self, x - (extending_leftwards ? 0 : 1), &y1, &y2, &start, &end);
             if (found) {
                 if (extending_leftwards) {
                     self->selection.end_x = start; self->selection.end_y = y1;
-                    y1 = self->selection.start_y;
-                    found = screen_selection_range_for_word(self, self->selection.start_x, &y1, &y2, &start, &end);
+                    y1 = self->selection.anchor_y;
+                    found = screen_selection_range_for_word(self, self->selection.anchor_x, &y1, &y2, &start, &end);
                     if (found) {
                         self->selection.start_x = end; self->selection.start_y = y2;
                     }
                 } else {
                     self->selection.end_x = end; self->selection.end_y = y2;
-                    y1 = self->selection.start_y;
-                    found = screen_selection_range_for_word(self, self->selection.start_x, &y1, &y2, &start, &end);
+                    y1 = self->selection.anchor_y;
+                    found = screen_selection_range_for_word(self, self->selection.anchor_x, &y1, &y2, &start, &end);
                     if (found) {
                         self->selection.start_x = start; self->selection.start_y = y1;
                     }
@@ -2063,8 +2098,8 @@ screen_update_selection(Screen *self, index_type x, index_type y, bool ended) {
             break;
         }
         case EXTEND_LINE: {
-            index_type top_line = extending_leftwards ? self->selection.end_y : self->selection.start_y;
-            index_type bottom_line = extending_leftwards ? self->selection.start_y : self->selection.end_y;
+            index_type top_line = self->selection.start_y;
+            index_type bottom_line = self->selection.end_y;
             while(top_line > 0 && visual_line_(self, top_line)->continued) top_line--;
             while(bottom_line < self->lines - 1 && visual_line_(self, bottom_line + 1)->continued) bottom_line++;
             found = screen_selection_range_for_line(self, top_line, &start, &end);
@@ -2087,6 +2122,7 @@ screen_update_selection(Screen *self, index_type x, index_type y, bool ended) {
         }
         case EXTEND_CELL:
             break;
+        }
     }
     call_boss(set_primary_selection, NULL);
 }

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -25,7 +25,7 @@
 #include "control-codes.h"
 
 static const ScreenModes empty_modes = {0, .mDECAWM=true, .mDECTCEM=true, .mDECARM=true};
-static Selection EMPTY_SELECTION = {0};
+static Selection EMPTY_SELECTION = {0, .start_x=UINT_MAX, .start_y=UINT_MAX, .end_x=UINT_MAX, .end_y=UINT_MAX};
 typedef struct {
     unsigned int x; int y;
 } FullSelectionBoundary;

--- a/kitty/screen.h
+++ b/kitty/screen.h
@@ -25,7 +25,7 @@ typedef struct {
 typedef enum SelectionExtendModes { EXTEND_CELL, EXTEND_WORD, EXTEND_LINE } SelectionExtendMode;
 
 typedef struct {
-    unsigned int start_x, start_y, start_scrolled_by, end_x, end_y, end_scrolled_by;
+    unsigned int anchor_x, anchor_y, start_x, start_y, start_scrolled_by, end_x, end_y, end_scrolled_by;
     bool in_progress, rectangle_select;
     SelectionExtendMode extend_mode;
 } Selection;

--- a/kitty/screen.h
+++ b/kitty/screen.h
@@ -25,7 +25,9 @@ typedef struct {
 typedef enum SelectionExtendModes { EXTEND_CELL, EXTEND_WORD, EXTEND_LINE } SelectionExtendMode;
 
 typedef struct {
-    unsigned int anchor_x, anchor_y, start_x, start_y, start_scrolled_by, end_x, end_y, end_scrolled_by;
+    unsigned int anchor_x, anchor_y, start_x, start_y, end_x, end_y;
+    int scroll_offset;
+    int anchor_scroll_offset;
     bool in_progress, rectangle_select;
     SelectionExtendMode extend_mode;
 } Selection;

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -66,6 +66,7 @@ typedef struct {
     PyObject *title;
     ScreenRenderData render_data;
     unsigned int mouse_cell_x, mouse_cell_y;
+    unsigned int mouse_edge_x, mouse_edge_y;
     WindowGeometry geometry;
     ClickQueue click_queue;
     double last_drag_scroll_at;

--- a/kitty_tests/screen.py
+++ b/kitty_tests/screen.py
@@ -423,7 +423,7 @@ class TestScreen(BaseTest):
                 s.carriage_return(), s.linefeed()
             s.draw(str(i) * s.columns)
         s.start_selection(0, 0, False)
-        s.update_selection(4, 4, True)
+        s.update_selection(5, 4, True)
         expected = ('55555', '\n66666', '\n77777', '\n88888', '\n99999')
         self.ae(s.text_for_selection(), expected)
         s.scroll(2, True)


### PR DESCRIPTION
Base mouse selection on the edges between cells rather than the cells themselves.

For finding the start and end line in regular selection, the vertical cell index is used rather than the edge.  However, the vertical edge is used in rectangular selection mode.

Now allows selection of a single character.

This changes the semantics of `screen_start_selection` and `screen_update_selection` to accept an edge index instead of cell index for x, and an edge or cell index for y depending on whether rectangular selection is enabled.

Closes #945

Note: "extend word" mode is wonky when extending forward (to the right) but it was wonky before already so I've left it alone for now.

Also note that rectangular selection mode would feel better with a crosshair cursor. One for a future PR.