### PR TITLE
macOS Finder Service to open a directory in a new kitty tab or window

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -264,6 +264,10 @@ class Boss:
         cwd_from = w.child.pid_for_cwd if w is not None else None
         self._new_os_window(args, cwd_from)
 
+    def new_os_window_with_wd(self, wd):
+        special_window = SpecialWindow(None, cwd=wd)
+        self._new_os_window(special_window)
+
     def add_child(self, window):
         self.child_monitor.add_child(window.id, window.child.pid, window.child.child_fd, window.screen)
         self.window_id_map[window.id] = window
@@ -936,6 +940,10 @@ class Boss:
         w = self.active_window_for_cwd
         cwd_from = w.child.pid_for_cwd if w is not None else None
         self._create_tab(args, cwd_from=cwd_from)
+
+    def new_tab_with_wd(self, wd):
+        special_window = SpecialWindow(None, cwd=wd)
+        self._new_tab(special_window)
 
     def _new_window(self, args, cwd_from=None):
         tab = self.active_tab

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -206,9 +206,13 @@ void send_prerendered_sprites_for_window(OSWindow *w);
 #ifdef __APPLE__
 void get_cocoa_key_equivalent(int, int, unsigned short*, int*);
 typedef enum {
-    PREFERENCES_WINDOW = 1, NEW_OS_WINDOW = 2
+    PREFERENCES_WINDOW = 1,
+    NEW_OS_WINDOW = 2,
+    NEW_OS_WINDOW_WITH_WD = 4,
+    NEW_TAB_WITH_WD = 8
 } CocoaPendingAction;
 void set_cocoa_pending_action(CocoaPendingAction action);
+void set_cocoa_pending_action_with_wd(CocoaPendingAction action, const char *wd);
 bool application_quit_requested();
 void request_application_quit();
 #endif

--- a/setup.py
+++ b/setup.py
@@ -724,6 +724,20 @@ Categories=System;TerminalEmulator;
             NSSupportsAutomaticGraphicsSwitching=True,
             LSApplicationCategoryType='public.app-category.utilities',
             LSEnvironment={'KITTY_LAUNCHED_BY_LAUNCH_SERVICES': '1'},
+            NSServices=[
+                {
+                    'NSMenuItem': {'default': 'New ' + appname + ' Tab Here'},
+                    'NSMessage': 'openTab',
+                    'NSRequiredContext': {'NSTextContent': 'FilePath'},
+                    'NSSendTypes': ['NSFilenamesPboardType', 'public.plain-text'],
+                },
+                {
+                    'NSMenuItem': {'default': 'New ' + appname + ' Window Here'},
+                    'NSMessage': 'openOSWindow',
+                    'NSRequiredContext': {'NSTextContent': 'FilePath'},
+                    'NSSendTypes': ['NSFilenamesPboardType', 'public.plain-text'],
+                },
+            ],
         )
         with open('Info.plist', 'wb') as fp:
             plistlib.dump(pl, fp)


### PR DESCRIPTION
This pull request is supposed to implement a service on macOS that allows opening a new OS or kitty window or tab from Finder. I'm pretty bad at programming in Objective-C, so keep that in mind. Any suggestions are very welcome. Right now it's only a proof of concept, it only prints a message and doesn't actually open a new tab or whatever yet. The new files are probably in the wrong folder (glfw). I'm not sure if the new header file is needed. The code from iTerm2 helped me a lot. Could this be a problem since iTerm2 is licensed under GPLv2? Or does that not matter since it's only a very small part of it, which has been modified quite a bit?