### PR TITLE
Make adding more printable keys slightly easier

### DIFF
--- a/glfw/glfw3.h
+++ b/glfw/glfw3.h
@@ -394,6 +394,8 @@ extern "C" {
 #define GLFW_KEY_PLUS               163
 #define GLFW_KEY_UNDERSCORE         164
 
+#define GLFW_KEY_LAST_PRINTABLE     GLFW_KEY_UNDERSCORE
+
 /* Function keys */
 #define GLFW_KEY_ESCAPE             256
 #define GLFW_KEY_ENTER              257

--- a/glfw/input.c
+++ b/glfw/input.c
@@ -691,7 +691,7 @@ GLFWAPI const char* glfwGetKeyName(int key, int scancode)
     {
         if (key != GLFW_KEY_KP_EQUAL &&
             (key < GLFW_KEY_KP_0 || key > GLFW_KEY_KP_ADD) &&
-            (key < GLFW_KEY_APOSTROPHE || key > GLFW_KEY_WORLD_2))
+            (key < GLFW_KEY_APOSTROPHE || key > GLFW_KEY_LAST_PRINTABLE))
         {
             return NULL;
         }

--- a/kitty/glfw-wrapper.h
+++ b/kitty/glfw-wrapper.h
@@ -151,6 +151,8 @@
 #define GLFW_KEY_PLUS               163
 #define GLFW_KEY_UNDERSCORE         164
 
+#define GLFW_KEY_LAST_PRINTABLE     GLFW_KEY_UNDERSCORE
+
 /* Function keys */
 #define GLFW_KEY_ESCAPE             256
 #define GLFW_KEY_ENTER              257

--- a/kitty/key_encoding.py
+++ b/kitty/key_encoding.py
@@ -298,7 +298,7 @@ def update_encoding():
     for k in sorted(keys, key=lambda k: getattr(defines, k)):
         val = getattr(defines, k)
         name = symbolic_name(k)
-        if val <= defines.GLFW_KEY_LAST and name != 'LAST' and val != defines.GLFW_KEY_UNKNOWN:
+        if val <= defines.GLFW_KEY_LAST and name not in ('LAST', 'LAST_PRINTABLE') and val != defines.GLFW_KEY_UNKNOWN:
             if name not in ans:
                 ans[name] = encode(i)
                 i += 1


### PR DESCRIPTION
When adding keys after `GLFW_KEY_UNDERSCORE`, one now needs to change a `#define` right below the last printable key instead of changing it elsewhere in the code.
This commit now also marks `GLFW_KEY_PLUS` and `GLFW_KEY_UNDERSCORE` as printable characters.

Why does `GLFW_KEY_SPACE` not count as a printable character in `glfwGetKeyName()`?