### PR TITLE
Sort list of files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -481,12 +481,13 @@ class CompilationDatabase:
 
 def compile_c_extension(kenv, module, compilation_database, sources, headers, desc_prefix=''):
     prefix = os.path.basename(module)
+    sorted_sources = sorted(sources)
     objects = [
         os.path.join(build_dir, prefix + '-' + os.path.basename(src) + '.o')
-        for src in sources
+        for src in sorted_sources
     ]
 
-    for original_src, dest in zip(sources, objects):
+    for original_src, dest in zip(sorted_sources, objects):
         src = original_src
         cppflags = kenv.cppflags[:]
         is_special = src in SPECIAL_SOURCES


### PR DESCRIPTION
Sort list of source files
so that fast_data_types.so builds in a reproducible way
in spite of indeterministic filesystem readdir order
and random set iteration order.

See https://reproducible-builds.org/ for why this is good.

Note: I tested that it builds (on a clean VM) with 0.14.2, but it might need more testing than that.

This PR was done while working on reproducible builds for openSUSE.