### PR TITLE
Check if a pointer is null earlier

### DIFF
--- a/kittens/choose/main.c
+++ b/kittens/choose/main.c
@@ -193,6 +193,7 @@ match(PyObject *self, PyObject *args) {
             &output_positions, &limit, &opts.num_threads,
             &mark_before, &mark_after, &delimiter
     )) return NULL;
+    if (!lines) { return PyErr_NoMemory(); }
     opts.output_positions = output_positions ? true : false;
     opts.limit = limit;
     global.level1_len = copy_unicode_object(PyTuple_GET_ITEM(levels, 0), global.level1, arraysz(global.level1));
@@ -205,7 +206,7 @@ match(PyObject *self, PyObject *args) {
     size_t num_lines = PyList_GET_SIZE(lines);
     char **clines = malloc(sizeof(char*) * num_lines);
     size_t *sizes = malloc(sizeof(size_t) * num_lines);
-    if (!lines || !sizes) { return PyErr_NoMemory(); }
+    if (!sizes) { return PyErr_NoMemory(); }
     for (size_t i = 0; i < num_lines; i++) {
         clines[i] = PyBytes_AS_STRING(PyList_GET_ITEM(lines, i));
         sizes[i] = PyBytes_GET_SIZE(PyList_GET_ITEM(lines, i));


### PR DESCRIPTION
If `lines` is `NULL` but `sizes` is not `NULL`, we have a memory leak here. To prevent that, I check if `lines` is `NULL` earlier. I'm not sure if this is the correct place to put this line or if it should be placed a few lines below, just before `size_t num_lines = PyList_GET_SIZE(lines);`. I don't know what the few lines between the two places do and if they should be executed if `lines` is `NULL`.