### PR TITLE
Add file header to build-terminfo

### DIFF
--- a/build-terminfo
+++ b/build-terminfo
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# vim:fileencoding=utf-8
+# License: GPL v3 Copyright: 2019, Kovid Goyal <kovid at kovidgoyal.net>
 
 import glob
 import os


### PR DESCRIPTION
`build-terminfo` had no header with the encoding and license, so I added it.