### PR TITLE
Do not render ligatures under cursor

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -256,6 +256,11 @@ Syntax is::
 
 '''))
 
+o('disable_ligatures_under_cursor', False, long_text=_('''
+Render the characters of a ligature under the cursor individually
+to make editing more intuitive.
+'''))
+
 
 def box_drawing_scale(x):
     ans = tuple(float(x.strip()) for x in x.split(','))

--- a/kitty/fonts.h
+++ b/kitty/fonts.h
@@ -34,7 +34,7 @@ PyObject* face_from_descriptor(PyObject*, FONTS_DATA_HANDLE);
 
 void sprite_tracker_current_layout(FONTS_DATA_HANDLE data, unsigned int *x, unsigned int *y, unsigned int *z);
 void render_alpha_mask(uint8_t *alpha_mask, pixel* dest, Region *src_rect, Region *dest_rect, size_t src_stride, size_t dest_stride);
-void render_line(FONTS_DATA_HANDLE, Line *line);
+void render_line(FONTS_DATA_HANDLE, Line *line, index_type lnum, Cursor *cursor);
 void sprite_tracker_set_limits(size_t max_texture_size, size_t max_array_len);
 typedef void (*free_extra_data_func)(void*);
 StringCanvas render_simple_text_impl(PyObject *s, const char *text, unsigned int baseline);

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -1468,7 +1468,7 @@ screen_reset_dirty(Screen *self) {
 }
 
 void
-screen_update_cell_data(Screen *self, void *address, FONTS_DATA_HANDLE fonts_data) {
+screen_update_cell_data(Screen *self, void *address, FONTS_DATA_HANDLE fonts_data, bool update_cursor_pos) {
     unsigned int history_line_added_count = self->history_line_added_count;
     index_type lnum;
     bool was_dirty = self->is_dirty;
@@ -1478,8 +1478,9 @@ screen_update_cell_data(Screen *self, void *address, FONTS_DATA_HANDLE fonts_dat
     for (index_type y = 0; y < MIN(self->lines, self->scrolled_by); y++) {
         lnum = self->scrolled_by - 1 - y;
         historybuf_init_line(self->historybuf, lnum, self->historybuf->line);
-        if (self->historybuf->line->has_dirty_text) {
-            render_line(fonts_data, self->historybuf->line);
+        if (self->historybuf->line->has_dirty_text ||
+            (update_cursor_pos && (self->cursor->y == lnum || self->last_rendered_cursor_y == lnum))) {
+            render_line(fonts_data, self->historybuf->line, lnum, self->cursor);
             historybuf_mark_line_clean(self->historybuf, lnum);
         }
         update_line_data(self->historybuf->line, y, address);
@@ -1487,8 +1488,9 @@ screen_update_cell_data(Screen *self, void *address, FONTS_DATA_HANDLE fonts_dat
     for (index_type y = self->scrolled_by; y < self->lines; y++) {
         lnum = y - self->scrolled_by;
         linebuf_init_line(self->linebuf, lnum);
-        if (self->linebuf->line->has_dirty_text) {
-            render_line(fonts_data, self->linebuf->line);
+        if (self->linebuf->line->has_dirty_text ||
+            (update_cursor_pos && (self->cursor->y == lnum || self->last_rendered_cursor_y == lnum))) {
+            render_line(fonts_data, self->linebuf->line, lnum, self->cursor);
             linebuf_mark_line_clean(self->linebuf, lnum);
         }
         update_line_data(self->linebuf->line, y, address);

--- a/kitty/screen.h
+++ b/kitty/screen.h
@@ -65,6 +65,7 @@ typedef struct {
     PyObject_HEAD
 
     unsigned int columns, lines, margin_top, margin_bottom, charset, scrolled_by, last_selection_scrolled_by;
+    unsigned int last_rendered_cursor_x, last_rendered_cursor_y;
     CellPixelSize cell_size;
     OverlayLine overlay_line;
     id_type window_id;
@@ -176,7 +177,7 @@ void screen_apply_selection(Screen *self, void *address, size_t size);
 bool screen_is_selection_dirty(Screen *self);
 bool screen_has_selection(Screen*);
 bool screen_invert_colors(Screen *self);
-void screen_update_cell_data(Screen *self, void *address, FONTS_DATA_HANDLE);
+void screen_update_cell_data(Screen *self, void *address, FONTS_DATA_HANDLE, bool update_cursor_pos);
 bool screen_is_cursor_visible(Screen *self);
 bool screen_selection_range_for_line(Screen *self, index_type y, index_type *start, index_type *end);
 bool screen_selection_range_for_word(Screen *self, index_type x, index_type *, index_type *, index_type *start, index_type *end);

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -286,12 +286,20 @@ cell_prepare_to_render(ssize_t vao_idx, ssize_t gvao_idx, Screen *screen, GLfloa
 
     ensure_sprite_map(fonts_data);
 
-    if (screen->scroll_changed || screen->is_dirty) {
+    bool cursor_pos_changed = screen->cursor->x != screen->last_rendered_cursor_x
+                           || screen->cursor->y != screen->last_rendered_cursor_y;
+
+    if (screen->scroll_changed || screen->is_dirty || (OPT(disable_ligatures_under_cursor) && cursor_pos_changed)) {
         sz = sizeof(GPUCell) * screen->lines * screen->columns;
         address = alloc_and_map_vao_buffer(vao_idx, sz, cell_data_buffer, GL_STREAM_DRAW, GL_WRITE_ONLY);
-        screen_update_cell_data(screen, address, fonts_data);
+        screen_update_cell_data(screen, address, fonts_data, OPT(disable_ligatures_under_cursor) && cursor_pos_changed);
         unmap_vao_buffer(vao_idx, cell_data_buffer); address = NULL;
         changed = true;
+    }
+
+    if (cursor_pos_changed) {
+        screen->last_rendered_cursor_x = screen->cursor->x;
+        screen->last_rendered_cursor_y = screen->cursor->y;
     }
 
     if (screen_is_selection_dirty(screen)) {

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -403,6 +403,7 @@ PYWRAP1(set_options) {
     S(macos_hide_from_tasks, PyObject_IsTrue);
     S(macos_thicken_font, PyFloat_AsDouble);
     S(tab_bar_min_tabs, PyLong_AsUnsignedLong);
+    S(disable_ligatures_under_cursor, PyObject_IsTrue);
 
     GA(tab_bar_style);
     global_state.tab_bar_hidden = PyUnicode_CompareWithASCIIString(ret, "hidden") == 0 ? true: false;

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -35,6 +35,7 @@ typedef struct {
     float window_padding_width;
     Edge tab_bar_edge;
     unsigned long tab_bar_min_tabs;
+    bool disable_ligatures_under_cursor;
     bool sync_to_monitor;
     bool close_on_child_death;
     bool window_alert_on_bell;


### PR DESCRIPTION
In #461 you gave a few helpful tips, and after a couple hours of trying different things, I came up with the following code that doesn't even touch any CPU or GPU cells and seems to work as a proof of concept. There is a line `render_ligature = (i != 4)` with a constant (4 in this case). All ligatures beginning in the third cell from the left of the screen will be rendered as individual characters.
Does this look promising to you? Is this the right approach?