### PR TITLE
Update changelog.rst to reflect change to disable_ligatures config option

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,7 +22,7 @@ To update |kitty|, :doc:`follow the instructions <binary>`.
 
 - Add an option :opt:`disable_ligatures` to disable
   multi-character ligatures under the cursor to make editing easier
-  (:iss:`461`)
+  or disable them completely (:iss:`461`)
 
 - Allow creating new OS windows in session files (:iss:`1514`)
 


### PR DESCRIPTION
In 934336e64278dae88ab87aa75c9bf553a5931fa6, the config option
`disable_ligatures_under_cursor` was renamed to `disable_ligatures` and the
behaviour of that option was altered so that it is now possible to
disable ligatures completely. This commit reflects that change in changelog.rst