### PR TITLE
Unify python encoding headers

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
+# vim:fileencoding=utf-8
 #
 # Configuration file for the Sphinx documentation builder.
 #


### PR DESCRIPTION
All the other python encoding headers are of the form `vim:fileencoding=utf-8`.