### PR TITLE
Fix undefined behavior

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -263,7 +263,16 @@ format_text(const char *src) {
     char *p = buf;
     if (!src[0]) return "<none>";
     while (*src) {
-        p += snprintf(p, sizeof(buf) - (p - buf), "0x%x ", (unsigned char)*(src++));
+        int max_new_chars = sizeof(buf) - (p - buf);
+        int new_chars = snprintf(p, max_new_chars, "0x%x ", (unsigned char)*(src++));
+        if (new_chars < 0) {
+            _glfwInputError(GLFW_PLATFORM_ERROR,
+                            "Cocoa: Failed to format string");
+            return "<error>";
+        } else if (new_chars > max_new_chars) { // buf was too short when new_chars >= max_new_chars but we only need to check for >
+            new_chars = max_new_chars;
+        }
+        p += new_chars;
     }
     if (p != buf) *(--p) = 0;
     return buf;


### PR DESCRIPTION
I'm fairly certain that this bug can't actually be triggered in practice with the current way `format_text()` is used but I'm fixing it just to be sure.

From the manpage of `snprintf()`:

> The snprintf() and vsnprintf() functions will write at most size-1 of the characters printed into the output string (the size'th character then gets the terminating '\0'); if the return value is greater than or equal to the size argument, the string was too short and some of the printed characters were discarded.

and

> These functions return the number of characters printed (not including the trailing '\0' used to end output to strings), except for snprintf() and vsnprintf(), which return the number of characters that would have been printed if the size were unlimited (again, not including the final '\0'). These functions return a negative value if an error occurs.

When `buf` is too short to hold the string, `snprintf()` may return a value so big, that `p` points outside of `buf`. `if (p != buf) *(--p) = 0;` will then write outside of `buf`, which is undefined behavior.
I fixed this by checking if `buf` was too short to hold the string and then clamping `p`. If the `while` loop continues after that, `max_new_chars` will be `0` and `snprintf()` should not do anything anymore.
I also handeled the case where the return value of `snprintf()` is negative.