### PR TITLE
Use SPECIAL_SOURCES to set the git hash

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -306,6 +306,9 @@ def run_tool(cmd, desc=None):
 SPECIAL_SOURCES = {
     'kitty/parser_dump.c': ('kitty/parser.c', ['DUMP_COMMANDS']),
 }
+if os.path.exists('.git'):
+    rev = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip()
+    SPECIAL_SOURCES.update({'kitty/data-types.c': ('kitty/data-types.c', ['KITTY_VCS_REV="{}"'.format(rev)])})
 
 
 def newer(dest, *sources):
@@ -394,10 +397,6 @@ def compile_c_extension(kenv, module, incremental, compilation_database, all_key
             src, defines = SPECIAL_SOURCES[src]
             cppflags.extend(map(define, defines))
 
-        if src == 'kitty/data-types.c':
-            if os.path.exists('.git'):
-                rev = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip()
-                cppflags.append(define('KITTY_VCS_REV="{}"'.format(rev)))
         cmd = [kenv.cc, '-MMD'] + cppflags + kenv.cflags
         key = original_src, os.path.basename(dest)
         all_keys.add(key)


### PR DESCRIPTION
Using the already existing functionality of `SPECIAL_SOURCES` makes the code cleaner IMO.
The `rev` variable pollutes the global namespace. Is there an easy way to prevent that or should we just ignore it?