### PR TITLE
glfw/xkb: fix leak of compose_table

### DIFF
--- a/glfw/xkb_glfw.h
+++ b/glfw/xkb_glfw.h
@@ -48,6 +48,7 @@ typedef struct {
     struct xkb_context*     context;
     struct xkb_keymap*      keymap;
     struct xkb_keymap*      default_keymap;
+    struct xkb_compose_table* compose_table;
     XKBStateGroup           states;
 
     xkb_mod_index_t         controlIdx;


### PR DESCRIPTION
xkb_compose_table_new_from_locale creates a ref-counted table, that needs unrefing with xkb_compose_table_unref

FWIW I noticed that yesterday after my 60 kitty windows split over 4 instance groups were consuming 8GB of swap and 5GB of ram :D this leaks approximatively 20MB per instance everytime I toggle ibus... Because even with a single window there are zillions of XkbMapNotify events (92!).
This also is verry annoying for me because it basically freezes the terminals until it's done (it's communication-intensive with the X server so takes a bit of time), I had removed the recompile keymap except for the first time as a test in a local branch but when I do that kitty sometimes goes back to default keymap after suspend... No clue why.
I don't think I can do anything about ibus sending 92 events, but I'll probably add a debouncer that only handles one per couple of seconds or something like that in another PR if you're ok with it.