### PR TITLE
Add prev_tab and prev_window as aliases for previous_tab and previous_window

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -125,7 +125,7 @@ Action                      Shortcut
 New tab                     :sc:`new_tab`
 Close tab                   :sc:`close_tab`
 Next tab                    :sc:`next_tab` (also :kbd:`control+tab` on macOS)
-Previous tab                :sc:`previous_tab` (also :kbd:`control+shift+tab` on macOS)
+Previous tab                :sc:`previous_tab` or :sc:`prev_tab` (also :kbd:`control+shift+tab` on macOS)
 Next layout                 :sc:`next_layout`
 Move tab forward            :sc:`move_tab_forward`
 Move tab backward           :sc:`move_tab_backward`
@@ -143,7 +143,7 @@ New window                  :sc:`new_window`
 New OS window               :sc:`new_os_window` (also :kbd:`⌘+n` on macOS)
 Close window                :sc:`close_window`
 Next window                 :sc:`next_window`
-Previous window             :sc:`previous_window`
+Previous window             :sc:`previous_window` or :sc:`prev_window`
 Move window forward         :sc:`move_window_forward`
 Move window backward        :sc:`move_window_backward`
 Move window to top          :sc:`move_window_to_top`

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -791,6 +791,8 @@ class Boss:
         if tm is not None:
             tm.next_tab(-1)
 
+    prev_tab = previous_tab
+
     def special_window_for_cmd(self, cmd, window=None, stdin=None, cwd_from=None, as_overlay=False):
         w = window or self.active_window
         if stdin:

--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -271,6 +271,8 @@ class Tab:  # {{{
     def previous_window(self):
         self._next_window(-1)
 
+    prev_window = previous_window
+
     def neighboring_window(self, which):
         neighbors = self.current_layout.neighbors(self.windows, self.active_window_idx)
         candidates = neighbors.get(which)


### PR DESCRIPTION
As discussed in #809.
I'm pretty sure the only two commands with `previous` in them are are `previous_tab` and `previous_window` and there are no others.
Is the change in `docs/index.rst` ok or do you want a different separator, like `,` instead of `or`?