### PR TITLE
Unify compilation_database access

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -428,7 +428,7 @@ class CompilationDatabase:
         except FileNotFoundError:
             compilation_database = []
         compilation_database = {
-            CompileKey(k['file'], k.get('output')): k['arguments'] for k in compilation_database
+            CompileKey(k['file'], k['output']): k['arguments'] for k in compilation_database
         }
         self.db = compilation_database
         return self


### PR DESCRIPTION
`file` and `arguments` are accessed using the square bracket syntax, while `output` is accessed using `.get()`. This commit uses square brackets for all three. This will throw a `KeyError` if `compilation_database` does not have the key, which is the correct behaviour IMO.