### PR TITLE
Change return type of two functions

### DIFF
--- a/glfw/cocoa_platform.h
+++ b/glfw/cocoa_platform.h
@@ -67,9 +67,9 @@ typedef void* CVDisplayLinkRef;
 
 typedef VkFlags VkMacOSSurfaceCreateFlagsMVK;
 typedef int (* GLFWcocoatextinputfilterfun)(int,int,unsigned int, unsigned long);
-typedef int (* GLFWapplicationshouldhandlereopenfun)(int);
+typedef bool (* GLFWapplicationshouldhandlereopenfun)(int);
 typedef void (* GLFWapplicationwillfinishlaunchingfun)(void);
-typedef int (* GLFWcocoatogglefullscreenfun)(GLFWwindow*);
+typedef bool (* GLFWcocoatogglefullscreenfun)(GLFWwindow*);
 typedef void (* GLFWcocoarenderframefun)(GLFWwindow*);
 
 typedef struct VkMacOSSurfaceCreateInfoMVK

--- a/glfw/glfw.py
+++ b/glfw/glfw.py
@@ -200,9 +200,9 @@ const char *action_text, int32_t timeout, GLFWDBusnotificationcreatedfun callbac
 {}
 
 typedef int (* GLFWcocoatextinputfilterfun)(int,int,unsigned int,unsigned long);
-typedef int (* GLFWapplicationshouldhandlereopenfun)(int);
+typedef bool (* GLFWapplicationshouldhandlereopenfun)(int);
 typedef void (* GLFWapplicationwillfinishlaunchingfun)(void);
-typedef int (* GLFWcocoatogglefullscreenfun)(GLFWwindow*);
+typedef bool (* GLFWcocoatogglefullscreenfun)(GLFWwindow*);
 typedef void (* GLFWcocoarenderframefun)(GLFWwindow*);
 typedef void (*GLFWwaylandframecallbackfunc)(unsigned long long id);
 typedef void (*GLFWDBusnotificationcreatedfun)(unsigned long long, uint32_t, void*);

--- a/kitty/glfw-wrapper.h
+++ b/kitty/glfw-wrapper.h
@@ -1575,9 +1575,9 @@ typedef struct GLFWgamepadstate
 
 
 typedef int (* GLFWcocoatextinputfilterfun)(int,int,unsigned int,unsigned long);
-typedef int (* GLFWapplicationshouldhandlereopenfun)(int);
+typedef bool (* GLFWapplicationshouldhandlereopenfun)(int);
 typedef void (* GLFWapplicationwillfinishlaunchingfun)(void);
-typedef int (* GLFWcocoatogglefullscreenfun)(GLFWwindow*);
+typedef bool (* GLFWcocoatogglefullscreenfun)(GLFWwindow*);
 typedef void (* GLFWcocoarenderframefun)(GLFWwindow*);
 typedef void (*GLFWwaylandframecallbackfunc)(unsigned long long id);
 typedef void (*GLFWDBusnotificationcreatedfun)(unsigned long long, uint32_t, void*);

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -461,19 +461,19 @@ filter_option(int key UNUSED, int mods, unsigned int native_key UNUSED, unsigned
 
 static GLFWwindow *application_quit_canary = NULL;
 
-static int
+static bool
 on_application_reopen(int has_visible_windows) {
     if (has_visible_windows) return true;
     set_cocoa_pending_action(NEW_OS_WINDOW, NULL);
     return false;
 }
 
-static int
+static bool
 intercept_cocoa_fullscreen(GLFWwindow *w) {
-    if (!OPT(macos_traditional_fullscreen) || !set_callback_window(w)) return 0;
+    if (!OPT(macos_traditional_fullscreen) || !set_callback_window(w)) return false;
     toggle_fullscreen_for_os_window(global_state.callback_os_window);
     global_state.callback_os_window = NULL;
-    return 1;
+    return true;
 }
 #endif
 


### PR DESCRIPTION
`on_application_reopen()` and `intercept_cocoa_fullscreen()` both only have two possible return values and can therefore have a return type of `bool`.

I got this idea because the first function returns `true` and `false` anyways.