### PR TITLE
Apply negative scroll multiplier in alternate screen mode

### DIFF
--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -615,6 +615,8 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags) {
             // Only use wheel_scroll_multiplier if we are scrolling kitty scrollback or in mouse
             // tracking mode, where the application is responsible for interpreting scroll events
             yoffset *= OPT(wheel_scroll_multiplier);
+        } else if (OPT(wheel_scroll_multiplier) < 0) {
+            yoffset *= -1;
         }
         s = (int) round(yoffset);
         // apparently on cocoa some mice generate really small yoffset values


### PR DESCRIPTION
Fixes #1299.
Instead of multiplying `s` as I said I would do, I multiplied `yoffset` because it is also the variable being multiplied in the other case and doing it this way requires a little less code because we can reuse the check from the `if` statement above.