### PR TITLE
Create macOS menu bar where GLFW creates it

### DIFF
--- a/glfw/cocoa_init.m
+++ b/glfw/cocoa_init.m
@@ -456,6 +456,8 @@ static GLFWapplicationshouldhandlereopenfun handle_reopen_callback = NULL;
     _glfwPollMonitorsNS();
 }
 
+static GLFWapplicationwillfinishlaunchingfun finish_launching_callback = NULL;
+
 - (void)applicationWillFinishLaunching:(NSNotification *)notification
 {
     (void)notification;
@@ -478,6 +480,8 @@ static GLFWapplicationshouldhandlereopenfun handle_reopen_callback = NULL;
         else */
             createMenuBar();
     }
+    if (finish_launching_callback)
+        finish_launching_callback();
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
@@ -552,6 +556,12 @@ is_cmd_period(NSEvent *event, NSEventModifierFlags modifierFlags) {
 GLFWAPI GLFWapplicationshouldhandlereopenfun glfwSetApplicationShouldHandleReopen(GLFWapplicationshouldhandlereopenfun callback) {
     GLFWapplicationshouldhandlereopenfun previous = handle_reopen_callback;
     handle_reopen_callback = callback;
+    return previous;
+}
+
+GLFWAPI GLFWapplicationwillfinishlaunchingfun glfwSetApplicationWillFinishLaunching(GLFWapplicationwillfinishlaunchingfun callback) {
+    GLFWapplicationwillfinishlaunchingfun previous = finish_launching_callback;
+    finish_launching_callback = callback;
     return previous;
 }
 

--- a/glfw/cocoa_platform.h
+++ b/glfw/cocoa_platform.h
@@ -68,6 +68,7 @@ typedef void* CVDisplayLinkRef;
 typedef VkFlags VkMacOSSurfaceCreateFlagsMVK;
 typedef int (* GLFWcocoatextinputfilterfun)(int,int,unsigned int, unsigned long);
 typedef int (* GLFWapplicationshouldhandlereopenfun)(int);
+typedef void (* GLFWapplicationwillfinishlaunchingfun)(void);
 typedef int (* GLFWcocoatogglefullscreenfun)(GLFWwindow*);
 typedef void (* GLFWcocoarenderframefun)(GLFWwindow*);
 

--- a/glfw/glfw.py
+++ b/glfw/glfw.py
@@ -165,6 +165,7 @@ def generate_wrappers(glfw_header):
     GLFWcocoatextinputfilterfun glfwSetCocoaTextInputFilter(GLFWwindow* window, GLFWcocoatextinputfilterfun callback)
     GLFWcocoatogglefullscreenfun glfwSetCocoaToggleFullscreenIntercept(GLFWwindow *window, GLFWcocoatogglefullscreenfun callback)
     GLFWapplicationshouldhandlereopenfun glfwSetApplicationShouldHandleReopen(GLFWapplicationshouldhandlereopenfun callback)
+    GLFWapplicationwillfinishlaunchingfun glfwSetApplicationWillFinishLaunching(GLFWapplicationwillfinishlaunchingfun callback)
     void glfwGetCocoaKeyEquivalent(int glfw_key, int glfw_mods, void* cocoa_key, void* cocoa_mods)
     void glfwCocoaRequestRenderFrame(GLFWwindow *w, GLFWcocoarenderframefun callback)
     void* glfwGetX11Display(void)
@@ -200,6 +201,7 @@ const char *action_text, int32_t timeout, GLFWDBusnotificationcreatedfun callbac
 
 typedef int (* GLFWcocoatextinputfilterfun)(int,int,unsigned int,unsigned long);
 typedef int (* GLFWapplicationshouldhandlereopenfun)(int);
+typedef void (* GLFWapplicationwillfinishlaunchingfun)(void);
 typedef int (* GLFWcocoatogglefullscreenfun)(GLFWwindow*);
 typedef void (* GLFWcocoarenderframefun)(GLFWwindow*);
 typedef void (*GLFWwaylandframecallbackfunc)(unsigned long long id);

--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -232,8 +232,6 @@ cocoa_send_notification(PyObject *self UNUSED, PyObject *args) {
 // global menu {{{
 void
 cocoa_create_global_menu(void) {
-    @autoreleasepool {
-
     NSString* app_name = find_app_name();
     NSMenu* bar = [[NSMenu alloc] init];
     GlobalMenuTarget *global_menu_target = [GlobalMenuTarget shared_instance];
@@ -325,8 +323,6 @@ cocoa_create_global_menu(void) {
 
 
     [NSApp setServicesProvider:[[[ServiceProvider alloc] init] autorelease]];
-
-    } // autoreleasepool
 }
 
 void

--- a/kitty/glfw-wrapper.c
+++ b/kitty/glfw-wrapper.c
@@ -389,6 +389,8 @@ load_glfw(const char* path) {
 
     *(void **) (&glfwSetApplicationShouldHandleReopen_impl) = dlsym(handle, "glfwSetApplicationShouldHandleReopen");
 
+    *(void **) (&glfwSetApplicationWillFinishLaunching_impl) = dlsym(handle, "glfwSetApplicationWillFinishLaunching");
+
     *(void **) (&glfwGetCocoaKeyEquivalent_impl) = dlsym(handle, "glfwGetCocoaKeyEquivalent");
 
     *(void **) (&glfwCocoaRequestRenderFrame_impl) = dlsym(handle, "glfwCocoaRequestRenderFrame");

--- a/kitty/glfw-wrapper.h
+++ b/kitty/glfw-wrapper.h
@@ -1576,6 +1576,7 @@ typedef struct GLFWgamepadstate
 
 typedef int (* GLFWcocoatextinputfilterfun)(int,int,unsigned int,unsigned long);
 typedef int (* GLFWapplicationshouldhandlereopenfun)(int);
+typedef void (* GLFWapplicationwillfinishlaunchingfun)(void);
 typedef int (* GLFWcocoatogglefullscreenfun)(GLFWwindow*);
 typedef void (* GLFWcocoarenderframefun)(GLFWwindow*);
 typedef void (*GLFWwaylandframecallbackfunc)(unsigned long long id);
@@ -2088,6 +2089,10 @@ glfwSetCocoaToggleFullscreenIntercept_func glfwSetCocoaToggleFullscreenIntercept
 typedef GLFWapplicationshouldhandlereopenfun (*glfwSetApplicationShouldHandleReopen_func)(GLFWapplicationshouldhandlereopenfun);
 glfwSetApplicationShouldHandleReopen_func glfwSetApplicationShouldHandleReopen_impl;
 #define glfwSetApplicationShouldHandleReopen glfwSetApplicationShouldHandleReopen_impl
+
+typedef GLFWapplicationwillfinishlaunchingfun (*glfwSetApplicationWillFinishLaunching_func)(GLFWapplicationwillfinishlaunchingfun);
+glfwSetApplicationWillFinishLaunching_func glfwSetApplicationWillFinishLaunching_impl;
+#define glfwSetApplicationWillFinishLaunching glfwSetApplicationWillFinishLaunching_impl
 
 typedef void (*glfwGetCocoaKeyEquivalent_func)(int, int, void*, void*);
 glfwGetCocoaKeyEquivalent_func glfwGetCocoaKeyEquivalent_impl;

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -517,6 +517,7 @@ create_os_window(PyObject UNUSED *self, PyObject *args) {
         cocoa_set_activation_policy(OPT(macos_hide_from_tasks));
         glfwWindowHint(GLFW_COCOA_GRAPHICS_SWITCHING, true);
         glfwSetApplicationShouldHandleReopen(on_application_reopen);
+        glfwSetApplicationWillFinishLaunching(cocoa_create_global_menu);
         if (OPT(hide_window_decorations)) glfwWindowHint(GLFW_DECORATED, false);
 #endif
 
@@ -595,9 +596,6 @@ create_os_window(PyObject UNUSED *self, PyObject *args) {
         PyObject *ret = PyObject_CallFunction(load_programs, "O", is_semi_transparent ? Py_True : Py_False);
         if (ret == NULL) return NULL;
         Py_DECREF(ret);
-#ifdef __APPLE__
-        cocoa_create_global_menu();
-#endif
 #define CC(dest, shape) {\
     if (!dest##_cursor) { \
         dest##_cursor = glfwCreateStandardCursor(GLFW_##shape##_CURSOR); \


### PR DESCRIPTION
GLFW creates the menu bar in the applicationWillFinishLaunching method, while kitty creates it in `create_os_window()`. This patch changes the behaviour to match GLFW.
In practice, without this change, there can be a short time where the menu bar is not fully populated.