### PR TITLE
Enable testing on python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,30 @@ matrix:
                 - libdbus-1-dev
                 - python3-pil
                 - clang
+
+        - os: linux
+          dist: xenial
+          group: beta
+          sudo: true
+          env:
+            - RUN_FLAKE=1 BUILD_PKG=linux-package
+          language: python
+          python: "3.7"
+          addons:
+            apt:
+              packages:
+                - libfontconfig1-dev
+                - libharfbuzz-dev
+                - libxi-dev
+                - libxrandr-dev
+                - libxinerama-dev
+                - libxcursor-dev
+                - libxcb-xkb-dev
+                - libpng-dev
+                - libdbus-1-dev
+                - python3-pil
+                - clang
+
         - os: osx
           language: generic
           env: SWBASE=/Users/Shared/buildbot/sw SW=$SWBASE/sw PATH=$SW/bin:$PATH


### PR DESCRIPTION
This enables testing on python 3.7.

Please note it requires `dist: xenial` instead of `trusty` (see travis-ci/travis-ci#9815)