### PR TITLE
[WIP/RFC] Handle multiple spaces after PUA glyphs

### DIFF
--- a/kitty/core_text.m
+++ b/kitty/core_text.m
@@ -221,6 +221,15 @@ is_glyph_empty(PyObject *s, glyph_index g) {
     return bounds.size.width <= 0;
 }
 
+int
+get_glyph_width(PyObject *s, glyph_index g) {
+    CTFace *self = (CTFace*)s;
+    CGGlyph gg = g;
+    CGRect bounds;
+    CTFontGetBoundingRectsForGlyphs(self->ct_font, kCTFontOrientationHorizontal, &gg, &bounds, 1);
+    return bounds.size.width;
+}
+
 static inline float
 scaled_point_sz(FONTS_DATA_HANDLE fg) {
     return ((fg->logical_dpi_x + fg->logical_dpi_y) / 144.0) * fg->font_sz_in_pts;

--- a/kitty/core_text.m
+++ b/kitty/core_text.m
@@ -383,7 +383,7 @@ render_glyphs(CTFontRef font, unsigned int width, unsigned int height, unsigned 
 }
 
 static inline bool
-do_render(CTFontRef ct_font, bool bold, bool italic, hb_glyph_info_t *info, hb_glyph_position_t *hb_positions, unsigned int num_glyphs, pixel *canvas, unsigned int cell_width, unsigned int cell_height, unsigned int num_cells, unsigned int baseline, bool *was_colored, bool allow_resize, FONTS_DATA_HANDLE fg) {
+do_render(CTFontRef ct_font, bool bold, bool italic, hb_glyph_info_t *info, hb_glyph_position_t *hb_positions, unsigned int num_glyphs, pixel *canvas, unsigned int cell_width, unsigned int cell_height, unsigned int num_cells, unsigned int baseline, bool *was_colored, bool allow_resize, FONTS_DATA_HANDLE fg, bool center_glyph) {
     unsigned int canvas_width = cell_width * num_cells;
     CGRect br = CTFontGetBoundingRectsForGlyphs(ct_font, kCTFontOrientationHorizontal, glyphs, boxes, num_glyphs);
     if (allow_resize) {
@@ -394,7 +394,7 @@ do_render(CTFontRef ct_font, bool bold, bool italic, hb_glyph_info_t *info, hb_g
             CGFloat sz = CTFontGetSize(ct_font);
             sz *= canvas_width / right;
             CTFontRef new_font = CTFontCreateCopyWithAttributes(ct_font, sz, NULL, NULL);
-            bool ret = do_render(new_font, bold, italic, info, hb_positions, num_glyphs, canvas, cell_width, cell_height, num_cells, baseline, was_colored, false, fg);
+            bool ret = do_render(new_font, bold, italic, info, hb_positions, num_glyphs, canvas, cell_width, cell_height, num_cells, baseline, was_colored, false, fg, center_glyph);
             CFRelease(new_font);
             return ret;
         }
@@ -420,10 +420,10 @@ do_render(CTFontRef ct_font, bool bold, bool italic, hb_glyph_info_t *info, hb_g
 }
 
 bool
-render_glyphs_in_cells(PyObject *s, bool bold, bool italic, hb_glyph_info_t *info, hb_glyph_position_t *hb_positions, unsigned int num_glyphs, pixel *canvas, unsigned int cell_width, unsigned int cell_height, unsigned int num_cells, unsigned int baseline, bool *was_colored, FONTS_DATA_HANDLE fg) {
+render_glyphs_in_cells(PyObject *s, bool bold, bool italic, hb_glyph_info_t *info, hb_glyph_position_t *hb_positions, unsigned int num_glyphs, pixel *canvas, unsigned int cell_width, unsigned int cell_height, unsigned int num_cells, unsigned int baseline, bool *was_colored, FONTS_DATA_HANDLE fg, bool center_glyph) {
     CTFace *self = (CTFace*)s;
     for (unsigned i=0; i < num_glyphs; i++) glyphs[i] = info[i].codepoint;
-    return do_render(self->ct_font, bold, italic, info, hb_positions, num_glyphs, canvas, cell_width, cell_height, num_cells, baseline, was_colored, true, fg);
+    return do_render(self->ct_font, bold, italic, info, hb_positions, num_glyphs, canvas, cell_width, cell_height, num_cells, baseline, was_colored, true, fg, center_glyph);
 }
 
 

--- a/kitty/fonts.c
+++ b/kitty/fonts.c
@@ -1008,12 +1008,25 @@ render_line(FONTS_DATA_HANDLE fg_, Line *line) {
         CPUCell *cpu_cell = line->cpu_cells + i;
         GPUCell *gpu_cell = line->gpu_cells + i;
         ssize_t cell_font_idx = font_for_cell(fg, cpu_cell, gpu_cell);
+
         if (is_private_use(cpu_cell->ch)
                 && cell_font_idx != BOX_FONT
                 && cell_font_idx != MISSING_FONT) {
+            int cells;
+            if (cell_font_idx > 0) {
+                Font *font = (fg->fonts + cell_font_idx);
+                glyph_index glyph_id = glyph_id_for_codepoint(font->face, cpu_cell->ch);
+
+                int width = get_glyph_width(font->face, glyph_id);
+                cells = ceilf((float)width / fg->cell_width);
+            } else {
+                cells = 1;
+            }
+
             int j = 0;
             while ((line->cpu_cells[i+j+1].ch == ' ' || line->cpu_cells[i+j+1].ch == 0)
                     && j < MAX_NUM_EXTRA_GLYPHS_PUA
+                    && j < cells
                     && i + j + 1 < line->xnum) {
                 j++;
                 // We have a private use char followed by space(s), render it as a multi-cell ligature.

--- a/kitty/fonts.c
+++ b/kitty/fonts.c
@@ -1010,12 +1010,12 @@ render_line(FONTS_DATA_HANDLE fg_, Line *line) {
                 && cell_font_idx != BOX_FONT
                 && cell_font_idx != MISSING_FONT) {
             int j = 0;
-            while ((line->cpu_cells[i+1+j].ch == ' ' || line->cpu_cells[i+1+j].ch == 0)
+            while ((line->cpu_cells[i+j+1].ch == ' ' || line->cpu_cells[i+j+1].ch == 0)
                     && j < MAX_NUM_EXTRA_GLYPHS
-                    && i + 1 + j < line->xnum) {
+                    && i + j + 1 < line->xnum) {
                 j++;
                 // We have a private use char followed by space(s), render it as a multi-cell ligature.
-                GPUCell *space_cell = line->gpu_cells + i+j;
+                GPUCell *space_cell = line->gpu_cells + i + j;
                 // Ensure the space cell uses the foreground/background colors from the PUA cell.
                 // This is needed because there are stupid applications like
                 // powerline that use PUA+space with different foreground colors
@@ -1028,8 +1028,8 @@ render_line(FONTS_DATA_HANDLE fg_, Line *line) {
                 RENDER;
                 render_run(fg, line->cpu_cells + i, line->gpu_cells + i, j + 1, cell_font_idx, true);
                 run_font_idx = NO_FONT;
-                first_cell_in_run = i + 1 + j;
-                prev_width = gpu_cell->attrs & WIDTH_MASK;
+                first_cell_in_run = i + j + 1;
+                prev_width = line->gpu_cells[i+1].attrs & WIDTH_MASK;
                 i += j;
                 continue;
             }

--- a/kitty/fonts.c
+++ b/kitty/fonts.c
@@ -14,6 +14,7 @@
 #define MISSING_GLYPH 4
 #define MAX_NUM_EXTRA_GLYPHS 8
 #define CELLS_IN_CANVAS ((MAX_NUM_EXTRA_GLYPHS + 1) * 3)
+#define MAX_NUM_EXTRA_GLYPHS_PUA 4
 
 typedef void (*send_sprite_to_gpu_func)(FONTS_DATA_HANDLE fg, unsigned int, unsigned int, unsigned int, pixel*);
 send_sprite_to_gpu_func current_send_sprite_to_gpu = NULL;
@@ -1012,7 +1013,7 @@ render_line(FONTS_DATA_HANDLE fg_, Line *line) {
                 && cell_font_idx != MISSING_FONT) {
             int j = 0;
             while ((line->cpu_cells[i+j+1].ch == ' ' || line->cpu_cells[i+j+1].ch == 0)
-                    && j < MAX_NUM_EXTRA_GLYPHS
+                    && j < MAX_NUM_EXTRA_GLYPHS_PUA
                     && i + j + 1 < line->xnum) {
                 j++;
                 // We have a private use char followed by space(s), render it as a multi-cell ligature.

--- a/kitty/fonts.h
+++ b/kitty/fonts.h
@@ -21,7 +21,7 @@ bool is_glyph_empty(PyObject *, glyph_index);
 hb_font_t* harfbuzz_font_for_face(PyObject*);
 bool set_size_for_face(PyObject*, unsigned int, bool, FONTS_DATA_HANDLE);
 void cell_metrics(PyObject*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*);
-bool render_glyphs_in_cells(PyObject *f, bool bold, bool italic, hb_glyph_info_t *info, hb_glyph_position_t *positions, unsigned int num_glyphs, pixel *canvas, unsigned int cell_width, unsigned int cell_height, unsigned int num_cells, unsigned int baseline, bool *was_colored, FONTS_DATA_HANDLE);
+bool render_glyphs_in_cells(PyObject *f, bool bold, bool italic, hb_glyph_info_t *info, hb_glyph_position_t *positions, unsigned int num_glyphs, pixel *canvas, unsigned int cell_width, unsigned int cell_height, unsigned int num_cells, unsigned int baseline, bool *was_colored, FONTS_DATA_HANDLE, bool center_glyph);
 PyObject* create_fallback_face(PyObject *base_face, CPUCell* cell, bool bold, bool italic, bool emoji_presentation, FONTS_DATA_HANDLE fg);
 PyObject* specialize_font_descriptor(PyObject *base_descriptor, FONTS_DATA_HANDLE);
 PyObject* face_from_path(const char *path, int index, FONTS_DATA_HANDLE);

--- a/kitty/fonts.h
+++ b/kitty/fonts.h
@@ -17,6 +17,7 @@
 // API that font backends need to implement
 typedef uint16_t glyph_index;
 unsigned int glyph_id_for_codepoint(PyObject *, char_type);
+int get_glyph_width(PyObject *, glyph_index);
 bool is_glyph_empty(PyObject *, glyph_index);
 hb_font_t* harfbuzz_font_for_face(PyObject*);
 bool set_size_for_face(PyObject*, unsigned int, bool, FONTS_DATA_HANDLE);

--- a/kitty/freetype.c
+++ b/kitty/freetype.c
@@ -487,7 +487,7 @@ render_glyphs_in_cells(PyObject *f, bool bold, bool italic, hb_glyph_info_t *inf
     Face *self = (Face*)f;
     bool is_emoji = *was_colored; *was_colored = is_emoji && self->has_color;
     float x = 0.f, y = 0.f, x_offset = 0.f;
-    ProcessedBitmap bm;
+    ProcessedBitmap bm = EMPTY_PBM;
     unsigned int canvas_width = cell_width * num_cells;
     for (unsigned int i = 0; i < num_glyphs; i++) {
         bm = EMPTY_PBM;

--- a/kitty/freetype.c
+++ b/kitty/freetype.c
@@ -483,7 +483,7 @@ place_bitmap_in_canvas(pixel *cell, ProcessedBitmap *bm, size_t cell_width, size
 static const ProcessedBitmap EMPTY_PBM = {.factor = 1};
 
 bool
-render_glyphs_in_cells(PyObject *f, bool bold, bool italic, hb_glyph_info_t *info, hb_glyph_position_t *positions, unsigned int num_glyphs, pixel *canvas, unsigned int cell_width, unsigned int cell_height, unsigned int num_cells, unsigned int baseline, bool *was_colored, FONTS_DATA_HANDLE fg) {
+render_glyphs_in_cells(PyObject *f, bool bold, bool italic, hb_glyph_info_t *info, hb_glyph_position_t *positions, unsigned int num_glyphs, pixel *canvas, unsigned int cell_width, unsigned int cell_height, unsigned int num_cells, unsigned int baseline, bool *was_colored, FONTS_DATA_HANDLE fg, bool center_glyph) {
     Face *self = (Face*)f;
     bool is_emoji = *was_colored; *was_colored = is_emoji && self->has_color;
     float x = 0.f, y = 0.f, x_offset = 0.f;
@@ -507,12 +507,13 @@ render_glyphs_in_cells(PyObject *f, bool bold, bool italic, hb_glyph_info_t *inf
         if (bm.needs_free) free(bm.buf);
     }
 
-    // center the glyphs in the canvas
-    unsigned int right_edge = (unsigned int)x, delta;
-    // x_advance is wrong for colored bitmaps that have been downsampled
-    if (*was_colored) right_edge = num_glyphs == 1 ? bm.right_edge : canvas_width;
-    if (num_cells > 1 && right_edge < canvas_width && (delta = (canvas_width - right_edge) / 2) && delta > 1) {
-        right_shift_canvas(canvas, canvas_width, cell_height, delta);
+    if (center_glyph) {
+        unsigned int right_edge = (unsigned int)x, delta;
+        // x_advance is wrong for colored bitmaps that have been downsampled
+        if (*was_colored) right_edge = num_glyphs == 1 ? bm.right_edge : canvas_width;
+        if (num_cells > 1 && right_edge < canvas_width && (delta = (canvas_width - right_edge) / 2) && delta > 1) {
+            right_shift_canvas(canvas, canvas_width, cell_height, delta);
+        }
     }
     return true;
 }

--- a/kitty/freetype.c
+++ b/kitty/freetype.c
@@ -294,6 +294,20 @@ is_glyph_empty(PyObject *s, glyph_index g) {
 #undef M
 }
 
+int
+get_glyph_width(PyObject *s, glyph_index g) {
+    Face *self = (Face*)s;
+    if (!load_glyph(self, g, FT_LOAD_DEFAULT)) { PyErr_Print(); return false; }
+    FT_Bitmap *bitmap = &self->face->glyph->bitmap;
+#define M self->face->glyph->metrics
+#define B self->face->glyph->bitmap
+    /* printf("glyph: %u bitmap.width: %d bitmap.rows: %d horiAdvance: %ld horiBearingX: %ld horiBearingY: %ld vertBearingX: %ld vertBearingY: %ld vertAdvance: %ld width: %ld height: %ld\n", */
+    /*         g, B.width, B.rows, M.horiAdvance, M.horiBearingX, M.horiBearingY, M.vertBearingX, M.vertBearingY, M.vertAdvance, M.width, M.height); */
+    return bitmap->width;
+#undef M
+#undef B
+}
+
 hb_font_t*
 harfbuzz_font_for_face(PyObject *self) { return ((Face*)self)->harfbuzz_font; }
 


### PR DESCRIPTION
This handles multiple spaces after a PUA glyph (instead of just one).

Before:
![multi-pua-before](https://user-images.githubusercontent.com/9766/46211671-739a2e00-c334-11e8-8a7e-18210b410395.png)

After:
![multi-pua-after](https://user-images.githubusercontent.com/9766/46211670-739a2e00-c334-11e8-82f9-5da51b5bde4a.png)

It still does not work as in (patched) urxvt, because kitty appears to shrink it to fit its height into the cell.  In urxvt it looks like follows:
![multi-pua-urxvt](https://user-images.githubusercontent.com/9766/46211672-739a2e00-c334-11e8-990b-e08f8e7ec3ec.png)

Where does the shrinking / fitting to cells happen?  I would rather have it take the full width of the 3 cells, and be cut at the top/bottom.