### PR TITLE
docs: added '@selection' to pipe documentation.

### DIFF
--- a/docs/pipe.rst
+++ b/docs/pipe.rst
@@ -56,6 +56,9 @@ Input placeholders
 
 There are various different kinds of placeholders
 
+``@selection``
+   Plain text, currently selected text
+
 ``@text``
    Plain text, current screen + scrollback buffer
 


### PR DESCRIPTION
The @selection input placeholder is not currently listed in the documentation. This commit adds it to the top of the list.