### PR TITLE
fix kitty +kitten panel -c <config> resulting in no config at all

### DIFF
--- a/kittens/panel/main.py
+++ b/kittens/panel/main.py
@@ -130,8 +130,8 @@ def main(sys_args):
     if not items:
         raise SystemExit('You must specify the program to run')
     sys.argv = ['kitty']
-    if args.config:
-        sys.argv.append('--config={}'.format(args.config))
+    for config in args.config:
+        sys.argv.append('--config={}'.format(config))
     for override in args.override:
         sys.argv.append('--override={}'.format(override))
     sys.argv.extend(items)


### PR DESCRIPTION
Opening a panel with `kitty +kitten panel -c <config>` results in no config file loading at all, the same way it happens when an invalid file is given to `kitty -c`.

This PR fixes that.