### PR TITLE
Make the copyright year dynamic for the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from functools import partial
 
 from docutils import nodes
@@ -32,7 +33,7 @@ str_version = importlib.import_module('kitty.constants').str_version
 # -- Project information -----------------------------------------------------
 
 project = 'kitty'
-copyright = '2018, Kovid Goyal'
+copyright = time.strftime('%Y, Kovid Goyal')
 author = 'Kovid Goyal'
 building_man_pages = 'man' in sys.argv
 


### PR DESCRIPTION
The man page showed the year 2018 at the bottom. Instead of changing it to 2019, I made it dynamic so that it is always current the year at the time of building.