### PR TITLE
Scroll at least one line per low-resolution scroll event

### DIFF
--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -584,7 +584,13 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags) {
         if (pixels < 0) s *= -1;
         global_state.callback_os_window->pending_scroll_pixels = pixels - s * (int) global_state.callback_os_window->fonts_data->cell_height;
     } else {
-        s = (int) round(yoffset * OPT(wheel_scroll_multiplier));
+        yoffset *= OPT(wheel_scroll_multiplier);
+        s = (int) round(yoffset);
+        if (s == 0) {
+            // Scroll at least one line
+            if (yoffset > 0) s = 1;
+            else if (yoffset < 0) s = -1;
+        }
         global_state.callback_os_window->pending_scroll_pixels = 0;
     }
     if (s == 0) return;


### PR DESCRIPTION
Fixes #1238.
under macOS the `yoffset` can be less than 1 when scrolling slowly with a low-resolution mouse, in which case kitty never scrolls.
I implemented it to scroll at least one line per low-resolution scroll event.
Another option would be to do it like the code for high-resolution scrolling does it and remember the remainder of the rounding or better yet, to combine the two cases and do the computation only with pixels.