### PR TITLE
Wayland: Don’t reload the cursor on every pointer motion

### DIFF
--- a/glfw/wl_init.c
+++ b/glfw/wl_init.c
@@ -165,6 +165,7 @@ static void setCursor(GLFWCursorShape shape)
     wl_surface_damage(surface, 0, 0,
                       image->width, image->height);
     wl_surface_commit(surface);
+    _glfw.wl.cursorPreviousShape = shape;
 }
 
 static void pointerHandleMotion(void* data UNUSED,
@@ -219,7 +220,8 @@ static void pointerHandleMotion(void* data UNUSED,
         default:
             assert(0);
     }
-    setCursor(cursorShape);
+    if (_glfw.wl.cursorPreviousShape != cursorShape)
+        setCursor(cursorShape);
 }
 
 static void pointerHandleButton(void* data UNUSED,

--- a/glfw/wl_platform.h
+++ b/glfw/wl_platform.h
@@ -248,6 +248,7 @@ typedef struct _GLFWlibraryWayland
 
     struct wl_cursor_theme*     cursorTheme;
     struct wl_surface*          cursorSurface;
+    GLFWCursorShape             cursorPreviousShape;
     uint32_t                    pointerSerial;
 
     int32_t                     keyboardRepeatRate;


### PR DESCRIPTION
From upstream: https://github.com/glfw/glfw/commit/a9f674e719cd663560418de2a7fa1147ce6c6c9b.