### PR TITLE
Cocoa: Move app delegate and menu creation to init

### DIFF
--- a/glfw/cocoa_platform.h
+++ b/glfw/cocoa_platform.h
@@ -153,6 +153,7 @@ typedef struct _GLFWlibraryNS
 {
     CGEventSourceRef    eventSource;
     id                  delegate;
+    bool                finishedLaunching;
     bool                cursorHidden;
     TISInputSourceRef   inputSource;
     IOHIDManagerRef     hidManager;
@@ -160,6 +161,7 @@ typedef struct _GLFWlibraryNS
     id                  helper;
     id                  keyUpMonitor;
     id                  keyDownMonitor;
+    id                  nibObjects;
 
     char                keyName[64];
     char                text[256];


### PR DESCRIPTION
From https://github.com/glfw/glfw/commit/ea7eb2ddab823e21c846c68d112d90f91fcba318.

I'm trying to apply this commit from upstream but I ran into a little problem:
`glfwSetApplicationShouldHandleReopen()` and `applicationShouldHandleReopen()` in `glfw/cocoa_window.m` access the variable `handle_reopen_callback`. I need to move `applicationShouldHandleReopen()` to `glfw/cocoa_init.m`. One of the two functions will no longer be able to access the variable.
What is the best way to solve this problem? Can I somehow move `glfwSetApplicationShouldHandleReopen()` or make the variable visible in the two files?