### PR TITLE
Change URL to avoid redirect

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,5 +1,5 @@
 = kitty - the fast, featureful, GPU based, terminal emulator
 
-See https://sw.kovidgoyal.net/kitty
+See https://sw.kovidgoyal.net/kitty/
 
 image:https://circleci.com/gh/kovidgoyal/kitty.svg?style=svg["Build status", link="https://circleci.com/gh/kovidgoyal/kitty"]

--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -225,7 +225,7 @@ Run the :italic:`{appname}` terminal emulator. You can also specify the :italic:
 to run inside :italic:`{appname}` as normal arguments following the :italic:`options`.
 For example: {appname} /bin/sh
 
-For comprehensive documentation for kitty, please see: https://sw.kovidgoyal.net/kitty''').format(appname=appname)
+For comprehensive documentation for kitty, please see: https://sw.kovidgoyal.net/kitty/''').format(appname=appname)
 
 
 def print_help_for_seq(seq, usage, message, appname):

--- a/setup.py
+++ b/setup.py
@@ -757,7 +757,7 @@ def macos_info_plist():
         NSRequiresAquaSystemAppearance='NO',
         NSHumanReadableCopyright=time.strftime(
             'Copyright %Y, Kovid Goyal'),
-        CFBundleGetInfoString='kitty, an OpenGL based terminal emulator https://sw.kovidgoyal.net/kitty',
+        CFBundleGetInfoString='kitty, an OpenGL based terminal emulator https://sw.kovidgoyal.net/kitty/',
         CFBundleIconFile=appname + '.icns',
         NSHighResolutionCapable=True,
         NSSupportsAutomaticGraphicsSwitching=True,


### PR DESCRIPTION
Since `https://sw.kovidgoyal.net/kitty` redirects to `https://sw.kovidgoyal.net/kitty/`, it would be better to directly use the second URL.