### PR TITLE
add option to show tab index in tab_bar title

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -608,6 +608,10 @@ entries to this list.
 o('tab_separator', '"{}"'.format(default_tab_separator), option_type=tab_separator, long_text=_('''
 The separator between tabs in the tab bar when using :code:`separator` as the :opt:`tab_bar_style`.'''))
 
+o('tab_title_index', False, long_text=_('''
+Show the tab index in the tab title, starting with 1. Useful if you have a maps for :code:`goto_tab N`.
+'''))
+
 o('active_tab_foreground', '#000', option_type=to_color, long_text=_('''
 Tab bar colors and styles'''))
 o('active_tab_background', '#eee', option_type=to_color)


### PR DESCRIPTION
I didn't see any tests for tabs / the tab_bar, and I'm not sure how to setup such a test. I'm happy to add tests with some guidance on how to setup a tab_bar test.

As the PR is now, there is no space after the tab index and the title:

```
1:~ ┇2:vi ┇3:less
```

Related to #1223 