### PR TITLE
Fix margin issue with use of scale on wayland. #2133

### DIFF
--- a/glfw/glfw3.h
+++ b/glfw/glfw3.h
@@ -3229,6 +3229,7 @@ GLFWAPI monotonic_t glfwGetDoubleClickInterval(GLFWwindow* window);
  *  @ingroup window
  */
 GLFWAPI float glfwGetWindowOpacity(GLFWwindow* window);
+GLFWAPI int glfwGetMonitorCount(GLFWwindow* window);
 
 /*! @brief Sets the opacity of the whole window.
  *

--- a/glfw/internal.h
+++ b/glfw/internal.h
@@ -710,6 +710,7 @@ int _glfwPlatformWindowMaximized(_GLFWwindow* window);
 int _glfwPlatformWindowHovered(_GLFWwindow* window);
 int _glfwPlatformFramebufferTransparent(_GLFWwindow* window);
 float _glfwPlatformGetWindowOpacity(_GLFWwindow* window);
+int _glfwGetMonitorCount(_GLFWwindow* window);
 void _glfwPlatformSetWindowResizable(_GLFWwindow* window, bool enabled);
 void _glfwPlatformSetWindowDecorated(_GLFWwindow* window, bool enabled);
 void _glfwPlatformSetWindowFloating(_GLFWwindow* window, bool enabled);

--- a/glfw/window.c
+++ b/glfw/window.c
@@ -739,6 +739,15 @@ GLFWAPI void glfwGetWindowContentScale(GLFWwindow* handle,
     _glfwPlatformGetWindowContentScale(window, xscale, yscale);
 }
 
+GLFWAPI int glfwGetMonitorCount(GLFWwindow* handle)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    assert(window != NULL);
+
+    _GLFW_REQUIRE_INIT_OR_RETURN(99);
+    return _glfwGetMonitorCount(window);
+}
+
 GLFWAPI monotonic_t glfwGetDoubleClickInterval(GLFWwindow* handle)
 {
     _GLFWwindow* window = (_GLFWwindow*) handle;

--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -1053,6 +1053,11 @@ void _glfwPlatformGetWindowContentScale(_GLFWwindow* window,
         *yscale = (float) window->wl.scale;
 }
 
+int _glfwGetMonitorCount(_GLFWwindow* window UNUSED)
+{
+    return window->wl.monitorsCount;
+}
+
 monotonic_t _glfwPlatformGetDoubleClickInterval(_GLFWwindow* window UNUSED)
 {
     return ms_to_monotonic_t(500ll);

--- a/kitty/glfw-wrapper.c
+++ b/kitty/glfw-wrapper.c
@@ -152,6 +152,9 @@ load_glfw(const char* path) {
     *(void **) (&glfwGetWindowContentScale_impl) = dlsym(handle, "glfwGetWindowContentScale");
     if (glfwGetWindowContentScale_impl == NULL) fail("Failed to load glfw function glfwGetWindowContentScale with error: %s", dlerror());
 
+    *(void **) (&glfwGetMonitorCount_impl) = dlsym(handle, "glfwGetMonitorCount");
+    if (glfwGetMonitorCount_impl == NULL) fail("Failed to load glfw function glfwGetMonitorCount with error: %s", dlerror());
+
     *(void **) (&glfwGetDoubleClickInterval_impl) = dlsym(handle, "glfwGetDoubleClickInterval");
     if (glfwGetDoubleClickInterval_impl == NULL) fail("Failed to load glfw function glfwGetDoubleClickInterval with error: %s", dlerror());
 

--- a/kitty/glfw-wrapper.h
+++ b/kitty/glfw-wrapper.h
@@ -1765,6 +1765,10 @@ typedef void (*glfwGetWindowContentScale_func)(GLFWwindow*, float*, float*);
 glfwGetWindowContentScale_func glfwGetWindowContentScale_impl;
 #define glfwGetWindowContentScale glfwGetWindowContentScale_impl
 
+typedef int (*glfwGetMonitorCount_func)(GLFWwindow*);
+glfwGetMonitorCount_func glfwGetMonitorCount_impl;
+#define glfwGetMonitorCount glfwGetMonitorCount_impl
+
 typedef monotonic_t (*glfwGetDoubleClickInterval_func)(GLFWwindow*);
 glfwGetDoubleClickInterval_func glfwGetDoubleClickInterval_impl;
 #define glfwGetDoubleClickInterval glfwGetDoubleClickInterval_impl

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -139,6 +139,7 @@ typedef struct {
     monotonic_t cursor_blink_zero_time, last_mouse_activity_at;
     double mouse_x, mouse_y;
     double logical_dpi_x, logical_dpi_y, font_sz_in_pts;
+    float xscale, yscale;
     bool mouse_button_pressed[20];
     PyObject *window_title;
     bool is_key_pressed[MAX_KEY_COUNT];
@@ -175,6 +176,7 @@ typedef struct {
     bool tab_bar_hidden;
     double font_sz_in_pts;
     struct { double x, y; } default_dpi;
+    struct { float x, y; } default_scale;
     id_type active_drag_in_window;
 } GlobalState;
 


### PR DESCRIPTION
This PR tries to fix a bug with sway (wayland) and a scale different than 1.

The margin of the first default tab is not the same as the second or third or x tab.
It seems that the scale value of the window isn't detected because there is no monitor in the first `checkScaleChange` and the default scale value to 1 is used.

**Explanation:**
In `glfw_init`, when kitty gets the monitor scale (2, for example), I store it in a new `global_state.default_scale` struct. To pass the data, I have added 2 keys in `OSWindow`, `xscale` and `yscale`.
I have added a `glfwGetMonitorCount` for access to the monitor count value and now in `get_window_content_scale`, I can test, if there is no window, I use the monitor scale by default instead of 1.

**EDIT:** I'm not sure it's the right way to fix it but it's an attempt.
I fix the linker for cocoa tomorrow.