### PR TITLE
Convert HTTP URLs to HTTPS URLs where possible

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -645,7 +645,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/__main__.py
+++ b/__main__.py
@@ -88,7 +88,7 @@ def setup_openssl_environment():
     # Workaround for Linux distros that have still failed to get their heads
     # out of their asses and implement a common location for SSL certificates.
     # It's not that hard people, there exists a wonderful tool called the symlink
-    # See http://www.mobileread.com/forums/showthread.php?t=256095
+    # See https://www.mobileread.com/forums/showthread.php?t=256095
     if 'SSL_CERT_FILE' not in os.environ and 'SSL_CERT_DIR' not in os.environ:
         if os.access('/etc/pki/tls/certs/ca-bundle.crt', os.R_OK):
             os.environ['SSL_CERT_FILE'] = '/etc/pki/tls/certs/ca-bundle.crt'

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -107,7 +107,7 @@ without needing to install all of |kitty|.
         development package of :file:`ncurses`. Also, if you are building from
         a git checkout instead of the released source code tarball, you will
         need :file:`sphinx-build` from the `Sphinx documentation generator
-        <http://www.sphinx-doc.org/>`_.
+        <https://www.sphinx-doc.org/>`_.
 
 This applies to creating packages for |kitty| for macOS package managers such as
 brew or MacPorts as well.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@
 #
 # This file does only contain a selection of the most common options. For a
 # full list see the documentation:
-# http://www.sphinx-doc.org/en/master/config
+# https://www.sphinx-doc.org/en/master/config
 
 import os
 import re

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -96,7 +96,7 @@ How do I change the colors in a running kitty instance?
 ------------------------------------------------------------
 
 You can either use the
-`OSC terminal escape codes <http://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Operating-System-Commands>`_
+`OSC terminal escape codes <https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Operating-System-Commands>`_
 to set colors or you can enable :doc:`remote control <remote-control>`
 for |kitty| and use :ref:`at_set-colors`.
 

--- a/docs/protocol-extensions.rst
+++ b/docs/protocol-extensions.rst
@@ -171,7 +171,7 @@ The motivation for this extension is the various problems with the existing
 solution for erasing to background color, namely the *background color erase
 (bce)* capability. See
 `this discussion <https://github.com/kovidgoyal/kitty/issues/160#issuecomment-346470545>`_
-and `this FAQ <http://invisible-island.net/ncurses/ncurses.faq.html#bce_mismatches>`_
+and `this FAQ <https://invisible-island.net/ncurses/ncurses.faq.html#bce_mismatches>`_
 for a summary of problems with *bce*.
 
 For example, to set the background color to blue in a

--- a/kitty/charsets.c
+++ b/kitty/charsets.c
@@ -211,7 +211,7 @@ translation_table(uint32_t which) {
 
 uint32_t *latin1_charset = charset_translations[0];
 
-// UTF-8 decode taken from: http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
+// UTF-8 decode taken from: https://bjoern.hoehrmann.de/utf-8/decoder/dfa/
 
 static const uint8_t utf8_data[] = {
   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 00..1f

--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -85,9 +85,9 @@ as color16 to color255.''')
         _('Keyboard shortcuts'),
         _('''\
 For a list of key names, see: :link:`GLFW keys
-<http://www.glfw.org/docs/latest/group__keys.html>`. The name to use is the part
+<https://www.glfw.org/docs/latest/group__keys.html>`. The name to use is the part
 after the :code:`GLFW_KEY_` prefix. For a list of modifier names, see:
-:link:`GLFW mods <http://www.glfw.org/docs/latest/group__mods.html>`
+:link:`GLFW mods <https://www.glfw.org/docs/latest/group__mods.html>`
 
 On Linux you can also use XKB key names to bind keys that are not supported by
 GLFW. See :link:`XKB keys

--- a/kitty/khrplatform.h
+++ b/kitty/khrplatform.h
@@ -38,7 +38,7 @@
  *
  * See the Implementer's Guidelines for information about where this file
  * should be located on your system and for more details of its use:
- *    http://www.khronos.org/registry/implementers_guide.pdf
+ *    https://www.khronos.org/registry/implementers_guide.pdf
  *
  * This file should be included as
  *        #include <KHR/khrplatform.h>

--- a/kitty/modes.h
+++ b/kitty/modes.h
@@ -71,7 +71,7 @@
 #define ALTERNATE_SCREEN  (1049 << 5)
 
 // Bracketed paste mode
-// http://cirw.in/blog/bracketed-paste
+// https://cirw.in/blog/bracketed-paste
 #define BRACKETED_PASTE (2004 << 5)
 #define BRACKETED_PASTE_START "200~"
 #define BRACKETED_PASTE_END  "201~"

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -459,7 +459,7 @@ screen_align(Screen *self) {
 
 void
 screen_alignment_display(Screen *self) {
-    // http://www.vt100.net/docs/vt510-rm/DECALN.html
+    // https://www.vt100.net/docs/vt510-rm/DECALN.html
     screen_cursor_position(self, 1, 1);
     self->margin_top = 0; self->margin_bottom = self->lines - 1;
     for (unsigned int y = 0; y < self->linebuf->ynum; y++) {

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -29,7 +29,7 @@ alloc_sprite_map(unsigned int cell_width, unsigned int cell_height) {
         glGetIntegerv(GL_MAX_ARRAY_TEXTURE_LAYERS, &(max_array_texture_layers));
 #ifdef __APPLE__
         // Since on Apple we could have multiple GPUs, with different capabilities,
-        // upper bound the values according to the data from http://developer.apple.com/graphicsimaging/opengl/capabilities/
+        // upper bound the values according to the data from https://developer.apple.com/graphicsimaging/opengl/capabilities/
         max_texture_size = MIN(8192, max_texture_size);
         max_array_texture_layers = MIN(512, max_array_texture_layers);
 #endif


### PR DESCRIPTION
I converted those URLs because HTTPS should provide a bit more security than HTTP.
I checked every single URL by hand and ran `make linkcheck` to make sure that the site supports HTTPS.
Is it ok to change the URLs in the LICENSE? Not sure.
I didn't change the URL for `http://man7.org/linux/man-pages/man7/shm_overview.7.html` as `man7.org` doesn't even allow connections on port 443. I didn't change `http://pygments.org/` because the certificate is only valid for a different domain. The same is true for `http://cocoadev.com/index.pl?GameKeyboardHandlingAlmost` but that site seems to be totally dead atm, showing a 404 for that specific page and the nginx welcome page in the root directory. There are also some HTTP URLs in the tests, which I did not touch because I'm pretty sure that no connection is actually made. I also left the URLs in `logo/kitty.svg` alone as it's an automatically generated file.