### PR TITLE
Respect $SHELL environment variable

### DIFF
--- a/kitty/constants.py
+++ b/kitty/constants.py
@@ -119,7 +119,7 @@ logo_data_file = os.path.join(base_dir, 'logo', 'kitty.rgba')
 logo_png_file = os.path.join(base_dir, 'logo', 'kitty.png')
 beam_cursor_data_file = os.path.join(base_dir, 'logo', 'beam-cursor.png')
 try:
-    shell_path = pwd.getpwuid(os.geteuid()).pw_shell or '/bin/sh'
+    shell_path = os.getenv("SHELL", None) or pwd.getpwuid(os.geteuid()).pw_shell or '/bin/sh'
 except KeyError:
     try:
         print('Failed to read login shell via getpwuid() for current user, falling back to /bin/sh', file=sys.stderr)


### PR DESCRIPTION
According to `login(1)`:

The value for $HOME, $USER, $SHELL, $PATH, $LOGNAME, and $MAIL are set according to the appropriate  fields  in
the password entry.

Prefering `$SHELL` to the entry read from the password database makes it easy
for users to override the interactive shell without changing their login shell.

If you use a non-bash-compatible shell like "fish" as your shell, setting it as the login
shell might break some programs while just overriding SHELL can be done in a controlled way
and nicely scoped to only programs launched from the window manager for example (whereas setting the login shell is a somewhat global option that is not so easily changed for just a few programs).