### PR TITLE
bash completion: make complete helper start with _

### DIFF
--- a/kitty/complete.py
+++ b/kitty/complete.py
@@ -44,7 +44,7 @@ _kitty() {
 compdef _kitty kitty
 ''',
     'bash': '''
-kitty_completions() {
+_kitty_completions() {
     local src
     local limit
     # Send all words up to the word the cursor is currently on
@@ -55,7 +55,7 @@ kitty_completions() {
     fi
 }
 
-complete -o nospace -F kitty_completions kitty
+complete -o nospace -F _kitty_completions kitty
 ''',
     'fish': '''
 function __kitty_completions


### PR DESCRIPTION
It is standard to start complete helpers with underscore to avoid
clobbering the function namespace ; like other shells do.

It is ironic for a completion helper to make completion less agreable...