### PR TITLE
Cocoa: Fix window creation blocking after re-init

### DIFF
--- a/glfw/cocoa_init.m
+++ b/glfw/cocoa_init.m
@@ -565,6 +565,9 @@ int _glfwPlatformInit(void)
                              toTarget:_glfw.ns.helper
                            withObject:nil];
 
+    if (NSApp)
+        _glfw.ns.finishedLaunching = true;
+
     [GLFWApplication sharedApplication];
 
     _glfw.ns.delegate = [[GLFWApplicationDelegate alloc] init];


### PR DESCRIPTION
From https://github.com/glfw/glfw/commit/2fbb560eb72fea695687d33066c91a329d6d0465.

I don't think this bug actually affects kitty.