### PR TITLE
Direct user to rebuild fc-cache in font FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -189,6 +189,11 @@ following :file:`~/.config/fontconfig/fonts.conf`::
     </match>
     </fontconfig>
 
+After creating (or modifying) this file, you may need to run the following
+command to rebuild your fontconfig cache::
+
+    fc-cache -r
+
 Then, the font will be available in ``kitty list-fonts``.
 
 


### PR DESCRIPTION
The configuration file that's suggested to force a font to
show up as monospace is very helpful, but it appears you may
need to force fontconfig to rebuild the cache in order for the
change to take effect.