### PR TITLE
Move definition of GL_SILENCE_DEPRECATION

### DIFF
--- a/glfw/cocoa_platform.h
+++ b/glfw/cocoa_platform.h
@@ -28,6 +28,11 @@
 #include <dlfcn.h>
 
 #include <Carbon/Carbon.h>
+
+// NOTE: All of NSGL was deprecated in the 10.14 SDK
+//       This disables the pointless warnings for every symbol we use
+#define GL_SILENCE_DEPRECATION
+
 #if defined(__OBJC__)
 #import <Cocoa/Cocoa.h>
 #import <CoreVideo/CoreVideo.h>

--- a/glfw/glfw.py
+++ b/glfw/glfw.py
@@ -35,7 +35,6 @@ def init_env(env, pkg_config, at_least_version, test_compile, module='x11'):
     ans.cppflags.append('-D_GLFW_BUILD_DLL')
 
     if is_macos:
-        ans.cppflags.append('-DGL_SILENCE_DEPRECATION')
         ans.ldpaths.extend(
             "-framework Cocoa -framework IOKit -framework CoreFoundation -framework CoreVideo".
             split()

--- a/setup.py
+++ b/setup.py
@@ -259,9 +259,6 @@ def kitty_env():
     cflags.extend(pkg_config('libpng', '--cflags-only-I'))
     if is_macos:
         font_libs = ['-framework', 'CoreText', '-framework', 'CoreGraphics']
-        # Apple deprecated OpenGL in Mojave (10.14) silence the endless
-        # warnings about it
-        cppflags.append('-DGL_SILENCE_DEPRECATION')
     else:
         cflags.extend(pkg_config('fontconfig', '--cflags-only-I'))
         font_libs = pkg_config('fontconfig', '--libs')


### PR DESCRIPTION
Move definition of GL_SILENCE_DEPRECATION from `setup.py` and `glfw/glfw.py` to `cocoa_platform.m`. This is where GLFW defines it.