### PR TITLE
Use more specific exception

### DIFF
--- a/kitty/borders.py
+++ b/kitty/borders.py
@@ -11,7 +11,7 @@ from .utils import load_shaders
 
 try:
     from enum import IntFlag
-except Exception:
+except ImportError:
     from enum import IntEnum as IntFlag
 
 


### PR DESCRIPTION
I think it's better to use `ImportError` here instead of the much more generic `Exception`.