### PR TITLE
 More detailed "kitty --version" when new commits are present since the latest version tag

### DIFF
--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -171,12 +171,12 @@ def prettify_rst(text):
     return re.sub(r':([a-z]+):`([^`]+)`(=[^\s.]+)', r':\1:`\2`:code:`\3`', text)
 
 
-def version(add_rev=False):
-    rev = ''
+def version(add_hash=False):
+    vcs_hash = ''
     from . import fast_data_types
-    if add_rev and hasattr(fast_data_types, 'KITTY_VCS_REV'):
-        rev = ' ({})'.format(fast_data_types.KITTY_VCS_REV[:10])
-    return '{} {}{} created by {}'.format(italic(appname), green(str_version), rev, title('Kovid Goyal'))
+    if add_hash and hasattr(fast_data_types, 'KITTY_VCS_HASH'):
+        vcs_hash = ' ({})'.format(fast_data_types.KITTY_VCS_HASH[:10])
+    return '{} {}{} created by {}'.format(italic(appname), green(str_version), vcs_hash, title('Kovid Goyal'))
 
 
 def wrap(text, limit=80):
@@ -709,7 +709,7 @@ def create_opts(args, debug_config=False):
     from .config import load_config
     config = tuple(resolve_config(SYSTEM_CONF, defconf, args.config))
     if debug_config:
-        print(version(add_rev=True))
+        print(version(add_hash=True))
         print(' '.join(os.uname()))
         if is_macos:
             import subprocess

--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -172,11 +172,23 @@ def prettify_rst(text):
 
 
 def version(add_hash=False):
+    v = ''
+    vcs_info = ''
     vcs_hash = ''
     from . import fast_data_types
     if add_hash and hasattr(fast_data_types, 'KITTY_VCS_HASH'):
         vcs_hash = ' ({})'.format(fast_data_types.KITTY_VCS_HASH[:10])
-    return '{} {}{} created by {}'.format(italic(appname), green(str_version), vcs_hash, title('Kovid Goyal'))
+    if hasattr(fast_data_types, 'KITTY_VCS_VERSION'):
+        vcs_version_parts = fast_data_types.KITTY_VCS_VERSION.split('-', 1)
+        vcs_str_version = vcs_version_parts[0]
+        if vcs_str_version[0] == 'v':
+            vcs_str_version = vcs_str_version[1:]
+            if vcs_str_version != str_version:
+                print('WARNING: The version number indicated by the latest git tag does not match the version number constant of kitty')
+            if len(vcs_version_parts) >= 2:
+                v = 'v'
+                vcs_info = '-{}'.format(vcs_version_parts[1])
+    return '{} {}{}{}{} created by {}'.format(italic(appname), v, green(str_version), vcs_info, vcs_hash, title('Kovid Goyal'))
 
 
 def wrap(text, limit=80):

--- a/kitty/data-types.c
+++ b/kitty/data-types.c
@@ -270,8 +270,8 @@ PyInit_fast_data_types(void) {
         PyModule_AddIntConstant(m, "DIM", DIM_SHIFT);
         PyModule_AddIntConstant(m, "DECORATION", DECORATION_SHIFT);
         PyModule_AddStringMacro(m, ERROR_PREFIX);
-#ifdef KITTY_VCS_REV
-        PyModule_AddStringMacro(m, KITTY_VCS_REV);
+#ifdef KITTY_VCS_HASH
+        PyModule_AddStringMacro(m, KITTY_VCS_HASH);
 #endif
         PyModule_AddIntMacro(m, CURSOR_BLOCK);
         PyModule_AddIntMacro(m, CURSOR_BEAM);

--- a/kitty/data-types.c
+++ b/kitty/data-types.c
@@ -273,6 +273,9 @@ PyInit_fast_data_types(void) {
 #ifdef KITTY_VCS_HASH
         PyModule_AddStringMacro(m, KITTY_VCS_HASH);
 #endif
+#ifdef KITTY_VCS_VERSION
+        PyModule_AddStringMacro(m, KITTY_VCS_VERSION);
+#endif
         PyModule_AddIntMacro(m, CURSOR_BLOCK);
         PyModule_AddIntMacro(m, CURSOR_BEAM);
         PyModule_AddIntMacro(m, CURSOR_UNDERLINE);

--- a/setup.py
+++ b/setup.py
@@ -376,8 +376,8 @@ def compile_c_extension(kenv, module, incremental, compilation_database, all_key
 
         if src == 'kitty/data-types.c':
             if os.path.exists('.git'):
-                rev = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip()
-                cppflags.append(define('KITTY_VCS_REV="{}"'.format(rev)))
+                vcs_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip()
+                cppflags.append(define('KITTY_VCS_HASH="{}"'.format(vcs_hash)))
         cmd = [kenv.cc, '-MMD'] + cppflags + kenv.cflags
         key = original_src, os.path.basename(dest)
         all_keys.add(key)

--- a/setup.py
+++ b/setup.py
@@ -377,7 +377,9 @@ def compile_c_extension(kenv, module, incremental, compilation_database, all_key
         if src == 'kitty/data-types.c':
             if os.path.exists('.git'):
                 vcs_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip()
+                vcs_version = subprocess.check_output(['git', 'describe', '--abbrev=4', '--dirty', '--always', '--tags']).decode('utf-8').strip()
                 cppflags.append(define('KITTY_VCS_HASH="{}"'.format(vcs_hash)))
+                cppflags.append(define('KITTY_VCS_VERSION="{}"'.format(vcs_version)))
         cmd = [kenv.cc, '-MMD'] + cppflags + kenv.cflags
         key = original_src, os.path.basename(dest)
         all_keys.add(key)


### PR DESCRIPTION
`kitty --version` will now print the output of `git describe --abbrev=4 --dirty --always --tags` when there are new commits since the latest version tag. The colour of the version number is still green like it is currently. `kitty --debug-config` will print the same version as `kitty --version`, and also the first 10 hex digits of the latest commit hash, just like before. The `v` of a git tag is not printed when there are no new commits since the latest version tag to preserve the current behaviour of `kitty --version` for releases, this can be changed if you prefer to always print a version number like `v0.12.1` instead of `0.12.1`. In the future, if you would decide to only rely on the version tags and not the version constant anymore, we could probably parse the version number but since you prefer to manage the version number manually I just compare the two versions and print a warning if they are different. Is `print()` like I use it here good or should that be done differently? This check and the parsing could also be done at compile time but I don't know how to do that, maybe you can help me a bit if you're interested in that.