### PR TITLE
Comment commented out code back in

### DIFF
--- a/glfw/cocoa_init.m
+++ b/glfw/cocoa_init.m
@@ -470,14 +470,13 @@ static GLFWapplicationwillfinishlaunchingfun finish_launching_callback = NULL;
         // finishLaunching below, in order to properly emulate the behavior
         // of NSApplicationMain
 
-        // disabled by Kovid
-        /* if ([[NSBundle mainBundle] pathForResource:@"MainMenu" ofType:@"nib"])
+        if ([[NSBundle mainBundle] pathForResource:@"MainMenu" ofType:@"nib"])
         {
             [[NSBundle mainBundle] loadNibNamed:@"MainMenu"
                                           owner:NSApp
                                 topLevelObjects:&_glfw.ns.nibObjects];
         }
-        else */
+        else
             createMenuBar();
     }
     if (finish_launching_callback)


### PR DESCRIPTION
This piece of code is not run when the `GLFW_COCOA_MENUBAR` init hint is set to `0`, which kitty does.
This reduces the difference to GLFW upstream a little.