### PR TITLE
Start hints at 1 instead of 0

### DIFF
--- a/kittens/hints/main.py
+++ b/kittens/hints/main.py
@@ -316,7 +316,7 @@ def run(args, text):
 
         largest_index = all_marks[-1].index
         for m in all_marks:
-            m.index = largest_index - m.index
+            m.index = largest_index - m.index + 1
         index_map = {m.index: m for m in all_marks}
     except Exception:
         import traceback


### PR DESCRIPTION
0 and 1 are far apart on the keyboard, so opening the first match with 0
and the second with 1 is a bit inconvenient. By starting from 1, all the
first matches are together on the keyboard. They're also close to the
default ctrl+shift+e binding, so you can open the matches using only the
left hand.

Fixes #1289