### PR TITLE
Add `resize_window` configuration action

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -223,6 +223,22 @@ example, in the Tall layout you can make the first window wider/narrower, but
 not taller/shorter. Note that what you are resizing is actually not a window,
 but a row/column in the layout, all windows in that row/column will be resized.
 
+You can define shortcuts in :file:`kitty.conf` to make the active window
+wider, narrower, taller, or shorter by mapping to the ``resize_window``
+action, for example::
+
+   map ctrl+left resize_window narrower
+   map ctrl+right resize_window wider
+   map ctrl+up resize_window taller
+   map shift+down move_window shorter
+   ...
+
+The ``resize_window`` action has a second, optional argument to control
+the resizing increment (a positive integer)::
+
+   map ctrl+up resize_window taller 3
+   ...
+
 Some layouts take options to control their behavior. For example, the ``fat``
 and ``tall`` layouts accept the ``bias`` option to control how the available
 space is split up. To specify the option, in :opt:`kitty.conf <enabled_layouts>` use::

--- a/kitty/config.py
+++ b/kitty/config.py
@@ -150,6 +150,27 @@ def neighboring_window(func, rest):
     return func, [rest]
 
 
+@func_with_args('resize_window')
+def resize_window(func, rest):
+    vals = rest.split(' ', 1)
+    if len(vals) > 2:
+        log_error('resize_window needs one or two arguments, using defaults')
+        args = ['wider', 1]
+    else:
+        quality = vals[0].lower()
+        if quality not in ('taller', 'shorter', 'wider', 'narrower'):
+            log_error('Invalid quality specification: {}'.format(quality))
+            quality = 'wider'
+        increment = 1
+        if len(vals) == 2:
+            try:
+                increment = int(vals[1])
+            except Exception:
+                log_error('Invalid increment specification: {}'.format(vals[1]))
+        args = [quality, increment]
+    return func, args
+
+
 @func_with_args('move_window')
 def move_window(func, rest):
     rest = rest.lower()

--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -199,6 +199,24 @@ class Tab:  # {{{
             return
         return 'Could not resize'
 
+    def resize_window(self, quality, increment):
+        if increment < 1:
+            raise ValueError(increment)
+        if quality == 'taller':
+            is_horizontal = False
+        elif quality == 'shorter':
+            is_horizontal = False
+            increment *= -1
+        elif quality == 'wider':
+            is_horizontal = True
+        elif quality == 'narrower':
+            is_horizontal = True
+            increment *= -1
+        else:
+            raise ValueError(quality)
+        self.resize_window_by(self.windows[self.active_window_idx].id,
+                              increment, is_horizontal)
+
     def reset_window_sizes(self):
         if self.current_layout.remove_all_biases():
             self.relayout()


### PR DESCRIPTION
This patch adds the `resize_window` configuration action, which has the following arguments:

1. Quality of resize amongst `wider`, `narrower`, `taller`, `shorter` (mandatory).
2. Increment in number of cells (optional, default: 1).

This makes it possible to configure keys as such:

    map ctrl+shift+left resize_window narrower
    map ctrl+shift+right resize_window wider
    map ctrl+shift+up resize_window taller
    map ctrl+shift+down resize_window shorter

and have a behaviour which is somewhat close to Terminator's.

Should you accept this idea, I can add documentation in a subsequent patch.