### PR TITLE
Double-click + drag to select multiple words

### DIFF
--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -321,7 +321,7 @@ multi_click(Window *w, unsigned int count) {
     }
     if (found_selection) {
         screen_start_selection(screen, start, y1, false, mode);
-        screen_update_selection(screen, end, y2, true);
+        screen_update_selection(screen, end, y2, false);
     }
 }
 


### PR DESCRIPTION
I know that you wrote in #1516 that this was never an intended feature, but as I wrote in the commit message:

> I believe this behaviour has come to be expected by users, since GNOME Terminal, Terminator, xterm, rxvt, major browsers, LibreOffice, and many more significant applications have it.