### PR TITLE
Correctly draw spaces around tab separators.

### DIFF
--- a/kitty/tab_bar.py
+++ b/kitty/tab_bar.py
@@ -49,8 +49,9 @@ def draw_tab_with_separator(draw_data, screen, tab, before, max_title_length, in
         screen.draw(' ' * draw_data.trailing_spaces)
     extra = screen.cursor.x - before - max_title_length
     if extra > 0:
-        screen.cursor.x -= extra + 1
+        screen.cursor.x -= extra - draw_data.trailing_spaces + 1
         screen.draw('…')
+        screen.draw(' ' * draw_data.trailing_spaces)
     end = screen.cursor.x
     screen.cursor.bold = screen.cursor.italic = False
     screen.cursor.fg = screen.cursor.bg = 0


### PR DESCRIPTION
Good day,

Before, the tab bar would end right before the separator to the next tab.
We have to take the actual separator with spaces on both sides into account though. Basically if the tab separator is '  |  ' it was before:

 `shortened_tab_title…|  next_tab_title_with_leading_spaces`

And it is now

 `shortened_tab_tit…  |  next_tab_title_with_leading_spaces`

This now respects what the tab separator is set to.

Thanks!