### PR TITLE
Remove unused function

### DIFF
--- a/kitty/window.py
+++ b/kitty/window.py
@@ -60,9 +60,6 @@ def load_shader_programs(semi_transparent=False):
     compile_program(BLIT_PROGRAM, *load_shaders('blit'))
     v, f = load_shaders('cell')
 
-    def color_as_vec3(x):
-        return 'vec3({}, {}, {})'.format(x.red / 255, x.green / 255, x.blue / 255)
-
     for which, p in {
             'SIMPLE': CELL_PROGRAM,
             'BACKGROUND': CELL_BG_PROGRAM,


### PR DESCRIPTION
Searching for `color_as_vec3` yielded no results in the entire project
but I encourage you to verify that this function is really not used
anywhere.