### PR TITLE
Avoid catching all exceptions

### DIFF
--- a/kitty/main.py
+++ b/kitty/main.py
@@ -219,8 +219,9 @@ def read_shell_environment(opts=None):
                     ret = p.wait(0.01)
                 except TimeoutExpired:
                     ret = None
-                with suppress(Exception):
-                    raw += stdout.read()
+                read = stdout.read()
+                if read is not None:
+                    raw += read
                 if ret is not None:
                     break
             if p.returncode == 0:


### PR DESCRIPTION
Catching all exceptions just to know when `read()` didn't read anything is not necessary.