### PR TITLE
Allow for scrolling acceleration in alternate screen mode when using low-resolution input devices like mice

### DIFF
--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -570,6 +570,7 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags) {
 
     int s;
     bool is_high_resolution = flags & 1;
+    Screen *screen = w->render_data.screen;
     if (is_high_resolution) {
         yoffset *= OPT(touch_scroll_multiplier);
         if (yoffset * global_state.callback_os_window->pending_scroll_pixels < 0) {
@@ -583,7 +584,12 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags) {
         s = (int)round(pixels) / (int)global_state.callback_os_window->fonts_data->cell_height;
         global_state.callback_os_window->pending_scroll_pixels = pixels - s * (int) global_state.callback_os_window->fonts_data->cell_height;
     } else {
-        s = (int) round(yoffset * OPT(wheel_scroll_multiplier));
+        // If we are about to send a mouse button 4/5 event,
+        // we ignore 'wheel_scroll_multiplier'
+        if (screen->linebuf == screen->main_linebuf || !screen->modes.mouse_tracking_mode) {
+            yoffset *= OPT(wheel_scroll_multiplier);
+        }
+        s = (int) round(yoffset);
         // apparently on cocoa some mice generate really small yoffset values
         // when scrolling slowly https://github.com/kovidgoyal/kitty/issues/1238
         if (s == 0 && yoffset != 0) s = yoffset > 0 ? 1 : -1;
@@ -591,7 +597,6 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags) {
     }
     if (s == 0) return;
     bool upwards = s > 0;
-    Screen *screen = w->render_data.screen;
     if (screen->linebuf == screen->main_linebuf) {
         screen_history_scroll(screen, abs(s), upwards);
     } else {
@@ -599,13 +604,7 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags) {
             int sz = encode_mouse_event(w, upwards ? GLFW_MOUSE_BUTTON_4 : GLFW_MOUSE_BUTTON_5, PRESS, 0);
             if (sz > 0) {
                 mouse_event_buf[sz] = 0;
-                if (is_high_resolution) {
-                    for (s = abs(s); s > 0; s--) {
-                        write_escape_code_to_child(screen, CSI, mouse_event_buf);
-                    }
-                } else {
-                    // Since we are sending a mouse button 4/5 event, we ignore 's'
-                    // and simply send one event per received scroll event
+                for (s = abs(s); s > 0; s--) {
                     write_escape_code_to_child(screen, CSI, mouse_event_buf);
                 }
             }


### PR DESCRIPTION
Fixes #1257.
This commit ignores `wheel_scroll_multiplier` so that nothing changes on platforms that only ever report a `yoffset` of 1 or -1.