### PR TITLE
Fix macOS input method

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -1014,20 +1014,20 @@ is_ascii_control_char(char x) {
 }
 
 void _glfwPlatformUpdateIMEState(_GLFWwindow *w, int which, int a, int b, int c, int d) {
-    [w->ns.view updateIMEStateFor: which left:a top:b cellWidth:c cellHeight:d];
+    [w->ns.view updateIMEStateFor: which left:(CGFloat)a top:(CGFloat)b cellWidth:(CGFloat)c cellHeight:(CGFloat)d];
 }
 
 - (void)updateIMEStateFor:(int)which
-                     left:(int)left
-                      top:(int)top
-                cellWidth:(int)cellWidth
-               cellHeight:(int)cellHeight
+                     left:(CGFloat)left
+                      top:(CGFloat)top
+                cellWidth:(CGFloat)cellWidth
+               cellHeight:(CGFloat)cellHeight
 {
     left /= window->ns.xscale;
     top /= window->ns.yscale;
     cellWidth /= window->ns.xscale;
     cellHeight /= window->ns.yscale;
-    debug_key(@"updateIMEState: %d, %d, %d, %d\n", left, top, cellWidth, cellHeight);
+    debug_key(@"updateIMEState: %f, %f, %f, %f\n", left, top, cellWidth, cellHeight);
     const NSRect frame = [window->ns.view frame];
     markedRect = NSMakeRect(left,
                             frame.size.height - top - cellHeight,

--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -1031,9 +1031,10 @@ void _glfwPlatformUpdateIMEState(_GLFWwindow *w, int which, int a, int b, int c,
     cellHeight /= window->ns.yscale;
     debug_key(@"updateIMEState: %f, %f, %f, %f\n", left, top, cellWidth, cellHeight);
     const NSRect frame = [window->ns.view frame];
-    markedRect = NSMakeRect(left,
-                            frame.size.height - top - cellHeight,
-                            cellWidth, cellHeight);
+    const NSRect rectInView = NSMakeRect(left,
+                                         frame.size.height - top - cellHeight,
+                                         cellWidth, cellHeight);
+    markedRect = [window->ns.object convertRectToScreen: rectInView];
 }
 
 - (NSArray*)validAttributesForMarkedText

--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -862,8 +862,17 @@ is_ascii_control_char(char x) {
     debug_key(@"text: %s glfw_key: %s\n",
             format_text(_glfw.ns.text), _glfwGetKeyName(key));
     debug_key(@"marked text: %@", markedText);
-    if (([self hasMarkedText] || previous_has_marked_text) && !_glfw.ns.text[0])
+    if ([self hasMarkedText]) {
+        _glfwInputKeyboard(window, key, scancode, GLFW_PRESS, mods,
+                           [[markedText string] UTF8String], 1); // update pre-edit text
+    } else if (previous_has_marked_text) {
+        _glfwInputKeyboard(window, key, scancode, GLFW_PRESS, mods,
+                           "\0", 1); // clear pre-edit text
+    }
+    if (([self hasMarkedText] || previous_has_marked_text) && !_glfw.ns.text[0]) {
+        // do not pass keys like BACKSPACE while there's pre-edit text, let IME handle it
         return;
+    }
     _glfwInputKeyboard(window, key, scancode, GLFW_PRESS, mods, _glfw.ns.text, 0);
 }
 

--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -869,7 +869,7 @@ is_ascii_control_char(char x) {
                            [[markedText string] UTF8String], 1); // update pre-edit text
     } else if (previous_has_marked_text) {
         _glfwInputKeyboard(window, key, scancode, GLFW_PRESS, mods,
-                           "\0", 1); // clear pre-edit text
+                           NULL, 1); // clear pre-edit text
     }
     if (([self hasMarkedText] || previous_has_marked_text) && !_glfw.ns.text[0]) {
         // do not pass keys like BACKSPACE while there's pre-edit text, let IME handle it

--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -864,16 +864,18 @@ is_ascii_control_char(char x) {
     debug_key(@"text: %s glfw_key: %s\n",
             format_text(_glfw.ns.text), _glfwGetKeyName(key));
     debug_key(@"marked text: %@", markedText);
-    if ([self hasMarkedText]) {
-        _glfwInputKeyboard(window, key, scancode, GLFW_PRESS, mods,
-                           [[markedText string] UTF8String], 1); // update pre-edit text
-    } else if (previous_has_marked_text) {
-        _glfwInputKeyboard(window, key, scancode, GLFW_PRESS, mods,
-                           NULL, 1); // clear pre-edit text
-    }
-    if (([self hasMarkedText] || previous_has_marked_text) && !_glfw.ns.text[0]) {
-        // do not pass keys like BACKSPACE while there's pre-edit text, let IME handle it
-        return;
+    if (!window->ns.deadKeyState) {
+        if ([self hasMarkedText]) {
+            _glfwInputKeyboard(window, key, scancode, GLFW_PRESS, mods,
+                               [[markedText string] UTF8String], 1); // update pre-edit text
+        } else if (previous_has_marked_text) {
+            _glfwInputKeyboard(window, key, scancode, GLFW_PRESS, mods,
+                               NULL, 1); // clear pre-edit text
+        }
+        if (([self hasMarkedText] || previous_has_marked_text) && !_glfw.ns.text[0]) {
+            // do not pass keys like BACKSPACE while there's pre-edit text, let IME handle it
+            return;
+        }
     }
     _glfwInputKeyboard(window, key, scancode, GLFW_PRESS, mods, _glfw.ns.text, 0);
 }

--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -815,6 +815,8 @@ is_ascii_control_char(char x) {
     const int mods = translateFlags(flags);
     const int key = translateKey(scancode, GLFW_TRUE);
     const GLFWbool process_text = !window->ns.textInputFilterCallback || window->ns.textInputFilterCallback(key, mods, scancode, flags) != 1;
+    const bool previous_has_marked_text = [self hasMarkedText];
+    [self unmarkText];
     _glfw.ns.text[0] = 0;
     if (!_glfw.ns.unicodeData) {
         // Using the cocoa API for key handling is disabled, as there is no
@@ -859,6 +861,9 @@ is_ascii_control_char(char x) {
     if (is_ascii_control_char(_glfw.ns.text[0])) _glfw.ns.text[0] = 0;  // don't send text for ascii control codes
     debug_key(@"text: %s glfw_key: %s\n",
             format_text(_glfw.ns.text), _glfwGetKeyName(key));
+    debug_key(@"marked text: %@", markedText);
+    if (([self hasMarkedText] || previous_has_marked_text) && !_glfw.ns.text[0])
+        return;
     _glfwInputKeyboard(window, key, scancode, GLFW_PRESS, mods, _glfw.ns.text, 0);
 }
 

--- a/glfw/input.c
+++ b/glfw/input.c
@@ -919,7 +919,7 @@ GLFWAPI void glfwUpdateIMEState(GLFWwindow* handle, int which, int a, int b, int
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT();
-#if defined(_GLFW_X11) || defined(_GLFW_WAYLAND)
+#if defined(_GLFW_X11) || defined(_GLFW_WAYLAND) || defined(_GLFW_COCOA)
     _glfwPlatformUpdateIMEState(window, which, a, b, c, d);
 #else
     (void)window; (void)which; (void)a; (void)b; (void)c; (void)d;

--- a/kitty/keys.c
+++ b/kitty/keys.c
@@ -143,6 +143,11 @@ on_key_input(int key, int scancode, int action, int mods, const char* text, int 
             } else debug("committed pre-edit text: (null)\n");
             return;
         case 0:
+            // for macOS, update ime position on every key input
+            // because the position is required before next input
+#if defined(__APPLE__)
+            update_ime_position(global_state.callback_os_window, w, screen);
+#endif
             break;
         default:
             debug("invalid state, ignoring\n");


### PR DESCRIPTION
1. Backspace now works with input method. Fixes #1461 
2. Pre-edit texts from input method are correctly displayed.
3. Input method dialog now follows the cursor.


Screencast: https://youtu.be/R4ZfSM3KE0Y

<img width="717" alt="Screen Shot 2019-05-02 at 16 39 43" src="https://user-images.githubusercontent.com/1308450/57064443-e7504f00-6cf8-11e9-8b2a-35e772dc9fdc.png">

 @xiaket I believe you would be interested in this, could you please give it a test?