### PR TITLE
Add command to disable/enable ligatures per window

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1051,3 +1051,9 @@ class Boss:
             dbus_notification_activated(*args)
         else:
             dbus_notification_created(*args)
+
+    def set_disable_ligatures(self, value, window=None):
+        if window is None:
+            window = self.active_window
+        window.screen.disable_ligatures = value
+        window.screen.dirty_sprite_positions()

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1052,7 +1052,7 @@ class Boss:
         else:
             dbus_notification_created(*args)
 
-    def set_disable_ligatures(self, value, window=None):
+    def disable_ligatures(self, value, window=None):
         if window is None:
             window = self.active_window
         window.screen.disable_ligatures = value

--- a/kitty/cmds.py
+++ b/kitty/cmds.py
@@ -815,6 +815,40 @@ def set_background_opacity(boss, window, payload):
 # }}}
 
 
+# disable_ligatures {{{
+@cmd(
+    'Disable ligatures',
+    'Set disable ligatures mode (override global config) for the specified window. '
+    'This accepts the same options as in the kitty config (never, cursor, always). '
+    'By default, this command applys to current active window, use following options to specify others. '
+    'For example: kitty @ disable_ligatures always',
+    options_spec=MATCH_WINDOW_OPTION + '''\n
+--self
+type=bool-set
+If specified set the window this command is run in, rather than the active window.
+''',
+    argspec='MODE',
+    args_count=1
+)
+def cmd_disable_ligatures(global_opts, opts, args):
+    from .config_data import disable_ligatures
+    return {'value': disable_ligatures(args[0]), 'match': opts.match, 'self': opts.self}
+
+
+def disable_ligatures(boss, window, payload):
+    match = payload['match']
+    if match:
+        windows = tuple(boss.match_windows(match))
+        if not windows:
+            raise MatchError(match)
+    else:
+        windows = [window if window and payload['self'] else boss.active_window]
+    for window in windows:
+        if window:
+            boss.set_disable_ligatures(payload['value'], window)
+# }}}
+
+
 # kitten {{{
 @cmd(
     'Run a kitten',

--- a/kitty/cmds.py
+++ b/kitty/cmds.py
@@ -845,7 +845,7 @@ def disable_ligatures(boss, window, payload):
         windows = [window if window and payload['self'] else boss.active_window]
     for window in windows:
         if window:
-            boss.set_disable_ligatures(payload['value'], window)
+            boss.disable_ligatures(payload['value'], window)
 # }}}
 
 

--- a/kitty/config.py
+++ b/kitty/config.py
@@ -214,6 +214,12 @@ def nth_window(func, rest):
     return func, [num]
 
 
+@func_with_args('disable_ligatures')
+def disable_ligatures_parse(func, val):
+    from .config_data import disable_ligatures
+    return func, [disable_ligatures(val)]
+
+
 def parse_key_action(action):
     parts = action.strip().split(maxsplit=1)
     func = parts[0]

--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -1154,6 +1154,8 @@ and clear the screen, instead of just clearing the screen::
 
     map ctrl+l combine : clear_terminal scroll active : send_text normal,application \\x0c
 '''))
+k('disable_ligatures', 'ctrl+shift+alt+l', 'disable_ligatures always', _('Set disable_ligatures to always for current window'),
+  add_to_default=False)
 k('send_text', 'ctrl+shift+alt+h', 'send_text all Hello World', _('Send arbitrary text on key presses'),
   add_to_default=False, long_text=_('''
 You can tell kitty to send arbitrary (UTF-8) encoded text to

--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -46,6 +46,8 @@ typedef enum MouseTrackingModes { NO_TRACKING, BUTTON_MODE, MOTION_MODE, ANY_MOD
 typedef enum MouseTrackingProtocols { NORMAL_PROTOCOL, UTF8_PROTOCOL, SGR_PROTOCOL, URXVT_PROTOCOL} MouseTrackingProtocol;
 typedef enum MouseShapes { BEAM, HAND, ARROW } MouseShape;
 
+typedef enum { DISABLE_LIGATURES_NEVER, DISABLE_LIGATURES_CURSOR, DISABLE_LIGATURES_ALWAYS } DisableLigature;
+
 #define MAX_CHILDREN 512
 #define BLANK_CHAR 0
 #define ATTRS_MASK_WITHOUT_WIDTH 0xFFC

--- a/kitty/fonts.h
+++ b/kitty/fonts.h
@@ -34,7 +34,7 @@ PyObject* face_from_descriptor(PyObject*, FONTS_DATA_HANDLE);
 
 void sprite_tracker_current_layout(FONTS_DATA_HANDLE data, unsigned int *x, unsigned int *y, unsigned int *z);
 void render_alpha_mask(uint8_t *alpha_mask, pixel* dest, Region *src_rect, Region *dest_rect, size_t src_stride, size_t dest_stride);
-void render_line(FONTS_DATA_HANDLE, Line *line, index_type lnum, Cursor *cursor);
+void render_line(FONTS_DATA_HANDLE, Line *line, index_type lnum, Cursor *cursor, DisableLigature disable_ligatures);
 void sprite_tracker_set_limits(size_t max_texture_size, size_t max_array_len);
 typedef void (*free_extra_data_func)(void*);
 StringCanvas render_simple_text_impl(PyObject *s, const char *text, unsigned int baseline);

--- a/kitty/screen.h
+++ b/kitty/screen.h
@@ -87,6 +87,7 @@ typedef struct {
     ScreenModes modes;
     ColorProfile *color_profile;
     double start_visual_bell_at;
+    DisableLigature disable_ligatures;
 
     uint32_t parser_buf[PARSER_BUF_SZ];
     unsigned int parser_state, parser_text_start, parser_buf_pos;

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -293,7 +293,7 @@ cell_prepare_to_render(ssize_t vao_idx, ssize_t gvao_idx, Screen *screen, GLfloa
 
     bool cursor_pos_changed = screen->cursor->x != screen->last_rendered_cursor_x
                            || screen->cursor->y != screen->last_rendered_cursor_y;
-    bool disable_ligatures = OPT(disable_ligatures) == DISABLE_LIGATURES_CURSOR;
+    bool disable_ligatures = screen->disable_ligatures == DISABLE_LIGATURES_CURSOR;
 
     if (screen->scroll_changed || screen->is_dirty || (disable_ligatures && cursor_pos_changed)) {
         sz = sizeof(GPUCell) * screen->lines * screen->columns;

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -11,7 +11,6 @@
 #define OPT(name) global_state.opts.name
 
 typedef enum { LEFT_EDGE, TOP_EDGE, RIGHT_EDGE, BOTTOM_EDGE } Edge;
-typedef enum { DISABLE_LIGATURES_NEVER, DISABLE_LIGATURES_CURSOR, DISABLE_LIGATURES_ALWAYS } DisableLigature;
 
 typedef struct {
     double visual_bell_duration, cursor_blink_interval, cursor_stop_blinking_after, mouse_hide_wait, click_interval, wheel_scroll_multiplier, touch_scroll_multiplier;


### PR DESCRIPTION
Font ligatures are good for code editing, but not good for some other terminal applications (e.g. htop).

This patch allows user to disable/enable ligatures dynamically, per window.