### PR TITLE
Revert "macOS: Fix cocoa mouse y-coord off by one"

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -660,7 +660,7 @@ static GLFWapplicationshouldhandlereopenfun handle_reopen_callback = NULL;
         // NOTE: The returned location uses base 0,1 not 0,0
         const NSPoint pos = [event locationInWindow];
 
-        _glfwInputCursorPos(window, pos.x, contentRect.size.height - pos.y - 1);
+        _glfwInputCursorPos(window, pos.x, contentRect.size.height - pos.y);
     }
 
     window->ns.cursorWarpDeltaX = 0;


### PR DESCRIPTION
This reverts commit 89692064503ccfbb66374a42d63401a96511501f.
Fixes #1621.
When committing b3f1acd400d524c079a0a5ea833756053834db5d, applying the glfw upstream patch https://github.com/glfw/glfw/commit/3c3981a4f00cdee0f20be6866305715a29b94125 for https://github.com/glfw/glfw/issues/1461, this commit should have been reverted as it was just a quick fix for https://github.com/glfw/glfw/issues/1461.