### PR TITLE
Add more momentum scroll phases

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -940,8 +940,7 @@ is_ascii_control_char(char x) {
             break;
     }
 
-    if (fabs(deltaX) > 0.0 || fabs(deltaY) > 0.0)
-        _glfwInputScroll(window, deltaX, deltaY, flags);
+    _glfwInputScroll(window, deltaX, deltaY, flags);
 }
 
 - (NSDragOperation)draggingEntered:(id <NSDraggingInfo>)sender

--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -925,10 +925,17 @@ is_ascii_control_char(char x) {
     switch([event momentumPhase]) {
         case NSEventPhaseBegan:
             flags |= (1 << 1); break;
-        case NSEventPhaseChanged:
+        case NSEventPhaseStationary:
             flags |= (2 << 1); break;
-        case NSEventPhaseEnded:
+        case NSEventPhaseChanged:
             flags |= (3 << 1); break;
+        case NSEventPhaseEnded:
+            flags |= (4 << 1); break;
+        case NSEventPhaseCancelled:
+            flags |= (5 << 1); break;
+        case NSEventPhaseMayBegin:
+            flags |= (6 << 1); break;
+        case NSEventPhaseNone:
         default:
             break;
     }

--- a/glfw/glfw3.h
+++ b/glfw/glfw3.h
@@ -1383,9 +1383,10 @@ typedef void (* GLFWcursorenterfun)(GLFWwindow*,int);
  *  @param[in] flags A bit-mask providing extra data about the event.
  *  flags & 1 will be true if and only if the offset values are "high-precision".
  *  Typically pixel values. Otherwise the offset values are number of lines.
- *  (flags >> 1) & 3 will have value 1 for start of momentum scrolling,
- *  value 2 for momentum scrolling in progress and value 3 for momentum
- *  scrolling ended.
+ *  (flags >> 1) & 7 will have value 1 for the start of momentum scrolling,
+ *  value 2 for stationary momentum scrolling, value 3 for momentum scrolling
+ *  in progress, value 4 for momentum scrolling ended, value 5 for momentum
+ *  scrolling cancelled and value 6 if scrolling may begin soon.
  *
  *  @sa @ref scrolling
  *  @sa @ref glfwSetScrollCallback

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -586,6 +586,7 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags) {
         default:
             break;
     }
+    if (yoffset == 0.0) return;
     if (is_high_resolution) {
         yoffset *= OPT(touch_scroll_multiplier);
         if (yoffset * global_state.callback_os_window->pending_scroll_pixels < 0) {

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -569,9 +569,6 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags) {
     }
     if (!w) return;
 
-    int s;
-    bool is_high_resolution = flags & 1;
-    Screen *screen = w->render_data.screen;
     enum MomentumData { NoMomentumData, MomentumPhaseBegan, MomentumPhaseStationary, MomentumPhaseActive, MomentumPhaseEnded, MomentumPhaseCancelled, MomentumPhaseMayBegin };
     enum MomentumData momentum_data = (flags >> 1) & 7;
 
@@ -587,6 +584,11 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags) {
             break;
     }
     if (yoffset == 0.0) return;
+
+    int s;
+    bool is_high_resolution = flags & 1;
+    Screen *screen = w->render_data.screen;
+
     if (is_high_resolution) {
         yoffset *= OPT(touch_scroll_multiplier);
         if (yoffset * global_state.callback_os_window->pending_scroll_pixels < 0) {

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -572,17 +572,18 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags) {
     int s;
     bool is_high_resolution = flags & 1;
     Screen *screen = w->render_data.screen;
-    enum MomentumData { NoMomentumData, StartMomentumPhase, MomentumPhaseActive, MomentumPhaseEnded };
-    enum MomentumData momentum_data = (flags >> 1) & 3;
+    enum MomentumData { NoMomentumData, MomentumPhaseBegan, MomentumPhaseStationary, MomentumPhaseActive, MomentumPhaseEnded, MomentumPhaseCancelled, MomentumPhaseMayBegin };
+    enum MomentumData momentum_data = (flags >> 1) & 7;
+
     switch(momentum_data) {
-        case StartMomentumPhase:
+        case MomentumPhaseBegan:
             window_for_momentum_scroll = w->id; break;
         case MomentumPhaseActive:
             if (window_for_momentum_scroll != w->id) return;
             break;
         case MomentumPhaseEnded:
             window_for_momentum_scroll = 0; break;
-        case NoMomentumData:
+        default:
             break;
     }
     if (is_high_resolution) {


### PR DESCRIPTION
I added the other `NSEvent.Phase`s from https://developer.apple.com/documentation/appkit/nsevent/phase. We need one more bit in the flags variable. I changed the documentation to reflect my changes. I renamed one of the enum values from `StartMomentumPhase` to `MomentumPhaseBegan` for more consistency with the other values and the values in the cocoa code. I also moved the check for no scrolling distance from the cocoa code to `scroll_event()` because some `NSEvent.Phase`s can have zero `scrollingDeltaX` and `scrollingDeltaY` and with that check we would never see them in `scroll_event()`. I only check if `yoffset` is zero in `scroll_event()` because we don't care about `xoffset`. I also moved three lines of code down a bit because we don't need them if we return due to `if (yoffset == 0.0)` or if we return in the switch statement.