### PR TITLE
Remove double assignment

### DIFF
--- a/gen-apc-parsers.py
+++ b/gen-apc-parsers.py
@@ -93,7 +93,7 @@ def generate(function_name, callback_name, report_name, keymap, command_class, i
     report_cmd = cmd_for_report(report_name, keymap, type_map, payload_allowed)
     if payload_allowed:
         payload_after_value = "case ';': state = PAYLOAD; break;"
-        payload = payload = ', PAYLOAD'
+        payload = ', PAYLOAD'
         parr = 'static uint8_t payload[4096];'
         payload_case = f'''
             case PAYLOAD: {{


### PR DESCRIPTION
The `payload` variable is assigned twice.
Static program analysis FTW!