### PR TITLE
Fix function returning the wrong type

### DIFF
--- a/glfw/ibus_glfw.c
+++ b/glfw/ibus_glfw.c
@@ -56,7 +56,7 @@ test_env_var(const char *name, const char *val) {
     return (q && strcmp(q, val) == 0) ? GLFW_TRUE : GLFW_FALSE;
 }
 
-static inline GLFWbool
+static inline size_t
 MIN(size_t a, size_t b) {
     return a < b ? a : b;
 }


### PR DESCRIPTION
Im pretty sure this function is not supposed to return a boolean. I think this function is only used for `memcpy(ans, addr, MIN(strlen(addr), sizeof(ans)));`. Using a boolean here means that `memcpy()` copies at most one byte (I think). What sort of bugs would this cause?