### PR TITLE
Fix error when two linker processes fail

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -379,8 +379,9 @@ def parallel_run(items):
             return
         pid, s = os.wait()
         compile_cmd, w = workers.pop(pid, (None, None))
-        if compile_cmd is not None and ((s & 0xff) != 0 or ((s >> 8) & 0xff) != 0) and failed is None:
-            failed = compile_cmd
+        if compile_cmd is not None and ((s & 0xff) != 0 or ((s >> 8) & 0xff) != 0):
+            if failed is None:
+                failed = compile_cmd
         elif compile_cmd.on_success is not None:
             compile_cmd.on_success()
 


### PR DESCRIPTION
When a linker process fails, `failed` will be set to a value other than `None`. When a second linker process fails, the `else` case will be taken because `failed is None`, which executes `compile_cmd.on_success()`. This function tries to rename or move the file generated by the linker but since the linker process failed, the file will most likely not exist. This will throw an error, which will prevent printing the actual error message from the linker.