### PR TITLE
AttributeError: 'Window' object has no attribute 'window_id'

### DIFF
--- a/kitty/window.py
+++ b/kitty/window.py
@@ -267,7 +267,7 @@ class Window:
 
     # screen callbacks {{{
     def use_utf8(self, on):
-        get_boss().child_monitor.set_iutf8(self.window_id, on)
+        get_boss().child_monitor.set_iutf8(self.os_window_id, on)
 
     def focus_changed(self, focused):
         if focused:


### PR DESCRIPTION
I found the following bug:
```pytb
Traceback (most recent call last):
  File "/path/to/kitty.app/Contents/MacOS/../Frameworks/kitty/kitty/window.py", line 270, in use_utf8
    get_boss().child_monitor.set_iutf8(self.window_id, on)
AttributeError: 'Window' object has no attribute 'window_id'
```
I'm guessing you meant `os_window_id`, when you wrote `window_id`.