### PR TITLE
Improve terminfo compilation code

### DIFF
--- a/build-terminfo
+++ b/build-terminfo
@@ -2,17 +2,15 @@
 
 import os
 import sys
-import shutil
-import subprocess
 
 base = os.path.dirname(os.path.abspath(__file__))
 os.chdir(base)
 sys.path.insert(0, base)
 
 from kitty.terminfo import generate_terminfo  # noqa
+from kitty.terminfo import compile_terminfo
 
 with open('terminfo/kitty.terminfo', 'w') as f:
     f.write(generate_terminfo())
 
-os.environ['TERMINFO'] = os.path.join(base, 'terminfo')
-subprocess.check_call(['tic', '-x', 'terminfo/kitty.terminfo'])
+compile_terminfo(base)

--- a/setup.py
+++ b/setup.py
@@ -635,16 +635,9 @@ def package(args, for_bundle=False, sh_launcher=False):
     if os.path.exists(libdir):
         shutil.rmtree(libdir)
     os.makedirs(os.path.join(libdir, 'logo'))
+    from kitty.terminfo import compile_terminfo
     for x in (libdir, os.path.join(ddir, 'share')):
-        odir = os.path.join(x, 'terminfo')
-        safe_makedirs(odir)
-        proc = subprocess.run(['tic', '-x', '-o' + odir, 'terminfo/kitty.terminfo'], check=True, stderr=subprocess.PIPE)
-        regex = '^"terminfo/kitty.terminfo", line [0-9]+, col [0-9]+, terminal \'xterm-kitty\': older tic versions may treat the description field as an alias$'
-        for error in proc.stderr.decode('utf-8').splitlines():
-            if not re.match(regex, error):
-                print(error, file=sys.stderr)
-        if not glob.glob(os.path.join(odir, '*/xterm-kitty')):
-            raise SystemExit('tic failed to output the compiled kitty terminfo file')
+        compile_terminfo(x)
     shutil.copy2('__main__.py', libdir)
     shutil.copy2('logo/kitty.rgba', os.path.join(libdir, 'logo'))
     shutil.copy2('logo/kitty.png', os.path.join(libdir, 'logo'))


### PR DESCRIPTION
`setup.py` and `build-terminfo` do essentially the same thing when compiling the terminfo file by calling `tic` so I moved the common functionality into a new function in `kitty/terminfo.py` and hopefully improved things along the way.
The code in `setup.py` had a check `if not glob.glob(os.path.join(odir, '*/xterm-kitty'))` that checked if `tic` actually wrote the file to the filesystem. `build-terminfo` did not have this functionality. Here the same check would not work because the file would already exist before executing `tic`. I solved this by simply creating an temporary directory and letting `tic` write the file there. I can then check if the file exists and move it to the correct location.
I was also very careful to not assume if the output directory is called `x` or `78`; I simply create the destination directory (e.g. `terminfo/x` or `terminfo/78`) if it doesn't exist already and copy the compiled terminfo file into it. `build-terminfo` was setting the output directory with the `TERMINFO` environment variable while `setup.py` set it via the `-o` command line option. I chose to use the second option.
I also kept my stderr filtering code so that the output from `build-terminfo` is now also filtered. Let me know what you think about that change.
You should also look at the new imports and if they are in a good place or if they should be somewhere else (if the imports in the middle of the code should be at the beginning of the file and if the imports at the beginning of a file should be in a function).