### PR TITLE
Consistent case for color codes

### DIFF
--- a/kittens/diff/config_data.py
+++ b/kittens/diff/config_data.py
@@ -85,7 +85,7 @@ c('hunk_bg', '#f1f8ff')
 
 c('search_bg', '#444', long_text=_('Highlighting'))
 c('search_fg', 'white')
-c('select_bg', '#B4D5FE')
+c('select_bg', '#b4d5fe')
 c('select_fg', 'black')
 
 g('shortcuts')

--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -371,7 +371,7 @@ Use negative numbers to change scroll direction.'''))
 
 g('mouse')  # {{{
 
-o('url_color', '#0087BD', option_type=to_color, long_text=_('''
+o('url_color', '#0087bd', option_type=to_color, long_text=_('''
 The color and style for highlighting URLs on mouse-over.
 :code:`url_style` can be one of: none, single, double, curly'''))
 
@@ -693,7 +693,7 @@ def selection_foreground(x):
 
 o('selection_foreground', '#000000', option_type=selection_foreground, long_text=_('''
 The foreground for text selected with the mouse. A value of none means to leave the color unchanged.'''))
-o('selection_background', '#FFFACD', option_type=to_color, long_text=_('''
+o('selection_background', '#fffacd', option_type=to_color, long_text=_('''
 The background for text selected with the mouse.'''))
 
 g('colors.table')


### PR DESCRIPTION
Most color codes are lower case. This pull request changes three color codes that have upper case characters in them.