### PR TITLE
Add Homebrew and Nix (not only on NixOS) as package manager to the installation instructions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,12 +56,13 @@ Pre-built binaries of |kitty| are available for both macOS and Linux.
 See the :doc:`binary install instructions </binary>`. You can also
 :doc:`build from source </build>`.
 
-If you are on Linux, you can also use your distribution's |kitty| package.
+You can also use your favorite package manager to install the |kitty| package.
 |kitty| packages are available for:
+`macOS with Homebrew (Cask) <https://formulae.brew.sh/cask/kitty>`_,
+`macOS and Linux with Nix <https://nixos.org/nixos/packages.html#kitty>`_,
 `Debian <https://packages.debian.org/buster/kitty>`_,
 `openSUSE <https://build.opensuse.org/package/show/X11:terminals/kitty>`_,
 `Arch Linux <https://www.archlinux.org/packages/community/x86_64/kitty/>`_,
-`NixOS <https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/kitty/default.nix>`_,
 `Gentoo <https://packages.gentoo.org/packages/x11-terms/kitty>`_,
 `Fedora <https://copr.fedorainfracloud.org/coprs/gagbo/kitty-latest/>`_,
 `Void Linux <https://github.com/void-linux/void-packages/blob/master/srcpkgs/kitty/template>`_,


### PR DESCRIPTION
I rewrote the first sentence since there are also package managers for macOS and Nix can be used on most Linux distributions. I didn't include MacPorts since the kitty package there doesn't currently have a maintainer: https://www.macports.org/ports.php?by=name&substr=kitty.
I verified that kitty works when installed on macOS via Homebrew and Nix.
Since Nix doesn't only work on NixOS but also on macOS and on Linux, I removed the line specifically mentioning NixOS since people using NixOS will most likely know that Nix works on NixOS. I changed the link to the Nix package because in my opinion the new link is more helpful to the average user than the old one.
Does putting `(` and `)` into the name for the link cause any problems?