### PR TITLE
Allow borders for single windows

### DIFF
--- a/kitty/borders.py
+++ b/kitty/borders.py
@@ -68,7 +68,7 @@ class Borders:
         bw, pw = self.border_width, self.padding_width
         if bw + pw <= 0:
             return
-        draw_borders = bw > 0 and draw_window_borders and len(windows) > 1
+        draw_borders = bw > 0 and draw_window_borders
         if draw_borders:
             border_data = current_layout.resolve_borders(windows, active_window)
 


### PR DESCRIPTION
I'm an iTerm convert, and a particular feature I liked was the ability to maximise any window to fill a tab. The zoom_toggle.py sample was a great starting point for me to build a new feature just how I wanted, and a great example of why I've moved to kitty - extensibility.

One thing I do miss is a visual cue that I'm zoomed in - after a time I can easily forget. I modded [my script][0] to enable borders but it wasn't working. Checking the source, I found that borders for single window tabs are explicitly prevented in a way that isn't easy to work around (short of duplicating a lot of existing logic in my script).

This PR removes the hardcoded limitation, on the off chance this was a bit of an oversight and you're happy to just accept it (I've tested locally with the linked script, it works how I want). If not I'd love to hear some more context around the current behaviour, and am happy to put some work into a better solution.

[0]: https://gist.github.com/DazWorrall/a83d9fb49ebd0dd0bd7a8291891585c5
