### PR TITLE
Ignore mouse modes option

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -419,6 +419,9 @@ o('focus_follows_mouse', False, long_text=_('''
 Set the active window to the window under the mouse when
 moving the mouse around'''))
 
+o('mouse_modes', True, long_text=_('''
+Ignore terminal mouse modes if set to no'''))
+
 # }}}
 
 g('performance')  # {{{

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -606,8 +606,10 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags) {
                     write_escape_code_to_child(screen, CSI, mouse_event_buf);
                 }
             }
-        } else {
+        } else if (OPT(mouse_modes)) {
             fake_scroll(abs(s), upwards);
+        } else {
+            screen_history_scroll(screen, abs(s), upwards);
         }
     }
 }

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -604,7 +604,7 @@ set_mode_from_const(Screen *self, unsigned int mode, bool val) {
 
 #define MOUSE_MODE(name, attr, value) \
     case name: \
-        self->modes.attr = val ? value : 0; break;
+        if (OPT(mouse_modes)) self->modes.attr = val ? value : 0; break;
 
     bool private;
     switch(mode) {

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -361,6 +361,7 @@ PYWRAP1(set_options) {
     S(visual_bell_duration, PyFloat_AsDouble);
     S(enable_audio_bell, PyObject_IsTrue);
     S(focus_follows_mouse, PyObject_IsTrue);
+    S(mouse_modes, PyObject_IsTrue);
     S(cursor_blink_interval, PyFloat_AsDouble);
     S(cursor_stop_blinking_after, PyFloat_AsDouble);
     S(background_opacity, PyFloat_AsDouble);

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -23,7 +23,7 @@ typedef struct {
     char_type select_by_word_characters[256]; size_t select_by_word_characters_count;
     color_type url_color, background, active_border_color, inactive_border_color, bell_border_color;
     double repaint_delay, input_delay;
-    bool focus_follows_mouse, hide_window_decorations;
+    bool focus_follows_mouse, hide_window_decorations, mouse_modes;
     bool macos_option_as_alt, macos_hide_from_tasks, macos_quit_when_last_window_closed, macos_window_resizable, macos_traditional_fullscreen;
     float macos_thicken_font;
     int adjust_line_height_px, adjust_column_width_px;

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -535,26 +535,26 @@ class Window:
                 open_url(text, cwd=cwd)
 
     def scroll_line_up(self):
-        if self.screen.is_main_linebuf():
+        if self.screen.is_main_linebuf() or not self.opts.mouse_modes:
             self.screen.scroll(SCROLL_LINE, True)
 
     def scroll_line_down(self):
-        if self.screen.is_main_linebuf():
+        if self.screen.is_main_linebuf() or not self.opts.mouse_modes:
             self.screen.scroll(SCROLL_LINE, False)
 
     def scroll_page_up(self):
-        if self.screen.is_main_linebuf():
+        if self.screen.is_main_linebuf() or not self.opts.mouse_modes:
             self.screen.scroll(SCROLL_PAGE, True)
 
     def scroll_page_down(self):
-        if self.screen.is_main_linebuf():
+        if self.screen.is_main_linebuf() or not self.opts.mouse_modes:
             self.screen.scroll(SCROLL_PAGE, False)
 
     def scroll_home(self):
-        if self.screen.is_main_linebuf():
+        if self.screen.is_main_linebuf() or not self.opts.mouse_modes:
             self.screen.scroll(SCROLL_FULL, True)
 
     def scroll_end(self):
-        if self.screen.is_main_linebuf():
+        if self.screen.is_main_linebuf() or not self.opts.mouse_modes:
             self.screen.scroll(SCROLL_FULL, False)
     # }}}


### PR DESCRIPTION
This adds a `mouse_modes` option defaulting to yes, which when set two no:
 - disables entering the various mouse modes when receiving the appropriate sequences
 - scrolls the main scrollback buffer even in alt screen mode (mouse wheel no longer does anything within any program, so might as well map it to something slightly more useful)

In theory the terminfo should be changed to just say these aren't supported, but in practice this just works: applications think the mode is supported and send the switch sequence but it's just ignored, and since mode isn't actually changed in kitty we never send the mouse event sequences back on mouse activity.
I guess some app might behave differently if they know it's not supported but I don't think I've seen any like that.


Happy to discuss the option name or whatever else, I just can't get used to in-app mouse events especially when it messes with copying into selection buffer - I'm sure there's a modifier you can press to work around that but I don't want to (and I know I could spend time figuring out how to configure every program that support these, but there are way too many on way too many servers and some don't have obvious disabling options).
Speaking of that modifier I guess I'd also be happy inverting the meaning of the modifier (no modifier = dumb mouse, modifier = mouse event), but there is no value for me here.