### PR TITLE
Mentioned `kitty list-fonts` command

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -199,6 +199,7 @@ o(
     'monospace',
     long_text=_('''
 You can specify different fonts for the bold/italic/bold-italic variants.
+To get a full list of supported fonts use `kitty list-fonts` command.
 By default they are derived automatically, by the OSes font system. Setting
 them manually is useful for font families that have many weight variants like
 Book, Medium, Thick, etc. For example::

--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -199,7 +199,7 @@ o(
     'monospace',
     long_text=_('''
 You can specify different fonts for the bold/italic/bold-italic variants.
-To get a full list of supported fonts use `kitty list-fonts` command.
+To get a full list of supported fonts use the `kitty list-fonts` command.
 By default they are derived automatically, by the OSes font system. Setting
 them manually is useful for font families that have many weight variants like
 Book, Medium, Thick, etc. For example::


### PR DESCRIPTION
It was really hard to find why some font didn't work, I tried to use `Hack Nerd Font` as in `fc-list` output, but kitty accepts another name: `Hack Regular`.
I found this command `kitty list-fonts` in https://github.com/kovidgoyal/kitty/issues/1098#issuecomment-433576219 but not in docs and not in `man kitty`. So I think it should be mentioned in font related docs. 