### PR TITLE
Remove PLUS key from key_name_aliases

### DIFF
--- a/kitty/key_names.py
+++ b/kitty/key_names.py
@@ -21,7 +21,6 @@ key_name_aliases = {
     '\\': 'BACKSLASH',
     ']': 'RIGHT_BRACKET',
     '`': 'GRAVE_ACCENT',
-    '+': 'PLUS',
 
     'ESC': 'ESCAPE',
     'PGUP': 'PAGE_UP',


### PR DESCRIPTION
In #1928 I accidentally added `PLUS` to `key_name_aliases` even though in https://github.com/kovidgoyal/kitty/pull/1942#issuecomment-526873757 you said that this won't work.