### PR TITLE
Update fish completion docs for fish 3.0.0

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -478,7 +478,8 @@ completions happens after the call to :file:`compinit`.
 fish
 ~~~~~~~~
 
-Add the following to your :file:`~/.config/fish/config.fish`
+For versions of fish earlier than 3.0.0, add the following to your
+:file:`~/.config/fish/config.fish`. Later versions source completions by default.
 
 .. code-block:: sh
 


### PR DESCRIPTION
As of 3.0.0, fish sources `kitty +complete fish` by default.

Relevant fish commit: https://github.com/fish-shell/fish-shell/commit/9c6bd8b1b4fc2069d1e9aed0945e1b9aff0f493d#diff-2974c7d52acf4bc7a0580f6a2cd35fe1