### PR TITLE
Respect macOS selection color

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -1521,10 +1521,10 @@ double _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window)
 
 
 int _glfwPlatformGetSelectionColor(_GLFWwindow* window,
-                                    uint8_t* red,
-                                    uint8_t* green,
-                                    uint8_t* blue,
-                                    uint8_t* alpha)
+                                   uint8_t* red,
+                                   uint8_t* green,
+                                   uint8_t* blue,
+                                   uint8_t* alpha)
 {
     NSColorSpace *colorSpace = [NSColorSpace deviceRGBColorSpace]; // genericRGBColorSpace
     NSColor *aColor = [[NSColor selectedControlColor] colorUsingColorSpace:colorSpace];

--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -1518,6 +1518,25 @@ double _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window)
     return [NSEvent doubleClickInterval];
 }
 
+
+
+int _glfwPlatformGetSelectionColor(_GLFWwindow* window,
+                                    uint8_t* red,
+                                    uint8_t* green,
+                                    uint8_t* blue,
+                                    uint8_t* alpha)
+{
+    NSColorSpace *colorSpace = [NSColorSpace deviceRGBColorSpace]; // genericRGBColorSpace
+    NSColor *aColor = [[NSColor selectedControlColor] colorUsingColorSpace:colorSpace];
+    if (!aColor) return GLFW_FALSE;
+    //NSLog(@"%@", aColor);
+    *red    = 255 * aColor.redComponent;
+    *green  = 255 * aColor.greenComponent;
+    *blue   = 255 * aColor.blueComponent;
+    *alpha  = 255 * aColor.alphaComponent;
+    return GLFW_TRUE;
+}
+
 void _glfwPlatformIconifyWindow(_GLFWwindow* window)
 {
     [window->ns.object miniaturize:nil];

--- a/glfw/glfw3.h
+++ b/glfw/glfw3.h
@@ -3012,6 +3012,35 @@ GLFWAPI void glfwGetWindowContentScale(GLFWwindow* window, float* xscale, float*
  */
 GLFWAPI double glfwGetDoubleClickInterval(GLFWwindow* window);
 
+/*! @brief Retrieves the selection color.
+ *
+ *  This function retrieves the red, green, blue and alpha components of
+ *  the color used for selection and returns GLFW_TRUE if successful.
+ *
+ *  The four color components are numbers between 0 and 255. If the
+ *  system does not support a double click interval, this function always returns GLFW_FALSE.
+ *
+ *  @return GLFW_FALSE if success.
+ *
+ *  @param[in] window The window to query.
+ *  @param[out] red The red color component.
+ *  @param[out] red The green color component.
+ *  @param[out] red The blue color component.
+ *  @param[out] red The alpha color component.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref selection_color
+ *
+ *  @since Added in version 3.3.
+ *
+ *  @ingroup window
+ */
+GLFWAPI int glfwGetPlatformSelectionColor(GLFWwindow* window, uint8_t* red, uint8_t* green, uint8_t* blue, uint8_t* alpha);
+
 /*! @brief Returns the opacity of the whole window.
  *
  *  This function returns the opacity of the window, including any decorations.

--- a/glfw/internal.h
+++ b/glfw/internal.h
@@ -662,6 +662,7 @@ void _glfwPlatformGetWindowFrameSize(_GLFWwindow* window,
 void _glfwPlatformGetWindowContentScale(_GLFWwindow* window,
                                         float* xscale, float* yscale);
 double _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window);
+int _glfwPlatformGetSelectionColor(_GLFWwindow* window, uint8_t* red, uint8_t* green, uint8_t* blue, uint8_t* alpha);
 void _glfwPlatformIconifyWindow(_GLFWwindow* window);
 void _glfwPlatformRestoreWindow(_GLFWwindow* window);
 void _glfwPlatformMaximizeWindow(_GLFWwindow* window);

--- a/glfw/null_window.c
+++ b/glfw/null_window.c
@@ -154,10 +154,10 @@ double _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window)
 }
 
 int _glfwPlatformGetSelectionColor(_GLFWwindow* window,
-                                    uint8_t* UNUSED red,
-                                    uint8_t* UNUSED green,
-                                    uint8_t* UNUSED blue,
-                                    uint8_t* UNUSED alpha)
+                                    uint8_t* red,
+                                    uint8_t* green,
+                                    uint8_t* blue,
+                                    uint8_t* alpha)
 {
     return GLFW_FALSE;
 }

--- a/glfw/null_window.c
+++ b/glfw/null_window.c
@@ -153,6 +153,15 @@ double _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window)
     return 0.5;
 }
 
+int _glfwPlatformGetSelectionColor(_GLFWwindow* window,
+                                    uint8_t* UNUSED red,
+                                    uint8_t* UNUSED green,
+                                    uint8_t* UNUSED blue,
+                                    uint8_t* UNUSED alpha)
+{
+    return GLFW_FALSE;
+}
+
 void _glfwPlatformIconifyWindow(_GLFWwindow* window)
 {
 }

--- a/glfw/null_window.c
+++ b/glfw/null_window.c
@@ -154,10 +154,10 @@ double _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window)
 }
 
 int _glfwPlatformGetSelectionColor(_GLFWwindow* window,
-                                    uint8_t* red,
-                                    uint8_t* green,
-                                    uint8_t* blue,
-                                    uint8_t* alpha)
+                                   uint8_t* red,
+                                   uint8_t* green,
+                                   uint8_t* blue,
+                                   uint8_t* alpha)
 {
     return GLFW_FALSE;
 }

--- a/glfw/window.c
+++ b/glfw/window.c
@@ -744,6 +744,19 @@ GLFWAPI double glfwGetDoubleClickInterval(GLFWwindow* handle)
     return _glfwPlatformGetDoubleClickInterval(window);
 }
 
+GLFWAPI int glfwGetPlatformSelectionColor(GLFWwindow* handle,
+                                           uint8_t* red,
+                                           uint8_t* green,
+                                           uint8_t* blue,
+                                           uint8_t* alpha)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    assert(window != NULL);
+
+    _GLFW_REQUIRE_INIT_OR_RETURN(GLFW_FALSE);
+    return _glfwPlatformGetSelectionColor(window, red, green, blue, alpha);
+}
+
 GLFWAPI float glfwGetWindowOpacity(GLFWwindow* handle)
 {
     _GLFWwindow* window = (_GLFWwindow*) handle;

--- a/glfw/window.c
+++ b/glfw/window.c
@@ -745,10 +745,10 @@ GLFWAPI double glfwGetDoubleClickInterval(GLFWwindow* handle)
 }
 
 GLFWAPI int glfwGetPlatformSelectionColor(GLFWwindow* handle,
-                                           uint8_t* red,
-                                           uint8_t* green,
-                                           uint8_t* blue,
-                                           uint8_t* alpha)
+                                          uint8_t* red,
+                                          uint8_t* green,
+                                          uint8_t* blue,
+                                          uint8_t* alpha)
 {
     _GLFWwindow* window = (_GLFWwindow*) handle;
     assert(window != NULL);

--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -1177,10 +1177,10 @@ double _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window)
 }
 
 int _glfwPlatformGetSelectionColor(_GLFWwindow* window,
-                                    uint8_t* red,
-                                    uint8_t* green,
-                                    uint8_t* blue,
-                                    uint8_t* alpha)
+                                   uint8_t* red,
+                                   uint8_t* green,
+                                   uint8_t* blue,
+                                   uint8_t* alpha)
 {
     return GLFW_FALSE;
 }

--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -1177,10 +1177,10 @@ double _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window)
 }
 
 int _glfwPlatformGetSelectionColor(_GLFWwindow* window,
-                                    uint8_t* UNUSED red,
-                                    uint8_t* UNUSED green,
-                                    uint8_t* UNUSED blue,
-                                    uint8_t* UNUSED alpha)
+                                    uint8_t* red,
+                                    uint8_t* green,
+                                    uint8_t* blue,
+                                    uint8_t* alpha)
 {
     return GLFW_FALSE;
 }

--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -1176,6 +1176,15 @@ double _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window)
     return 0.5;
 }
 
+int _glfwPlatformGetSelectionColor(_GLFWwindow* window,
+                                    uint8_t* UNUSED red,
+                                    uint8_t* UNUSED green,
+                                    uint8_t* UNUSED blue,
+                                    uint8_t* UNUSED alpha)
+{
+    return GLFW_FALSE;
+}
+
 void _glfwPlatformIconifyWindow(_GLFWwindow* window)
 {
     if (_glfw.wl.wmBase)

--- a/glfw/x11_window.c
+++ b/glfw/x11_window.c
@@ -2116,6 +2116,15 @@ double _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window)
     return 0.5;
 }
 
+int _glfwPlatformGetSelectionColor(_GLFWwindow* window,
+                                    uint8_t* UNUSED red,
+                                    uint8_t* UNUSED green,
+                                    uint8_t* UNUSED blue,
+                                    uint8_t* UNUSED alpha)
+{
+    return GLFW_FALSE;
+}
+
 void _glfwPlatformIconifyWindow(_GLFWwindow* window)
 {
     if (window->x11.overrideRedirect)

--- a/glfw/x11_window.c
+++ b/glfw/x11_window.c
@@ -2117,10 +2117,10 @@ double _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window)
 }
 
 int _glfwPlatformGetSelectionColor(_GLFWwindow* window,
-                                    uint8_t* red,
-                                    uint8_t* green,
-                                    uint8_t* blue,
-                                    uint8_t* alpha)
+                                   uint8_t* red,
+                                   uint8_t* green,
+                                   uint8_t* blue,
+                                   uint8_t* alpha)
 {
     return GLFW_FALSE;
 }

--- a/glfw/x11_window.c
+++ b/glfw/x11_window.c
@@ -2117,10 +2117,10 @@ double _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window)
 }
 
 int _glfwPlatformGetSelectionColor(_GLFWwindow* window,
-                                    uint8_t* UNUSED red,
-                                    uint8_t* UNUSED green,
-                                    uint8_t* UNUSED blue,
-                                    uint8_t* UNUSED alpha)
+                                    uint8_t* red,
+                                    uint8_t* green,
+                                    uint8_t* blue,
+                                    uint8_t* alpha)
 {
     return GLFW_FALSE;
 }

--- a/kitty/glfw-wrapper.c
+++ b/kitty/glfw-wrapper.c
@@ -155,6 +155,9 @@ load_glfw(const char* path) {
     *(void **) (&glfwGetDoubleClickInterval_impl) = dlsym(handle, "glfwGetDoubleClickInterval");
     if (glfwGetDoubleClickInterval_impl == NULL) fail("Failed to load glfw function glfwGetDoubleClickInterval with error: %s", dlerror());
 
+    *(void **) (&glfwGetPlatformSelectionColor_impl) = dlsym(handle, "glfwGetPlatformSelectionColor");
+    if (glfwGetPlatformSelectionColor_impl == NULL) fail("Failed to load glfw function glfwGetPlatformSelectionColor with error: %s", dlerror());
+
     *(void **) (&glfwGetWindowOpacity_impl) = dlsym(handle, "glfwGetWindowOpacity");
     if (glfwGetWindowOpacity_impl == NULL) fail("Failed to load glfw function glfwGetWindowOpacity with error: %s", dlerror());
 

--- a/kitty/glfw-wrapper.h
+++ b/kitty/glfw-wrapper.h
@@ -1596,6 +1596,10 @@ typedef double (*glfwGetDoubleClickInterval_func)(GLFWwindow*);
 glfwGetDoubleClickInterval_func glfwGetDoubleClickInterval_impl;
 #define glfwGetDoubleClickInterval glfwGetDoubleClickInterval_impl
 
+typedef int (*glfwGetPlatformSelectionColor_func)(GLFWwindow*, uint8_t*, uint8_t*, uint8_t*, uint8_t*);
+glfwGetPlatformSelectionColor_func glfwGetPlatformSelectionColor_impl;
+#define glfwGetPlatformSelectionColor glfwGetPlatformSelectionColor_impl
+
 typedef float (*glfwGetWindowOpacity_func)(GLFWwindow*);
 glfwGetWindowOpacity_func glfwGetWindowOpacity_impl;
 #define glfwGetWindowOpacity glfwGetWindowOpacity_impl

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -586,6 +586,12 @@ create_os_window(PyObject UNUSED *self, PyObject *args) {
     CC(standard, IBEAM); CC(click, HAND); CC(arrow, ARROW);
 #undef CC
         if (OPT(click_interval) < 0) OPT(click_interval) = glfwGetDoubleClickInterval(glfw_window);
+        {
+            uint8_t red, green, blue, alpha;
+            if (glfwGetPlatformSelectionColor(glfw_window, &red, &green, &blue, &alpha)) {
+                printf("Selection color: %u\t%u\t%u\t%u\n", red, green, blue, alpha);
+            }
+        }
         if (OPT(cursor_blink_interval) < 0) {
             OPT(cursor_blink_interval) = 0.5;
 #ifdef __APPLE__


### PR DESCRIPTION
In macOS under General, there is a setting for "Highlight color", which is used for all sorts of selection highlighting, e.g. selecting text in Safari or selecting a file in Finder.
This pull request aims to change the `selection_background` config option to accept a new value like "system" that makes kitty use the system default.
Most apps allow dynamically changing the highlight color while running by just changing the setting. This pull request does not aim to do that. Changing the color will require a restart for now.
In `kitty/glfw.c` I'm currently only printing the color. How do I actually set it? It is not available with the `OPT()` macro. I think I need to set it in the Screen struct with `screen->color_profile->overridden.highlight_bg`. Could you give me a few tips on how to do that exactly?
I'm also not sure if a I should change the GLFW API like I did it now or if I should just create one new function in the cocoa code. The cursor blink interval for example can be read with `cocoa_cursor_blink_interval()`, while the double click interval can be read with `glfwGetDoubleClickInterval()`.