### PR TITLE
Filter tic output to remove "older tic versions may treat the description field as an alias"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -599,9 +599,9 @@ def package(args, for_bundle=False, sh_launcher=False):
     for x in (libdir, os.path.join(ddir, 'share')):
         odir = os.path.join(x, 'terminfo')
         safe_makedirs(odir)
-        proc = subprocess.run(['tic', '-x', '-o' + odir, 'terminfo/kitty.terminfo'], check=True, text=True, stderr=subprocess.PIPE)
+        proc = subprocess.run(['tic', '-x', '-o' + odir, 'terminfo/kitty.terminfo'], check=True, stderr=subprocess.PIPE)
         regex = '^"terminfo/kitty.terminfo", line [0-9]+, col [0-9]+, terminal \'xterm-kitty\': older tic versions may treat the description field as an alias$'
-        err_msg = proc.stderr.rstrip()
+        err_msg = proc.stderr.decode('utf-8').rstrip()
         if not re.match(regex, err_msg):
             print(err_msg, file=sys.stderr)
         if not glob.glob(os.path.join(odir, '*/xterm-kitty')):

--- a/setup.py
+++ b/setup.py
@@ -599,7 +599,11 @@ def package(args, for_bundle=False, sh_launcher=False):
     for x in (libdir, os.path.join(ddir, 'share')):
         odir = os.path.join(x, 'terminfo')
         safe_makedirs(odir)
-        subprocess.check_call(['tic', '-x', '-o' + odir, 'terminfo/kitty.terminfo'])
+        proc = subprocess.run(['tic', '-x', '-o' + odir, 'terminfo/kitty.terminfo'], check=True, text=True, stderr=subprocess.PIPE)
+        regex = '^"terminfo/kitty.terminfo", line [0-9]+, col [0-9]+, terminal \'xterm-kitty\': older tic versions may treat the description field as an alias$'
+        err_msg = proc.stderr.rstrip()
+        if not re.match(regex, err_msg):
+            print(err_msg, file=sys.stderr)
         if not glob.glob(os.path.join(odir, '*/xterm-kitty')):
             raise SystemExit('tic failed to output the compiled kitty terminfo file')
     shutil.copy2('__main__.py', libdir)

--- a/setup.py
+++ b/setup.py
@@ -601,9 +601,9 @@ def package(args, for_bundle=False, sh_launcher=False):
         safe_makedirs(odir)
         proc = subprocess.run(['tic', '-x', '-o' + odir, 'terminfo/kitty.terminfo'], check=True, stderr=subprocess.PIPE)
         regex = '^"terminfo/kitty.terminfo", line [0-9]+, col [0-9]+, terminal \'xterm-kitty\': older tic versions may treat the description field as an alias$'
-        err_msg = proc.stderr.decode('utf-8').rstrip()
-        if not re.match(regex, err_msg):
-            print(err_msg, file=sys.stderr)
+        for error in proc.stderr.decode('utf-8').splitlines():
+            if not re.match(regex, error):
+                print(error, file=sys.stderr)
         if not glob.glob(os.path.join(odir, '*/xterm-kitty')):
             raise SystemExit('tic failed to output the compiled kitty terminfo file')
     shutil.copy2('__main__.py', libdir)


### PR DESCRIPTION
Since you mentioned in #840 that you don't want to miss actually useful warnings from tic, I implemented a simple filter that ignores all messages that match a very specific regex.