### PR TITLE
Make high resolution scrolling more responsive and configurable

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -356,6 +356,12 @@ precision scrolling devices, not for high precision scrolling on platforms such
 as macOS and Wayland. Use negative numbers to change scroll direction.'''))
 # }}}
 
+o('touch_scroll_multiplier', 1.0, long_text=_('''
+Modify the amount scrolled by a touchpad. Note this is only used for high
+precision scrolling devices on platforms such as macOS and Wayland.
+Use negative numbers to change scroll direction.'''))
+# }}}
+
 g('mouse')  # {{{
 
 o('url_color', '#0087BD', option_type=to_color, long_text=_('''

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -549,7 +549,7 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags) {
     int s;
     bool is_high_resolution = flags & 1;
     if (is_high_resolution) {
-        yoffset *= global_state.callback_os_window->viewport_y_ratio * OPT(wheel_scroll_multiplier);
+        yoffset *= OPT(touch_scroll_multiplier);
         if (yoffset * global_state.callback_os_window->pending_scroll_pixels < 0) {
             global_state.callback_os_window->pending_scroll_pixels = 0;  // change of direction
         }

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -549,6 +549,7 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags) {
     int s;
     bool is_high_resolution = flags & 1;
     if (is_high_resolution) {
+        yoffset *= global_state.callback_os_window->viewport_y_ratio * OPT(wheel_scroll_multiplier);
         if (yoffset * global_state.callback_os_window->pending_scroll_pixels < 0) {
             global_state.callback_os_window->pending_scroll_pixels = 0;  // change of direction
         }

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -373,6 +373,7 @@ PYWRAP1(set_options) {
     S(tab_bar_edge, PyLong_AsLong);
     S(mouse_hide_wait, PyFloat_AsDouble);
     S(wheel_scroll_multiplier, PyFloat_AsDouble);
+    S(touch_scroll_multiplier, PyFloat_AsDouble);
     S(open_url_modifiers, convert_mods);
     S(rectangle_select_modifiers, convert_mods);
     S(click_interval, PyFloat_AsDouble);

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -13,7 +13,7 @@
 typedef enum { LEFT_EDGE, TOP_EDGE, RIGHT_EDGE, BOTTOM_EDGE } Edge;
 
 typedef struct {
-    double visual_bell_duration, cursor_blink_interval, cursor_stop_blinking_after, mouse_hide_wait, click_interval, wheel_scroll_multiplier;
+    double visual_bell_duration, cursor_blink_interval, cursor_stop_blinking_after, mouse_hide_wait, click_interval, wheel_scroll_multiplier, touch_scroll_multiplier;
     bool enable_audio_bell;
     CursorShape cursor_shape;
     unsigned int open_url_modifiers;


### PR DESCRIPTION
I was testing high resolution scrolling under Wayland and found that scrolling becomes acceptable if I multiply `yoffset` by `10` and awesome if I multiply it by `20`.

Since `wheel_scroll_multiplier` is not used under high resolution scrolling at all, I thought we could put it to good use here, so that responsiveness becomes configurable.

Under Wayland, my `viewport_y_ratio` is `2`. I added it to this patch because it was suggested by @Luflosi in #1112, if you want to keep it, https://github.com/kovidgoyal/kitty/commit/82f9aecacbc0f76ca9e7aec809fc8cf3fd73ff5a probably needs to be reverted.

With this formula, scrolling is acceptable with default settings and I can further improve it if I change `wheel_scroll_multiplier` to `10`.

If we remove `viewport_y_ratio` from the formula, the default value of `wheel_scroll_multiplier` (`5`) is too slow, and I would need to change it to at least `10`, but better to `20`.