### PR TITLE
[WIP] Add more common macOS keyboard shortcuts

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ Changelog
 
 - Fix window title for minimized windows not being updated (:iss:`1332`)
 
+- macOS: Add a bunch of common macOS keyboard shortcuts
 
 0.13.3 [2019-01-19]
 ------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -194,8 +194,6 @@ Increase background opacity         :sc:`increase_background_opacity`
 Decrease background opacity         :sc:`decrease_background_opacity`
 Full background opacity             :sc:`full_background_opacity`
 Reset background opacity            :sc:`reset_background_opacity`
-Jump left one word                  :kbd:`⌥+←` (only on macOS)
-Jump right one word                 :kbd:`⌥+→` (only on macOS)
 ==================================  =======================
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -140,7 +140,7 @@ Windows
 ========================    =======================
 Action                      Shortcut
 ========================    =======================
-New window                  :sc:`new_window`
+New window                  :sc:`new_window` (also :kbd:`⌘+↩` on macOS)
 New OS window               :sc:`new_os_window` (also :kbd:`⌘+n` on macOS)
 New OS window with cwd      :sc:`new_os_window_with_cwd` (also :kbd:`⇧+⌘+n` on macOS)
 Close window                :sc:`close_window` (also :kbd:`⇧+⌘+d` on macOS)
@@ -150,6 +150,7 @@ Move window forward         :sc:`move_window_forward`
 Move window backward        :sc:`move_window_backward`
 Move window to top          :sc:`move_window_to_top`
 Focus specific window       :sc:`first_window`, :sc:`second_window` ... :sc:`tenth_window`
+                            (also :kbd:`⌘+1`, :kbd:`⌘+2` ... :kbd:`⌘+9` on macOS)
                             (clockwise from the top-left)
 ========================    =======================
 
@@ -185,7 +186,7 @@ Restore font size                   :sc:`reset_font_size` (also :kbd:`⌘+0` on 
 Toggle fullscreen                   :sc:`toggle_fullscreen` (also :kbd:`^+⌘+f` on macOS)
 Input unicode character             :sc:`input_unicode_character`
 Click URL using the keyboard        :sc:`open_url`
-Reset the terminal                  :sc:`reset_terminal` (also :kbd:`⌘+r` on macOS)
+Reset the terminal                  :sc:`reset_terminal`
 Pass current selection to program   :sc:`pass_selection_to_program`
 Edit |kitty| config file            :sc:`edit_config_file`
 Open a |kitty| shell                :sc:`kitty_shell`
@@ -217,7 +218,7 @@ You can switch between layouts using the :sc:`next_layout` key combination. You 
 also create shortcuts to select particular layouts, and choose which layouts
 you want to enable/disable, see :ref:`conf-kitty-shortcuts.layout` for examples.
 
-You can resize windows inside layouts. Press :sc:`start_resizing_window` to
+You can resize windows inside layouts. Press :sc:`start_resizing_window` (also :kbd:`⌘+r` on macOS) to
 enter resizing mode and follow the on-screen instructions.  In a given window
 layout only some operations may be possible for a particular window. For
 example, in the Tall layout you can make the first window wider/narrower, but

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -194,6 +194,8 @@ Increase background opacity         :sc:`increase_background_opacity`
 Decrease background opacity         :sc:`decrease_background_opacity`
 Full background opacity             :sc:`full_background_opacity`
 Reset background opacity            :sc:`reset_background_opacity`
+Jump left one word                  :kbd:`⌥+←` (only on macOS)
+Jump right one word                 :kbd:`⌥+→` (only on macOS)
 ==================================  =======================
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -108,12 +108,12 @@ Scrolling
 ========================    =======================
 Action                      Shortcut
 ========================    =======================
-Scroll line up              :sc:`scroll_line_up`
-Scroll line down            :sc:`scroll_line_down`
-Scroll page up              :sc:`scroll_page_up`
-Scroll page down            :sc:`scroll_page_down`
-Scroll to top               :sc:`scroll_home`
-Scroll to bottom            :sc:`scroll_end`
+Scroll line up              :sc:`scroll_line_up` (also :kbd:`⌥+⌘+⇞` and :kbd:`⌘+↑` on macOS)
+Scroll line down            :sc:`scroll_line_down` (also :kbd:`⌥+⌘+⇟` and :kbd:`⌘+↓` on macOS)
+Scroll page up              :sc:`scroll_page_up` (also :kbd:`⌘+⇞` on macOS)
+Scroll page down            :sc:`scroll_page_down` (also :kbd:`⌘+⇟` on macOS)
+Scroll to top               :sc:`scroll_home` (also :kbd:`⌘+↖` on macOS)
+Scroll to bottom            :sc:`scroll_end` (also :kbd:`⌘+↘` on macOS)
 ========================    =======================
 
 Tabs
@@ -123,13 +123,14 @@ Tabs
 Action                      Shortcut
 ========================    =======================
 New tab                     :sc:`new_tab` (also :kbd:`⌘+t` on macOS)
-Close tab                   :sc:`close_tab`
-Next tab                    :sc:`next_tab` (also :kbd:`control+tab` on macOS)
-Previous tab                :sc:`previous_tab` (also :kbd:`control+shift+tab` on macOS)
+New tab with cwd            :sc:`new_tab_with_cwd` (also :kbd:`⇧+⌘+t` on macOS)
+Close tab                   :sc:`close_tab` (also :kbd:`⌘+w` on macOS)
+Next tab                    :sc:`next_tab` (also :kbd:`^+⇥` on macOS)
+Previous tab                :sc:`previous_tab` (also :kbd:`⇧+^+⇥` on macOS)
 Next layout                 :sc:`next_layout`
 Move tab forward            :sc:`move_tab_forward`
 Move tab backward           :sc:`move_tab_backward`
-Set tab title               :sc:`set_tab_title`
+Set tab title               :sc:`set_tab_title` (also :kbd:`⇧+⌘+i` on macOS)
 ========================    =======================
 
 
@@ -141,7 +142,8 @@ Action                      Shortcut
 ========================    =======================
 New window                  :sc:`new_window`
 New OS window               :sc:`new_os_window` (also :kbd:`⌘+n` on macOS)
-Close window                :sc:`close_window` (also :kbd:`⌘+w` on macOS)
+New OS window with cwd      :sc:`new_os_window_with_cwd` (also :kbd:`⇧+⌘+n` on macOS)
+Close window                :sc:`close_window` (also :kbd:`⇧+⌘+d` on macOS)
 Next window                 :sc:`next_window`
 Previous window             :sc:`previous_window`
 Move window forward         :sc:`move_window_forward`
@@ -177,13 +179,13 @@ Action                              Shortcut
 Copy to clipboard                   :sc:`copy_to_clipboard` (also :kbd:`⌘+c` on macOS)
 Paste from clipboard                :sc:`paste_from_clipboard` (also :kbd:`⌘+v` on macOS)
 Paste from selection                :sc:`paste_from_selection`
-Increase font size                  :sc:`increase_font_size`
-Decrease font size                  :sc:`decrease_font_size`
-Restore font size                   :sc:`reset_font_size`
-Toggle fullscreen                   :sc:`toggle_fullscreen` (also :kbd:`^⌘+f` on macOS)
+Increase font size                  :sc:`increase_font_size` (also :kbd:`⌘++` on macOS)
+Decrease font size                  :sc:`decrease_font_size` (also :kbd:`⌘+-` on macOS)
+Restore font size                   :sc:`reset_font_size` (also :kbd:`⌘+0` on macOS)
+Toggle fullscreen                   :sc:`toggle_fullscreen` (also :kbd:`^+⌘+f` on macOS)
 Input unicode character             :sc:`input_unicode_character`
 Click URL using the keyboard        :sc:`open_url`
-Reset the terminal                  :sc:`reset_terminal`
+Reset the terminal                  :sc:`reset_terminal` (also :kbd:`⌘+r` on macOS)
 Pass current selection to program   :sc:`pass_selection_to_program`
 Edit |kitty| config file            :sc:`edit_config_file`
 Open a |kitty| shell                :sc:`kitty_shell`

--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -798,7 +798,7 @@ incompatible with :opt:`background_opacity`. If you want to use both, you are
 probably better off just hiding the titlebar with :opt:`hide_window_decorations`.
 '''))
 
-o('macos_option_as_alt', True, long_text=_('''
+o('macos_option_as_alt', False, long_text=_('''
 Use the option key as an alt key. With this set to no, kitty will use
 the macOS native :kbd:`Option+Key` = unicode character behavior. This will
 break any :kbd:`Alt+key` keyboard shortcuts in your terminal programs, but you

--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -1091,6 +1091,9 @@ the line (same as pressing the Home key)::
     map ctrl+alt+a send_text normal Word\\x1b[H
     map ctrl+alt+a send_text application Word\\x1bOH
 '''))
+if is_macos:
+    k('send_text', 'alt+left', 'send_text all \x1b\x62', _('Jump left one word'), add_to_docs=False)
+    k('send_text', 'alt+right', 'send_text all \x1b\x66', _('Jump right one word'), add_to_docs=False)
 # }}}
 # }}}
 

--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -1091,9 +1091,6 @@ the line (same as pressing the Home key)::
     map ctrl+alt+a send_text normal Word\\x1b[H
     map ctrl+alt+a send_text application Word\\x1bOH
 '''))
-if is_macos:
-    k('send_text', 'alt+left', 'send_text all \x1b\x62', _('Jump left one word'), add_to_docs=False)
-    k('send_text', 'alt+right', 'send_text all \x1b\x66', _('Jump right one word'), add_to_docs=False)
 # }}}
 # }}}
 

--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -935,6 +935,8 @@ For example::
 
     map ctrl+enter new_window @ some_program
 '''))
+if is_macos:
+    k('new_window', 'cmd+enter', 'new_window', _('New window'), add_to_docs=False)
 k('new_os_window', 'kitty_mod+n', 'new_os_window', _('New OS window'))
 if is_macos:
     k('new_os_window', 'cmd+n', 'new_os_window', _('New OS window'), add_to_docs=False)
@@ -948,6 +950,8 @@ k('move_window_forward', 'kitty_mod+f', 'move_window_forward', _('Move window fo
 k('move_window_backward', 'kitty_mod+b', 'move_window_backward', _('Move window backward'))
 k('move_window_to_top', 'kitty_mod+`', 'move_window_to_top', _('Move window to top'))
 k('start_resizing_window', 'kitty_mod+r', 'start_resizing_window', _('Start resizing window'))
+if is_macos:
+    k('start_resizing_window', 'cmd+r', 'start_resizing_window', _('Start resizing window'), add_to_docs=False)
 k('first_window', 'kitty_mod+1', 'first_window', _('First window'))
 k('second_window', 'kitty_mod+2', 'second_window', _('Second window'))
 k('third_window', 'kitty_mod+3', 'third_window', _('Third window'))
@@ -958,6 +962,16 @@ k('seventh_window', 'kitty_mod+7', 'seventh_window', _('Seventh window'))
 k('eighth_window', 'kitty_mod+8', 'eighth_window', _('Eight window'))
 k('ninth_window', 'kitty_mod+9', 'ninth_window', _('Ninth window'))
 k('tenth_window', 'kitty_mod+0', 'tenth_window', _('Tenth window'))
+if is_macos:
+    k('first_window', 'cmd+1', 'first_window', _('First window'), add_to_docs=False)
+    k('second_window', 'cmd+2', 'second_window', _('Second window'), add_to_docs=False)
+    k('third_window', 'cmd+3', 'third_window', _('Third window'), add_to_docs=False)
+    k('fourth_window', 'cmd+4', 'fourth_window', _('Fourth window'), add_to_docs=False)
+    k('fifth_window', 'cmd+5', 'fifth_window', _('Fifth window'), add_to_docs=False)
+    k('sixth_window', 'cmd+6', 'sixth_window', _('Sixth window'), add_to_docs=False)
+    k('seventh_window', 'cmd+7', 'seventh_window', _('Seventh window'), add_to_docs=False)
+    k('eighth_window', 'cmd+8', 'eighth_window', _('Eight window'), add_to_docs=False)
+    k('ninth_window', 'cmd+9', 'ninth_window', _('Ninth window'), add_to_docs=False)
 # }}}
 
 g('shortcuts.tab')  # {{{
@@ -1034,8 +1048,6 @@ k('increase_background_opacity', 'kitty_mod+a>m', 'set_background_opacity +0.1',
 k('decrease_background_opacity', 'kitty_mod+a>l', 'set_background_opacity -0.1', _('Decrease background opacity'))
 k('full_background_opacity', 'kitty_mod+a>1', 'set_background_opacity 1', _('Make background fully opaque'))
 k('reset_background_opacity', 'kitty_mod+a>d', 'set_background_opacity default', _('Reset background opacity'))
-if is_macos:
-    k('reset_terminal', 'cmd+r', 'clear_terminal reset active', _('Reset the terminal'), add_to_docs=False)
 k('reset_terminal', 'kitty_mod+delete', 'clear_terminal reset active', _('Reset the terminal'),
     long_text=_('''
 You can create shortcuts to clear/reset the terminal. For example::

--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -854,13 +854,14 @@ You can have kitty remove all shortcut definition seen up to this point. Useful,
 instance, to remove the default shortcuts.'''))
 
 g('shortcuts.clipboard')  # {{{
-if is_macos:
-    k('copy_to_clipboard', 'cmd+c', 'copy_to_clipboard', _('Copy to clipboard'), add_to_docs=False)
-    k('paste_from_clipboard', 'cmd+v', 'paste_from_clipboard', _('Paste from clipboard'), add_to_docs=False)
 k('copy_to_clipboard', 'kitty_mod+c', 'copy_to_clipboard', _('Copy to clipboard'), long_text=_('''
 There is also a :code:`copy_or_interrupt` action that can be optionally mapped to :kbd:`Ctrl+c`.
 It will copy only if there is a selection and send an interrupt otherwise.'''))
+if is_macos:
+    k('copy_to_clipboard', 'cmd+c', 'copy_to_clipboard', _('Copy to clipboard'), add_to_docs=False)
 k('paste_from_clipboard', 'kitty_mod+v', 'paste_from_clipboard', _('Paste from clipboard'))
+if is_macos:
+    k('paste_from_clipboard', 'cmd+v', 'paste_from_clipboard', _('Paste from clipboard'), add_to_docs=False)
 k('paste_from_selection', 'kitty_mod+s', 'paste_from_selection', _('Paste from selection'))
 k('paste_from_selection', 'shift+insert', 'paste_from_selection', _('Paste from selection'))
 k('pass_selection_to_program', 'kitty_mod+o', 'pass_selection_to_program', _('Pass selection to program'), long_text=_('''
@@ -880,13 +881,27 @@ window, by using the @selection placeholder::
 
 g('shortcuts.scrolling')  # {{{
 k('scroll_line_up', 'kitty_mod+up', 'scroll_line_up', _('Scroll line up'))
+if is_macos:
+    k('scroll_line_up', 'alt+cmd+page_up', 'scroll_line_up', _('Scroll line up'), add_to_docs=False)
+    k('scroll_line_up', 'cmd+up', 'scroll_line_up', _('Scroll line up'), add_to_docs=False)
 k('scroll_line_up', 'kitty_mod+k', 'scroll_line_up')
 k('scroll_line_down', 'kitty_mod+down', 'scroll_line_down', _('Scroll line down'))
 k('scroll_line_down', 'kitty_mod+j', 'scroll_line_down')
+if is_macos:
+    k('scroll_line_down', 'alt+cmd+page_down', 'scroll_line_down', _('Scroll line down'), add_to_docs=False)
+    k('scroll_line_down', 'cmd+down', 'scroll_line_down', _('Scroll line down'), add_to_docs=False)
 k('scroll_page_up', 'kitty_mod+page_up', 'scroll_page_up', _('Scroll page up'))
+if is_macos:
+    k('scroll_page_up', 'cmd+page_up', 'scroll_page_up', _('Scroll page up'), add_to_docs=False)
 k('scroll_page_down', 'kitty_mod+page_down', 'scroll_page_down', _('Scroll page down'))
+if is_macos:
+    k('scroll_page_down', 'cmd+page_down', 'scroll_page_down', _('Scroll page down'), add_to_docs=False)
 k('scroll_home', 'kitty_mod+home', 'scroll_home', _('Scroll to top'))
+if is_macos:
+    k('scroll_home', 'cmd+home', 'scroll_home', _('Scroll to top'), add_to_docs=False)
 k('scroll_end', 'kitty_mod+end', 'scroll_end', _('Scroll to bottom'))
+if is_macos:
+    k('scroll_end', 'cmd+end', 'scroll_end', _('Scroll to bottom'), add_to_docs=False)
 k('show_scrollback', 'kitty_mod+h', 'show_scrollback', _('Browse scrollback buffer in less'), long_text=_('''
 
 You can pipe the contents of the current screen + history buffer as
@@ -920,12 +935,13 @@ For example::
 
     map ctrl+enter new_window @ some_program
 '''))
-if is_macos:
-    k('new_os_window', 'cmd+n', 'new_os_window', _('New OS window'))
 k('new_os_window', 'kitty_mod+n', 'new_os_window', _('New OS window'))
+if is_macos:
+    k('new_os_window', 'cmd+n', 'new_os_window', _('New OS window'), add_to_docs=False)
+    k('new_os_window_with_cwd', 'shift+cmd+n', 'new_os_window_with_cwd', _('New OS window with cwd'), add_to_docs=False)
 k('close_window', 'kitty_mod+w', 'close_window', _('Close window'))
 if is_macos:
-    k('close_window', 'cmd+w', 'close_window', _('Close window'), add_to_docs=False)
+    k('close_window', 'shift+cmd+d', 'close_window', _('Close window'), add_to_docs=False)
 k('next_window', 'kitty_mod+]', 'next_window', _('Next window'))
 k('previous_window', 'kitty_mod+[', 'previous_window', _('Previous window'))
 k('move_window_forward', 'kitty_mod+f', 'move_window_forward', _('Move window forward'))
@@ -945,19 +961,26 @@ k('tenth_window', 'kitty_mod+0', 'tenth_window', _('Tenth window'))
 # }}}
 
 g('shortcuts.tab')  # {{{
-if is_macos:
-    k('next_tab', 'ctrl+tab', 'next_tab', _('Next tab'), add_to_docs=False)
 k('next_tab', 'kitty_mod+right', 'next_tab', _('Next tab'))
 if is_macos:
-    k('previous_tab', 'ctrl+shift+tab', 'previous_tab', _('Previous tab'), add_to_docs=False)
+    k('next_tab', 'ctrl+tab', 'next_tab', _('Next tab'), add_to_docs=False)
 k('previous_tab', 'kitty_mod+left', 'previous_tab', _('Previous tab'))
+if is_macos:
+    k('previous_tab', 'shift+ctrl+tab', 'previous_tab', _('Previous tab'), add_to_docs=False)
 k('new_tab', 'kitty_mod+t', 'new_tab', _('New tab'))
 if is_macos:
     k('new_tab', 'cmd+t', 'new_tab', _('New tab'), add_to_docs=False)
+    k('new_tab_with_cwd', 'shift+cmd+t', 'new_tab_with_cwd', _('New tab with cwd'), add_to_docs=False)
 k('close_tab', 'kitty_mod+q', 'close_tab', _('Close tab'))
+if is_macos:
+    k('close_tab', 'cmd+w', 'close_tab', _('Close tab'), add_to_docs=False)
+    #  Not yet implemented
+    #  k('close_os_window', 'shift+cmd+w', 'close_os_window', _('Close os window'), add_to_docs=False)
 k('move_tab_forward', 'kitty_mod+.', 'move_tab_forward', _('Move tab forward'))
 k('move_tab_backward', 'kitty_mod+,', 'move_tab_backward', _('Move tab backward'))
 k('set_tab_title', 'kitty_mod+alt+t', 'set_tab_title', _('Set tab title'))
+if is_macos:
+    k('set_tab_title', 'shift+cmd+i', 'set_tab_title', _('Set tab title'), add_to_docs=False)
 # }}}
 
 g('shortcuts.layout')  # {{{
@@ -966,8 +989,14 @@ k('next_layout', 'kitty_mod+l', 'next_layout', _('Next layout'))
 
 g('shortcuts.fonts')  # {{{
 k('increase_font_size', 'kitty_mod+equal', 'change_font_size all +2.0', _('Increase font size'))
+if is_macos:
+    k('increase_font_size', 'cmd+plus', 'change_font_size all +2.0', _('Increase font size'), add_to_docs=False)
 k('decrease_font_size', 'kitty_mod+minus', 'change_font_size all -2.0', _('Decrease font size'))
+if is_macos:
+    k('decrease_font_size', 'cmd+minus', 'change_font_size all -2.0', _('Decrease font size'), add_to_docs=False)
 k('reset_font_size', 'kitty_mod+backspace', 'change_font_size all 0', _('Reset font size'))
+if is_macos:
+    k('reset_font_size', 'cmd+0', 'change_font_size all 0', _('Reset font size'), add_to_docs=False)
 # }}}
 
 g('shortcuts.selection')   # {{{
@@ -1005,6 +1034,8 @@ k('increase_background_opacity', 'kitty_mod+a>m', 'set_background_opacity +0.1',
 k('decrease_background_opacity', 'kitty_mod+a>l', 'set_background_opacity -0.1', _('Decrease background opacity'))
 k('full_background_opacity', 'kitty_mod+a>1', 'set_background_opacity 1', _('Make background fully opaque'))
 k('reset_background_opacity', 'kitty_mod+a>d', 'set_background_opacity default', _('Reset background opacity'))
+if is_macos:
+    k('reset_terminal', 'cmd+r', 'clear_terminal reset active', _('Reset the terminal'), add_to_docs=False)
 k('reset_terminal', 'kitty_mod+delete', 'clear_terminal reset active', _('Reset the terminal'),
     long_text=_('''
 You can create shortcuts to clear/reset the terminal. For example::


### PR DESCRIPTION
Don't merge this yet @kovidgoyal. I'll change a few minor things, like removing the commented out `close_os_window` keyboard shortcut, before this is merged. I'd also like to get some feedback from other macOS users first, especially about the behaviour of `cmd+w`, the default of `macos_option_as_alt`, if there are any keyboard shortcuts I didn't add that should be added and if there are any issues. Should we ping some macOS users?

I went through all the options in `kitty/config_data.py`, my config file and the generic, Terminal.app specific and Safari specific Apple keyboard shortcut documentation and added all options that could apply to kitty on macOS, which are common in other macOS apps or which I think are sensible.
I've put the Mac specific keyboard shortcuts always right after the other options for consistency.
I've added `add_to_docs=False` to `k('new_os_window', 'cmd+n', 'new_os_window', _('New OS window'))` to be consistent with all the other options, I'm not sure why it wasn't used before. I've used `shift+cmd+...` instead of `cmd+shift+...` because that's the order of the options in the official Apple documentation but if you want the other order, I can change it. I'm not really sure what the parameters of `s()` mean, I hope I did everything correctly, for example with `new_os_window_with_cwd`. The documentation of `new_tab_with_cwd` and `new_os_window_with_cwd` is probably incorrect. I've changed the behaviour of `cmd+w` from `close_window` to `close_tab`, since that seems to be more standard, but I'm not too sure what's the best behaviour. Terminal.app for example uses `cmd+w` to close tabs and `shift+cmd+d` to close split windows. I'd like to hear everyone's opinion about what they think `cmd+w` should do.

Here are all the macOS specific options, what they would do if this patch were to be merged without any change and an example app that uses this option or an explanation:
- `cmd+c`: `copy_to_clipboard`
- `cmd+v`: `paste_from_clipboard`
- `alt+cmd+page_up`: `scroll_line_up`, like Terminal.app
- `cmd+up`: `scroll_line_up`, shorter than the other option and isn't used by anything else as far as I can tell
- `alt+cmd+page_down`: `scroll_line_down`, like Terminal.app
- `cmd+down`: `scroll_line_down` shorter than the other option and isn't used by anything else as far as I can tell
- `cmd+page_up`: `scroll_page_up`, like Terminal.app
- `cmd+page_down`: `scroll_page_down`, like Terminal.app
- `cmd+home`: `scroll_home`, like Terminal.app
- `cmd+end`: `scroll_end`, like Terminal.app
- `cmd+n`: `new_os_window`, like Terminal.app
- `shift+cmd+n`: `new_os_window_with_cwd`
- `shift+cmd+d`: `close_window`, Terminal.app closes split window
- `ctrl+tab`: `next_tab`, like e.g. Terminal.app, Safari, Firefox, Sublime Text
- `shift+ctrl+tab`: `previous_tab`, like e.g. Terminal.app, Safari, Firefox, Sublime Text
- `cmd+t`: `new_tab`, like e.g. Terminal.app, Safari, Firefox, Sublime Text
- `shift+cmd+t`: `new_tab_with_cwd`
- `cmd+w`: `close_tab`, like e.g. Terminal.app, Safari, Firefox, Sublime Text
- `shift+cmd+i`: `set_tab_title`, like Terminal.app
- `cmd+plus`: `increase_font_size` like e.g. Terminal.app, Safari, Firefox, Sublime Text
- `cmd+minus`: `decrease_font_size` like e.g. Terminal.app, Safari, Firefox, Sublime Text
- `cmd+0`: `reset_font_size` like e.g. Terminal.app, Safari, Firefox
- `cmd+r`: `reset_terminal`, like the reload/refresh function in some apps, Terminal.app has `alt+cmd+r` to "soft reset" and `ctrl+alt+cmd+r` to "hard reset", whatever that really does

The following key bindings are not config options but still work on macOS, maybe there are some more that I missed. These key bindings take precedence over any key binding defined in the kitty config file as far as I can tell. Maybe we should list them in the documentation.
- `cmd+h`: `hide window`
- `cmd+m`: `minimize window`
- `control+cmd+f`: `toggle fullscreen`
- `cmd+comma`: `open preferences`

I really do think `macos_option_as_alt` should be false by default. Pretty much all macOS apps allow unicode input with the alt key. The three terminal emulators Terminal.app, iTerm2 and Alacritty I have installed and used in the past behave this way by default as far as I can tell. If someone switches from any of those terminal emulators to kitty, then they will be frustrated, that this no longer works by default. I think you have mentioned in the past, that the option is true by default because people would file bug reports, that certain programs which use the alt key won't work correctly but the only way I can imagine this to be really surprising is if someone switches from Linux to macOS while using kitty on both systems. I found many bug reports that were at least partially resolved by setting the config option to no: #1294, #1086, #874, #871, #847, #708, #587, #560, #351. I'd like to get not only @kovidgoyal's opinion about this but I'd also like to hear what other people think.

We have `close_window` and `close_tab` but not `close_os_window`, maybe we should implement such an option. It would simply close all the tabs in the current OS window.

Maybe I overdid it a bit with all the unicode characters in the documentation. Let me know if we should just spell the key names out that aren't printed exactly like that on the keyboard. I'm also not sure whether or not there should be a `+` between `^` and `⌘`.