### PR TITLE
Fix memory leak

### DIFF
--- a/kitty/gl-wrapper.c
+++ b/kitty/gl-wrapper.c
@@ -173,9 +173,14 @@ static int get_exts(void) {
         num_exts_i = 0;
         glGetIntegerv(GL_NUM_EXTENSIONS, &num_exts_i);
         if (num_exts_i > 0) {
-            exts_i = (char **)realloc((void *)exts_i, (size_t)num_exts_i * (sizeof *exts_i));
-        }
-        if (exts_i == NULL) {
+            char **tmp = NULL;
+            tmp = (char **)realloc((void *)exts_i, (size_t)num_exts_i * (sizeof *exts_i));
+            if (tmp == NULL) {
+                free(exts_i);
+                return 0;
+            }
+            exts_i = tmp;
+        } else if (exts_i == NULL) {
             return 0;
         }
         for(index = 0; index < (unsigned)num_exts_i; index++) {


### PR DESCRIPTION
When the call to `realloc` in kitty/gl-wrapper.c fails, the pointer `exts_i` is overwritten, even though the original memory needs to be freed. I'm not sure wether you prefer the fix in the commit or this one:
```C
if (num_exts_i > 0) {
    char **tmp = NULL;
    tmp = (char **)realloc((void *)exts_i, (size_t)num_exts_i * (sizeof *exts_i));
    if (tmp == NULL) free(exts_i);
    exts_i = tmp;
}
if (exts_i == NULL) {
    return 0;
}
```
The fix in the commit doesn't check for null twice but this one might look nicer.
I found this using static analysis with cppcheck.