### PR TITLE
Micro-optimization

### DIFF
--- a/linux-launcher.c
+++ b/linux-launcher.c
@@ -95,11 +95,12 @@ end:
 
 #else
 static int run_embedded(const char* exe_dir_, int argc, wchar_t **argv) {
-    (void)exe_dir_;
 #ifdef __APPLE__
     wchar_t *exe_dir = Py_DecodeLocale(exe_dir_, NULL);
     if (exe_dir == NULL) { fprintf(stderr, "Fatal error: cannot decode exe_dir\n"); return 1; }
     set_bundle_exe_dir(exe_dir);
+#else
+    (void)exe_dir_;
 #endif
     return Py_Main(argc, argv);
 }


### PR DESCRIPTION
I'm pretty sure `(void)exe_dir_;` doesn't actually do anything besides suppress a warning about an unused variable. Since `exe_dir_` is used in the `#ifdef __APPLE__` block, this statement can be moved into an `#else` block.