### PR TITLE
Add shebang for docs/conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # Configuration file for the Sphinx documentation builder.


### PR DESCRIPTION
`docs/conf.py` had no shebang, so I added it.
You may also want to add the usual
```
# vim:fileencoding=utf-8
# License: GPL v3 Copyright: 2019, Kovid Goyal <kovid at kovidgoyal.net>
```
but I'm not sure if you want that in this file.