### PR TITLE
Use datatype monotonic_t instead of double to keep track of time

### DIFF
--- a/glfw/backend_utils.h
+++ b/glfw/backend_utils.h
@@ -25,6 +25,7 @@
 //========================================================================
 
 #pragma once
+#include "../kitty/monotonic.h"
 #include <poll.h>
 #include <unistd.h>
 #include <stdbool.h>
@@ -55,7 +56,7 @@ typedef struct {
 
 typedef struct {
     id_type id;
-    double interval, trigger_at;
+    monotonic_t interval, trigger_at;
     timer_callback_func callback;
     void *callback_data;
     GLFWuserdatafreefun free;
@@ -82,14 +83,14 @@ void check_for_wakeup_events(EventLoopData *eld);
 id_type addWatch(EventLoopData *eld, const char *name, int fd, int events, int enabled, watch_callback_func cb, void *cb_data);
 void removeWatch(EventLoopData *eld, id_type watch_id);
 void toggleWatch(EventLoopData *eld, id_type watch_id, int enabled);
-id_type addTimer(EventLoopData *eld, const char *name, double interval, int enabled, bool repeats, timer_callback_func cb, void *cb_data, GLFWuserdatafreefun free);
+id_type addTimer(EventLoopData *eld, const char *name, monotonic_t interval, int enabled, bool repeats, timer_callback_func cb, void *cb_data, GLFWuserdatafreefun free);
 void removeTimer(EventLoopData *eld, id_type timer_id);
 void removeAllTimers(EventLoopData *eld);
 void toggleTimer(EventLoopData *eld, id_type timer_id, int enabled);
-void changeTimerInterval(EventLoopData *eld, id_type timer_id, double interval);
-double prepareForPoll(EventLoopData *eld, double timeout);
-int pollWithTimeout(struct pollfd *fds, nfds_t nfds, double timeout);
-int pollForEvents(EventLoopData *eld, double timeout);
+void changeTimerInterval(EventLoopData *eld, id_type timer_id, monotonic_t interval);
+monotonic_t prepareForPoll(EventLoopData *eld, monotonic_t timeout);
+int pollWithTimeout(struct pollfd *fds, nfds_t nfds, monotonic_t timeout);
+int pollForEvents(EventLoopData *eld, monotonic_t timeout);
 unsigned dispatchTimers(EventLoopData *eld);
 void finalizePollData(EventLoopData *eld);
 bool initPollData(EventLoopData *eld, int display_fd);

--- a/glfw/cocoa_platform.h
+++ b/glfw/cocoa_platform.h
@@ -144,7 +144,7 @@ typedef struct _GLFWDisplayLinkNS
 {
     CVDisplayLinkRef displayLink;
     CGDirectDisplayID displayID;
-    double lastRenderFrameRequestedAt;
+    monotonic_t lastRenderFrameRequestedAt;
 } _GLFWDisplayLinkNS;
 
 // Cocoa-specific global data

--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -27,6 +27,7 @@
 //========================================================================
 
 #include "internal.h"
+#include "../kitty/monotonic.h"
 
 #include <float.h>
 #include <string.h>
@@ -120,7 +121,7 @@ CGDirectDisplayID displayIDForWindow(_GLFWwindow *w) {
 }
 
 static unsigned long long display_link_shutdown_timer = 0;
-#define DISPLAY_LINK_SHUTDOWN_CHECK_INTERVAL 30
+#define DISPLAY_LINK_SHUTDOWN_CHECK_INTERVAL s_to_monotonic_t(30ll)
 
 void
 _glfwShutdownCVDisplayLink(unsigned long long timer_id UNUSED, void *user_data UNUSED) {
@@ -147,7 +148,7 @@ requestRenderFrame(_GLFWwindow *w, GLFWcocoarenderframefun callback) {
     } else {
         display_link_shutdown_timer = _glfwPlatformAddTimer(DISPLAY_LINK_SHUTDOWN_CHECK_INTERVAL, false, _glfwShutdownCVDisplayLink, NULL, NULL);
     }
-    double now = glfwGetTime();
+    monotonic_t now = glfwGetTime();
     for (size_t i = 0; i < _glfw.ns.displayLinks.count; i++) {
         _GLFWDisplayLinkNS *dl = &_glfw.ns.displayLinks.entries[i];
         if (dl->displayID == displayID) {
@@ -1853,9 +1854,9 @@ void _glfwPlatformGetWindowContentScale(_GLFWwindow* window,
         *yscale = (float) (pixels.size.height / points.size.height);
 }
 
-double _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window UNUSED)
+monotonic_t _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window UNUSED)
 {
-    return [NSEvent doubleClickInterval];
+    return s_double_to_monotonic_t([NSEvent doubleClickInterval]);
 }
 
 void _glfwPlatformIconifyWindow(_GLFWwindow* window)

--- a/glfw/dbus_glfw.c
+++ b/glfw/dbus_glfw.c
@@ -27,6 +27,7 @@
 
 #include "internal.h"
 #include "dbus_glfw.h"
+#include "../kitty/monotonic.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -107,7 +108,7 @@ on_dbus_timer_ready(id_type timer_id UNUSED, void *data) {
 static dbus_bool_t
 add_dbus_timeout(DBusTimeout *timeout, void *data) {
     int enabled = dbus_timeout_get_enabled(timeout) ? 1 : 0;
-    double interval = ((double)dbus_timeout_get_interval(timeout)) / 1000.0;
+    monotonic_t interval = ms_to_monotonic_t(dbus_timeout_get_interval(timeout));
     if (interval < 0) return FALSE;
     id_type timer_id = addTimer(dbus_data->eld, data, interval, enabled, true, on_dbus_timer_ready, timeout, NULL);
     if (!timer_id) return FALSE;

--- a/glfw/glfw3.h
+++ b/glfw/glfw3.h
@@ -1707,8 +1707,8 @@ typedef struct GLFWgamepadstate
 GLFWAPI int glfwInit(void);
 GLFWAPI void glfwRunMainLoop(GLFWtickcallback callback, void *callback_data);
 GLFWAPI void glfwStopMainLoop(void);
-GLFWAPI unsigned long long glfwAddTimer(double interval, bool repeats, GLFWuserdatafun callback, void * callback_data, GLFWuserdatafun free_callback);
-GLFWAPI void glfwUpdateTimer(unsigned long long timer_id, double interval, bool enabled);
+GLFWAPI unsigned long long glfwAddTimer(monotonic_t interval, bool repeats, GLFWuserdatafun callback, void * callback_data, GLFWuserdatafun free_callback);
+GLFWAPI void glfwUpdateTimer(unsigned long long timer_id, monotonic_t interval, bool enabled);
 GLFWAPI void glfwRemoveTimer(unsigned long long);
 
 /*! @brief Terminates the GLFW library.
@@ -3072,7 +3072,7 @@ GLFWAPI void glfwGetWindowContentScale(GLFWwindow* window, float* xscale, float*
  *
  *  @ingroup window
  */
-GLFWAPI double glfwGetDoubleClickInterval(GLFWwindow* window);
+GLFWAPI monotonic_t glfwGetDoubleClickInterval(GLFWwindow* window);
 
 /*! @brief Returns the opacity of the whole window.
  *
@@ -5002,7 +5002,7 @@ GLFWAPI const char* glfwGetClipboardString(GLFWwindow* window);
  *
  *  @ingroup input
  */
-GLFWAPI double glfwGetTime(void);
+GLFWAPI monotonic_t glfwGetTime(void);
 
 /*! @brief Sets the GLFW timer.
  *
@@ -5029,7 +5029,7 @@ GLFWAPI double glfwGetTime(void);
  *
  *  @ingroup input
  */
-GLFWAPI void glfwSetTime(double time);
+GLFWAPI void glfwSetTime(monotonic_t time);
 
 /*! @brief Returns the current value of the raw timer.
  *

--- a/glfw/init.c
+++ b/glfw/init.c
@@ -201,7 +201,7 @@ _glfwDebug(const char *format, ...) {
     {
         va_list vl;
 
-        fprintf(stderr, "[%.4f] ", glfwGetTime());
+        fprintf(stderr, "[%.4f] ", monotonic_t_to_s_double(glfwGetTime()));
         va_start(vl, format);
         vfprintf(stderr, format, vl);
         va_end(vl);
@@ -350,13 +350,13 @@ GLFWAPI void glfwStopMainLoop(void) {
 }
 
 GLFWAPI unsigned long long glfwAddTimer(
-        double interval, bool repeats, GLFWuserdatafun callback,
+        monotonic_t interval, bool repeats, GLFWuserdatafun callback,
         void *callback_data, GLFWuserdatafun free_callback)
 {
     return _glfwPlatformAddTimer(interval, repeats, callback, callback_data, free_callback);
 }
 
-GLFWAPI void glfwUpdateTimer(unsigned long long timer_id, double interval, bool enabled) {
+GLFWAPI void glfwUpdateTimer(unsigned long long timer_id, monotonic_t interval, bool enabled) {
     _glfwPlatformUpdateTimer(timer_id, interval, enabled);
 }
 

--- a/glfw/input.c
+++ b/glfw/input.c
@@ -28,6 +28,7 @@
 //========================================================================
 
 #include "internal.h"
+#include "../kitty/monotonic.h"
 
 #include <assert.h>
 #include <float.h>
@@ -1477,25 +1478,23 @@ GLFWAPI const char* glfwGetPrimarySelectionString(GLFWwindow* handle UNUSED)
 }
 #endif
 
-GLFWAPI double glfwGetTime(void)
+GLFWAPI monotonic_t glfwGetTime(void)
 {
-    _GLFW_REQUIRE_INIT_OR_RETURN(0.0);
-    return (double) (_glfwPlatformGetTimerValue() - _glfw.timer.offset) /
-        _glfwPlatformGetTimerFrequency();
+    _GLFW_REQUIRE_INIT_OR_RETURN(0);
+    return monotonic();
 }
 
-GLFWAPI void glfwSetTime(double time)
+GLFWAPI void glfwSetTime(monotonic_t time)
 {
     _GLFW_REQUIRE_INIT();
 
-    if (time != time || time < 0.0 || time > 18446744073.0)
+    if (time < 0)
     {
-        _glfwInputError(GLFW_INVALID_VALUE, "Invalid time %f", time);
+        _glfwInputError(GLFW_INVALID_VALUE, "Invalid time %f", monotonic_t_to_s_double(time));
         return;
     }
 
-    _glfw.timer.offset = _glfwPlatformGetTimerValue() -
-        (uint64_t) (time * _glfwPlatformGetTimerFrequency());
+    // Do nothing
 }
 
 GLFWAPI uint64_t glfwGetTimerValue(void)

--- a/glfw/internal.h
+++ b/glfw/internal.h
@@ -27,6 +27,8 @@
 
 #pragma once
 
+#include "../kitty/monotonic.h"
+
 #if defined(_GLFW_USE_CONFIG_H)
  #include "glfw_config.h"
 #endif
@@ -687,7 +689,7 @@ void _glfwPlatformGetWindowFrameSize(_GLFWwindow* window,
                                      int* right, int* bottom);
 void _glfwPlatformGetWindowContentScale(_GLFWwindow* window,
                                         float* xscale, float* yscale);
-double _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window);
+monotonic_t _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window);
 void _glfwPlatformIconifyWindow(_GLFWwindow* window);
 void _glfwPlatformRestoreWindow(_GLFWwindow* window);
 void _glfwPlatformMaximizeWindow(_GLFWwindow* window);
@@ -716,7 +718,7 @@ void _glfwPlatformUpdateIMEState(_GLFWwindow *w, int which, int a, int b, int c,
 
 void _glfwPlatformPollEvents(void);
 void _glfwPlatformWaitEvents(void);
-void _glfwPlatformWaitEventsTimeout(double timeout);
+void _glfwPlatformWaitEventsTimeout(monotonic_t timeout);
 void _glfwPlatformPostEmptyEvent(void);
 
 void _glfwPlatformGetRequiredInstanceExtensions(char** extensions);
@@ -824,8 +826,8 @@ _GLFWwindow* _glfwFocusedWindow(void);
 _GLFWwindow* _glfwWindowForId(GLFWid id);
 void _glfwPlatformRunMainLoop(GLFWtickcallback, void*);
 void _glfwPlatformStopMainLoop(void);
-unsigned long long _glfwPlatformAddTimer(double interval, bool repeats, GLFWuserdatafun callback, void *callback_data, GLFWuserdatafun free_callback);
-void _glfwPlatformUpdateTimer(unsigned long long timer_id, double interval, bool enabled);
+unsigned long long _glfwPlatformAddTimer(monotonic_t interval, bool repeats, GLFWuserdatafun callback, void *callback_data, GLFWuserdatafun free_callback);
+void _glfwPlatformUpdateTimer(unsigned long long timer_id, monotonic_t interval, bool enabled);
 void _glfwPlatformRemoveTimer(unsigned long long timer_id);
 
 char* _glfw_strdup(const char* source);

--- a/glfw/main_loop.h
+++ b/glfw/main_loop.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "internal.h"
+#include "../kitty/monotonic.h"
 
 #ifndef GLFW_LOOP_BACKEND
 #define GLFW_LOOP_BACKEND x11
@@ -36,7 +37,7 @@ void _glfwPlatformRunMainLoop(GLFWtickcallback tick_callback, void* data) {
     EVDBG("main loop exiting");
 }
 
-unsigned long long _glfwPlatformAddTimer(double interval, bool repeats, GLFWuserdatafreefun callback, void *callback_data, GLFWuserdatafreefun free_callback) {
+unsigned long long _glfwPlatformAddTimer(monotonic_t interval, bool repeats, GLFWuserdatafreefun callback, void *callback_data, GLFWuserdatafreefun free_callback) {
     return addTimer(&_glfw.GLFW_LOOP_BACKEND.eventLoopData, "user timer", interval, 1, repeats, callback, callback_data, free_callback);
 }
 
@@ -44,7 +45,7 @@ void _glfwPlatformRemoveTimer(unsigned long long timer_id) {
     removeTimer(&_glfw.GLFW_LOOP_BACKEND.eventLoopData, timer_id);
 }
 
-void _glfwPlatformUpdateTimer(unsigned long long timer_id, double interval, bool enabled) {
+void _glfwPlatformUpdateTimer(unsigned long long timer_id, monotonic_t interval, bool enabled) {
     changeTimerInterval(&_glfw.GLFW_LOOP_BACKEND.eventLoopData, timer_id, interval);
     toggleTimer(&_glfw.GLFW_LOOP_BACKEND.eventLoopData, timer_id, enabled);
 }

--- a/glfw/null_window.c
+++ b/glfw/null_window.c
@@ -28,6 +28,7 @@
 //========================================================================
 
 #include "internal.h"
+#include "../kitty/monotonic.h"
 
 
 static int createNativeWindow(_GLFWwindow* window,
@@ -150,9 +151,9 @@ void _glfwPlatformGetWindowContentScale(_GLFWwindow* window UNUSED,
         *yscale = 1.f;
 }
 
-double _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window UNUSED)
+monotonic_t _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window UNUSED)
 {
-    return 0.5;
+    return ms_to_monotonic_t(500ll);
 }
 
 void _glfwPlatformIconifyWindow(_GLFWwindow* window UNUSED)
@@ -257,7 +258,7 @@ void _glfwPlatformWaitEvents(void)
 {
 }
 
-void _glfwPlatformWaitEventsTimeout(double timeout UNUSED)
+void _glfwPlatformWaitEventsTimeout(monotonic_t timeout UNUSED)
 {
 }
 

--- a/glfw/window.c
+++ b/glfw/window.c
@@ -29,6 +29,7 @@
 //========================================================================
 
 #include "internal.h"
+#include "../kitty/monotonic.h"
 
 #include <assert.h>
 #include <string.h>
@@ -738,12 +739,12 @@ GLFWAPI void glfwGetWindowContentScale(GLFWwindow* handle,
     _glfwPlatformGetWindowContentScale(window, xscale, yscale);
 }
 
-GLFWAPI double glfwGetDoubleClickInterval(GLFWwindow* handle)
+GLFWAPI monotonic_t glfwGetDoubleClickInterval(GLFWwindow* handle)
 {
     _GLFWwindow* window = (_GLFWwindow*) handle;
     assert(window != NULL);
 
-    _GLFW_REQUIRE_INIT_OR_RETURN(0.5f);
+    _GLFW_REQUIRE_INIT_OR_RETURN(ms_to_monotonic_t(500ll));
     return _glfwPlatformGetDoubleClickInterval(window);
 }
 

--- a/glfw/wl_platform.h
+++ b/glfw/wl_platform.h
@@ -250,7 +250,7 @@ typedef struct _GLFWlibraryWayland
     uint32_t                    pointerSerial;
 
     int32_t                     keyboardRepeatRate;
-    int32_t                     keyboardRepeatDelay;
+    monotonic_t                 keyboardRepeatDelay;
     struct {
         uint32_t                key;
         id_type                 keyRepeatTimer;

--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -7,6 +7,7 @@
 
 
 #include "state.h"
+#include "monotonic.h"
 #include <Cocoa/Cocoa.h>
 
 #include <AvailabilityMacros.h>
@@ -411,7 +412,7 @@ cocoa_get_lang(PyObject UNUSED *self) {
     } // autoreleasepool
 }
 
-double
+monotonic_t
 cocoa_cursor_blink_interval(void) {
     @autoreleasepool {
 
@@ -425,7 +426,7 @@ cocoa_cursor_blink_interval(void) {
     } else if (period_ms) {
         ans = period_ms;
     }
-    return ans > max_value ? 0.0 : ans;
+    return ans > max_value ? 0ll : ms_double_to_monotonic_t(ans);
 
     } // autoreleasepool
 }

--- a/kitty/data-types.c
+++ b/kitty/data-types.c
@@ -22,31 +22,10 @@
 #ifdef WITH_PROFILER
 #include <gperftools/profiler.h>
 #endif
-
-/* To millisecond (10^-3) */
-#define SEC_TO_MS 1000
-
-/* To microseconds (10^-6) */
-#define MS_TO_US 1000
-#define SEC_TO_US (SEC_TO_MS * MS_TO_US)
-
-/* To nanoseconds (10^-9) */
-#define US_TO_NS 1000
-#define MS_TO_NS (MS_TO_US * US_TO_NS)
-#define SEC_TO_NS (SEC_TO_MS * MS_TO_NS)
-
-/* Conversion from nanoseconds */
-#define NS_TO_MS (1000 * 1000)
-#define NS_TO_US (1000)
+#include "monotonic.h"
 
 #ifdef __APPLE__
 #include <libproc.h>
-#include <mach/mach_time.h>
-static mach_timebase_info_data_t timebase = {0};
-
-static inline double monotonic_(void) {
-    return ((double)(mach_absolute_time() * timebase.numer) / timebase.denom)/SEC_TO_NS;
-}
 
 static PyObject*
 user_cache_dir() {
@@ -73,25 +52,7 @@ process_group_map() {
     free(buf);
     return ans;
 }
-
-#else
-#include <time.h>
-static inline double monotonic_(void) {
-    struct timespec ts = {0};
-#ifdef CLOCK_HIGHRES
-    clock_gettime(CLOCK_HIGHRES, &ts);
-#elif CLOCK_MONOTONIC_RAW
-    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
-#else
-    clock_gettime(CLOCK_MONOTONIC, &ts);
 #endif
-    return (((double)ts.tv_nsec) / SEC_TO_NS) + (double)ts.tv_sec;
-}
-#endif
-
-static double start_time = 0;
-
-double monotonic() { return monotonic_() - start_time; }
 
 static PyObject*
 redirect_std_streams(PyObject UNUSED *self, PyObject *args) {
@@ -254,9 +215,8 @@ PyInit_fast_data_types(void) {
     m = PyModule_Create(&module);
     if (m == NULL) return NULL;
 #ifdef __APPLE__
-    mach_timebase_info(&timebase);
 #endif
-    start_time = monotonic_();
+    init_monotonic();
 
     if (m != NULL) {
         if (!init_logging(m)) return NULL;

--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -292,7 +292,6 @@ void apply_sgr_to_cells(GPUCell *first_cell, unsigned int cell_count, unsigned i
 const char* cell_as_sgr(const GPUCell *, const GPUCell *);
 const char* cursor_as_sgr(const Cursor *);
 
-double monotonic(void);
 PyObject* cm_thread_write(PyObject *self, PyObject *args);
 bool schedule_write_to_child(unsigned long id, unsigned int num, ...);
 bool set_iutf8(int, bool);

--- a/kitty/glfw-wrapper.h
+++ b/kitty/glfw-wrapper.h
@@ -7,6 +7,7 @@
 #pragma once
 #include <stddef.h>
 #include <stdint.h>
+#include "../kitty/monotonic.h"
 
 
 
@@ -1487,11 +1488,11 @@ typedef void (*glfwStopMainLoop_func)(void);
 glfwStopMainLoop_func glfwStopMainLoop_impl;
 #define glfwStopMainLoop glfwStopMainLoop_impl
 
-typedef unsigned long long (*glfwAddTimer_func)(double, bool, GLFWuserdatafun, void *, GLFWuserdatafun);
+typedef unsigned long long (*glfwAddTimer_func)(monotonic_t, bool, GLFWuserdatafun, void *, GLFWuserdatafun);
 glfwAddTimer_func glfwAddTimer_impl;
 #define glfwAddTimer glfwAddTimer_impl
 
-typedef void (*glfwUpdateTimer_func)(unsigned long long, double, bool);
+typedef void (*glfwUpdateTimer_func)(unsigned long long, monotonic_t, bool);
 glfwUpdateTimer_func glfwUpdateTimer_impl;
 #define glfwUpdateTimer glfwUpdateTimer_impl
 
@@ -1659,7 +1660,7 @@ typedef void (*glfwGetWindowContentScale_func)(GLFWwindow*, float*, float*);
 glfwGetWindowContentScale_func glfwGetWindowContentScale_impl;
 #define glfwGetWindowContentScale glfwGetWindowContentScale_impl
 
-typedef double (*glfwGetDoubleClickInterval_func)(GLFWwindow*);
+typedef monotonic_t (*glfwGetDoubleClickInterval_func)(GLFWwindow*);
 glfwGetDoubleClickInterval_func glfwGetDoubleClickInterval_impl;
 #define glfwGetDoubleClickInterval glfwGetDoubleClickInterval_impl
 
@@ -1911,11 +1912,11 @@ typedef const char* (*glfwGetClipboardString_func)(GLFWwindow*);
 glfwGetClipboardString_func glfwGetClipboardString_impl;
 #define glfwGetClipboardString glfwGetClipboardString_impl
 
-typedef double (*glfwGetTime_func)(void);
+typedef monotonic_t (*glfwGetTime_func)(void);
 glfwGetTime_func glfwGetTime_impl;
 #define glfwGetTime glfwGetTime_impl
 
-typedef void (*glfwSetTime_func)(double);
+typedef void (*glfwSetTime_func)(monotonic_t);
 glfwSetTime_func glfwSetTime_impl;
 #define glfwSetTime glfwSetTime_impl
 

--- a/kitty/graphics.c
+++ b/kitty/graphics.c
@@ -121,7 +121,7 @@ trim_predicate(Image *img) {
 
 static int
 oldest_last(const void* a, const void *b) {
-    double ans = ((Image*)(b))->atime - ((Image*)(a))->atime;
+    monotonic_t ans = ((Image*)(b))->atime - ((Image*)(a))->atime;
     return ans < 0 ? -1 : (ans == 0 ? 0 : 1);
 }
 

--- a/kitty/graphics.h
+++ b/kitty/graphics.h
@@ -6,6 +6,7 @@
 
 #pragma once
 #include "data-types.h"
+#include "monotonic.h"
 
 typedef struct {
     unsigned char action, transmission_type, compressed, delete_action;
@@ -50,7 +51,7 @@ typedef struct {
 
     ImageRef *refs;
     size_t refcnt, refcap;
-    double atime;
+    monotonic_t atime;
     size_t used_storage;
 } Image;
 

--- a/kitty/kittens.c
+++ b/kitty/kittens.c
@@ -6,6 +6,7 @@
  */
 
 #include "data-types.h"
+#include "monotonic.h"
 
 #define CMD_BUF_SZ 2048
 
@@ -34,13 +35,13 @@ add_char(char buf[CMD_BUF_SZ], size_t *pos, char ch, PyObject *ans) {
 }
 
 static inline bool
-read_response(int fd, double timeout, PyObject *ans) {
+read_response(int fd, monotonic_t timeout, PyObject *ans) {
     static char buf[CMD_BUF_SZ];
     size_t pos = 0;
     enum ReadState {START, STARTING_ESC, P, AT, K, I, T, T2, Y, HYPHEN, C, M, BODY, TRAILING_ESC};
     enum ReadState state = START;
     char ch;
-    double end_time = monotonic() + timeout;
+    monotonic_t end_time = monotonic() + timeout;
     while(monotonic() <= end_time) {
         ssize_t len = read(fd, &ch, 1);
         if (len == 0) continue;
@@ -94,7 +95,7 @@ read_command_response(PyObject *self UNUSED, PyObject *args) {
     int fd;
     PyObject *ans;
     if (!PyArg_ParseTuple(args, "idO!", &fd, &timeout, &PyList_Type, &ans)) return NULL;
-    if (!read_response(fd, timeout, ans)) return NULL;
+    if (!read_response(fd, s_double_to_monotonic_t(timeout), ans)) return NULL;
     Py_RETURN_NONE;
 }
 

--- a/kitty/monotonic.h
+++ b/kitty/monotonic.h
@@ -1,0 +1,84 @@
+/*
+ * monotonic.h
+ * Copyright (C) 2019 Kovid Goyal <kovid at kovidgoyal.net>
+ *
+ * Distributed under terms of the GPL3 license.
+ */
+
+#pragma once
+
+
+#include <stdint.h>
+#include <time.h>
+
+#define MONOTONIC_T_MAX INT64_MAX
+#define MONOTONIC_T_MIN INT64_MIN
+
+typedef int64_t monotonic_t;
+
+static inline monotonic_t calc_nano_time(struct timespec time) {
+    int64_t result = (monotonic_t)time.tv_sec;
+    result *= 1000LL;
+    result *= 1000LL;
+    result *= 1000LL;
+    result += (monotonic_t)time.tv_nsec;
+    return result;
+}
+
+static inline struct timespec calc_time(monotonic_t nsec) {
+    struct timespec result;
+    result.tv_sec  = nsec / (1000LL * 1000LL * 1000LL);
+    result.tv_nsec = nsec % (1000LL * 1000LL * 1000LL);
+    return result;
+}
+
+static inline monotonic_t s_double_to_monotonic_t(double time) {
+    time *= 1000.0;
+    time *= 1000.0;
+    time *= 1000.0;
+    return (monotonic_t)time;
+}
+
+static inline monotonic_t ms_double_to_monotonic_t(double time) {
+    time *= 1000.0;
+    time *= 1000.0;
+    return (monotonic_t)time;
+}
+
+static inline monotonic_t s_to_monotonic_t(monotonic_t time) {
+    return time * 1000ll * 1000ll * 1000ll;
+}
+
+static inline monotonic_t ms_to_monotonic_t(monotonic_t time) {
+    return time * 1000ll * 1000ll;
+}
+
+static inline int monotonic_t_to_ms(monotonic_t time) {
+    return time / 1000ll / 1000ll;
+}
+
+static inline double monotonic_t_to_s_double(monotonic_t time) {
+    return (double)time / 1000.0 / 1000.0 / 1000.0;
+}
+
+static monotonic_t start_time = 0;
+
+static inline monotonic_t monotonic_(void) {
+    struct timespec ts = {0};
+#ifdef CLOCK_HIGHRES
+    clock_gettime(CLOCK_HIGHRES, &ts);
+#elif CLOCK_MONOTONIC_RAW
+    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+#else
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+#endif
+    return calc_nano_time(ts);
+}
+
+static inline monotonic_t monotonic(void) {
+	return monotonic_() - start_time;
+}
+
+static inline void init_monotonic(void) {
+	start_time = monotonic_();
+}

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -13,6 +13,7 @@
 #include <math.h>
 #include "glfw-wrapper.h"
 #include "control-codes.h"
+#include "monotonic.h"
 
 static MouseShape mouse_cursor_shape = BEAM;
 typedef enum MouseActions { PRESS, RELEASE, DRAG, MOVE } MouseAction;
@@ -292,8 +293,8 @@ HANDLER(handle_move_event) {
     bool handle_in_kitty = !in_tracking_mode || has_terminal_select_modifiers;
     if (handle_in_kitty) {
         if (screen->selection.in_progress && button == GLFW_MOUSE_BUTTON_LEFT) {
-            double now = monotonic();
-            if ((now - w->last_drag_scroll_at) >= 0.02 || mouse_cell_changed) {
+            monotonic_t now = monotonic();
+            if ((now - w->last_drag_scroll_at) >= ms_to_monotonic_t(20ll) || mouse_cell_changed) {
                 update_drag(false, w, false, 0);
                 w->last_drag_scroll_at = now;
             }
@@ -338,7 +339,7 @@ distance(double x1, double y1, double x2, double y2) {
 HANDLER(add_click) {
     ClickQueue *q = &w->click_queue;
     if (q->length == CLICK_QUEUE_SZ) { memmove(q->clicks, q->clicks + 1, sizeof(Click) * (CLICK_QUEUE_SZ - 1)); q->length--; }
-    double now = monotonic();
+    monotonic_t now = monotonic();
 #define N(n) (q->clicks[q->length - n])
     N(0).at = now; N(0).button = button; N(0).modifiers = modifiers; N(0).x = w->mouse_pos.x; N(0).y = w->mouse_pos.y;
     q->length++;

--- a/kitty/parser.c
+++ b/kitty/parser.c
@@ -9,6 +9,7 @@
 #include "screen.h"
 #include "graphics.h"
 #include "charsets.h"
+#include "monotonic.h"
 #include <time.h>
 
 extern PyTypeObject Screen_Type;
@@ -1196,7 +1197,7 @@ end:
 }
 
 static inline void
-do_parse_bytes(Screen *screen, const uint8_t *read_buf, const size_t read_buf_sz, double now, PyObject *dump_callback DUMP_UNUSED) {
+do_parse_bytes(Screen *screen, const uint8_t *read_buf, const size_t read_buf_sz, monotonic_t now, PyObject *dump_callback DUMP_UNUSED) {
     enum STATE {START, PARSE_PENDING, PARSE_READ_BUF, QUEUE_PENDING};
     enum STATE state = START;
     size_t read_buf_pos = 0;
@@ -1272,7 +1273,7 @@ FNAME(parse_bytes)(PyObject UNUSED *self, PyObject *args) {
 
 
 void
-FNAME(parse_worker)(Screen *screen, PyObject *dump_callback, double now) {
+FNAME(parse_worker)(Screen *screen, PyObject *dump_callback, monotonic_t now) {
 #ifdef DUMP_COMMANDS
     if (screen->read_buf_sz) {
         Py_XDECREF(PyObject_CallFunction(dump_callback, "sy#", "bytes", screen->read_buf, screen->read_buf_sz)); PyErr_Clear();

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -1730,7 +1730,7 @@ static PyObject*
 set_pending_timeout(Screen *self, PyObject *val) {
     if (!PyFloat_Check(val)) { PyErr_SetString(PyExc_TypeError, "timeout must be a float"); return NULL; }
     PyObject *ans = PyFloat_FromDouble(self->pending_mode.wait_time);
-    self->pending_mode.wait_time = PyFloat_AS_DOUBLE(val);
+    self->pending_mode.wait_time = s_double_to_monotonic_t(PyFloat_AS_DOUBLE(val));
     return ans;
 }
 

--- a/kitty/screen.h
+++ b/kitty/screen.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "graphics.h"
+#include "monotonic.h"
 
 typedef enum ScrollTypes { SCROLL_LINE = -999999, SCROLL_PAGE, SCROLL_FULL } ScrollType;
 
@@ -86,13 +87,13 @@ typedef struct {
     bool *tabstops, *main_tabstops, *alt_tabstops;
     ScreenModes modes;
     ColorProfile *color_profile;
-    double start_visual_bell_at;
+    monotonic_t start_visual_bell_at;
 
     uint32_t parser_buf[PARSER_BUF_SZ];
     unsigned int parser_state, parser_text_start, parser_buf_pos;
     bool parser_has_pending_text;
     uint8_t read_buf[READ_BUF_SZ], *write_buf;
-    double new_input_at;
+    monotonic_t new_input_at;
     size_t read_buf_sz, write_buf_sz, write_buf_used;
     pthread_mutex_t read_buf_lock, write_buf_lock;
 
@@ -101,7 +102,7 @@ typedef struct {
     struct {
         size_t capacity, used, stop_buf_pos;
         uint8_t *buf;
-        double activated_at, wait_time;
+        monotonic_t activated_at, wait_time;
         int state;
         uint8_t stop_buf[32];
     } pending_mode;
@@ -110,8 +111,8 @@ typedef struct {
 } Screen;
 
 
-void parse_worker(Screen *screen, PyObject *dump_callback, double now);
-void parse_worker_dump(Screen *screen, PyObject *dump_callback, double now);
+void parse_worker(Screen *screen, PyObject *dump_callback, monotonic_t now);
+void parse_worker_dump(Screen *screen, PyObject *dump_callback, monotonic_t now);
 void screen_align(Screen*);
 void screen_restore_cursor(Screen *);
 void screen_save_cursor(Screen *);

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -300,9 +300,14 @@ color_as_int(PyObject *color) {
 #undef I
 }
 
-static inline double
-repaint_delay(PyObject *val) {
-    return (double)(PyLong_AsUnsignedLong(val)) / 1000.0;
+static inline monotonic_t
+parse_s_double_to_monotonic_t(PyObject *val) {
+    return s_double_to_monotonic_t(PyFloat_AsDouble(val));
+}
+
+static inline monotonic_t
+parse_ms_long_to_monotonic_t(PyObject *val) {
+    return ms_to_monotonic_t(PyLong_AsUnsignedLong(val));
 }
 
 static int kitty_mod = 0;
@@ -390,11 +395,11 @@ PYWRAP1(set_options) {
 #define S(name, convert) SS(name, OPT(name), convert)
     SS(kitty_mod, kitty_mod, PyLong_AsLong);
     S(hide_window_decorations, PyObject_IsTrue);
-    S(visual_bell_duration, PyFloat_AsDouble);
+    S(visual_bell_duration, parse_s_double_to_monotonic_t);
     S(enable_audio_bell, PyObject_IsTrue);
     S(focus_follows_mouse, PyObject_IsTrue);
-    S(cursor_blink_interval, PyFloat_AsDouble);
-    S(cursor_stop_blinking_after, PyFloat_AsDouble);
+    S(cursor_blink_interval, parse_s_double_to_monotonic_t);
+    S(cursor_stop_blinking_after, parse_s_double_to_monotonic_t);
     S(background_opacity, PyFloat_AsDouble);
     S(dim_opacity, PyFloat_AsDouble);
     S(dynamic_background_opacity, PyObject_IsTrue);
@@ -404,14 +409,14 @@ PYWRAP1(set_options) {
     S(cursor_shape, PyLong_AsLong);
     S(url_style, PyLong_AsUnsignedLong);
     S(tab_bar_edge, PyLong_AsLong);
-    S(mouse_hide_wait, PyFloat_AsDouble);
+    S(mouse_hide_wait, parse_s_double_to_monotonic_t);
     S(wheel_scroll_multiplier, PyFloat_AsDouble);
     S(touch_scroll_multiplier, PyFloat_AsDouble);
     S(open_url_modifiers, convert_mods);
     S(rectangle_select_modifiers, convert_mods);
     S(terminal_select_modifiers, convert_mods);
-    S(click_interval, PyFloat_AsDouble);
-    S(resize_debounce_time, PyFloat_AsDouble);
+    S(click_interval, parse_s_double_to_monotonic_t);
+    S(resize_debounce_time, parse_s_double_to_monotonic_t);
     S(url_color, color_as_int);
     S(background, color_as_int);
     S(foreground, color_as_int);
@@ -420,8 +425,8 @@ PYWRAP1(set_options) {
     default_color = 0;
     S(inactive_border_color, color_as_int);
     S(bell_border_color, color_as_int);
-    S(repaint_delay, repaint_delay);
-    S(input_delay, repaint_delay);
+    S(repaint_delay, parse_ms_long_to_monotonic_t);
+    S(input_delay, parse_ms_long_to_monotonic_t);
     S(sync_to_monitor, PyObject_IsTrue);
     S(close_on_child_death, PyObject_IsTrue);
     S(window_alert_on_bell, PyObject_IsTrue);

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -7,6 +7,7 @@
 #pragma once
 #include "data-types.h"
 #include "screen.h"
+#include "monotonic.h"
 
 #define OPT(name) global_state.opts.name
 
@@ -14,7 +15,8 @@ typedef enum { LEFT_EDGE, TOP_EDGE, RIGHT_EDGE, BOTTOM_EDGE } Edge;
 typedef enum { RESIZE_DRAW_STATIC, RESIZE_DRAW_SCALED, RESIZE_DRAW_BLANK, RESIZE_DRAW_SIZE } ResizeDrawStrategy;
 
 typedef struct {
-    double visual_bell_duration, cursor_blink_interval, cursor_stop_blinking_after, mouse_hide_wait, click_interval, wheel_scroll_multiplier, touch_scroll_multiplier;
+    monotonic_t visual_bell_duration, cursor_blink_interval, cursor_stop_blinking_after, mouse_hide_wait, click_interval;
+    double wheel_scroll_multiplier, touch_scroll_multiplier;
     bool enable_audio_bell;
     CursorShape cursor_shape;
     unsigned int open_url_modifiers;
@@ -24,7 +26,7 @@ typedef struct {
     unsigned int scrollback_pager_history_size;
     char_type select_by_word_characters[256]; size_t select_by_word_characters_count;
     color_type url_color, background, foreground, active_border_color, inactive_border_color, bell_border_color;
-    double repaint_delay, input_delay;
+    monotonic_t repaint_delay, input_delay;
     bool focus_follows_mouse, hide_window_decorations;
     bool macos_hide_from_tasks, macos_quit_when_last_window_closed, macos_window_resizable, macos_traditional_fullscreen;
     unsigned int macos_option_as_alt;
@@ -44,7 +46,7 @@ typedef struct {
     bool close_on_child_death;
     bool window_alert_on_bell;
     bool debug_keyboard;
-    double resize_debounce_time;
+    monotonic_t resize_debounce_time;
     MouseShape pointer_shape_when_grabbed;
 } Options;
 
@@ -59,7 +61,7 @@ typedef struct {
 } WindowGeometry;
 
 typedef struct {
-    double at;
+    monotonic_t at;
     int button, modifiers;
     double x, y;
 } Click;
@@ -83,7 +85,7 @@ typedef struct {
     } mouse_pos;
     WindowGeometry geometry;
     ClickQueue click_queue;
-    double last_drag_scroll_at;
+    monotonic_t last_drag_scroll_at;
 } Window;
 
 typedef struct {
@@ -114,7 +116,7 @@ typedef struct {
 enum RENDER_STATE { RENDER_FRAME_NOT_REQUESTED, RENDER_FRAME_REQUESTED, RENDER_FRAME_READY };
 
 typedef struct {
-    double last_resize_event_at;
+    monotonic_t last_resize_event_at;
     bool in_progress;
     bool from_os_notification;
     bool os_says_resize_complete;
@@ -134,7 +136,7 @@ typedef struct {
     ScreenRenderData tab_bar_render_data;
     bool tab_bar_data_updated;
     bool is_focused;
-    double cursor_blink_zero_time, last_mouse_activity_at;
+    monotonic_t cursor_blink_zero_time, last_mouse_activity_at;
     double mouse_x, mouse_y;
     double logical_dpi_x, logical_dpi_y, font_sz_in_pts;
     bool mouse_button_pressed[20];
@@ -151,7 +153,7 @@ typedef struct {
     id_type temp_font_group_id;
     double pending_scroll_pixels;
     enum RENDER_STATE render_state;
-    double last_render_frame_received_at;
+    monotonic_t last_render_frame_received_at;
     id_type last_focused_counter;
     ssize_t gvao_idx;
 } OSWindow;
@@ -239,8 +241,8 @@ void request_frame_render(OSWindow *w);
 void request_tick_callback(void);
 typedef void (* timer_callback_fun)(id_type, void*);
 typedef void (* tick_callback_fun)(void*);
-id_type add_main_loop_timer(double interval, bool repeats, timer_callback_fun callback, void *callback_data, timer_callback_fun free_callback);
+id_type add_main_loop_timer(monotonic_t interval, bool repeats, timer_callback_fun callback, void *callback_data, timer_callback_fun free_callback);
 void remove_main_loop_timer(id_type timer_id);
-void update_main_loop_timer(id_type timer_id, double interval, bool enabled);
+void update_main_loop_timer(id_type timer_id, monotonic_t interval, bool enabled);
 void run_main_loop(tick_callback_fun, void*);
 void stop_main_loop(void);


### PR DESCRIPTION
See #1885.
This patch is a *little* bigger than 30 lines now but I think I have changed pretty much all the time variables except for those in the GLFW code.
The code should compile without the second commit, I'll have to figure out how to make it compile with the second commit. I will also have to figure out what I broke because kitty renders very infrequently now. Maybe I just forgot to change a `double` somewhere.
I chose to use `int64_t` instead of `uint64_t` because a few pieces of the code rely on the value being negative and I couldn't be bothered to use two types, carefully track which values can be negative and casting the types all the time. This means that the variable will "only" be good for about 290 years.