### PR TITLE
Add option to disable switching to the previous tab when closing the current one.

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -631,6 +631,11 @@ o('tab_bar_min_tabs', 2, option_type=lambda x: max(1, positive_int(x)), long_tex
 The minimum number of tabs that must exist before the tab bar is shown
 '''))
 
+o('tab_bar_switch_to_previous_when_closing_current_tab', True, long_text=_('''
+Switch to the previously active tab when the current tab is closed. The default is yes.
+If no, the tab to the left of the current tab is selected when the current tab is closed.
+'''))
+
 
 def tab_fade(x):
     return tuple(map(unit_float, x.split()))

--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -562,6 +562,16 @@ class TabManager:  # {{{
                     break
         if next_active_tab < 0:
             next_active_tab = max(0, min(self.active_tab_idx, len(self.tabs) - 1))
+
+        if not self.opts.tab_bar_switch_to_previous_when_closing_current_tab:
+            # When we do not switch to the previously active tab, we set the next left tab
+            # as active. Unless there are no further tabs on the left, in which case
+            # we select the new leftmost tab.
+            if self.active_tab_idx > 0:
+                next_active_tab = self.active_tab_idx - 1
+            else:
+                next_active_tab = 0
+
         self._set_active_tab(next_active_tab)
         self.mark_tab_bar_dirty()
         tab.destroy()


### PR DESCRIPTION
When setting `tab_bar_switch_to_previous_when_closing_current_tab` kitty will now switch to the left tab instead of the previously active one when the currently active tab is closed. This makes the closing of tabs a bit more predictable. It works well in my workflows as I tend to open and close a lot of tabs.

Note that we are not touching the handling of the active_tab_history at all. I was considering it, but we want to keep track of it in any case to keep the 'switch to previous tab' shortcut working.

Thanks!