### PR TITLE
Fixed bug in loading libcanberra when falling back on alternative library names

### DIFF
--- a/kitty/desktop.c
+++ b/kitty/desktop.c
@@ -113,8 +113,8 @@ load_libcanberra(void) {
     if (done) return;
     done = true;
     libcanberra_handle = dlopen(libname, RTLD_LAZY);
-    if (libcanberra_handle == NULL) libsn_handle = dlopen(libname2, RTLD_LAZY);
-    if (libcanberra_handle == NULL) libsn_handle = dlopen(libname3, RTLD_LAZY);
+    if (libcanberra_handle == NULL) libcanberra_handle = dlopen(libname2, RTLD_LAZY);
+    if (libcanberra_handle == NULL) libcanberra_handle = dlopen(libname3, RTLD_LAZY);
     if (libcanberra_handle == NULL) {
         fprintf(stderr, "Failed to load %s, cannot play beep sound, with error: %s\n", libname, dlerror());
         return;


### PR DESCRIPTION
Hi there, I was building kitty from source and upon launching the built binary, I encountered the following error when pressing backspace when there's no input in the terminal:

```
Failed to load libcanberra.so, cannot play beep sound, with error: (null)
```

After inspecting kitty/desktop.c, I found a bug in the loading of libcanberra (the wrong variable is used) and fixed it in this pull request.