### PR TITLE
Fix memory leak on compose table creation

### DIFF
--- a/glfw/xkb_glfw.c
+++ b/glfw/xkb_glfw.c
@@ -255,6 +255,7 @@ load_compose_tables(_GLFWXKBData *xkb) {
     if (!xkb->states.composeState) {
         _glfwInputError(GLFW_PLATFORM_ERROR, "Failed to create XKB compose state");
     }
+    xkb_compose_table_unref(compose_table);
 }
 
 GLFWbool


### PR DESCRIPTION
`xkb_compose_state_new` [creates](https://github.com/xkbcommon/libxkbcommon/blob/110d17c6bee504569f68a105b2d4d06fe5e7e0b0/src/compose/state.c#L57) its own reference to a table, so this one is no more needed and causes the [leak](https://github.com/kovidgoyal/kitty/issues/1165).