### PR TITLE
Rename setup.py argument kitty.app -> app to match argument of make (make app)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ logo/kitty.iconset/icon_256x256.png: logo/kitty.svg logo/make.py
 rendered_logo: logo/kitty.iconset/icon_256x256.png
 
 app: rendered_logo
-	python3 setup.py kitty.app $(VVAL)
+	python3 setup.py app $(VVAL)
 
 man:
 	$(MAKE) FAIL_WARN=$(FAIL_WARN) -C docs man

--- a/setup.py
+++ b/setup.py
@@ -802,7 +802,7 @@ def option_parser():  # {{{
         'action',
         nargs='?',
         default='build',
-        choices='build test linux-package kitty.app macos-bundle osx-bundle clean'.split(),
+        choices='build test linux-package app kitty.app macos-bundle osx-bundle clean'.split(),
         help='Action to perform (default is build)'
     )
     p.add_argument(
@@ -894,7 +894,7 @@ def main():
     elif args.action in ('macos-bundle', 'osx-bundle'):
         build(args, native_optimizations=False)
         package(args, for_bundle=True)
-    elif args.action == 'kitty.app':
+    elif args.action in ('app', 'kitty.app'):
         args.prefix = 'kitty.app'
         if os.path.exists(args.prefix):
             shutil.rmtree(args.prefix)


### PR DESCRIPTION
I kept the `kitty.app` argument for backwards compatibility.