### PR TITLE
Always clean files manually instead of using git

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -780,17 +780,6 @@ Categories=System;TerminalEmulator;
 
 def clean():
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
-    if os.path.exists('.git'):
-        for f in subprocess.check_output(
-            'git ls-files --others --ignored --exclude-from=.gitignore'.split()
-        ).decode('utf-8').splitlines():
-            if f.startswith('logo/kitty.iconset') or f.startswith('dev/'):
-                continue
-            os.unlink(f)
-            if os.sep in f and not os.listdir(os.path.dirname(f)):
-                os.rmdir(os.path.dirname(f))
-        return
-    # Not a git checkout, clean manually
 
     def safe_remove(*entries):
         for x in entries:

--- a/setup.py
+++ b/setup.py
@@ -790,7 +790,9 @@ def clean():
                     os.unlink(x)
 
     safe_remove('build', 'compile_commands.json', 'linux-package', 'kitty.app')
-    for root, dirs, files in os.walk('.'):
+    exclude = ('.git',)
+    for root, dirs, files in os.walk('.', topdown=True):
+        dirs[:] = [d for d in dirs if d not in exclude]
         remove_dirs = {d for d in dirs if d == '__pycache__'}
         [(shutil.rmtree(os.path.join(root, d)), dirs.remove(d)) for d in remove_dirs]
         for f in files:


### PR DESCRIPTION
I see a couple problems with using git to determine the files to delete:
- git needs to be installed
- The manual cleaning code is supposed to function correctly, so why not always use it? That way bugs in the manual cleaning code are also more likely to get discovered
- If some files ignored by git should not be deleted, they need to be added to a sort of blacklist. If some files should be deleted by the manual cleanup code, they need to be added to a sort of whitelist. If someone forgets to add files to one of these lists, then not deleting files that should be deleted is better than deleting files that should not be deleted.