### PR TITLE
make canberra sound theme configurable

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -523,6 +523,11 @@ o('bell_on_tab', True, long_text=_('''
 Show a bell symbol on the tab if a bell occurs in one of the windows in the
 tab and the window is not the currently focused window'''))
 
+o('bell_theme_name', 'freedesktop', long_text=_('''
+If audio bell is enabled on Linux, sets the XDG Sound Theme kitty will
+use to play the bell sound.
+'''))
+
 o('command_on_bell', 'none', option_type=to_cmdline, long_text=_('''
 Program to run when a bell occurs.
 '''))

--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -312,7 +312,7 @@ void set_special_key_combo(int glfw_key, int mods, bool is_native);
 void on_key_input(GLFWkeyevent *ev);
 void request_window_attention(id_type, bool);
 #ifndef __APPLE__
-void play_canberra_sound(const char *which_sound, const char *event_id);
+void play_canberra_sound(const char *which_sound, const char *event_id, const char *theme_name);
 #endif
 SPRITE_MAP_HANDLE alloc_sprite_map(unsigned int, unsigned int);
 SPRITE_MAP_HANDLE free_sprite_map(SPRITE_MAP_HANDLE);

--- a/kitty/desktop.c
+++ b/kitty/desktop.c
@@ -132,13 +132,14 @@ load_libcanberra(void) {
 }
 
 void
-play_canberra_sound(const char *which_sound, const char *event_id) {
+play_canberra_sound(const char *which_sound, const char *event_id, const char *theme_name) {
     load_libcanberra();
     if (libcanberra_handle == NULL || canberra_ctx == NULL) return;
     ca_context_play(
         canberra_ctx, 0,
         "event.id", which_sound,
         "event.description", event_id,
+        "canberra.xdg-theme.name", theme_name,
         NULL
     );
 }

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -864,7 +864,7 @@ ring_audio_bell(OSWindow *w UNUSED) {
         glfwWindowBell(w->handle);
     }
 #else
-    play_canberra_sound("bell", "kitty bell");
+    play_canberra_sound("bell", "kitty bell", OPT(bell_theme_name));
 #endif
 }
 

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -401,6 +401,11 @@ convert_mods(PyObject *obj) {
     return resolve_mods(PyLong_AsLong(obj));
 }
 
+static const char *
+pyunicode_as_char(PyObject *str) {
+   return PyUnicode_AsUTF8(str);
+}
+
 static WindowTitleIn
 window_title_in(PyObject *title_in) {
     const char *in = PyUnicode_AsUTF8(title_in);
@@ -478,6 +483,7 @@ PYWRAP1(set_options) {
     S(hide_window_decorations, PyObject_IsTrue);
     S(visual_bell_duration, parse_s_double_to_monotonic_t);
     S(enable_audio_bell, PyObject_IsTrue);
+    S(bell_theme_name, pyunicode_as_char);
     S(focus_follows_mouse, PyObject_IsTrue);
     S(cursor_blink_interval, parse_s_double_to_monotonic_t);
     S(cursor_stop_blinking_after, parse_s_double_to_monotonic_t);

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -18,6 +18,7 @@ typedef struct {
     monotonic_t visual_bell_duration, cursor_blink_interval, cursor_stop_blinking_after, mouse_hide_wait, click_interval;
     double wheel_scroll_multiplier, touch_scroll_multiplier;
     bool enable_audio_bell;
+    const char *bell_theme_name;
     CursorShape cursor_shape;
     unsigned int open_url_modifiers;
     unsigned int rectangle_select_modifiers;


### PR DESCRIPTION
On Linux, kitty uses libcanberra to play an audible bell following the
XDG Sound Theming Specification. The library expects the application to
include the sound theme in the context, otherwise it plays from the
"freedesktop" theme; it does not query the environment or configuration.

Instead of linking against Gtk and querying GtkSettings, I've chosen to
allow the sound theme to be configured with a new kitty setting
"bell_sound_theme".

Change-Id: Ib6168fdd4a9ed5a8fb635ba02340613fb35ac426