### PR TITLE
Fix memory leak

### DIFF
--- a/kittens/choose/main.c
+++ b/kittens/choose/main.c
@@ -128,8 +128,9 @@ run_search(Options *opts, GlobalData *global, const char * const *lines, const s
     Chars chars = {0};
 
     ALLOC_VEC(text_t, chars, 8192 * 20);
+    if (chars.data == NULL) return 1;
     ALLOC_VEC(Candidate, candidates, 8192);
-    if (chars.data == NULL || candidates.data == NULL) return 1;
+    if (candidates.data == NULL) { FREE_VEC(candidates) return 1; }
 
     for (size_t i = 0; i < num_lines; i++) {
         sz = sizes[i];


### PR DESCRIPTION
If either `chars.data` or `candidates.data` is `NULL`, then the other one isn't freed, this pull request fixes that. I didn't put a semicolon behind `FREE_VEC(candidates)` because the definition of `FREE_VEC(vec)` already has a semicolon at the end.