### PR TITLE
Add option to hide the window title on macOS

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -212,7 +212,7 @@ To update |kitty|, :doc:`follow the instructions <binary>`.
 
 - macOS: Fix :kbd:`cmd+period` key not working (:iss:`1318`)
 
-- macOS: Add an option :opt:`macos_show_window_title_in_menubar` to not
+- macOS: Add an option `macos_show_window_title_in_menubar` to not
   show the current window title in the menu-bar (:iss:`1066`)
 
 - macOS: Workaround for cocoa bug that could cause the mouse cursor to become

--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -518,7 +518,7 @@ update_window_title(Window *w, OSWindow *os_window) {
         Py_INCREF(os_window->window_title);
         set_os_window_title(os_window, PyUnicode_AsUTF8(w->title));
 #ifdef __APPLE__
-        if (os_window->is_focused && OPT(macos_show_window_title_in_menubar)) cocoa_update_menu_bar_title(w->title);
+        if (os_window->is_focused && (OPT(macos_show_window_title_in) & MENUBAR)) cocoa_update_menu_bar_title(w->title);
 #endif
         return true;
     }

--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -477,6 +477,17 @@ cleanup() {
     } // autoreleasepool
 }
 
+void
+cocoa_hide_window_title(void *w)
+{
+    @autoreleasepool {
+
+    NSWindow *window = (NSWindow*)w;
+    [window setTitleVisibility:NSWindowTitleHidden];
+
+    } // autoreleasepool
+}
+
 static PyMethodDef module_methods[] = {
     {"cocoa_get_lang", (PyCFunction)cocoa_get_lang, METH_NOARGS, ""},
     {"cocoa_set_new_window_trigger", (PyCFunction)cocoa_set_new_window_trigger, METH_VARARGS, ""},

--- a/kitty/config.py
+++ b/kitty/config.py
@@ -429,6 +429,25 @@ def handle_deprecated_hide_window_decorations_aliases(key, val, ans):
             ans['hide_window_decorations'] = True
 
 
+@deprecated_handler('macos_show_window_title_in_menubar')
+def handle_deprecated_macos_show_window_title_in_menubar_alias(key, val, ans):
+    if not hasattr(handle_deprecated_macos_show_window_title_in_menubar_alias, key):
+        handle_deprecated_macos_show_window_title_in_menubar_alias.key = True
+        log_error('The option {} is deprecated. Use macos_show_window_title_in menubar instead.'.format(key))
+    macos_show_window_title_in = ans.get('macos_show_window_title_in', 'all')
+    if to_bool(val):
+        if macos_show_window_title_in == 'none':
+            macos_show_window_title_in = 'menubar'
+        elif macos_show_window_title_in == 'window':
+            macos_show_window_title_in = 'all'
+    else:
+        if macos_show_window_title_in == 'all':
+            macos_show_window_title_in = 'window'
+        elif macos_show_window_title_in == 'menubar':
+            macos_show_window_title_in = 'none'
+    ans['macos_show_window_title_in'] = macos_show_window_title_in
+
+
 def expandvars(val, env):
 
     def sub(m):

--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -964,9 +964,15 @@ o('macos_traditional_fullscreen', False, long_text=_('''
 Use the traditional full-screen transition, that is faster, but less pretty.
 '''))
 
-o('macos_show_window_title_in_menubar', True, long_text=_('''
-Show the title of the currently active window in the macOS
-menu-bar, making use of otherwise wasted space.'''))
+o('macos_show_window_title_in', 'all', option_type=choices('all', 'window', 'menubar', 'none'), long_text=_('''
+Show or hide the window title in the macOS window or menu-bar.
+A value of :code:`window` will show the title of the currently
+active window at the top of the macOS window. A value of
+:code:`menubar` will show the title of the currently active window
+in the macOS menu-bar, making use of otherwise wasted space.
+:code:`all` will show the title everywhere and :code:`none`
+hides the title in the window and the menu-bar.
+'''))
 
 # Disabled by default because of https://github.com/kovidgoyal/kitty/issues/794
 o('macos_custom_beam_cursor', False, long_text=_('''

--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -53,6 +53,7 @@ typedef enum { DISABLE_LIGATURES_NEVER, DISABLE_LIGATURES_CURSOR, DISABLE_LIGATU
 typedef enum MouseTrackingModes { NO_TRACKING, BUTTON_MODE, MOTION_MODE, ANY_MODE } MouseTrackingMode;
 typedef enum MouseTrackingProtocols { NORMAL_PROTOCOL, UTF8_PROTOCOL, SGR_PROTOCOL, URXVT_PROTOCOL} MouseTrackingProtocol;
 typedef enum MouseShapes { BEAM, HAND, ARROW } MouseShape;
+typedef enum { NONE, MENUBAR, WINDOW, ALL } WindowTitleIn;
 
 #define MAX_CHILDREN 512
 #define BLANK_CHAR 0

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -12,6 +12,7 @@
 extern bool cocoa_make_window_resizable(void *w, bool);
 extern void cocoa_focus_window(void *w);
 extern void cocoa_create_global_menu(void);
+extern void cocoa_hide_window_title(void *w);
 extern void cocoa_set_activation_policy(bool);
 extern void cocoa_set_titlebar_color(void *w, color_type color);
 extern bool cocoa_alt_option_key_pressed(unsigned long);
@@ -580,6 +581,10 @@ create_os_window(PyObject UNUSED *self, PyObject *args) {
         Py_DECREF(ret);
 #ifdef __APPLE__
         cocoa_create_global_menu();
+        if (!(OPT(macos_show_window_title_in) & WINDOW)) {
+            if (glfwGetCocoaWindow) cocoa_hide_window_title(glfwGetCocoaWindow(glfw_window));
+            else log_error("Failed to load glfwGetCocoaWindow");
+        }
 #endif
 #define CC(dest, shape) {\
     if (!dest##_cursor) { \

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -320,6 +320,19 @@ convert_mods(PyObject *obj) {
     return resolve_mods(PyLong_AsLong(obj));
 }
 
+static WindowTitleIn
+window_title_in(PyObject *title_in) {
+    const char *in = PyUnicode_AsUTF8(title_in);
+    switch(in[0]) {
+        case 'a': return ALL;
+        case 'w': return WINDOW;
+        case 'm': return MENUBAR;
+        case 'n': return NONE;
+        default: break;
+    }
+    return ALL;
+}
+
 static MouseShape
 pointer_shape(PyObject *shape_name) {
     const char *name = PyUnicode_AsUTF8(shape_name);
@@ -415,7 +428,7 @@ PYWRAP1(set_options) {
     S(macos_option_as_alt, PyLong_AsUnsignedLong);
     S(macos_traditional_fullscreen, PyObject_IsTrue);
     S(macos_quit_when_last_window_closed, PyObject_IsTrue);
-    S(macos_show_window_title_in_menubar, PyObject_IsTrue);
+    S(macos_show_window_title_in, window_title_in);
     S(macos_window_resizable, PyObject_IsTrue);
     S(macos_hide_from_tasks, PyObject_IsTrue);
     S(macos_thicken_font, PyFloat_AsDouble);

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -26,9 +26,10 @@ typedef struct {
     color_type url_color, background, foreground, active_border_color, inactive_border_color, bell_border_color;
     double repaint_delay, input_delay;
     bool focus_follows_mouse, hide_window_decorations;
-    bool macos_hide_from_tasks, macos_quit_when_last_window_closed, macos_window_resizable, macos_traditional_fullscreen, macos_show_window_title_in_menubar;
+    bool macos_hide_from_tasks, macos_quit_when_last_window_closed, macos_window_resizable, macos_traditional_fullscreen;
     unsigned int macos_option_as_alt;
     float macos_thicken_font;
+    WindowTitleIn macos_show_window_title_in;
     int adjust_line_height_px, adjust_column_width_px;
     float adjust_line_height_frac, adjust_column_width_frac;
     float background_opacity, dim_opacity;


### PR DESCRIPTION
See #1072.
Don't merge this yet please.
I have a couple questions:
Do I need the autoreleasepool in `cocoa_hide_window_title()`?
Why are there seemingly two places for the deprecated config options? One below
```Python
@deprecated_handler('macos_show_window_title_in_menubar')
```
and one here:
```Python
if not getattr(opts, 'macos_show_window_title_in_menubar', True):
    opts.macos_show_window_title_in = 0b01
```
Is there some way to have one config option but two independent variables where that option is stored? `macos_show_window_title_in_menubar` and `macos_show_window_title_in_window` are really two different, independent options. I agree that having one config option for the two things is better but in the code I'd like to treat them separately, so I don't need to use bit masks and bit shifts when I'm using the options in the code. The way I partially solved it now is a bit ugly, still requires not-so-readable bit operations and doesn't allow me to access `macos_show_window_title_in_menubar` and `macos_show_window_title_in_window` from the python code. It also doesn't allow me to properly handle the case where both `macos_show_window_title_in` and `macos_show_window_title_in_menubar` are present in the config.