### PR TITLE
parser: accept `reset` sequence to exit accumulate functions

### DIFF
--- a/kitty/parser.c
+++ b/kitty/parser.c
@@ -905,6 +905,7 @@ accumulate_osc(Screen *screen, uint32_t ch, PyObject DUMP_UNUSED *dump_callback)
         case DEL:
             break;
         case ESC_ST:
+        case ESC_RIS:
             if (screen->parser_buf_pos > 0 && screen->parser_buf[screen->parser_buf_pos - 1] == ESC) {
                 screen->parser_buf_pos--;
                 return true;
@@ -957,6 +958,7 @@ accumulate_oth(Screen *screen, uint32_t ch, PyObject DUMP_UNUSED *dump_callback)
         case ST:
             return true;
         case ESC_ST:
+        case ESC_RIS:
             if (screen->parser_buf_pos > 0 && screen->parser_buf[screen->parser_buf_pos - 1] == ESC) {
                 screen->parser_buf_pos--;
                 return true;


### PR DESCRIPTION
Input looks stuck until the accumulate buffer fills up; after displaying
random bytes (e.g. cat a binary) nothing would print anymore but input
would still work.

In that situation, one would normally expect the `reset` command to "fix
things" - so getting out of the accumulate loop with this sequence would
make sense.

I'd actually be tempted to bail out even more easily (e.g. when getting
color codes as well, so a colorful PS1 prompt would already get out of
the loop) but it might not really go well with the logic behind these
accumulating sequences.

You can try with `echo -e '\xc2\x9e'` for PM

(re-reading this all now, I guess it is subjective; but I don't think it'd hurt anyone)