### PR TITLE
Wayland: Unset the cursor shape on border exit

### DIFF
--- a/glfw/wl_init.c
+++ b/glfw/wl_init.c
@@ -137,6 +137,7 @@ static void pointerHandleLeave(void* data UNUSED,
     _glfw.wl.pointerSerial = serial;
     _glfw.wl.pointerFocus = NULL;
     _glfwInputCursorEnter(window, false);
+    _glfw.wl.cursorPreviousShape = NULL;
 }
 
 static void setCursor(GLFWCursorShape shape)
@@ -192,6 +193,7 @@ static void pointerHandleMotion(void* data UNUSED,
             window->wl.cursorPosX = x;
             window->wl.cursorPosY = y;
             _glfwInputCursorPos(window, x, y);
+            _glfw.wl.cursorPreviousShape = NULL;
             return;
         case topDecoration:
             if (y < _GLFW_DECORATION_WIDTH)


### PR DESCRIPTION
From upstream: https://github.com/glfw/glfw/commit/ef6189f348d7f911afe640e6b817e2e945dc86a1.