### PR TITLE
Only show the hand cursor shape over a URL if the `open_url_modifiers` are pressed

### DIFF
--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -297,6 +297,7 @@ void copy_color_table_to_buffer(ColorProfile *self, color_type *address, int off
 void colorprofile_push_dynamic_colors(ColorProfile*);
 void colorprofile_pop_dynamic_colors(ColorProfile*);
 
+void update_url_cursor_shape(MouseTrackingMode mouse_tracking_mode, int modifiers);
 void set_mouse_cursor(MouseShape);
 void enter_event(void);
 void mouse_event(int, int, int);

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -218,6 +218,14 @@ refresh_callback(GLFWwindow *w) {
 
 static int mods_at_last_key_or_button_event = 0;
 
+static inline Window*
+active_window(void) {
+    Tab *t = global_state.callback_os_window->tabs + global_state.callback_os_window->active_tab;
+    Window *w = t->windows + t->active_window;
+    if (w->render_data.screen) return w;
+    return NULL;
+}
+
 static void
 key_callback(GLFWwindow *w, int key, int scancode, int action, int mods, const char* text, int state) {
     if (!set_callback_window(w)) return;
@@ -227,6 +235,7 @@ key_callback(GLFWwindow *w, int key, int scancode, int action, int mods, const c
         global_state.callback_os_window->is_key_pressed[key] = action == GLFW_RELEASE ? false : true;
     }
     if (is_window_ready_for_callbacks()) on_key_input(key, scancode, action, mods, text, state);
+    update_url_cursor_shape(active_window()->render_data.screen->modes.mouse_tracking_mode, mods);
     global_state.callback_os_window = NULL;
     request_tick_callback();
 }

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -271,9 +271,9 @@ update_url_cursor_shape(MouseTrackingMode mouse_tracking_mode, int modifiers) {
 static inline void
 detect_url(Screen *screen, unsigned int x, unsigned int y, int modifiers) {
     url_under_mouse_cursor = false;
-    index_type url_start, url_end = 0;
+    index_type url_start = 0, url_end = 0;
     Line *line = screen_visual_line(screen, y);
-    char_type sentinel;
+    char_type sentinel = 0;
     if (line) {
         url_start = line_url_start_at(line, x);
         sentinel = get_url_sentinel(line, url_start);


### PR DESCRIPTION
Don't merge this yet please.
The hand cursor suggests that whatever the mouse cursor is over at the moment can be clicked on. This is not the case for URLs, where pressing one or more modifier keys is necessary to be able to click on a URL. This pull request makes changes that only show the hand cursor if the right modifier keys are pressed.
This is very hacked together atm but I'd like to hear your opinion on this functionality first and then get some help to improve the code quality.