### PR TITLE
Add --help to options_spec

### DIFF
--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -463,6 +463,10 @@ def parse_cmdline(oc, disabled, args=None):
 def options_spec():
     if not hasattr(options_spec, 'ans'):
         OPTIONS = '''
+--help -h
+Receive help from and for kitty.
+
+
 --class
 dest=cls
 default={appname}


### PR DESCRIPTION
Needed to show `--help` and `-h` in completion.