### PR TITLE
`change_font_size current ...` changes the current OS window's font size

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -169,14 +169,14 @@ Similarly, to switch back to the previous layout::
 ''')],
     'shortcuts.fonts': [
         _('Font sizes'), _('''\
-You can change the font size for all top-level kitty windows at a time
+You can change the font size for all top-level kitty OS windows at a time
 or only the current one.
 '''), _('''\
 To setup shortcuts for specific font sizes::
 
     map kitty_mod+f6 change_font_size all 10.0
 
-To setup shortcuts to change only the current window's font size::
+To setup shortcuts to change only the current OS window's font size::
 
     map kitty_mod+f6 change_font_size current 10.0
 ''')],


### PR DESCRIPTION
When I first read this in the docs:

> To setup shortcuts to change only the current window’s font size:
> `map kitty_mod+f6 change_font_size current 10.0`

I thought _current window_ meant the current layout's window (the window that you create with Ctrl+Shift+Enter), in that it would resize only this window's font size. Terminator has this feature, hence the confusion for me:

![image](https://user-images.githubusercontent.com/1816705/50234471-c4458400-0383-11e9-8a75-50629282b23d.png)

I thought this was a bug in kitty, but after reading the code I can see that it's meant to resize the whole OS window's font size:

```
        if all_windows:
            current_global_size = global_font_size()
            new_size = calc_new_size(current_global_size)
            if new_size != current_global_size:
                global_font_size(new_size)
            os_windows = tuple(self.os_window_map.keys())
        else:
            os_windows = []
            w = self.active_window
            if w is not None:
                os_windows.append(w.os_window_id)
```

Therefore I am suggesting to make it more explicit in the documentation.

Would changing a single "subwindow"'s font size be possible in kitty considering the way it's designed?