### PR TITLE
Fix white background color not allowing transparency

### DIFF
--- a/kitty/border_fragment.glsl
+++ b/kitty/border_fragment.glsl
@@ -4,5 +4,5 @@ in vec3 color;
 out vec4 final_color;
 
 void main() {
-    final_color = vec4(color, background_opacity);
+    final_color = vec4(color * background_opacity, background_opacity);
 }

--- a/kitty/cell_fragment.glsl
+++ b/kitty/cell_fragment.glsl
@@ -101,7 +101,7 @@ void main() {
 #else
     // SIMPLE
 #ifdef TRANSPARENT
-    final_color = alpha_blend_premul(fg.rgb, fg.a, background, bg_alpha);
+    final_color = alpha_blend_premul(fg.rgb, fg.a, background * bg_alpha, bg_alpha);
     final_color = vec4(final_color.rgb, final_color.a);
 #else
     // since background alpha is 1.0, it is effectively pre-multiplied


### PR DESCRIPTION
Fixes #1285.
I played around with the cell_fragment shader code some more and while I don't really understand what's going on, this patch fixes the issue (while introducing a slight problem, which you should look at, I'll explain it later). This patch essentially undoes 074614bc8e940725939aa7a316f0a7086e01e05c and 96229becd1bef8bd69b412e61fac96146300646e except that it multiplies except of dividing. `final_color`, the result of the computation seems to need pre-multiplication and `final_color` before my new multiplication seems to not be pre-multiplied. Otherwise I can't explain why this patch works.
Here are some screenshots with various `background_opacity` settings and `background #ffffff` and `background #000000` colors in `kitty.conf` with and without the fix in front of a checkerboard pattern:

- Without the fix
  - `background #000000`
    - `background_opacity 1.0`
![black 1 0](https://user-images.githubusercontent.com/15217907/50793540-d9e60380-12c8-11e9-8bcf-e7945189a99d.png)
    - `background_opacity 0.5`
![black 0 5](https://user-images.githubusercontent.com/15217907/50793560-e79b8900-12c8-11e9-8c02-746934b1a94c.png)
    - `background_opacity 0.0`
![black 0 0](https://user-images.githubusercontent.com/15217907/50793579-f8e49580-12c8-11e9-930a-21e47c465a48.png)
  - `background #ffffff`
    - `background_opacity 1.0`
![white 1 0](https://user-images.githubusercontent.com/15217907/50793606-0dc12900-12c9-11e9-861a-bc4887275789.png)
    - `background_opacity 0.5`
![white 0 5](https://user-images.githubusercontent.com/15217907/50793618-174a9100-12c9-11e9-8203-61f3a595c7de.png)
    - `background_opacity 0.0`
![white 0 0](https://user-images.githubusercontent.com/15217907/50793636-1f0a3580-12c9-11e9-984d-53c802b7ea16.png)
- With the fix
  - `background #000000`
    - `background_opacity 1.0`
![black 1 0](https://user-images.githubusercontent.com/15217907/50793696-47922f80-12c9-11e9-977b-f9e84b004c4b.png)
    - `background_opacity 0.5`
![black 0 5](https://user-images.githubusercontent.com/15217907/50793704-4c56e380-12c9-11e9-9672-a53bbc640470.png)
    - `background_opacity 0.0`
![black 0 0](https://user-images.githubusercontent.com/15217907/50793709-511b9780-12c9-11e9-97b5-205ddab2a164.png)
  - `background #ffffff`
    - `background_opacity 1.0`
![white 1 0](https://user-images.githubusercontent.com/15217907/50793716-55e04b80-12c9-11e9-8b22-e9d17dc5a375.png)
    - `background_opacity 0.5`
![white 0 5](https://user-images.githubusercontent.com/15217907/50793719-5b3d9600-12c9-11e9-95d3-5c9cdbce8fd4.png)
    - `background_opacity 0.0`
![white 0 0](https://user-images.githubusercontent.com/15217907/50793728-5ed11d00-12c9-11e9-9f54-d5ac4414c217.png)

Here is the problem: If you look closely at the bottom-right side of the left triangle in the bottom screenshot (a little less noticeable in the screenshot above that), you can see, that anti-aliasing is creating a few while-ish pixels where there should only be different mixes of blue and transparent ones, letting the black background shine through. That also happens with the other triangle but that isn't visible because of the white color behind the kitty window in that spot. I also think this is happening with the text but I'm not sure. That would mean, that #1005 is only partially fixed.

If my theory at the top with the pre-multiplication is correct, that means, that `alpha_blend_premul()` is taking the pre-multiplied (according to one comment in the code) color from `calculate_foreground()` and converting it to non-pre-multiplied color. I furthermore assume, that the `vec4` datatype uses values 0-255 for the color information. That would explain the weird white pixels because the back and forth calculation looses some color information.

There are also still some other issues with transparency like the weird borders with white background color but that should be looked at another time IMHO since I find #1005 and #1285 being fixed more important for now.

Wow, this pull request took several hours to create with all the testing and screenshots and the text and stuff 😅.