### PR TITLE
Make final_color computation consistent across cases

### DIFF
--- a/kitty/cell_fragment.glsl
+++ b/kitty/cell_fragment.glsl
@@ -106,7 +106,7 @@ void main() {
 #else
     // since background alpha is 1.0, it is effectively pre-multiplied
     final_color = vec4(premul_blend(fg.rgb, fg.a, background), 1.0f);
-    final_color = vec4(final_color.rgb / final_color.a, final_color.a);
+    final_color = vec4(final_color.rgb, final_color.a);
 #endif
 #endif
 


### PR DESCRIPTION
In 074614bc8e940725939aa7a316f0a7086e01e05c you removed the division by `final_color.a` in the case where `TRANSPARENT` is defined but that division is still there in the other case. I think, that `final_color.a` is always 1 in the case where `TRANSPARENT` is not defined. If that's the case, the division should be removed to be consistent with the other case.