### PR TITLE
Correct indentation for two _glfwInputError() messages

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -692,8 +692,8 @@ static GLFWapplicationshouldhandlereopenfun handle_reopen_callback = NULL;
             [window->context.nsgl.object update];
         } @catch (NSException *e) {
             _glfwInputError(GLFW_PLATFORM_ERROR,
-                    "Failed to update NSGL Context object with error: %s (%s)",
-                    [[e name] UTF8String], [[e reason] UTF8String]);
+                            "Failed to update NSGL Context object with error: %s (%s)",
+                            [[e name] UTF8String], [[e reason] UTF8String]);
         }
     }
 

--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -1836,7 +1836,7 @@ static inline bool _glfwEnsureDataDevice(void) {
         if (!_glfw.wl.dataDevice)
         {
             _glfwInputError(GLFW_PLATFORM_ERROR,
-                    "Wayland: Cannot use clipboard, failed to create data device");
+                            "Wayland: Cannot use clipboard, failed to create data device");
             return false;
         }
     }


### PR DESCRIPTION
This commit changes the indentation of two error messages to match the indentation in the rest of the code.

Mostly unrelated: Why are the functions `_glfwPlatformSetClipboardString()` and `_glfwPlatformGetClipboardString()` in `wl_window.c` so different between the GLFW version in kitty and the upstream version? I thought we could maybe combine the two to get the best from both and then try to get the new version upstream as well.