### PR TITLE
cursor_as_sgr: fix bold/dim

### DIFF
--- a/kitty/cursor.c
+++ b/kitty/cursor.c
@@ -245,8 +245,8 @@ cursor_as_sgr(Cursor *self, Cursor *prev) {
     char *p = buf;
     bool intensity_differs = self->bold != prev->bold || self->dim != prev->dim;
     if (intensity_differs) {
-        if (!self->bold || !self->dim) { P("%d", 22); }
-        else P("%d;%d", 1, 2);
+        if (!self->bold && !self->dim) { P("%d", 22); }
+        else { if (self->bold) P("%d", 1); if (self->dim) P("%d", 2); }
     }
     if (self->italic != prev->italic) P("%d", self->italic ? 3 : 23);
     if (self->reverse != prev->reverse) P("%d", self->reverse ? 7 : 27);


### PR DESCRIPTION
The old code would print "\e[22m" if either bold or dim was unset, which
is the "normal, neither bold nor dim" control sequence.

Print that only if neither are set, and instead print "1" and "2" (bold,
dim) values individually.