### PR TITLE
Fix POSIX conformance issues for clock_gettime

### DIFF
--- a/glfw/posix_time.c
+++ b/glfw/posix_time.c
@@ -27,8 +27,11 @@
 // It is fine to use C99 in this file because it will not be built with VS
 //========================================================================
 
+#define _POSIX_C_SOURCE 199309L
+
 #include "internal.h"
 
+#include <unistd.h>
 #include <sys/time.h>
 #include <time.h>
 
@@ -41,7 +44,7 @@
 //
 void _glfwInitTimerPOSIX(void)
 {
-#if defined(CLOCK_MONOTONIC)
+#if defined(_POSIX_TIMERS) && defined(_POSIX_MONOTONIC_CLOCK)
     struct timespec ts;
 
     if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0)
@@ -64,7 +67,7 @@ void _glfwInitTimerPOSIX(void)
 
 uint64_t _glfwPlatformGetTimerValue(void)
 {
-#if defined(CLOCK_MONOTONIC)
+#if defined(_POSIX_TIMERS) && defined(_POSIX_MONOTONIC_CLOCK)
     if (_glfw.timer.posix.monotonic)
     {
         struct timespec ts;

--- a/glfw/wl_init.c
+++ b/glfw/wl_init.c
@@ -27,6 +27,8 @@
 //========================================================================
 
 #define _GNU_SOURCE
+#define _POSIX_C_SOURCE 199309L
+
 #include "internal.h"
 #include "backend_utils.h"
 #include "../kitty/monotonic.h"
@@ -40,6 +42,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <time.h>
 #include <wayland-client.h>
 // Needed for the BTN_* defines
 #ifdef __has_include

--- a/glfw/x11_init.c
+++ b/glfw/x11_init.c
@@ -38,6 +38,7 @@
 #include <limits.h>
 #include <stdio.h>
 #include <locale.h>
+#include <unistd.h>
 #include <fcntl.h>
 #include <unistd.h>
 


### PR DESCRIPTION
From upstream: https://github.com/glfw/glfw/commit/081484ed340da6ccab5d0e3442c9d10a1b385ec3.

Does this commit introduce any problems similar to what my `monotonic_t` patch introduced?
Should I create a similar patch to change the macros in kitty's code?