### PR TITLE
Secondary pager history buffer

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -323,6 +323,13 @@ def scrollback_lines(x):
     return x
 
 
+def size_mb(x):
+    x = int(x)
+    if x < 0 or x > 2 ** 12 - 1:
+        raise ValueError('Size {} is in MB (positive & <4GB)'.format(x))
+    return x
+
+
 o('scrollback_lines', 2000, option_type=scrollback_lines, long_text=_('''
 Number of lines of history to keep in memory for scrolling back. Memory is allocated
 on demand. Negative numbers are (effectively) infinite scrollback. Note that using
@@ -335,6 +342,13 @@ passed as STDIN to this program. If you change it, make sure the program you
 use can handle ANSI escape sequences for colors and text formatting.
 INPUT_LINE_NUMBER in the command line above will be replaced by an integer
 representing which line should be at the top of the screen.'''))
+
+o('scrollback_pager_history_size', 10, option_type=size_mb, long_text=_('''
+Separate scrollback history size, used only for pager, in MB.
+This separate buffer is not available for interactive scrolling but will be
+prepended to the pager program when viewing scrollback.
+The current implementation stores one character in 4 bytes, so approximatively
+2500 lines per megabyte at 100 chars per line'''))
 
 o('wheel_scroll_multiplier', 5.0, long_text=_('''
 Modify the amount scrolled by the mouse wheel. Note this is only used for low

--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -174,7 +174,7 @@ typedef struct {
 } HistoryBufSegment;
 
 typedef struct {
-    index_type bufsize;
+    index_type bufsize, maxsz;
     Py_UCS4 *buffer;
     index_type start, end;
     index_type bufend;

--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -174,10 +174,18 @@ typedef struct {
 } HistoryBufSegment;
 
 typedef struct {
+    index_type bufsize;
+    Py_UCS4 *buffer;
+    index_type start, end;
+    index_type bufend;
+} PagerHistoryBuf;
+
+typedef struct {
     PyObject_HEAD
 
     index_type xnum, ynum, num_segments;
-    HistoryBufSegment* segments;
+    HistoryBufSegment *segments;
+    PagerHistoryBuf pagerhist;
     Line *line;
     index_type start_of_data, count;
 } HistoryBuf;

--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -178,6 +178,7 @@ typedef struct {
     Py_UCS4 *buffer;
     index_type start, end;
     index_type bufend;
+    bool rewrap_needed;
 } PagerHistoryBuf;
 
 typedef struct {

--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -185,7 +185,7 @@ typedef struct {
 
     index_type xnum, ynum, num_segments;
     HistoryBufSegment *segments;
-    PagerHistoryBuf pagerhist;
+    PagerHistoryBuf *pagerhist;
     Line *line;
     index_type start_of_data, count;
 } HistoryBuf;
@@ -262,7 +262,7 @@ const char* base64_decode(const uint32_t *src, size_t src_sz, uint8_t *dest, siz
 Line* alloc_line();
 Cursor* alloc_cursor();
 LineBuf* alloc_linebuf(unsigned int, unsigned int);
-HistoryBuf* alloc_historybuf(unsigned int, unsigned int);
+HistoryBuf* alloc_historybuf(unsigned int, unsigned int, unsigned int);
 ColorProfile* alloc_color_profile();
 PyObject* create_256_color_table();
 PyObject* parse_bytes_dump(PyObject UNUSED *, PyObject *);

--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -276,7 +276,7 @@ void cursor_copy_to(Cursor *src, Cursor *dest);
 void cursor_reset_display_attrs(Cursor*);
 void cursor_from_sgr(Cursor *self, unsigned int *params, unsigned int count);
 void apply_sgr_to_cells(GPUCell *first_cell, unsigned int cell_count, unsigned int *params, unsigned int count);
-const char* cursor_as_sgr(Cursor*, Cursor*);
+const char* cell_as_sgr(GPUCell *, GPUCell *);
 
 double monotonic();
 PyObject* cm_thread_write(PyObject *self, PyObject *args);

--- a/kitty/history.c
+++ b/kitty/history.c
@@ -172,16 +172,8 @@ pagerhist_push(HistoryBuf *self) {
     }
     ph->end += line_as_ansi(&l, ph->buffer + ph->end, 1023);
     ph->buffer[ph->end++] = '\r';
-    if (ph->bufend) {
-#if NEXTLINE
-        /* something like wcsrchr would be more accurate, but is *slow* */
-        Py_UCS4 *newstart = (Py_UCS4 *)strchr((char *)ph->buffer + ph->end, '\n');
-        if (!newstart || newstart - ph->buffer > ph->bufend) ph->start = 0;
-        else ph->start = newstart - ph->buffer;
-#else
+    if (ph->bufend)
         ph->start = ph->end + 1 < ph->bufend ? ph->end + 1 : 0;
-#endif
-    }
 }
 
 static inline index_type

--- a/kitty/line.c
+++ b/kitty/line.c
@@ -235,7 +235,6 @@ line_as_ansi(Line *self, Py_UCS4 *buf, index_type buflen) {
     if (limit == 0) return 0;
     char_type previous_width = 0;
 
-    WRITE_SGR("0");
     Cursor c1 = {{0}}, c2 = {{0}};
     Cursor *cursor = &c1, *prev_cursor = &c2;
     char_type prev_attrs = 0;

--- a/kitty/line.c
+++ b/kitty/line.c
@@ -259,11 +259,8 @@ line_as_ansi(Line *self, Py_UCS4 *buf, index_type buflen) {
         previous_width = attrs & WIDTH_MASK;
     }
     return i;
-#undef CHECK_BOOL
-#undef CHECK_COLOR
 #undef WRITE_SGR
 #undef WRITE_CH
-#undef WRITE_COLOR
 }
 
 static PyObject*

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -107,7 +107,7 @@ new(PyTypeObject *type, PyObject *args, PyObject UNUSED *kwds) {
         self->color_profile = alloc_color_profile();
         self->main_linebuf = alloc_linebuf(lines, columns); self->alt_linebuf = alloc_linebuf(lines, columns);
         self->linebuf = self->main_linebuf;
-        self->historybuf = alloc_historybuf(MAX(scrollback, lines), columns);
+        self->historybuf = alloc_historybuf(MAX(scrollback, lines), columns, OPT(scrollback_pager_history_size));
         self->main_grman = grman_alloc();
         self->alt_grman = grman_alloc();
         self->grman = self->main_grman;
@@ -165,8 +165,9 @@ screen_dirty_sprite_positions(Screen *self) {
 
 static inline HistoryBuf*
 realloc_hb(HistoryBuf *old, unsigned int lines, unsigned int columns) {
-    HistoryBuf *ans = alloc_historybuf(lines, columns);
+    HistoryBuf *ans = alloc_historybuf(lines, columns, 0);
     if (ans == NULL) { PyErr_NoMemory(); return NULL; }
+    ans->pagerhist = old->pagerhist; old->pagerhist = NULL;
     historybuf_rewrap(old, ans);
     return ans;
 }

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -1406,7 +1406,6 @@ screen_request_capabilities(Screen *self, char c, PyObject *q) {
     static char buf[128];
     int shape = 0;
     const char *query;
-    Cursor blank_cursor = {{0}};
     switch(c) {
         case '+':
             CALLBACK("request_capabilities", "O", q);
@@ -1430,7 +1429,13 @@ screen_request_capabilities(Screen *self, char c, PyObject *q) {
                 shape = snprintf(buf, sizeof(buf), "1$r%d q", shape);
             } else if (strcmp("m", query) == 0) {
                 // SGR
-                shape = snprintf(buf, sizeof(buf), "1$r%sm", cursor_as_sgr(self->cursor, &blank_cursor));
+                GPUCell blank_cell = { 0 }, cursor_cell = {
+                    .attrs = CURSOR_TO_ATTRS(self->cursor, 1),
+                    .fg = self->cursor->fg & COL_MASK,
+                    .bg = self->cursor->bg & COL_MASK,
+                    .decoration_fg = self->cursor->decoration_fg & COL_MASK,
+                };
+                shape = snprintf(buf, sizeof(buf), "1$r%sm", cell_as_sgr(&cursor_cell, &blank_cell));
             } else if (strcmp("r", query) == 0) {
                 shape = snprintf(buf, sizeof(buf), "1$r%u;%ur", self->margin_top + 1, self->margin_bottom + 1);
             } else {

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -367,6 +367,7 @@ PYWRAP1(set_options) {
     S(dynamic_background_opacity, PyObject_IsTrue);
     S(inactive_text_alpha, PyFloat_AsDouble);
     S(window_padding_width, PyFloat_AsDouble);
+    S(scrollback_pager_history_size, PyLong_AsLong);
     S(cursor_shape, PyLong_AsLong);
     S(url_style, PyLong_AsUnsignedLong);
     S(tab_bar_edge, PyLong_AsLong);

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -19,6 +19,7 @@ typedef struct {
     unsigned int open_url_modifiers;
     unsigned int rectangle_select_modifiers;
     unsigned int url_style;
+    unsigned int scrollback_pager_history_size;
     char_type select_by_word_characters[256]; size_t select_by_word_characters_count;
     color_type url_color, background, active_border_color, inactive_border_color, bell_border_color;
     double repaint_delay, input_delay;

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -436,7 +436,7 @@ class Window:
             self.screen.reset_callbacks()
         self.screen = None
 
-    def as_text(self, as_ansi=False, add_history=False, add_wrap_markers=False, alternate_screen=False):
+    def as_text(self, as_ansi=False, add_history=False, add_pager_history=False, add_wrap_markers=False, alternate_screen=False):
         lines = []
         add_history = add_history and not self.screen.is_using_alternate_linebuf() and not alternate_screen
         if alternate_screen:
@@ -446,6 +446,9 @@ class Window:
         f(lines.append, as_ansi, add_wrap_markers)
         if add_history:
             h = []
+            if add_pager_history:
+                # assert as_ansi and add_wrap_markers?
+                self.screen.historybuf.pagerhist_as_text(h.append)
             self.screen.historybuf.as_text(h.append, as_ansi, add_wrap_markers)
             lines = h + lines
         return ''.join(lines)
@@ -461,7 +464,7 @@ class Window:
     # actions {{{
 
     def show_scrollback(self):
-        data = self.as_text(as_ansi=True, add_history=True, add_wrap_markers=True)
+        data = self.as_text(as_ansi=True, add_history=True, add_pager_history=True, add_wrap_markers=True)
         data = data.replace('\r\n', '\n').replace('\r', '\n')
         lines = data.count('\n')
         input_line_number = (lines - (self.screen.lines - 1) - self.screen.scrolled_by)

--- a/kitty_tests/__init__.py
+++ b/kitty_tests/__init__.py
@@ -4,6 +4,8 @@
 
 from unittest import TestCase
 
+from kitty.config import Options, defaults, merge_configs
+from kitty.fast_data_types import set_options
 from kitty.fast_data_types import LineBuf, Cursor, Screen, HistoryBuf
 
 
@@ -72,7 +74,9 @@ class BaseTest(TestCase):
     ae = TestCase.assertEqual
     maxDiff = 2000
 
-    def create_screen(self, cols=5, lines=5, scrollback=5, cell_width=10, cell_height=20):
+    def create_screen(self, cols=5, lines=5, scrollback=5, cell_width=10, cell_height=20, options={}):
+        options = Options(merge_configs(defaults._asdict(), options))
+        set_options(options)
         c = Callbacks()
         return Screen(c, lines, cols, scrollback, cell_width, cell_height, 0, c)
 

--- a/kitty_tests/bench_scrollback.py
+++ b/kitty_tests/bench_scrollback.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+from time import clock_gettime, CLOCK_MONOTONIC, sleep
+from argparse import ArgumentParser
+from random import Random
+from string import printable
+import sys
+
+
+def main():
+    parser = ArgumentParser(description='Generate text')
+    parser.add_argument('--freq', default=10000, type=int, help='Number of lines to try to write per second. Will warn if not attained.')
+    parser.add_argument('--color', action='store_true', help='Add color to the output')
+    parser.add_argument('--unicode', action='store_true', help='Mix in some unicode characters')
+    parser.add_argument('--length', default=50, type=int, help='Average line length')
+    parser.add_argument('--lengthvar', default=0.3, type=float, help='Variation for line length, in ratio of line length')
+    parser.add_argument('--emptylines', default=0.1, type=float, help='ratio of empty lines')
+    parser.add_argument('--linesperwrite', default=1, type=int, help='number of lines to repeat/write at a time')
+    parser.add_argument('--patterns', default=1000, type=int, help='number of different pattern to alternate')
+    parser.add_argument('--seed', default=sys.argv[0], type=str, help='seed to get different output')
+    args = parser.parse_args()
+
+    rng = Random()
+    rng.seed(args.seed)
+
+    characters = [c for c in printable if c not in '\r\n\x0b\x0c']
+    if args.color:
+        characters += ['\x1b[91m', '\x1b[0m', '\x1b[1;32m', '\x1b[22m', '\x1b[35m']
+
+    if args.unicode:
+        characters += [u'日', u'本', u'💜', u'☃', u'🎩', u'🍀', u'、']
+
+    patterns = []
+    for _ in range(0, args.patterns):
+        s = ""
+        for _ in range(0, args.linesperwrite):
+            cnt = int(rng.gauss(args.length, args.length * args.lengthvar))
+            if cnt < 0 or rng.random() < args.emptylines:
+                cnt = 0
+            s += "".join(rng.choices(characters, k=cnt)) + '\n'
+        patterns += [s]
+
+    time_per_print = args.linesperwrite / args.freq
+    t1 = clock_gettime(CLOCK_MONOTONIC)
+    cnt = 0
+    while True:
+        sys.stdout.write(patterns[rng.randrange(0, args.patterns)])
+        sys.stdout.flush()
+        cnt += 1
+        t2 = clock_gettime(CLOCK_MONOTONIC)
+        if t2 - t1 < cnt * time_per_print:
+            sleep(cnt * time_per_print - (t2 - t1))
+            t1 = t2
+            cnt = 0
+        elif cnt >= 100:
+            print("Cannot print fast enough, printed %d lines in %f seconds instead of %f seconds target" %
+                  (cnt * args.linesperwrite, t2 - t1, cnt * time_per_print))
+            break
+        else:
+            cnt += 1
+
+
+if __name__ == '__main__':
+    main()

--- a/kitty_tests/datatypes.py
+++ b/kitty_tests/datatypes.py
@@ -447,10 +447,10 @@ class TestDataTypes(BaseTest):
     def test_ansi_repr(self):
         lb = filled_line_buf()
         l0 = lb.line(0)
-        self.ae(l0.as_ansi(), '\x1b[0m00000')
+        self.ae(l0.as_ansi(), '00000')
         a = []
         lb.as_ansi(a.append)
-        self.ae(a, ['\x1b[0m' + str(lb.line(i)) + '\n' for i in range(lb.ynum)])
+        self.ae(a, [str(lb.line(i)) + '\n' for i in range(lb.ynum)])
         l2 = lb.line(0)
         c = C()
         c.bold = c.italic = c.reverse = c.strikethrough = c.dim = True
@@ -458,15 +458,15 @@ class TestDataTypes(BaseTest):
         c.bg = (1 << 24) | (2 << 16) | (3 << 8) | 2
         c.decoration_fg = (5 << 8) | 1
         l2.set_text('1', 0, 1, c)
-        self.ae(l2.as_ansi(), '\x1b[0m\x1b[1;2;3;7;9;34;48:2:1:2:3;58:5:5m' '1'
+        self.ae(l2.as_ansi(), '\x1b[1;2;3;7;9;34;48:2:1:2:3;58:5:5m' '1'
                 '\x1b[22;23;27;29;39;49;59m' '0000')
         lb = filled_line_buf()
         for i in range(lb.ynum):
             lb.set_continued(i, True)
         a = []
         lb.as_ansi(a.append)
-        self.ae(a, ['\x1b[0m' + str(lb.line(i)) for i in range(lb.ynum)])
+        self.ae(a, [str(lb.line(i)) for i in range(lb.ynum)])
         hb = filled_history_buf(5, 5)
         a = []
         hb.as_ansi(a.append)
-        self.ae(a, ['\x1b[0m' + str(hb.line(i)) + '\n' for i in range(hb.count - 1, -1, -1)])
+        self.ae(a, [str(hb.line(i)) + '\n' for i in range(hb.count - 1, -1, -1)])

--- a/kitty_tests/screen.py
+++ b/kitty_tests/screen.py
@@ -441,4 +441,4 @@ class TestScreen(BaseTest):
             return ''.join(d)
 
         self.ae(as_text(), 'ababababab\nc\n\n')
-        self.ae(as_text(True), '\x1b[0mababa\x1b[0mbabab\n\x1b[0mc\n\n')
+        self.ae(as_text(True), 'ababababab\nc\n\n')


### PR DESCRIPTION
PR as discussed in #970

This implements a straight circular buffer to dump lines as ansi text when they get ejected from the scrollback buffer

The behaviour can be disabled by setting a 0 size.

A couple of commits also look at `line_as_ansi()` as it is now performance-critical for scrollback, it might be possible to do better still.

There are no bugs/missing part of this that I am aware of but I'd like to test a bit more and probably clean up a bit