### PR TITLE
Rename OS X -> macOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           - run: python3 logo/make.py
           - run: python3 setup.py build --debug --verbose
           - run: python3 test.py
-          - run: python3 setup.py osx-bundle
+          - run: python3 setup.py macos-bundle
 
 
 workflows:

--- a/build-terminfo
+++ b/build-terminfo
@@ -16,7 +16,7 @@ with open('terminfo/kitty.terminfo', 'w') as f:
 
 os.environ['TERMINFO'] = os.path.join(base, 'terminfo')
 subprocess.check_call(['tic', '-x', 'terminfo/kitty.terminfo'])
-# On OS X tic puts the compiled database into a different directory
+# On macOS tic puts the compiled database into a different directory
 try:
     os.mkdir('terminfo/78')
 except FileExistsError:

--- a/kitty/main.py
+++ b/kitty/main.py
@@ -152,7 +152,7 @@ run_app.first_window_callback = lambda window_handle: None
 run_app.initial_window_size_func = initial_window_size_func
 
 
-def ensure_osx_locale():
+def ensure_macos_locale():
     # Ensure the LANG env var is set. See
     # https://github.com/kovidgoyal/kitty/issues/90
     from .fast_data_types import cocoa_get_lang
@@ -214,7 +214,7 @@ def _main():
     except AttributeError:
         pass  # python compiled without threading
     if is_macos:
-        ensure_osx_locale()
+        ensure_macos_locale()
     try:
         locale.setlocale(locale.LC_ALL, '')
     except Exception:

--- a/setup.py
+++ b/setup.py
@@ -768,7 +768,7 @@ def option_parser():  # {{{
         'action',
         nargs='?',
         default='build',
-        choices='build test linux-package kitty.app osx-bundle clean'.split(),
+        choices='build test linux-package kitty.app macos-bundle clean'.split(),
         help='Action to perform (default is build)'
     )
     p.add_argument(
@@ -849,7 +849,7 @@ def main():
         if not os.path.exists(os.path.join(base, 'docs/_build/html')):
             run_tool(['make', 'docs'])
         package(args)
-    elif args.action == 'osx-bundle':
+    elif args.action == 'macos-bundle' or args.action == 'osx-bundle':
         build(args, native_optimizations=False)
         package(args, for_bundle=True)
     elif args.action == 'kitty.app':


### PR DESCRIPTION
I renamed some instances of `OS X` and `osx` to `macOS`, since that is the correct name since macOS 10.12 Sierra, which was released in September of 2016. `setup.py` can be called with `osx-bundle` as an argument. I added a new argument `macos-bundle` but kept the old one for backwards compatibility since I don't want to break anything. Should I keep that option in the list of `choices`?
Some instances of `osx` remain, mainly in `publish.py`, `.circleci/config.yml` and both in the filename and content of `update-on-ox` but I didn't change those because I'm too afraid, that that could break something.