### PR TITLE
Mark kitty/unicode-data.c as being generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@ kitty/emoji.h linguist-generated=true
 kitty/keys.h linguist-generated=true
 kitty/charsets.c linguist-generated=true
 kitty/key_encoding.py linguist-generated=true
-kitty/unicode-data.c
+kitty/unicode-data.c linguist-generated=true
 kitty/rgb.py linguist-generated=true
 kitty/gl-wrapper.* linguist-generated=true
 kitty/khrplatform.h linguist-generated=true


### PR DESCRIPTION
I think `linguist-generated=true` is missing here. This line was added in 5faa649452fd8c3006cc113ecb4f8ad8349f866a.