### PR TITLE
Simplify access to os.environ

### DIFF
--- a/kitty/constants.py
+++ b/kitty/constants.py
@@ -49,9 +49,8 @@ def _get_config_dir():
     locations.append(os.path.expanduser('~/.config'))
     if is_macos:
         locations.append(os.path.expanduser('~/Library/Preferences'))
-    if 'XDG_CONFIG_DIRS' in os.environ:
-        for loc in os.environ['XDG_CONFIG_DIRS'].split(os.pathsep):
-            locations.append(os.path.abspath(os.path.expanduser(loc)))
+    for loc in filter(None, os.environ.get('XDG_CONFIG_DIRS', '').split(os.pathsep)):
+        locations.append(os.path.abspath(os.path.expanduser(loc)))
     for loc in locations:
         if loc:
             q = os.path.join(loc, appname)


### PR DESCRIPTION
The `if` can be removed by using `get()` with a default parameter to access `os.environ`. This also reduces the number of accesses to `os.environ`.