### PR TITLE
Add remaining momentum scroll phases to switch statement

### DIFF
--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -575,16 +575,21 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags) {
     enum MomentumData momentum_data = (flags >> 1) & 7;
 
     switch(momentum_data) {
+        case NoMomentumData:
+            break;
         case MomentumPhaseBegan:
             window_for_momentum_scroll = w->id;
             main_screen_for_momentum_scroll = screen->linebuf == screen->main_linebuf;
             break;
+        case MomentumPhaseStationary:
         case MomentumPhaseActive:
             if (window_for_momentum_scroll != w->id || main_screen_for_momentum_scroll != (screen->linebuf == screen->main_linebuf)) return;
             break;
         case MomentumPhaseEnded:
+        case MomentumPhaseCancelled:
             window_for_momentum_scroll = 0;
             break;
+        case MomentumPhaseMayBegin:
         default:
             break;
     }


### PR DESCRIPTION
According to https://developer.apple.com/documentation/appkit/nsevent/1533550-phase the momentum phase may end with `cancelled` instead of `ended`. I added `MomentumPhaseStationary` to the same block as `MomentumPhaseActive` because that seems like the most sensible place for it. I added `NoMomentumData` to the top to keep the otherwise perfect ordering and so that the most common case comes first.