### PR TITLE
Fix bool indentation

### DIFF
--- a/glfw/glx_context.h
+++ b/glfw/glx_context.h
@@ -153,18 +153,18 @@ typedef struct _GLFWlibraryGLX
     PFNGLXSWAPINTERVALEXTPROC           SwapIntervalEXT;
     PFNGLXSWAPINTERVALMESAPROC          SwapIntervalMESA;
     PFNGLXCREATECONTEXTATTRIBSARBPROC   CreateContextAttribsARB;
-    bool        SGI_swap_control;
-    bool        EXT_swap_control;
-    bool        MESA_swap_control;
-    bool        ARB_multisample;
-    bool        ARB_framebuffer_sRGB;
-    bool        EXT_framebuffer_sRGB;
-    bool        ARB_create_context;
-    bool        ARB_create_context_profile;
-    bool        ARB_create_context_robustness;
-    bool        EXT_create_context_es2_profile;
-    bool        ARB_create_context_no_error;
-    bool        ARB_context_flush_control;
+    bool            SGI_swap_control;
+    bool            EXT_swap_control;
+    bool            MESA_swap_control;
+    bool            ARB_multisample;
+    bool            ARB_framebuffer_sRGB;
+    bool            EXT_framebuffer_sRGB;
+    bool            ARB_create_context;
+    bool            ARB_create_context_profile;
+    bool            ARB_create_context_robustness;
+    bool            EXT_create_context_es2_profile;
+    bool            ARB_create_context_no_error;
+    bool            ARB_context_flush_control;
 
 } _GLFWlibraryGLX;
 

--- a/glfw/linux_joystick.h
+++ b/glfw/linux_joystick.h
@@ -52,7 +52,7 @@ typedef struct _GLFWlibraryLinux
     int                     inotify;
     int                     watch;
     regex_t                 regex;
-    bool                dropped;
+    bool                    dropped;
 } _GLFWlibraryLinux;
 
 

--- a/glfw/posix_thread.h
+++ b/glfw/posix_thread.h
@@ -35,7 +35,7 @@
 //
 typedef struct _GLFWtlsPOSIX
 {
-    bool        allocated;
+    bool            allocated;
     pthread_key_t   key;
 
 } _GLFWtlsPOSIX;
@@ -44,7 +44,7 @@ typedef struct _GLFWtlsPOSIX
 //
 typedef struct _GLFWmutexPOSIX
 {
-    bool        allocated;
+    bool            allocated;
     pthread_mutex_t handle;
 
 } _GLFWmutexPOSIX;

--- a/glfw/posix_time.h
+++ b/glfw/posix_time.h
@@ -34,7 +34,7 @@
 //
 typedef struct _GLFWtimerPOSIX
 {
-    bool    monotonic;
+    bool        monotonic;
     uint64_t    frequency;
 
 } _GLFWtimerPOSIX;

--- a/glfw/xkb_glfw.h
+++ b/glfw/xkb_glfw.h
@@ -67,8 +67,8 @@ typedef struct {
 
 #ifdef _GLFW_X11
     int32_t                 keyboard_device_id;
-    bool                available;
-    bool                detectable;
+    bool                    available;
+    bool                    detectable;
     int                     majorOpcode;
     int                     eventBase;
     int                     errorBase;


### PR DESCRIPTION
The wrong indentation was caused by the removal of GLFWbool in https://github.com/kovidgoyal/kitty/commit/fe62700825ef4b9bb143b3792797959d85181b29.