### PR TITLE
macOS: implement drag and drop of text into kitty

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -619,12 +619,12 @@ class Boss:
         if tm is not None:
             tm.update_tab_bar_data()
 
-    def on_drop(self, os_window_id, paths):
+    def on_drop(self, os_window_id, strings):
         tm = self.os_window_map.get(os_window_id)
         if tm is not None:
             w = tm.active_window
             if w is not None:
-                w.paste('\n'.join(paths))
+                w.paste('\n'.join(strings))
 
     def on_os_window_closed(self, os_window_id, viewport_width, viewport_height):
         self.cached_values['window-size'] = viewport_width, viewport_height

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -319,13 +319,13 @@ window_focus_callback(GLFWwindow *w, int focused) {
 }
 
 static void
-drop_callback(GLFWwindow *w, int count, const char **paths) {
+drop_callback(GLFWwindow *w, int count, const char **strings) {
     if (!set_callback_window(w)) return;
-    PyObject *p = PyTuple_New(count);
-    if (p) {
-        for (int i = 0; i < count; i++) PyTuple_SET_ITEM(p, i, PyUnicode_FromString(paths[i]));
-        WINDOW_CALLBACK(on_drop, "O", p);
-        Py_CLEAR(p);
+    PyObject *s = PyTuple_New(count);
+    if (s) {
+        for (int i = 0; i < count; i++) PyTuple_SET_ITEM(s, i, PyUnicode_FromString(strings[i]));
+        WINDOW_CALLBACK(on_drop, "O", s);
+        Py_CLEAR(s);
         request_tick_callback();
     }
     global_state.callback_os_window = NULL;


### PR DESCRIPTION
Closes #1368.
Since two people asked for this feature and I agree that this would be nice to have, I implemented it.

Is calling `_glfwInputDrop()` for dropped text the right thing to do?
I also thought about adding a `flags` parameter to `_glfwInputDrop()` to signal if a string was a file URL or normal text. But since it's possible that the array of strings contains both types, I didn't do that. I would have to add this information to every string individually.
Is calling `_glfwInputError()` in the `else` case the right thing to do or can you think of a better solution? This code should never be called but I just want to make sure nothing bad can happen.
I'm not sure which convention to follow regarding the curly braces. GLFW seems to have them in new lines but your code seems to not do that. Just tell me if you would like me to change something regarding the curly braces.

This took me waaay too many hours to implement 😅.