### PR TITLE
Fix a crash when trying to read the environment from a shell

### DIFF
--- a/kitty/main.py
+++ b/kitty/main.py
@@ -210,13 +210,14 @@ def read_shell_environment(opts):
         shell = resolved_shell(opts)
         p = subprocess.Popen(shell + ['-l', '-c', 'env'], stdout=subprocess.PIPE)
         raw = p.stdout.read()
-        if p.wait() == 0:
-            raw = raw.decode('utf-8', 'replace')
-            ans = read_shell_environment.ans = {}
-            for line in raw.splitlines():
-                k, v = line.partition('=')[::2]
-                if k and v:
-                    ans[k] = v
+        if p.wait() != 0:
+            return {}
+        raw = raw.decode('utf-8', 'replace')
+        ans = read_shell_environment.ans = {}
+        for line in raw.splitlines():
+            k, v = line.partition('=')[::2]
+            if k and v:
+                ans[k] = v
     return read_shell_environment.ans
 
 


### PR DESCRIPTION
Fixes https://github.com/kovidgoyal/kitty/issues/1869.
If the shell from which the environment variables are being read exits with a non-zero exit code, kitty crashes. This commit fixes the crash by returning an empty environment in that case.

Note that I have not tested the fix.
I'm also not 100% sure if this is the right way to fix the crash.