### PR TITLE
ibus: deactivate overlay line on draw (unless drawing it)

### DIFF
--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -377,6 +377,7 @@ draw_combining_char(Screen *self, char_type ch) {
 
 void
 screen_draw(Screen *self, uint32_t och) {
+    if (self->overlay_line.is_active) deactivate_overlay_line(self);
     if (is_ignored_char(och)) return;
     uint32_t ch = och < 256 ? self->g_charset[och] : och;
     bool is_cc = is_combining_char(ch);
@@ -421,7 +422,6 @@ screen_draw_overlay_text(Screen *self, const char *utf8_text) {
     Line *line = range_line_(self, self->cursor->y);
     if (!line) return;
     line_save_cells(line, 0, self->columns, self->overlay_line.gpu_cells, self->overlay_line.cpu_cells);
-    self->overlay_line.is_active = true;
     self->overlay_line.ynum = self->cursor->y;
     self->overlay_line.xstart = self->cursor->x;
     self->overlay_line.xnum = 0;
@@ -441,6 +441,7 @@ screen_draw_overlay_text(Screen *self, const char *utf8_text) {
                 break;
         }
     }
+    self->overlay_line.is_active = true;
     self->cursor->reverse ^= true;
     self->modes.mDECAWM = orig_line_wrap_mode;
 }


### PR DESCRIPTION
When entering text with ibus, a commit that is handled asynchronously can be processed after the next preedit overlay is displayed.
That needs the peredit overlay hidden then shown again

This commit isn't optimal: it doesn't really do the "then shown again" part, so typing something with that overlay in a constantly moving buffer (e.g. irssi with a clock ticking for example) will just hide the buffer whenever the clock ticks and only print it again when one continues typing.
I'd need to remember the overlay line content at the start of `screen_draw` and redisplay it at the end... But the overlay line content isn't really kept around; currently that'd mean scanning the overlay positions to reconstruct the utf8 text and it's more than meh.
If anything, I'd prefer to store the utf8 text in a variable in the screen and use that for redrawing, but I'm not actually sure if that'd work well in practice (what about cursor movements? I'm afraid it'd just draw the overlay buffer over something else just after the clock update, and not where it should really be)


It's still a lot better than messing the screen up, so I've been using this for a while now and in practice it's not so bad, but I don't know how you feel about partial fixes.