### PR TITLE
Let all fatal messages begin with an upper case character

### DIFF
--- a/kitty/fonts.c
+++ b/kitty/fonts.c
@@ -399,8 +399,8 @@ calc_cell_metrics(FontGroup *fg) {
     if (OPT(adjust_column_width_frac) != 0.f) cell_width *= OPT(adjust_column_width_frac);
     cell_width = MAX(2, cell_width);
     int line_height_adjustment = cell_height - before_cell_height;
-    if (cell_height < 4) fatal("line height too small after adjustment");
-    if (cell_height > 1000) fatal("line height too large after adjustment");
+    if (cell_height < 4) fatal("Line height too small after adjustment");
+    if (cell_height > 1000) fatal("Line height too large after adjustment");
     underline_position = MIN(cell_height - 1, underline_position);
     // ensure there is at least a couple of pixels available to render styled underlines
     while (underline_position > baseline + 1 && cell_height - underline_position < 2) underline_position--;
@@ -1103,14 +1103,14 @@ send_prerendered_sprites(FontGroup *fg) {
     clear_canvas(fg);
     current_send_sprite_to_gpu((FONTS_DATA_HANDLE)fg, x, y, z, fg->canvas);
     do_increment(fg, &error);
-    if (error != 0) { sprite_map_set_error(error); PyErr_Print(); fatal("failed"); }
+    if (error != 0) { sprite_map_set_error(error); PyErr_Print(); fatal("Failed"); }
     PyObject *args = PyObject_CallFunction(prerender_function, "IIIIIdd", fg->cell_width, fg->cell_height, fg->baseline, fg->underline_position, fg->underline_thickness, fg->logical_dpi_x, fg->logical_dpi_y);
     if (args == NULL) { PyErr_Print(); fatal("Failed to pre-render cells"); }
     for (ssize_t i = 0; i < PyTuple_GET_SIZE(args) - 1; i++) {
         x = fg->sprite_tracker.x; y = fg->sprite_tracker.y; z = fg->sprite_tracker.z;
-        if (y > 0) { fatal("too many pre-rendered sprites for your GPU or the font size is too large"); }
+        if (y > 0) { fatal("Too many pre-rendered sprites for your GPU or the font size is too large"); }
         do_increment(fg, &error);
-        if (error != 0) { sprite_map_set_error(error); PyErr_Print(); fatal("failed"); }
+        if (error != 0) { sprite_map_set_error(error); PyErr_Print(); fatal("Failed"); }
         uint8_t *alpha_mask = PyLong_AsVoidPtr(PyTuple_GET_ITEM(args, i));
         clear_canvas(fg);
         Region r = { .right = fg->cell_width, .bottom = fg->cell_height };
@@ -1123,12 +1123,12 @@ send_prerendered_sprites(FontGroup *fg) {
 static inline size_t
 initialize_font(FontGroup *fg, unsigned int desc_idx, const char *ftype) {
     PyObject *d = PyObject_CallFunction(descriptor_for_idx, "I", desc_idx);
-    if (d == NULL) { PyErr_Print(); fatal("failed for %s font", ftype); }
+    if (d == NULL) { PyErr_Print(); fatal("Failed for %s font", ftype); }
     bool bold = PyObject_IsTrue(PyTuple_GET_ITEM(d, 1));
     bool italic = PyObject_IsTrue(PyTuple_GET_ITEM(d, 2));
     PyObject *face = desc_to_face(PyTuple_GET_ITEM(d, 0), (FONTS_DATA_HANDLE)fg);
     Py_CLEAR(d);
-    if (face == NULL) { PyErr_Print(); fatal("failed to convert descriptor to face for %s font", ftype); }
+    if (face == NULL) { PyErr_Print(); fatal("Failed to convert descriptor to face for %s font", ftype); }
     size_t idx = fg->fonts_count++;
     bool ok = init_font(fg->fonts + idx, face, bold, italic, false);
     Py_CLEAR(face);

--- a/kitty/gl.h
+++ b/kitty/gl.h
@@ -208,7 +208,7 @@ create_buffer(GLenum usage) {
         }
     }
     glDeleteBuffers(1, &buffer_id);
-    fatal("too many buffers");
+    fatal("Too many buffers");
     return -1;
 }
 
@@ -274,7 +274,7 @@ create_vao() {
         }
     }
     glDeleteVertexArrays(1, &vao_id);
-    fatal("too many VAOs");
+    fatal("Too many VAOs");
     return -1;
 }
 
@@ -282,7 +282,7 @@ static size_t
 add_buffer_to_vao(ssize_t vao_idx, GLenum usage) {
     VAO* vao = vaos + vao_idx;
     if (vao->num_buffers >= sizeof(vao->buffers) / sizeof(vao->buffers[0])) {
-        fatal("too many buffers in a single VAO");
+        fatal("Too many buffers in a single VAO");
     }
     ssize_t buf = create_buffer(usage);
     vao->buffers[vao->num_buffers++] = buf;

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -372,7 +372,7 @@ draw_cells_interleaved_premult(ssize_t vao_idx, ssize_t gvao_idx, Screen *screen
     glBindTexture(GL_TEXTURE_2D, 0);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, offscreen_framebuffer);
     glFramebufferTexture(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, os_window->offscreen_texture_id, 0);
-    /* if (glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) fatal("offscreen framebuffer not complete"); */
+    /* if (glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) fatal("Offscreen framebuffer not complete"); */
 
     bind_program(CELL_BG_PROGRAM);
     glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, screen->lines * screen->columns);


### PR DESCRIPTION
I think most `fatal()` messages begin with an upper case character so I changed the lower case ones. I didn't change the one message beginning with `read_png_error_handler:` as that is a function name.