### PR TITLE
Cocoa: Fix pre-window-creation event processing

### DIFF
--- a/glfw/cocoa_init.m
+++ b/glfw/cocoa_init.m
@@ -485,10 +485,10 @@ static GLFWapplicationwillfinishlaunchingfun finish_launching_callback = NULL;
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
 {
     (void)notification;
-    [NSApp stop:nil];
-
+    _glfw.ns.finishedLaunching = true;
     CGDisplayRegisterReconfigurationCallback(display_reconfigured, NULL);
     _glfwCocoaPostEmptyEvent();
+    [NSApp stop:nil];
 }
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification
@@ -744,6 +744,9 @@ request_tick_callback() {
 
 void _glfwPlatformPostEmptyEvent(void)
 {
+    if (!_glfw.ns.finishedLaunching)
+        [NSApp run];
+
     if (pthread_equal(pthread_self(), main_thread)) {
         request_tick_callback();
     } else if (tick_lock) {

--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -1429,10 +1429,7 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
 {
     window->ns.deadKeyState = 0;
     if (!_glfw.ns.finishedLaunching)
-    {
         [NSApp run];
-        _glfw.ns.finishedLaunching = true;
-    }
 
     if (!createNativeWindow(window, wndconfig, fbconfig))
         return false;
@@ -2349,6 +2346,9 @@ float _glfwTransformYNS(float y)
 }
 
 void _glfwCocoaPostEmptyEvent(void) {
+    if (!_glfw.ns.finishedLaunching)
+        [NSApp run];
+
     NSEvent* event = [NSEvent otherEventWithType:NSEventTypeApplicationDefined
                                         location:NSMakePoint(0, 0)
                                    modifierFlags:0


### PR DESCRIPTION
From upstream: https://github.com/glfw/glfw/commit/6e6805000ac7ddf39c8c5f6be3e877770cba5083.

Please check if the code added to `_glfwPlatformPostEmptyEvent()` is appropriate for kitty's version of GLFW or alternatively don't merge this.