### PR TITLE
Fix the scissor limits (again)

### DIFF
--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -512,10 +512,10 @@ draw_cells(ssize_t vao_idx, ssize_t gvao_idx, GLfloat xstart, GLfloat ystart, GL
     // kitty -o background=cyan -o background_opacity=0.7 -o window_margin_width=40 sh -c "kitty +kitten icat logo/kitty.png; read"
 #define SCALE(w, x) ((GLfloat)(os_window->viewport_##w) * (GLfloat)(x))
     glScissor(
-            (GLint)(ceilf(SCALE(width, (xstart + 1.0f) / 2.0f))), // x
-            (GLint)(ceilf(SCALE(height, ((ystart - h) + 1.0f) / 2.0f))), // y
-            (GLsizei)(floorf(SCALE(width, w / 2.0f))), // width
-            (GLsizei)(floorf(SCALE(height, h / 2.0f))) // height
+            (GLint)(round(SCALE(width, (xstart + 1.0f) / 2.0f))), // x
+            (GLint)(round(SCALE(height, ((ystart - h) + 1.0f) / 2.0f))), // y
+            (GLsizei)(round(SCALE(width, w / 2.0f))), // width
+            (GLsizei)(round(SCALE(height, h / 2.0f))) // height
     );
 #undef SCALE
     if (os_window->is_semi_transparent) {


### PR DESCRIPTION
When I execute the test case
```bash
kitty -o background=cyan -o background_opacity=0.7 -o window_margin_width=40 sh -c "kitty +kitten icat logo/kitty.png; read"
```
from the comment in the code, I get the following:
![original](https://user-images.githubusercontent.com/15217907/71173866-21f50080-2264-11ea-820a-593429a8d8fe.png)
With this commit, it looks like this:
![fixed](https://user-images.githubusercontent.com/15217907/71173892-2d482c00-2264-11ea-99cd-3985541f7a0b.png)
Please check that this patch actually makes sense and is the correct way to fix this as I don't know how the scissor limits work.