### PR TITLE
[WIP] Combine the "x11_hide_window_decorations" and "macos_hide_titlebar" options

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -747,6 +747,12 @@ different the terminal you are changing it to is, various things from
 key-presses, to colors, to various advanced features may not work.
 '''))
 
+o('hide_window_decorations', False, long_text=_('''
+Hide the window decorations (title bar and window borders).
+Whether this works and exactly what effect it has depends on the window
+manager, as it is the job of the window manager/compositor to draw window
+decorations.'''))
+
 # }}}
 
 g('os')  # {{{
@@ -769,17 +775,14 @@ an arbitrary color, such as :code:`#12af59` or :code:`red`. WARNING: This option
 using a hack, as there is no proper Cocoa API for it. It sets the background
 color of the entire window and makes the titlebar transparent. As such it is
 incompatible with :opt:`background_opacity`. If you want to use both, you are
-probably better off just hiding the titlebar with :opt:`macos_hide_titlebar`.
+probably better off just hiding the titlebar with :opt:`hide_window_decorations`.
 '''))
 
 o('macos_hide_titlebar', False, long_text=_('''
-Hide the kitty window's title bar on macOS.'''))
+Deprecated, use :opt:`hide_window_decorations` instead'''))
 
 o('x11_hide_window_decorations', False, long_text=_('''
-Hide the window decorations (title bar and window borders) on X11 and Wayland.
-Whether this works and exactly what effect it has depends on the window
-manager, as it is the job of the window manager/compositor to draw window
-decorations.'''))
+Deprecated, use :opt:`hide_window_decorations` instead'''))
 
 o('macos_option_as_alt', True, long_text=_('''
 Use the option key as an alt key. With this set to no, kitty will use

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -467,7 +467,6 @@ create_os_window(PyObject UNUSED *self, PyObject *args) {
         glfwWindowHint(GLFW_DEPTH_BITS, 0);
         glfwWindowHint(GLFW_STENCIL_BITS, 0);
 #ifdef __APPLE__
-        if (OPT(macos_hide_titlebar)) glfwWindowHint(GLFW_DECORATED, false);
         glfwWindowHint(GLFW_COCOA_GRAPHICS_SWITCHING, true);
         glfwSetApplicationShouldHandleReopen(on_application_reopen);
 #endif
@@ -478,10 +477,8 @@ create_os_window(PyObject UNUSED *self, PyObject *args) {
     glfwWindowHintString(GLFW_X11_INSTANCE_NAME, wm_class_name);
     glfwWindowHintString(GLFW_X11_CLASS_NAME, wm_class_class);
     glfwWindowHintString(GLFW_WAYLAND_APP_ID, wm_class_class);
-    if (OPT(x11_hide_window_decorations)) {
-        glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);
-    }
 #endif
+    if (OPT(hide_window_decorations)) glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);
 
     if (global_state.num_os_windows >= MAX_CHILDREN) {
         PyErr_SetString(PyExc_ValueError, "Too many windows");

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -388,12 +388,14 @@ PYWRAP1(set_options) {
     S(window_alert_on_bell, PyObject_IsTrue);
     S(macos_option_as_alt, PyObject_IsTrue);
     S(macos_traditional_fullscreen, PyObject_IsTrue);
-    S(macos_hide_titlebar, PyObject_IsTrue);
     S(macos_quit_when_last_window_closed, PyObject_IsTrue);
     S(macos_window_resizable, PyObject_IsTrue);
-    S(x11_hide_window_decorations, PyObject_IsTrue);
     S(macos_hide_from_tasks, PyObject_IsTrue);
     S(macos_thicken_font, PyFloat_AsDouble);
+
+    GA(macos_hide_titlebar); global_state.opts.hide_window_decorations = PyObject_IsTrue(ret); Py_DECREF(ret); if (PyErr_Occurred()) return NULL;
+    GA(x11_hide_window_decorations); global_state.opts.hide_window_decorations = PyObject_IsTrue(ret); Py_DECREF(ret); if (PyErr_Occurred()) return NULL;
+    S(hide_window_decorations, PyObject_IsTrue);
 
     GA(tab_bar_style); if (!ret) return NULL;
     global_state.tab_bar_hidden = PyUnicode_CompareWithASCIIString(ret, "hidden") == 0 ? true: false;

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -24,7 +24,7 @@ typedef struct {
     color_type url_color, background, active_border_color, inactive_border_color, bell_border_color;
     double repaint_delay, input_delay;
     bool focus_follows_mouse;
-    bool macos_option_as_alt, macos_hide_titlebar, macos_hide_from_tasks, x11_hide_window_decorations, macos_quit_when_last_window_closed, macos_window_resizable, macos_traditional_fullscreen;
+    bool macos_option_as_alt, macos_hide_from_tasks, hide_window_decorations, macos_quit_when_last_window_closed, macos_window_resizable, macos_traditional_fullscreen;
     float macos_thicken_font;
     int adjust_line_height_px, adjust_column_width_px;
     float adjust_line_height_frac, adjust_column_width_frac;


### PR DESCRIPTION
As discussed in #1106.
I'd like to only let the three options change the `hide_window_decorations` variable if they are different than the default. How could I do that? Currently the value will just be overwritten by the next option.
Are there any other things you'd like to be different?