### PR TITLE
Fix color index 232

### DIFF
--- a/kitty/colors.c
+++ b/kitty/colors.c
@@ -36,12 +36,12 @@ init_FG_BG_table(void) {
         // colors 16..232: the 6x6x6 color cube
         const uint8_t valuerange[6] = {0x00, 0x5f, 0x87, 0xaf, 0xd7, 0xff};
         uint8_t i, j=16;
-        for(i = 0; i < 217; i++, j++) {
+        for(i = 0; i < 216; i++, j++) {
             uint8_t r = valuerange[(i / 36) % 6], g = valuerange[(i / 6) % 6], b = valuerange[i % 6];
             FG_BG_256[j] = (r << 16) | (g << 8) | b;
         }
-        // colors 233..255: grayscale
-        for(i = 1; i < 24; i++, j++) {
+        // colors 232..255: grayscale
+        for(i = 0; i < 24; i++, j++) {
             uint8_t v = 8 + i * 10;
             FG_BG_256[j] = (v << 16) | (v << 8) | v;
         }


### PR DESCRIPTION
For reference: https://github.com/joejulian/xterm/blob/master/256colres.pl#L63-L88

Can be tested using `echo -e "\e[48;5;232m                \e[0m"` ([via](https://raw.githubusercontent.com/roosta/colors/master/scripts/support/256-colors.sh))