### PR TITLE
X11: Fix invalid read when clearing GLFW_FLOATING

### DIFF
--- a/glfw/x11_window.c
+++ b/glfw/x11_window.c
@@ -2483,7 +2483,7 @@ void _glfwPlatformSetWindowFloating(_GLFWwindow* window, bool enabled)
 
             XChangeProperty(_glfw.x11.display, window->x11.handle,
                             _glfw.x11.NET_WM_STATE, XA_ATOM, 32,
-                            PropModeReplace, (unsigned char*) &states, count);
+                            PropModeReplace, (unsigned char*) states, count);
         }
 
         XFree(states);


### PR DESCRIPTION
From upstream: https://github.com/glfw/glfw/commit/0b652a44d2afe593d6eca8a0d586c20555a0497c.