### PR TITLE
Fix memory leak

### DIFF
--- a/kittens/choose/main.c
+++ b/kittens/choose/main.c
@@ -206,7 +206,7 @@ match(PyObject *self, PyObject *args) {
     char **clines = malloc(sizeof(char*) * num_lines);
     if (!clines) { return PyErr_NoMemory(); }
     size_t *sizes = malloc(sizeof(size_t) * num_lines);
-    if (!sizes) { return PyErr_NoMemory(); }
+    if (!sizes) { free(clines); clines = NULL; return PyErr_NoMemory(); }
     for (size_t i = 0; i < num_lines; i++) {
         clines[i] = PyBytes_AS_STRING(PyList_GET_ITEM(lines, i));
         sizes[i] = PyBytes_GET_SIZE(PyList_GET_ITEM(lines, i));


### PR DESCRIPTION
If `sizes` is `NULL`, then `clines` isn't freed. This pull request fixes that. I added `clines = NULL` because I think it's good practice but it doesn't do anything here, so if you don't like it, you can remove it.