### PR TITLE
Fix typos

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,7 +25,7 @@ To update |kitty|, :doc:`follow the instructions <binary>`.
 - When running kittens, use the colorscheme of the current window
   rather than the configured colorscheme (:iss:`1906`)
 
-- Dont fail to start if running the shell to read the EDITOR env var fails
+- Don't fail to start if running the shell to read the EDITOR env var fails
   (:iss:`1869`)
 
 - Disable the ``liga`` and ``dlig`` OpenType features for broken fonts

--- a/docs/rc_protocol.rst
+++ b/docs/rc_protocol.rst
@@ -2,7 +2,7 @@ Documentation for the kitty remote control protocol
 ======================================================
 
 The kitty remote control protocol is a simple protocol that involves sending
-data to kitty in the form of JSON. Any individual command ot kitty has the
+data to kitty in the form of JSON. Any individual command of kitty has the
 form::
 
     <ESC>P@kitty-cmd<JSON object><ESC>\
@@ -21,7 +21,7 @@ standalone client, use the kitty version that you are developing against. Using
 a version greater than the version of the kitty instance you are talking to,
 will cause a failure.
 
-Set ``no_response`` to True if you dont want a response from kitty.
+Set ``no_response`` to True if you don't want a response from kitty.
 
 The optional payload is a JSON object that is specific to the actual command being sent.
 The fields in the object for every command are documented below.

--- a/glfw/glfw3.h
+++ b/glfw/glfw3.h
@@ -324,7 +324,7 @@ extern "C" {
  *
  *  The naming of the key codes follow these rules:
  *   - The US keyboard layout is used
- *   - Names of printable alpha-numeric characters are used (e.g. "A", "R",
+ *   - Names of printable alphanumeric characters are used (e.g. "A", "R",
  *     "3", etc.)
  *   - For non-alphanumeric characters, Unicode:ish names are used (e.g.
  *     "COMMA", "LEFT_SQUARE_BRACKET", etc.). Note that some names do not
@@ -2175,7 +2175,7 @@ GLFWAPI const GLFWvidmode* glfwGetVideoMode(GLFWmonitor* monitor);
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
  *  GLFW_INVALID_VALUE and @ref GLFW_PLATFORM_ERROR.
  *
- *  @remark @wayland Gamma handling is a priviledged protocol, this function
+ *  @remark @wayland Gamma handling is a privileged protocol, this function
  *  will thus never be implemented and emits @ref GLFW_PLATFORM_ERROR.
  *
  *  @thread_safety This function must only be called from the main thread.
@@ -2199,7 +2199,7 @@ GLFWAPI void glfwSetGamma(GLFWmonitor* monitor, float gamma);
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
  *  GLFW_PLATFORM_ERROR.
  *
- *  @remark @wayland Gamma handling is a priviledged protocol, this function
+ *  @remark @wayland Gamma handling is a privileged protocol, this function
  *  will thus never be implemented and emits @ref GLFW_PLATFORM_ERROR while
  *  returning `NULL`.
  *
@@ -2243,7 +2243,7 @@ GLFWAPI const GLFWgammaramp* glfwGetGammaRamp(GLFWmonitor* monitor);
  *
  *  @remark @win32 The gamma ramp size must be 256.
  *
- *  @remark @wayland Gamma handling is a priviledged protocol, this function
+ *  @remark @wayland Gamma handling is a privileged protocol, this function
  *  will thus never be implemented and emits @ref GLFW_PLATFORM_ERROR.
  *
  *  @pointer_lifetime The specified gamma ramp is copied before this function
@@ -2462,7 +2462,7 @@ GLFWAPI void glfwWindowHintString(int hint, const char* value);
  *
  *  @remark @macos When activating frame autosaving with
  *  [GLFW_COCOA_FRAME_NAME](@ref GLFW_COCOA_FRAME_NAME_hint), the specified
- *  window size and position may be overriden by previously saved values.
+ *  window size and position may be overridden by previously saved values.
  *
  *  @remark @x11 Some window managers will not respect the placement of
  *  initially hidden windows.
@@ -4524,7 +4524,7 @@ GLFWAPI const unsigned char* glfwGetJoystickHats(int jid, int* count);
  */
 GLFWAPI const char* glfwGetJoystickName(int jid);
 
-/*! @brief Returns the SDL comaptible GUID of the specified joystick.
+/*! @brief Returns the SDL compatible GUID of the specified joystick.
  *
  *  This function returns the SDL compatible GUID, as a UTF-8 encoded
  *  hexadecimal string, of the specified joystick.  The returned string is
@@ -4738,7 +4738,7 @@ GLFWAPI const char* glfwGetGamepadName(int jid);
 
 /*! @brief Retrieves the state of the specified joystick remapped as a gamepad.
  *
- *  This function retrives the state of the specified joystick remapped to
+ *  This function retrieves the state of the specified joystick remapped to
  *  an Xbox-like gamepad.
  *
  *  If the specified joystick is not present or does not have a gamepad mapping

--- a/glfw/input.c
+++ b/glfw/input.c
@@ -549,7 +549,7 @@ const char* _glfwGetKeyName(int key)
         case GLFW_KEY_KP_8:         return "KEYPAD 8";
         case GLFW_KEY_KP_9:         return "KEYPAD 9";
         case GLFW_KEY_KP_DIVIDE:    return "KEYPAD DIVIDE";
-        case GLFW_KEY_KP_MULTIPLY:  return "KEYPAD MULTPLY";
+        case GLFW_KEY_KP_MULTIPLY:  return "KEYPAD MULTIPLY";
         case GLFW_KEY_KP_SUBTRACT:  return "KEYPAD SUBTRACT";
         case GLFW_KEY_KP_ADD:       return "KEYPAD ADD";
         case GLFW_KEY_KP_DECIMAL:   return "KEYPAD DECIMAL";

--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -173,7 +173,7 @@ static void dispatchChangesAfterConfigure(_GLFWwindow *window, int32_t width, in
  * SCM_RIGHTS methods.
  *
  * posix_fallocate() is used to guarantee that disk space is available
- * for the file at the given size. If disk space is insufficent, errno
+ * for the file at the given size. If disk space is insufficient, errno
  * is set to ENOSPC. If posix_fallocate() is not supported, program may
  * receive SIGBUS on accessing mmap()'ed file contents instead.
  */

--- a/glfw/x11_window.c
+++ b/glfw/x11_window.c
@@ -78,7 +78,7 @@ handleEvents(double timeout) {
 
 static bool
 waitForX11Event(double timeout) {
-    // returns true iff there is X11 data waiting to be read, does not run watches and timers
+    // returns true if there is X11 data waiting to be read, does not run watches and timers
     double end_time = glfwGetTime() + timeout;
     while(true) {
         if (timeout >= 0) {
@@ -2512,7 +2512,7 @@ _glfwDispatchX11Events(void) {
     }
 
     XFlush(_glfw.x11.display);
-    // XFlush can cause events to be queued, we dont use QueuedAfterFlush here
+    // XFlush can cause events to be queued, we don't use QueuedAfterFlush here
     // as something might have inserted events into the queue, but we want to guarantee
     // a flush.
     dispatched += dispatch_x11_queued_events(XEventsQueued(_glfw.x11.display, QueuedAlready));

--- a/glfw/xkb_glfw.c
+++ b/glfw/xkb_glfw.c
@@ -434,7 +434,7 @@ glfw_xkb_key_from_ime(KeyEvent *ev, bool handled_by_ime, bool failed) {
     }
     static xkb_keycode_t last_handled_press_keycode = 0;
     // We filter out release events that correspond to the last press event
-    // handled by the IME system. This wont fix the case of multiple key
+    // handled by the IME system. This won't fix the case of multiple key
     // presses before a release, but is better than nothing. For that case
     // you'd need to implement a ring buffer to store pending key presses.
     xkb_keycode_t prev_handled_press = last_handled_press_keycode;

--- a/kittens/hints/main.py
+++ b/kittens/hints/main.py
@@ -370,7 +370,7 @@ Comma separated list of recognized URL prefixes.
 
 --word-characters
 Characters to consider as part of a word. In addition, all characters marked as
-alpha-numeric in the unicode database will be considered as word characters.
+alphanumeric in the unicode database will be considered as word characters.
 Defaults to the select_by_word_characters setting from kitty.conf.
 
 

--- a/kittens/ssh/main.py
+++ b/kittens/ssh/main.py
@@ -95,7 +95,7 @@ def parse_ssh_args(args):
 
 
 def quote(x):
-    # we have to escape unbalanced quotes and other unparseable
+    # we have to escape unbalanced quotes and other unparsable
     # args as they will break the shell script
     # But we do not want to quote things like * or 'echo hello'
     # See https://github.com/kovidgoyal/kitty/issues/1787

--- a/kitty/cell_vertex.glsl
+++ b/kitty/cell_vertex.glsl
@@ -114,7 +114,7 @@ vec3 choose_color(float q, vec3 a, vec3 b) {
     return mix(b, a, q);
 }
 
-float are_integers_equal(float a, float b) { // return 1 iff equal otherwise 0
+float are_integers_equal(float a, float b) { // return 1 if equal otherwise 0
     float delta = abs(a - b);  // delta can be 0, 1 or larger
     return step(delta, 0.5); // 0 if 0.5 < delta else 1
 }

--- a/kitty/child.py
+++ b/kitty/child.py
@@ -180,7 +180,7 @@ class Child:
             env['TERM'] = self.opts.term
             env['COLORTERM'] = 'truecolor'
             if self.cwd:
-                # needed incase cwd is a symlink, in which case shells
+                # needed in case cwd is a symlink, in which case shells
                 # can use it to display the current directory name rather
                 # than the resolved path
                 env['PWD'] = self.cwd

--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -461,7 +461,7 @@ The modifiers to override mouse selection even when a terminal application has g
 
 o('select_by_word_characters', ':@-./_~?&=%+#', long_text=_('''
 Characters considered part of a word when double clicking. In addition to these characters
-any character that is marked as an alpha-numeric character in the unicode
+any character that is marked as an alphanumeric character in the unicode
 database will be matched.'''))
 
 o('click_interval', -1.0, option_type=float, long_text=_('''

--- a/kitty/glfw-wrapper.h
+++ b/kitty/glfw-wrapper.h
@@ -81,7 +81,7 @@
  *
  *  The naming of the key codes follow these rules:
  *   - The US keyboard layout is used
- *   - Names of printable alpha-numeric characters are used (e.g. "A", "R",
+ *   - Names of printable alphanumeric characters are used (e.g. "A", "R",
  *     "3", etc.)
  *   - For non-alphanumeric characters, Unicode:ish names are used (e.g.
  *     "COMMA", "LEFT_SQUARE_BRACKET", etc.). Note that some names do not

--- a/kitty/macos_process_info.c
+++ b/kitty/macos_process_info.c
@@ -75,7 +75,7 @@ cmdline_of_process(PyObject *self UNUSED, PyObject *pid_) {
     mib[1] = KERN_PROCARGS2;
     mib[2] = (pid_t)pid;
     if (sysctl(mib, 3, procargs, &argmax, NULL, 0) < 0) {
-        // In case of zombie process or non-existant process we'll get EINVAL.
+        // In case of zombie process or non-existent process we'll get EINVAL.
         if (errno == EINVAL)
             PyErr_Format(PyExc_ValueError, "process with pid %ld either does not exist or is a zombie", pid);
         else
@@ -171,7 +171,7 @@ environ_of_process(PyObject *self UNUSED, PyObject *pid_) {
     mib[1] = KERN_PROCARGS2;
     mib[2] = (pid_t)pid;
     if (sysctl(mib, 3, procargs, &argmax, NULL, 0) < 0) {
-        // In case of zombie process or a non-existant process we'll get EINVAL
+        // In case of zombie process or a non-existent process we'll get EINVAL
         // to NSP and _psosx.py will translate it to ZP.
         if (errno == EINVAL)
             PyErr_Format(PyExc_ValueError, "process with pid %ld either does not exist or is a zombie", pid);

--- a/kitty/threading.h
+++ b/kitty/threading.h
@@ -12,7 +12,7 @@
 #define FREEBSD_SET_NAME
 #endif
 #if defined(__APPLE__)
-// I cant figure out how to get pthread.h to include this definition on macOS. MACOSX_DEPLOYMENT_TARGET does not work.
+// I can't figure out how to get pthread.h to include this definition on macOS. MACOSX_DEPLOYMENT_TARGET does not work.
 extern int pthread_setname_np(const char *name);
 #elif defined(FREEBSD_SET_NAME)
 // Function has a different name on FreeBSD


### PR DESCRIPTION
Inspired by https://github.com/glfw/glfw/pull/1549/commits/4d3ee554b31e734a7c341d4aa5e47d85306f7d74.
Found using `codespell`.

I replaced two instances of `iff` with `if`. I know that `iff` can mean "if and only if" in a math context, so if that's what you meant and you want to keep this spelling, please tell me.