### PR TITLE
Fix potential error when $PATH is not defined

### DIFF
--- a/kitty/constants.py
+++ b/kitty/constants.py
@@ -25,7 +25,7 @@ def kitty_exe():
     if ans is None:
         rpath = sys._xoptions.get('bundle_exe_dir')
         if not rpath:
-            items = os.environ['PATH'].split(os.pathsep)
+            items = filter(None, os.environ.get('PATH', '').split(os.pathsep))
             seen = set()
             for candidate in items:
                 if candidate not in seen:


### PR DESCRIPTION
When `PATH` is not in `os.environ`, kitty could potentially throw a `KeyError`.