### PR TITLE
[WIP] add support for custom cursor on mac

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -291,7 +291,8 @@ def cursor_text_color(x):
         return
     return to_color(x)
 
-
+o('macos_custom_beam_cursor', False, long_text=_('''Enable/disable custom cursor for macOS. WARNING, 
+this might make your cursor invisible on dual GPU machines.'''))
 o('cursor', '#cccccc', _('Default cursor color'), option_type=to_color)
 o('cursor_text_color', '#111111', option_type=cursor_text_color, long_text=_('''
 Choose the color of text under the cursor. If you want it rendered with the

--- a/kitty/main.py
+++ b/kitty/main.py
@@ -120,9 +120,7 @@ def get_new_os_window_trigger(opts):
 
 def _run_app(opts, args):
     new_os_window_trigger = get_new_os_window_trigger(opts)
-    if False and is_macos:
-        # This is disabled because using custom cursors fails
-        # on dual GPU machines: https://github.com/kovidgoyal/kitty/issues/794
+    if is_macos and opts.macos_custom_beam_cursor:
         set_custom_ibeam_cursor()
     load_all_shaders.cursor_text_color = opts.cursor_text_color
     if not is_wayland and not is_macos:  # no window icons on wayland


### PR DESCRIPTION
First off, I am not a C or Python person so please excuse any obvious or stupid mistakes :).

This is in reference to issue #359 and is an attempt to create a config option for folks to specify a custom ibeam cursor when using macos. Currently the code expects a `beam-cursor.png` file to live in the local kitty config directory. I'm not really sure the best way to handle this as I'm not sure if you want to include a custom set with the distributed app or not.

The feature can be turned on by setting the `custom_cursor` flag in kitty.conf to true/yes.

Thoughts? Suggestions?
