### PR TITLE
Add option to hide the window title

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -139,7 +139,7 @@ class Boss:
                 os_window_id = create_os_window(
                         initial_window_size_func(opts_for_size, self.cached_values),
                         pre_show_callback,
-                        appname, wname or self.args.name or cls, cls)
+                        '' if self.opts.hide_title else appname, wname or self.args.name or cls, cls)
         tm = TabManager(os_window_id, self.opts, self.args, startup_session)
         self.os_window_map[os_window_id] = tm
         return os_window_id

--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -544,7 +544,7 @@ update_window_title(Window *w, OSWindow *os_window) {
     if (w->title && w->title != os_window->window_title) {
         os_window->window_title = w->title;
         Py_INCREF(os_window->window_title);
-        set_os_window_title(os_window, PyUnicode_AsUTF8(w->title));
+        if (!OPT(hide_title)) set_os_window_title(os_window, PyUnicode_AsUTF8(w->title));
 #ifdef __APPLE__
         if (os_window->is_focused) cocoa_update_title(w->title);
 #endif

--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -524,6 +524,9 @@ Negative values will cause the value of :opt:`window_margin_width` to be used in
 o('window_padding_width', 0.0, option_type=positive_float, long_text=_('''
 The window padding (in pts) (blank area between the text and the window border)'''))
 
+o('hide_title', False, long_text=_('''
+Hide the kitty window title.'''))
+
 o('active_border_color', '#00ff00', option_type=to_color, long_text=_('''
 The color for the border of the active window'''))
 

--- a/kitty/main.py
+++ b/kitty/main.py
@@ -131,7 +131,7 @@ def _run_app(opts, args):
             window_id = create_os_window(
                     run_app.initial_window_size_func(opts, cached_values),
                     pre_show_callback,
-                    appname, args.name or args.cls or appname,
+                    '' if opts.hide_title else appname, args.name or args.cls or appname,
                     args.cls or appname, load_all_shaders)
         boss = Boss(window_id, opts, args, cached_values, new_os_window_trigger)
         boss.start()

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -386,6 +386,7 @@ PYWRAP1(set_options) {
     S(sync_to_monitor, PyObject_IsTrue);
     S(close_on_child_death, PyObject_IsTrue);
     S(window_alert_on_bell, PyObject_IsTrue);
+    S(hide_title, PyObject_IsTrue);
     S(macos_option_as_alt, PyObject_IsTrue);
     S(macos_traditional_fullscreen, PyObject_IsTrue);
     S(macos_hide_titlebar, PyObject_IsTrue);

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -31,6 +31,7 @@ typedef struct {
     float background_opacity, dim_opacity;
     bool dynamic_background_opacity;
     float inactive_text_alpha;
+    bool hide_title;
     float window_padding_width;
     Edge tab_bar_edge;
     bool sync_to_monitor;


### PR DESCRIPTION
I like the way kitty looks without a title. I know that I can configure my shell and probably all my other programs like vim to not update the title but that would also hide the title from the tabs, where I very much prefer having a title since I find it hard to navigate the tabs without it. This is why I added an option to do just that.
I'm a bit unsure if I implemented this in the best way. The description of the option might also need an explanation which is a little more verbose than just `Hide the kitty window title.`, but I could not think of one. I also did not test this on any OS other than macOS yet. Does creating new OS windows with an empty title have any unforeseen side effects?