### PR TITLE
Unjam event loop when adding pending cocoa action

### DIFF
--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -771,6 +771,9 @@ static unsigned int cocoa_pending_actions = 0;
 void
 set_cocoa_pending_action(CocoaPendingAction action) {
     cocoa_pending_actions |= action;
+    // The main loop may be blocking on the event queue, if e.g. unfocused.
+    // Unjam it so the pending action is processed right now.
+    unjam_event_loop();
 }
 #endif
 

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -172,6 +172,7 @@ void make_os_window_context_current(OSWindow *w);
 void update_os_window_references();
 void mark_os_window_for_close(OSWindow* w, bool yes);
 void update_os_window_viewport(OSWindow *window, bool);
+void unjam_event_loop();
 bool should_os_window_close(OSWindow* w);
 bool should_os_window_be_rendered(OSWindow* w);
 void wakeup_main_loop();


### PR DESCRIPTION
Fixes the problem reported in https://github.com/kovidgoyal/kitty/issues/1312.

I chose to do the unjamming in `set_cocoa_pending_action` to avoid similar issues in the future. This is probably not necessary for `PREFERENCES_WINDOW`, but the cost is minuscule.