### PR TITLE
pager history: fix bufsize calculation

### DIFF
--- a/kitty/history.c
+++ b/kitty/history.c
@@ -73,7 +73,7 @@ pagerhist_extend(PagerHistoryBuf *ph, size_t minsz) {
     void *newbuf = PyMem_Realloc(ph->buffer, newsz * sizeof(Py_UCS4));
     if (!newbuf) return false;
     ph->buffer = newbuf;
-    ph->bufsize += newsz;
+    ph->bufsize = newsz;
     return true;
 }
 


### PR DESCRIPTION
bufsize was bigger than the actual allocated memory

Fixes: b9e6557f729f ("Allow arbitrary sized lines in the secondary scrollback buffer")
