### PR TITLE
X11: Fix missing checks for EWMH attention atoms

### DIFF
--- a/glfw/x11_window.c
+++ b/glfw/x11_window.c
@@ -2226,6 +2226,9 @@ void _glfwPlatformHideWindow(_GLFWwindow* window)
 
 void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
 {
+    if (!_glfw.x11.NET_WM_STATE || !_glfw.x11.NET_WM_STATE_DEMANDS_ATTENTION)
+        return;
+
     sendEventToWM(window,
                   _glfw.x11.NET_WM_STATE,
                   _NET_WM_STATE_ADD,


### PR DESCRIPTION
From upstream: https://github.com/glfw/glfw/commit/9b6d68ec70da775c4e2bf6481f86117cf9d9f551.