### PR TITLE
Remove obsolete comment

### DIFF
--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -465,7 +465,6 @@ static int
 on_application_reopen(int has_visible_windows) {
     if (has_visible_windows) return true;
     set_cocoa_pending_action(NEW_OS_WINDOW, NULL);
-    // Without unjam wait_for_events() blocks until the next event
     return false;
 }
 


### PR DESCRIPTION
In bef9490fa8d06a3f2b64a63912b06f7e05604aa8, `unjam_event_loop()` was removed but not the corresponding comment.