### PR TITLE
Reduce the difference of glfw to upstream

### DIFF
--- a/glfw/egl_context.c
+++ b/glfw/egl_context.c
@@ -446,7 +446,7 @@ void _glfwTerminateEGL(void)
 
 #define setAttrib(a, v) \
 { \
-    assert((size_t) (index + 1) < sizeof(attribs) / sizeof(attribs[0])); \
+    assert(((size_t) index + 1) < sizeof(attribs) / sizeof(attribs[0])); \
     attribs[index++] = a; \
     attribs[index++] = v; \
 }

--- a/glfw/glx_context.c
+++ b/glfw/glx_context.c
@@ -433,7 +433,7 @@ void _glfwTerminateGLX(void)
 
 #define setAttrib(a, v) \
 { \
-    assert((size_t) (index + 1) < sizeof(attribs) / sizeof(attribs[0])); \
+    assert(((size_t) index + 1) < sizeof(attribs) / sizeof(attribs[0])); \
     attribs[index++] = a; \
     attribs[index++] = v; \
 }

--- a/glfw/input.c
+++ b/glfw/input.c
@@ -409,7 +409,7 @@ _GLFWjoystick* _glfwAllocJoystick(const char* name,
     js->present     = true;
     js->name        = _glfw_strdup(name);
     js->axes        = calloc(axisCount, sizeof(float));
-    js->buttons     = calloc(buttonCount + hatCount * 4, 1);
+    js->buttons     = calloc(buttonCount + (size_t) hatCount * 4, 1);
     js->hats        = calloc(hatCount, 1);
     js->axisCount   = axisCount;
     js->buttonCount = buttonCount;
@@ -571,9 +571,11 @@ const char* _glfwGetKeyName(int key)
 void _glfwCenterCursorInContentArea(_GLFWwindow* window)
 {
     int width, height;
+
     _glfwPlatformGetWindowSize(window, &width, &height);
     _glfwPlatformSetCursorPos(window, width / 2.0, height / 2.0);
 }
+
 
 //////////////////////////////////////////////////////////////////////////
 //////                        GLFW public API                       //////
@@ -672,7 +674,9 @@ GLFWAPI void glfwSetInputMode(GLFWwindow* handle, int mode, int value)
         window->stickyMouseButtons = value;
     }
     else if (mode == GLFW_LOCK_KEY_MODS)
+    {
         window->lockKeyMods = value ? true : false;
+    }
     else
         _glfwInputError(GLFW_INVALID_ENUM, "Invalid input mode 0x%08X", mode);
 }

--- a/glfw/monitor.c
+++ b/glfw/monitor.c
@@ -100,7 +100,7 @@ void _glfwInputMonitor(_GLFWmonitor* monitor, int action, int placement)
         {
             memmove(_glfw.monitors + 1,
                     _glfw.monitors,
-                    (_glfw.monitorCount - 1) * sizeof(_GLFWmonitor*));
+                    ((size_t) _glfw.monitorCount - 1) * sizeof(_GLFWmonitor*));
             _glfw.monitors[0] = monitor;
         }
         else
@@ -327,7 +327,9 @@ GLFWAPI void glfwGetMonitorPos(GLFWmonitor* handle, int* xpos, int* ypos)
     _glfwPlatformGetMonitorPos(monitor, xpos, ypos);
 }
 
-GLFWAPI void glfwGetMonitorWorkarea(GLFWmonitor* handle, int* xpos, int* ypos, int* width, int* height)
+GLFWAPI void glfwGetMonitorWorkarea(GLFWmonitor* handle,
+                                    int* xpos, int* ypos,
+                                    int* width, int* height)
 {
     _GLFWmonitor* monitor = (_GLFWmonitor*) handle;
     assert(monitor != NULL);
@@ -458,6 +460,7 @@ GLFWAPI void glfwSetGamma(GLFWmonitor* handle, float gamma)
         _glfwInputError(GLFW_INVALID_VALUE, "Invalid gamma value %f", gamma);
         return;
     }
+
     original = glfwGetGammaRamp(handle);
     if (!original)
         return;
@@ -472,10 +475,8 @@ GLFWAPI void glfwSetGamma(GLFWmonitor* handle, float gamma)
         value = i / (float) (original->size - 1);
         // Apply gamma curve
         value = powf(value, 1.f / gamma) * 65535.f + 0.5f;
-
         // Clamp to value range
-        if (value > 65535.f)
-            value = 65535.f;
+        value = fminf(value, 65535.f);
 
         values[i] = (unsigned short) value;
     }

--- a/glfw/nsgl_context.m
+++ b/glfw/nsgl_context.m
@@ -131,7 +131,6 @@ bool _glfwCreateContextNSGL(_GLFWwindow* window,
                             "NSGL: The targeted version of macOS does not support OpenGL 3.0 or 3.1 but may support 3.2 and above");
             return false;
         }
-
     }
 
     // Context robustness modes (GL_KHR_robustness) are not yet supported by
@@ -288,7 +287,8 @@ bool _glfwCreateContextNSGL(_GLFWwindow* window,
     if (fbconfig->transparent)
     {
         GLint opaque = 0;
-        [window->context.nsgl.object setValues:&opaque forParameter:NSOpenGLContextParameterSurfaceOpacity];
+        [window->context.nsgl.object setValues:&opaque
+                                  forParameter:NSOpenGLContextParameterSurfaceOpacity];
     }
 
     if (window->ns.retina)

--- a/glfw/osmesa_context.c
+++ b/glfw/osmesa_context.c
@@ -47,7 +47,7 @@ static void makeContextCurrentOSMesa(_GLFWwindow* window)
             free(window->context.osmesa.buffer);
 
             // Allocate the new buffer (width * height * 8-bit RGBA)
-            window->context.osmesa.buffer = calloc(4, width * height);
+            window->context.osmesa.buffer = calloc(4, (size_t) width * height);
             window->context.osmesa.width  = width;
             window->context.osmesa.height = height;
         }
@@ -188,7 +188,7 @@ void _glfwTerminateOSMesa(void)
 
 #define setAttrib(a, v) \
 { \
-    assert((size_t) (index + 1) < sizeof(attribs) / sizeof(attribs[0])); \
+    assert(((size_t) index + 1) < sizeof(attribs) / sizeof(attribs[0])); \
     attribs[index++] = a; \
     attribs[index++] = v; \
 }


### PR DESCRIPTION
This only changes some formatting, whitespace, etc.. There are no
changes to the functionality, except maybe
```diff
-if (value > 65535.f)
-    value = 65535.f;
+value = fminf(value, 65535.f);
```
Let me know if you don't like some of those changes.