### PR TITLE
Fix Wayland key repeat frequency

### DIFF
--- a/glfw/wl_init.c
+++ b/glfw/wl_init.c
@@ -407,7 +407,7 @@ static void
 dispatchPendingKeyRepeats(id_type timer_id, void *data) {
     if (_glfw.wl.keyRepeatInfo.keyboardFocus != _glfw.wl.keyboardFocus || _glfw.wl.keyboardRepeatRate == 0) return;
     glfw_xkb_handle_key_event(_glfw.wl.keyRepeatInfo.keyboardFocus, &_glfw.wl.xkb, _glfw.wl.keyRepeatInfo.key, GLFW_REPEAT);
-    changeTimerInterval(&_glfw.wl.eventLoopData, _glfw.wl.keyRepeatInfo.keyRepeatTimer, ((double)_glfw.wl.keyboardRepeatRate) / 1000.0);
+    changeTimerInterval(&_glfw.wl.eventLoopData, _glfw.wl.keyRepeatInfo.keyRepeatTimer, (1.0 / (double)_glfw.wl.keyboardRepeatRate));
     toggleTimer(&_glfw.wl.eventLoopData, _glfw.wl.keyRepeatInfo.keyRepeatTimer, 1);
 }
 


### PR DESCRIPTION
The Wayland protocol specification uses a Hz value in the key repeat rate field. The code however uses this value as a millisecond interval. This pull request makes the code calculate the interval from the Hz value.

This should probably be upstreamed to glfw but I'm not entirely sure how to go about that since the code seems to have seen quite a few changes there (but looks like it still does the wrong thing here).