### PR TITLE
Add Caps Lock to the list of modifier keys

### DIFF
--- a/kitty/keys.c
+++ b/kitty/keys.c
@@ -68,6 +68,7 @@ is_modifier_key(int key) {
         case GLFW_KEY_RIGHT_CONTROL:
         case GLFW_KEY_LEFT_SUPER:
         case GLFW_KEY_RIGHT_SUPER:
+        case GLFW_KEY_CAPS_LOCK:
             return true;
         default:
             return false;


### PR DESCRIPTION
When a key is pressed and `mouse_hide_wait` is less than zero, kitty will hide the mouse cursor. When a key is pressed, kitty will also scroll the history to the bottom. Both of these things don't happen if the key being pressed was a modifier key. Both of these things should not happen when Caps Lock is pressed, so this key should be added to the list of modifier keys.
`is_modifier_key()` is not used for anything else.