### PR TITLE
Make comment more accurate

### DIFF
--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -109,7 +109,7 @@ static size_t reaped_pids_count = 0;
 #define INCREF_CHILD(x) XREF_CHILD(x, Py_INCREF)
 #define DECREF_CHILD(x) XREF_CHILD(x, Py_DECREF)
 
-// The max time (in secs) to wait for events from the window system
+// The max time to wait for events from the window system
 // before ticking over the main loop. Negative values mean wait forever.
 static monotonic_t maximum_wait = -1;
 


### PR DESCRIPTION
Since all the time values use `monotonic_t` now, `maximum_wait` is no longer measured in seconds. Instead of replacing seconds with nanoseconds, I removed it because the definition of `monotonic_t` is supposed to be changed easily, in which case this comment would not be accurate again.