### PR TITLE
GLFW: Fix invalid ranges for gamepad axis sources

### DIFF
--- a/glfw/input.c
+++ b/glfw/input.c
@@ -1365,9 +1365,11 @@ GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state)
             const unsigned int bit = e->index & 0xf;
             if (js->hats[hat] & bit)
                 state->axes[i] = 1.f;
+            else
+                state->axes[i] = -1.f;
         }
         else if (e->type == _GLFW_JOYSTICK_BUTTON)
-            state->axes[i] = (float) js->buttons[e->index];
+            state->axes[i] = js->buttons[e->index] * 2.f - 1.f;
     }
 
     return true;


### PR DESCRIPTION
From https://github.com/glfw/glfw/commit/9420e6f0d090f2f3fe61f71d5e05220f5245c861.