### PR TITLE
Simplify code

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -135,13 +135,13 @@ class Boss:
         if new_os_window_trigger is not None:
             self.keymap.pop(new_os_window_trigger, None)
         for startup_session in startup_sessions:
-            os_window_id = self.add_os_window(startup_session, os_window_id=os_window_id)
+            self.add_os_window(startup_session, os_window_id=os_window_id)
+            os_window_id = None
             if args.start_as != 'normal':
                 if args.start_as == 'fullscreen':
                     self.toggle_fullscreen()
                 else:
                     change_os_window_state(args.start_as)
-            os_window_id = None
         if is_macos:
             from .fast_data_types import cocoa_set_notification_activated_callback
             cocoa_set_notification_activated_callback(self.notification_activated)


### PR DESCRIPTION
The result from `self.add_os_window()` is overwritten later and not used
between the two assignments, so I removed the first assignment and moved the second
assignment to the line after the call to `self.add_os_window()`.