### PR TITLE
macOS: Exit on SIGINT

### DIFF
--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -650,6 +650,12 @@ bool
 application_quit_requested() {
     return !application_quit_canary || glfwWindowShouldClose(application_quit_canary);
 }
+
+void
+request_application_quit() {
+    if (application_quit_canary)
+        glfwSetWindowShouldClose(application_quit_canary, true);
+}
 #endif
 
 // Global functions {{{

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -144,7 +144,7 @@ typedef struct {
     OSWindow *os_windows;
     size_t num_os_windows, capacity;
     OSWindow *callback_os_window;
-    bool close_all_windows;
+    bool terminate;
     bool is_wayland;
     bool debug_gl, debug_font_fallback;
     bool has_pending_resizes;
@@ -209,5 +209,6 @@ typedef enum {
 } CocoaPendingAction;
 void set_cocoa_pending_action(CocoaPendingAction action);
 bool application_quit_requested();
+void request_application_quit();
 #endif
 void wayland_request_frame_render(OSWindow *w);


### PR DESCRIPTION
When `macos_quit_when_last_window_closed` is set to `no` (the default), Kitty does not exit on SIGINT. The signal handler just kills all OS windows, which on Linux or with the option set to `yes` will cause Kitty to exit.

This behavior is certainly annoying when hacking on Kitty. In this case I launch kitty as `python3 .` and then want to kill it from the dev terminal with Ctrl-C. The only way to kill it from the command line is `^Z kill -9 %1`, but that seems heavy handed and not as convenient.

My fix is to close the canary window when a kill signal is received. I think this bug is caused by conflating termination with closing all windows, which is why I also renamed `GlobalState.close_all_windows` to `GlobalState.terminate`.