### PR TITLE
Use "#!/usr/bin/env bash" shebang instead of "#!/bin/bash"

### DIFF
--- a/count-lines-of-code
+++ b/count-lines-of-code
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cloc --exclude-list-file <(echo -e 'kitty/wcwidth-std.h\nkitty/glfw.c\nkitty/keys.h\nkitty/charsets.c\nkitty/unicode-data.c\nkitty/key_encoding.py\nkitty/rgb.py\nkitty/gl.h\nkitty/gl-wrapper.h\nkitty/gl-wrapper.c\nkitty/khrplatform.h\nkitty/glfw-wrapper.h\nkitty/glfw-wrapper.c\nkitty/emoji.h\nkittens/unicode_input/names.h') kitty kittens


### PR DESCRIPTION
All python scripts start with `#!/usr/bin/env python3` so I did the same
for a bash script.