### PR TITLE
Remove remaining references to kitty/khrplatform.h

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,6 @@ kitty/key_encoding.py linguist-generated=true
 kitty/unicode-data.c linguist-generated=true
 kitty/rgb.py linguist-generated=true
 kitty/gl-wrapper.* linguist-generated=true
-kitty/khrplatform.h linguist-generated=true
 kitty/glfw-wrapper.* linguist-generated=true
 glfw/*.c linguist-vendored=true
 glfw/*.h linguist-vendored=true

--- a/count-lines-of-code
+++ b/count-lines-of-code
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-cloc --exclude-list-file <(echo -e 'kitty/wcwidth-std.h\nkitty/glfw.c\nkitty/keys.h\nkitty/charsets.c\nkitty/unicode-data.c\nkitty/key_encoding.py\nkitty/rgb.py\nkitty/gl.h\nkitty/gl-wrapper.h\nkitty/gl-wrapper.c\nkitty/khrplatform.h\nkitty/glfw-wrapper.h\nkitty/glfw-wrapper.c\nkitty/emoji.h\nkittens/unicode_input/names.h') kitty kittens
+cloc --exclude-list-file <(echo -e 'kitty/wcwidth-std.h\nkitty/glfw.c\nkitty/keys.h\nkitty/charsets.c\nkitty/unicode-data.c\nkitty/key_encoding.py\nkitty/rgb.py\nkitty/gl.h\nkitty/gl-wrapper.h\nkitty/gl-wrapper.c\nkitty/glfw-wrapper.h\nkitty/glfw-wrapper.c\nkitty/emoji.h\nkittens/unicode_input/names.h') kitty kittens


### PR DESCRIPTION
`kitty/khrplatform.h` was removed in f872f955b02b4c352939d6ebb507d80f73de5da9.