### PR TITLE
Update PATH if the exact kitty executable path is not already present

### DIFF
--- a/kitty/constants.py
+++ b/kitty/constants.py
@@ -24,13 +24,7 @@ def kitty_exe():
     if ans is None:
         rpath = getattr(sys, 'bundle_exe_dir', None)
         if not rpath:
-            items = frozenset(os.environ['PATH'].split(os.pathsep))
-            for candidate in items:
-                if os.access(os.path.join(candidate, 'kitty'), os.X_OK):
-                    rpath = candidate
-                    break
-            else:
-                rpath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'launcher')
+            rpath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'launcher')
         ans = kitty_exe.ans = os.path.join(rpath, 'kitty')
     return ans
 


### PR DESCRIPTION
When I tried to test the new notification feature, I got `ModuleNotFoundError: No module named 'kitty.update_check'`. This is because I started the newer kitty version from inside an older kitty version. When kitty starts, it looks in `PATH` if there is a kitty executable already present. If so, it does not add anything new to `PATH`. But since`update_check.py` calls
```
p = subprocess.Popen([
    'kitty', '+runpy', 'from kitty.update_check import *; import time; time.sleep(2); print(get_released_version())'
], stdout=subprocess.PIPE)
```
and `kitty` was still the old kitty version, I got the error because the old version didn't have that module yet.
To reproduce (at least on macOS, didn't try on Linux):
- `git checkout 10f5461c` (just some commit before this module became available)
- `make app`
- Move `kitty.app` somewhere else, e.g. the Desktop
- Open `kitty.app` on the Desktop
- `cd` to the kitty git directory
- `git checkout master`
- `make app`
- `kitty.app/Contents/MacOS/kitty`
- The error message of the second kitty instance will be printed in the first kitty instance

This pull request removes the functionality to check if a kitty exe is already in the path. `main.py` has a check `if rpath and rpath not in items` that only adds `rpath` to `PATH` if it is not already present. Do you see any issues with this fix? This is still not fool proof since the correct kitty version could be later in the path than a different, wrong version but it seems very unlikely that this would happen by accident.