### PR TITLE
Fix warning with gcc 4.8

### DIFF
--- a/kitty/freetype.c
+++ b/kitty/freetype.c
@@ -366,9 +366,9 @@ render_bitmap(Face *self, int glyph_id, ProcessedBitmap *ans, unsigned int cell_
         // Normalize gray levels to the range [0..255]
         bitmap.num_grays = 256;
         unsigned int stride = bitmap.pitch < 0 ? -bitmap.pitch : bitmap.pitch;
-        for (unsigned int i = 0; i < bitmap.rows; ++i) {
+        for (unsigned i = 0; i < (unsigned)bitmap.rows; ++i) {
             // We only have 2 levels
-            for (unsigned int j = 0; j < bitmap.width; ++j) bitmap.buffer[i * stride + j] *= 255;
+            for (unsigned j = 0; j < (unsigned)bitmap.width; ++j) bitmap.buffer[i * stride + j] *= 255;
         }
         populate_processed_bitmap(self->face->glyph, &bitmap, ans, true);
         FT_Bitmap_Done(library, &bitmap);


### PR DESCRIPTION
gcc 4.8 produces the following warnings:

kitty/freetype.c: In function ‘render_bitmap’:
kitty/freetype.c:369:36: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
         for (unsigned int i = 0; i < bitmap.rows; ++i) {
                                    ^
kitty/freetype.c:371:40: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
             for (unsigned int j = 0; j < bitmap.width; ++j) bitmap.buffer[i * stride + j] *= 255;