### PR TITLE
Allow using the macOS "Quit" dock menu item after the last OS window has been closed with "macos_quit_when_last_window_closed" being set to no

### DIFF
--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -117,7 +117,7 @@ blank_os_window(OSWindow *w) {
 
 static void
 window_close_callback(GLFWwindow* window) {
-    if (!set_callback_window(window)) return;
+    set_callback_window(window);
     global_state.has_pending_closes = true;
     request_tick_callback();
     global_state.callback_os_window = NULL;
@@ -539,6 +539,7 @@ create_os_window(PyObject UNUSED *self, PyObject *args) {
 #ifdef __APPLE__
     if (is_first_window && !application_quit_canary) {
         application_quit_canary = glfwCreateWindow(100, 200, "quit_canary", NULL, NULL);
+        glfwSetWindowCloseCallback(application_quit_canary, window_close_callback);
     }
     if (!common_context) common_context = application_quit_canary;
 #endif


### PR DESCRIPTION
Steps to reproduce the issue I had:

1. Set `macos_quit_when_last_window_closed` to `no` (the default)
2. Open kitty (on macOS)
3. Make the program running inside kitty exit, e.g. ctrl-d
4. Right-click on the kitty dock icon
5. Click on quit (might be called slightly differently, it's in my native language for me)
6. Nothing happens

To actually quit after that, click in the kitty icon in the dock, a new OS window will open and make the program running inside kitty quit again. This can be very annoying.

The issue is caused by the `application_quit_canary` not doing anything besides changing a variable. Normal windows call `window_close_callback()` when the OS calls `applicationShouldTerminate()`, so I added that callback to the `application_quit_canary` too. I'm however not sure if the way I did it is the best way.
Also, removing the `if` statement and `return` from `window_close_callback()` feels very hacky as I have no idea what it was originally for but without that change, this patch doesn't work. Maybe you can find a proper solution.