### PR TITLE
Add the output filter capability

### DIFF
--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -235,7 +235,6 @@ set_child_fd(ChildMonitor *self, PyObject *args) {
     }
     for (unsigned int i = 0; i < self->count; i++) {
         if (children[i].id == id) {
-            
             update_queue[update_queue_count] = children[i];
             update_queue[update_queue_count].input_fd = fd;
             update_queue_count++;

--- a/kitty/child.c
+++ b/kitty/child.c
@@ -88,7 +88,7 @@ spawn(PyObject *self UNUSED, PyObject *args) {
             if (sigprocmask(SIG_SETMASK, &signals, NULL) != 0) exit_on_err("sigprocmask() in child process failed");
             // Use only signal-safe functions (man 7 signal-safety)
             if (chdir(cwd) != 0) { if (chdir("/") != 0) {} };  // ignore failure to chdir to /
-            if (setsid() == -1) exit_on_err("setsid() in child process failed");
+            if (stdin_read_fd == -1 && setsid() == -1) exit_on_err("setsid() in child process failed");
 
             // Establish the controlling terminal (see man 7 credentials)
             int tfd = open(name, O_RDWR);

--- a/kitty/child.py
+++ b/kitty/child.py
@@ -202,7 +202,11 @@ class Child:
         ready_read_fd, ready_write_fd = os.pipe()
         remove_cloexec(ready_read_fd)
         if stdin is not None:
-            stdin_read_fd, stdin_write_fd = os.pipe()
+            if isinstance(stdin, int):
+                stdin_read_fd = stdin
+                stdin_write_fd = -1
+            else:
+                stdin_read_fd, stdin_write_fd = os.pipe()
             remove_cloexec(stdin_read_fd)
         else:
             stdin_read_fd = stdin_write_fd = -1
@@ -230,7 +234,7 @@ class Child:
         os.close(slave)
         self.pid = pid
         self.child_fd = master
-        if stdin is not None:
+        if stdin is not None and not isinstance(stdin, int):
             os.close(stdin_read_fd)
             fast_data_types.thread_write(stdin_write_fd, stdin)
         os.close(ready_read_fd)

--- a/kitty/child.py
+++ b/kitty/child.py
@@ -242,6 +242,12 @@ class Child:
         remove_blocking(self.child_fd)
         return pid
 
+    def kill(self):
+        if not self.forked:
+            return
+        os.close(self.child_fd)
+
+
     def mark_terminal_ready(self):
         os.close(self.terminal_ready_fd)
         self.terminal_ready_fd = -1

--- a/kitty/child.py
+++ b/kitty/child.py
@@ -247,7 +247,6 @@ class Child:
             return
         os.close(self.child_fd)
 
-
     def mark_terminal_ready(self):
         os.close(self.terminal_ready_fd)
         self.terminal_ready_fd = -1

--- a/kitty/cmds.py
+++ b/kitty/cmds.py
@@ -1255,7 +1255,7 @@ def kitten(boss, window, payload):
 )
 def cmd_launch_filter(global_opts, opts, args):
     '''
-    cmd: The command to run as a filter
+    command: The command to run as a filter
     match: The window to run the filter over
     '''
     if len(args) < 1:

--- a/kitty/cmds.py
+++ b/kitty/cmds.py
@@ -1247,6 +1247,65 @@ def kitten(boss, window, payload):
 # }}}
 
 
+# launch_filter {{{
+@cmd(
+    'Start a filter program',
+    'Start a filter over the specified window (active window by default).',
+    options_spec=MATCH_WINDOW_OPTION,
+)
+def cmd_launch_filter(global_opts, opts, args):
+    '''
+    cmd: The command to run as a filter
+    match: The window to run the filter over
+    '''
+    if len(args) < 1:
+        raise SystemExit('Must specify filter program name')
+    return {'match': opts.match, 'command': list(args)}
+
+
+def launch_filter(boss, window, payload):
+    windows = [window or boss.active_window]
+    pg = cmd_launch_filter.payload_get
+    match = pg(payload, 'match')
+    if match:
+        windows = tuple(boss.match_windows(match))
+        if not windows:
+            raise MatchError(match)
+    for window in windows:
+        if window:
+            boss._launch_filter(command=tuple(payload.get('command', ())), window=window)
+            break
+# }}}
+
+
+# remove_filter {{{
+@cmd(
+    'Remove filter program',
+    'Remove the currently running filter program for the specified window (active window by default).',
+    options_spec=MATCH_WINDOW_OPTION,
+)
+def cmd_remove_filter(global_opts, opts, args):
+    '''
+    match: The window for which the filter should be removed
+    '''
+    return {'match': opts.match}
+
+
+def remove_filter(boss, window, payload):
+    windows = [window or boss.active_window]
+    pg = cmd_remove_filter.payload_get
+    match = pg(payload, 'match')
+    if match:
+        windows = tuple(boss.match_windows(match))
+        if not windows:
+            raise MatchError(match)
+    for window in windows:
+        if window:
+            boss._remove_filter(window=window)
+            break
+# }}}
+
+
 def cli_params_for(func):
     return (func.options_spec or '\n').format, func.argspec, func.desc, '{} @ {}'.format(appname, func.name)
 


### PR DESCRIPTION
This PR allows one to add an arbitrary filter program to a kitty window. All terminal output will go through the filter function, which can modify its input in any way. For example, this could be used to colorize or highlight text as it is output.

The PR adds two new kitty commands:
- launch-filter starts the passed program as a filter for a window. An arbitrary window can be specified with the --match argument, the default is the current window. The filter program should process data it receives on its stdin, and should output processed data to stdout.
- remove-filter removes the currently running filter from the specified window, defaulting to the current window.

This patch is experimental, but working. There are some known issues:
- Trying to close the window with "exit" after a filter has been specified causes the window to hang. 