### PR TITLE
Replace weird character with space

### DIFF
--- a/glfw/glfw3.h
+++ b/glfw/glfw3.h
@@ -1995,7 +1995,7 @@ GLFWAPI void glfwGetMonitorPos(GLFWmonitor* monitor, int* xpos, int* ypos);
  *  @param[out] xpos Where to store the monitor x-coordinate, or `NULL`.
  *  @param[out] ypos Where to store the monitor y-coordinate, or `NULL`.
  *  @param[out] width Where to store the monitor width, or `NULL`.
-￼*  @param[out] height Where to store the monitor height, or `NULL`.
+ *  @param[out] height Where to store the monitor height, or `NULL`.
  *
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
  *  GLFW_PLATFORM_ERROR.


### PR DESCRIPTION
In 4c4c6ab0e68c56710f9a1eb07ae8a4d878664ace you added a weird unicode character, which is apparently called an Object Replacement Character, instead of a space.