### PR TITLE
Ignore all *.dSYM directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@ logo/*.iconset
 compile_commands.json
 glad/out
 asan-launcher
-asan-launcher.dSYM
 kitty-profile
+*.dSYM
 dev
 __pycache__
 glfw/wayland-*-client-protocol.[ch]


### PR DESCRIPTION
Building `kitty-profile` on macOS creates a `kitty-profile.dSYM` directory, that should be ignored, just like `asan-launcher.dSYM`.