### PR TITLE
Use context managers to open files

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -107,7 +107,8 @@ features of the graphics protocol:
          sys.stdout.flush()
          cmd.clear()
 
-   write_chunked({'a': 'T', 'f': 100}, open(sys.argv[-1], 'rb').read())
+   with open(sys.argv[-1], 'rb') as f:
+      write_chunked({'a': 'T', 'f': 100}, f.read())
 
 
 Save this script as :file:`png.py`, then you can use it to display any PNG

--- a/docs/installer.py
+++ b/docs/installer.py
@@ -229,7 +229,8 @@ def script_launch():
 
 def update_intaller_wrapper():
     # To run: python3 -c "import runpy; runpy.run_path('installer.py', run_name='update_wrapper')" installer.sh
-    src = open(__file__, 'rb').read().decode('utf-8')
+    with open(__file__, 'rb') as f:
+        src = f.read().decode('utf-8')
     wrapper = sys.argv[-1]
     with open(wrapper, 'r+b') as f:
         raw = f.read().decode('utf-8')

--- a/glfw/glfw.py
+++ b/glfw/glfw.py
@@ -38,7 +38,8 @@ def init_env(env, pkg_config, at_least_version, test_compile, module='x11'):
         )
     else:
         ans.ldpaths.extend('-lrt -lm -ldl'.split())
-    sinfo = json.load(open(os.path.join(base, 'source-info.json')))
+    with open(os.path.join(base, 'source-info.json')) as f:
+        sinfo = json.load(f)
     module_sources = list(sinfo[module]['sources'])
     if module in ('x11', 'wayland'):
         remove = 'linux_joystick.c' if is_bsd else 'null_joystick.c'
@@ -157,7 +158,8 @@ class Function:
 
 
 def generate_wrappers(glfw_header):
-    src = open(glfw_header).read()
+    with open(glfw_header) as f:
+        src = f.read()
     functions = []
     first = None
     for m in re.finditer(r'^GLFWAPI\s+(.+[)]);\s*$', src, flags=re.MULTILINE):

--- a/kittens/tui/images.py
+++ b/kittens/tui/images.py
@@ -249,7 +249,8 @@ class ImageManager:
                 cmd, standard_b64encode(rgba_path.encode(fsenc)))
         else:
             import zlib
-            data = open(rgba_path, 'rb').read()
+            with open(rgba_path, 'rb') as f:
+                data = f.read()
             cmd['S'] = len(data)
             data = zlib.compress(data)
             cmd['o'] = 'z'

--- a/kitty/child.py
+++ b/kitty/child.py
@@ -30,14 +30,16 @@ if is_macos:
 else:
 
     def cmdline_of_process(pid):
-        return list(filter(None, open('/proc/{}/cmdline'.format(pid), 'rb').read().decode('utf-8').split('\0')))
+        with open('/proc/{}/cmdline'.format(pid), 'rb') as f:
+            return list(filter(None, f.read().decode('utf-8').split('\0')))
 
     def cwd_of_process(pid):
         ans = '/proc/{}/cwd'.format(pid)
         return os.path.realpath(ans)
 
     def _environ_of_process(pid):
-        return open('/proc/{}/environ'.format(pid), 'rb').read().decode('utf-8')
+        with open('/proc/{}/environ'.format(pid), 'rb') as f:
+            return f.read().decode('utf-8')
 
     def process_group_map():
         ans = defaultdict(list)
@@ -47,7 +49,8 @@ else:
             except Exception:
                 continue
             try:
-                raw = open('/proc/' + x + '/stat', 'rb').read().decode('utf-8')
+                with open('/proc/' + x + '/stat', 'rb') as f:
+                    raw = f.read().decode('utf-8')
             except EnvironmentError:
                 continue
             try:

--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -728,9 +728,11 @@ def create_opts(args, debug_config=False, accumulate_bad_lines=None):
             import subprocess
             print(' '.join(subprocess.check_output(['sw_vers']).decode('utf-8').splitlines()).strip())
         if os.path.exists('/etc/issue'):
-            print(open('/etc/issue', encoding='utf-8', errors='replace').read().strip())
+            with open('/etc/issue', encoding='utf-8', errors='replace') as f:
+                print(f.read().strip())
         if os.path.exists('/etc/lsb-release'):
-            print(open('/etc/lsb-release', encoding='utf-8', errors='replace').read().strip())
+            with open('/etc/lsb-release', encoding='utf-8', errors='replace') as f:
+                print(f.read().strip())
         config = tuple(x for x in config if os.path.exists(x))
         if config:
             print(green('Loaded config files:'), ', '.join(config))

--- a/kitty/client.py
+++ b/kitty/client.py
@@ -157,7 +157,8 @@ def replay(raw):
 
 
 def main(path):
-    raw = open(path).read()
+    with open(path) as f:
+        raw = f.read()
     replay(raw)
     with suppress(EOFError, KeyboardInterrupt):
         input()

--- a/kitty/conf/utils.py
+++ b/kitty/conf/utils.py
@@ -177,12 +177,11 @@ def load_config(Options, defaults, parse_config, merge_configs, *paths, override
         if not path:
             continue
         try:
-            f = open(path, encoding='utf-8', errors='replace')
+            with open(path, encoding='utf-8', errors='replace') as f:
+                vals = parse_config(f)
         except FileNotFoundError:
             continue
-        with f:
-            vals = parse_config(f)
-            ans = merge_configs(ans, vals)
+        ans = merge_configs(ans, vals)
     if overrides is not None:
         vals = parse_config(overrides)
         ans = merge_configs(ans, vals)

--- a/kitty/rgb.py
+++ b/kitty/rgb.py
@@ -835,14 +835,15 @@ if __name__ == '__main__':
     import sys
     import pprint
     data = {}
-    for line in open(sys.argv[-1]):
-        line = line.strip()
-        if not line or line.startswith('!'):
-            continue
-        parts = line.split()
-        r, g, b = map(int, parts[:3])
-        name = ' '.join(parts[3:]).lower()
-        data[name] = data[name.replace(' ', '')] = r, g, b
+    with open(sys.argv[-1]) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('!'):
+                continue
+            parts = line.split()
+            r, g, b = map(int, parts[:3])
+            name = ' '.join(parts[3:]).lower()
+            data[name] = data[name.replace(' ', '')] = r, g, b
     data = pprint.pformat(data).replace('{', '{\n ').replace('(', 'Color(')
     with open(__file__, 'r+') as src:
         raw = src.read()

--- a/kitty/utils.py
+++ b/kitty/utils.py
@@ -23,8 +23,10 @@ BASE = os.path.dirname(os.path.abspath(__file__))
 
 def load_shaders(name):
     from .fast_data_types import GLSL_VERSION
-    vert = open(os.path.join(BASE, '{}_vertex.glsl'.format(name))).read().replace('GLSL_VERSION', str(GLSL_VERSION), 1)
-    frag = open(os.path.join(BASE, '{}_fragment.glsl'.format(name))).read().replace('GLSL_VERSION', str(GLSL_VERSION), 1)
+    with open(os.path.join(BASE, '{}_vertex.glsl'.format(name))) as f:
+        vert = f.read().replace('GLSL_VERSION', str(GLSL_VERSION), 1)
+    with open(os.path.join(BASE, '{}_fragment.glsl'.format(name))) as f:
+        frag = f.read().replace('GLSL_VERSION', str(GLSL_VERSION), 1)
     return vert, frag
 
 

--- a/kitty_tests/gr.py
+++ b/kitty_tests/gr.py
@@ -56,7 +56,8 @@ def main():
         raise SystemExit('Must specify a PNG file to display')
     clear_screen()
     display(b'\xdd\xdd\xdd\xff', 1, 1, 0, 0, -10, 40, 20)
-    display(open(os.path.join(base, '../logo/kitty.rgba'), 'rb').read(), 256, 256, 0, 5, -9)
+    with open(os.path.join(base, '../logo/kitty.rgba'), 'rb') as f:
+        display(f.read(), 256, 256, 0, 5, -9)
     display(b'\0\0\0\xaa', 1, 1, 0, 7, -8, 40, 3)
     move_cursor(5, 8)
     print('kitty is \033[3m\033[32mawesome\033[m!')

--- a/publish.py
+++ b/publish.py
@@ -23,7 +23,8 @@ os.chdir(os.path.dirname(os.path.abspath(__file__)))
 build_path = os.path.abspath('../build-kitty')
 docs_dir = os.path.abspath('docs')
 publish_dir = os.path.abspath(os.path.join('..', 'kovidgoyal.github.io', 'kitty'))
-raw = open('kitty/constants.py').read()
+with open('kitty/constants.py') as f:
+    raw = f.read()
 nv = re.search(
     r'^version\s+=\s+\((\d+), (\d+), (\d+)\)', raw, flags=re.MULTILINE)
 version = '%s.%s.%s' % (nv.group(1), nv.group(2), nv.group(3))

--- a/setup.py
+++ b/setup.py
@@ -315,7 +315,8 @@ def get_vcs_rev_defines():
                 with open('.git/refs/heads/master') as f:
                     rev = f.read()
             except NotADirectoryError:
-                gitloc = open('.git').read()
+                with open('.git') as f:
+                    gitloc = f.read()
                 with open(os.path.join(gitloc, 'refs/heads/master')) as f:
                     rev = f.read()
 
@@ -343,7 +344,8 @@ def newer(dest, *sources):
 def dependecies_for(src, obj, all_headers):
     dep_file = obj.rpartition('.')[0] + '.d'
     try:
-        deps = open(dep_file).read()
+        with open(dep_file) as f:
+            deps = f.read()
     except FileNotFoundError:
         yield src
         yield from iter(all_headers)

--- a/update-on-ox
+++ b/update-on-ox
@@ -46,7 +46,8 @@ def run(what):
         raise SystemExit(ret.returncode)
 
 
-script = open(__file__, 'rb').read().decode('utf-8')
+with open(__file__, 'rb') as f:
+    script = f.read().decode('utf-8')
 script = script[:script.find('# EOF_REMOTE')].replace('if False:', 'if True:', 1)
 os.chdir(os.path.expanduser('~/work/build-kitty'))
 with tempfile.NamedTemporaryFile(prefix='install-dmg-', suffix='.py') as f:

--- a/update-on-ubuntu
+++ b/update-on-ubuntu
@@ -44,7 +44,8 @@ def run(what):
         raise SystemExit(ret.returncode)
 
 
-script = open(__file__, 'rb').read().decode('utf-8')
+with open(__file__, 'rb') as f:
+    script = f.read().decode('utf-8')
 script = script[:script.find('# EOF_REMOTE')].replace('if False:', 'if True:', 1)
 os.chdir(os.path.expanduser('~/work/build-kitty'))
 with tempfile.NamedTemporaryFile(prefix='install-tarball-', suffix='.py') as f:


### PR DESCRIPTION
Inspired by https://github.com/kovidgoyal/calibre/commit/d50a6ddc1b71a575283e344a0d7bc539539bc5d1.

There are a couple instances of `open()` left where we're not using context managers that I didn't change because I'm not sure how to do that: There are a couple instances of `sys.stdin = open(os.ctermid(), 'r')` in the kittens, `self.dump_bytes_to = open(args.dump_bytes, 'wb')` in `DumpCommands` in `kitty/boss.py`, `subprocess.call(['pprof', '--callgrind', exe, '/tmp/kitty-profile.log'], stdout=open(cg, 'wb'))` in `kitty/main.py`, `fd = os.open(path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC | os.O_CLOEXEC)` in `kitty/utils.py` and `io.BufferedReader.__init__(self, open(path, mode))` in `publish.py`.