### PR TITLE
Ignore the `build` directory only in the root of the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.pyc
 *.pyo
 tags
-build
+/build
 linux-package
 kitty.app
 compile_commands.json


### PR DESCRIPTION
The `build` directory is always located at the root directory of the repository. Therefore it's better to only ignore `build` in this location.