### PR TITLE
Allow no-append in clipboard_control

### DIFF
--- a/docs/protocol-extensions.rst
+++ b/docs/protocol-extensions.rst
@@ -219,3 +219,7 @@ first, for example::
     <ESC>]52;c;!<ESC>\
 
 Here ``!`` is not valid base64 encoded text, so it clears the clipboard.
+
+In case you're using software that can't be easily adapted to this
+protocol extension, it can be disabled by specifying ``no-append`` to the
+:opt:`clipboard_control` setting.

--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -798,8 +798,10 @@ Environment variables in the path are expanded.
 o('clipboard_control', 'write-clipboard write-primary', option_type=lambda x: frozenset(x.lower().split()), long_text=_('''
 Allow programs running in kitty to read and write from the clipboard. You can
 control exactly which actions are allowed. The set of possible actions is:
-write-clipboard read-clipboard write-primary read-primary
-The default is to allow writing to the clipboard and primary selection. Note
+write-clipboard read-clipboard write-primary read-primary. You can
+additionally specify no-append to disable kitty's protocol extension
+for clipboard concatenation. The default is to allow writing to the
+clipboard and primary selection with concatenation enabled. Note
 that enabling the read functionality is a security risk as it means that any
 program, even one running on a remote server via SSH can read your clipboard.
 '''))

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -429,7 +429,8 @@ class Window:
 
             def write(key, func):
                 if text:
-                    if len(self.clipboard_control_buffers[key]) > 1024*1024:
+                    if ('no-append' in self.opts.clipboard_control or
+                            len(self.clipboard_control_buffers[key]) > 1024*1024):
                         self.clipboard_control_buffers[key] = ''
                     self.clipboard_control_buffers[key] += text
                 else:


### PR DESCRIPTION
If no-append is present in clipboard_control, this will disable kitty's OSC 52 extension of concatenating to the clipboard. See #995

This is a compromise that I hope will be acceptable, since it doesn't change kitty's default behavior, and won't catch existing users off-guard.

I also considered using a separate option, but it seems unnecessary to add yet another option for something that only tweaks the behavior of OSC 52. Let me know if you'd prefer a separate option and I'm happy to update the PR.