### PR TITLE
Ignore asan-launcher.dSYM directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ logo/*.iconset
 compile_commands.json
 glad/out
 asan-launcher
+asan-launcher.dSYM
 kitty-profile
 dev
 __pycache__


### PR DESCRIPTION
When building kitty with `make asan` on macOS, a new directory `asan-launcher.dSYM` is created, which I think should be ignored.