### PR TITLE
glfw x11: update cursor position on enter event

### DIFF
--- a/glfw/x11_window.c
+++ b/glfw/x11_window.c
@@ -1291,12 +1291,20 @@ static void processEvent(XEvent *event)
 
         case EnterNotify:
         {
+            // XEnterWindowEvent is XCrossingEvent
+            const int x = event->xcrossing.x;
+            const int y = event->xcrossing.y;
+
             // HACK: This is a workaround for WMs (KWM, Fluxbox) that otherwise
             //       ignore the defined cursor for hidden cursor mode
             if (window->cursorMode == GLFW_CURSOR_HIDDEN)
                 updateCursorImage(window);
 
             _glfwInputCursorEnter(window, GLFW_TRUE);
+            _glfwInputCursorPos(window, x, y);
+
+            window->x11.lastCursorPosX = x;
+            window->x11.lastCursorPosY = y;
             return;
         }
 


### PR DESCRIPTION
kitty would have an incorrect position when clicking after changing window
without moving (e.g. change workspace, create new kitty etc)

For new kitty window, initial position would be 0 and selection paste would
not work because of this

FWIW I'll submit this one to glfw as well; I know you don't really care but if they request changes on this I'd like to update this patch to match - in this case I'll either do a subsequent PR, or we can wait for this, I have no clue if they're reactive for simple fixes like this.