### PR TITLE
Fix broken downward scrolling

### DIFF
--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -580,7 +580,7 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags) {
             global_state.callback_os_window->pending_scroll_pixels = pixels;
             return;
         }
-        s = ((int)round(pixels)) / global_state.callback_os_window->fonts_data->cell_height;
+        s = (int)round(pixels) / (int)global_state.callback_os_window->fonts_data->cell_height;
         global_state.callback_os_window->pending_scroll_pixels = pixels - s * (int) global_state.callback_os_window->fonts_data->cell_height;
     } else {
         s = (int) round(yoffset * OPT(wheel_scroll_multiplier));


### PR DESCRIPTION
In my comment https://github.com/kovidgoyal/kitty/commit/009ef54de74d8c8acdd9fda1ccd4d172b4b20ce2#r31766142 I said that
```C
s = abs(((int)round(pixels))) / global_state.callback_os_window->fonts_data->cell_height;
if (pixels < 0) s *= -1;
```
is equal to
```C
s = (int)round(pixels) / global_state.callback_os_window->fonts_data->cell_height;
```
which is not correct because global_state.callback_os_window->fonts_data->cell_height is unsigned. Currently when scrolling down, `s` will be extremely large and not negative. Sorry about that.