### PR TITLE
glfw xkb: debounce compile_keymap

### DIFF
--- a/glfw/xkb_glfw.c
+++ b/glfw/xkb_glfw.c
@@ -261,6 +261,11 @@ load_compose_tables(_GLFWXKBData *xkb) {
 GLFWbool
 glfw_xkb_compile_keymap(_GLFWXKBData *xkb, const char *map_str) {
     const char *err;
+    double time = glfwGetTime();
+    /* skip back-to-back keymap reloads */
+    if (xkb->reload_time != 0.0 && time - xkb->reload_time < 2.0)
+        return GLFW_TRUE;
+    xkb->reload_time = time;
     release_keyboard_data(xkb);
     err = load_keymaps(xkb, map_str);
     if (err) {

--- a/glfw/xkb_glfw.h
+++ b/glfw/xkb_glfw.h
@@ -64,6 +64,7 @@ typedef struct {
     xkb_mod_mask_t          numLockMask;
     xkb_mod_index_t         unknownModifiers[256];
     _GLFWIBUSData           ibus;
+    double                  reload_time;
 
 #ifdef _GLFW_X11
     int32_t                 keyboard_device_id;


### PR DESCRIPTION
Only allow reloading keymap once every 2 seconds at most.

Some programs like ibus generate a lot of XkbMapNotify events, which can be very slow with multiple kitty windows hammering the X server


(unrelated: that's my last PR for today, I have a few more commits that need cleanup at some point, but will try to force myself to finish selection first)