### PR TITLE
Format kitty/key_encoding.py with yapf

### DIFF
--- a/kitty/key_encoding.py
+++ b/kitty/key_encoding.py
@@ -298,7 +298,9 @@ def update_encoding():
     for k in sorted(keys, key=lambda k: getattr(defines, k)):
         val = getattr(defines, k)
         name = symbolic_name(k)
-        if val <= defines.GLFW_KEY_LAST and name not in ('LAST', 'LAST_PRINTABLE') and val != defines.GLFW_KEY_UNKNOWN:
+        if val <= defines.GLFW_KEY_LAST and name not in (
+            'LAST', 'LAST_PRINTABLE'
+        ) and val != defines.GLFW_KEY_UNKNOWN:
             if name not in ans:
                 ans[name] = encode(i)
                 i += 1


### PR DESCRIPTION
I did not run `update_encoding()` when I added `LAST_PRINTABLE` in b3b830bb5ffb8f42d5e2367e5aab03579be3a45f. This commit fixes that.