### PR TITLE
Prefer VISUAL to EDITOR

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -812,9 +812,9 @@ ensure that the shell starts in interactive mode and reads its startup rc files.
 
 o('editor', '.', long_text=_('''
 The console editor to use when editing the kitty config file or similar tasks.
-A value of . means to use the environment variable EDITOR. Note that this
-environment variable has to be set not just in your shell startup scripts but
-system-wide, otherwise kitty will not see it.
+A value of . means to use the environment variables VISUAL and EDITOR in that
+order. Note that this environment variable has to be set not just in your shell
+startup scripts but system-wide, otherwise kitty will not see it.
 '''))
 
 o('close_on_child_death', False, long_text=_('''

--- a/kitty/main.py
+++ b/kitty/main.py
@@ -247,19 +247,19 @@ def read_shell_environment(opts=None):
 def setup_environment(opts, args):
     extra_env = opts.env.copy()
     if opts.editor == '.':
-        if 'EDITOR' not in os.environ:
+        if 'VISUAL' not in os.environ and 'EDITOR' not in os.environ:
             shell_env = read_shell_environment(opts)
-            if 'EDITOR' in shell_env:
-                editor = shell_env['EDITOR']
-                if 'PATH' in shell_env:
-                    import shlex
-                    editor_cmd = shlex.split(editor)
-                    if not os.path.isabs(editor_cmd[0]):
-                        editor_cmd[0] = shutil.which(editor_cmd[0], path=shell_env['PATH'])
-                        if editor_cmd[0]:
-                            editor = ' '.join(map(shlex.quote, editor_cmd))
-                        else:
-                            editor = None
+            if 'VISUAL' in shell_env or 'EDITOR' in shell_env:
+                for editor in (shell_env['VISUAL'], shell_env['EDITOR']):
+                    if 'PATH' in shell_env:
+                        import shlex
+                        editor_cmd = shlex.split(editor)
+                        if not os.path.isabs(editor_cmd[0]):
+                            editor_cmd[0] = shutil.which(editor_cmd[0], path=shell_env['PATH'])
+                            if editor_cmd[0]:
+                                editor = ' '.join(map(shlex.quote, editor_cmd))
+                            else:
+                                editor = None
                 if editor:
                     os.environ['EDITOR'] = editor
     else:

--- a/kitty/utils.py
+++ b/kitty/utils.py
@@ -415,15 +415,12 @@ def get_editor():
     ans = getattr(get_editor, 'ans', False)
     if ans is False:
         import shlex
-        ans = os.environ.get('EDITOR')
-        if not ans or not exe_exists(shlex.split(ans)[0]):
-            for q in ('vim', 'nvim', 'vi', 'emacs', 'kak', 'micro', 'nano', 'vis'):
-                r = exe_exists(q)
-                if r:
-                    ans = r
-                    break
-            else:
-                ans = 'vim'
+        for ans in (os.environ.get('VISUAL'), os.environ.get('EDITOR'), 'vim',
+                    'nvim', 'vi', 'emacs', 'kak', 'micro', 'nano', 'vis'):
+            if ans and exe_exists(shlex.split(ans)[0]):
+                break
+        else:
+            ans = 'vim'
         ans = shlex.split(ans)
         get_editor.ans = ans
     return ans


### PR DESCRIPTION
Fix #2096

I've tried to maintain the current semantics. For example, I still try `EDITOR` if `VISUAL` isn't found on the system rather than blindly defaulting to `VISUAL` as long as it's set.

I'm not sure if any documentation needs updating outside of the config template?