### PR TITLE
Change keyboard shortcut selection algorithm for new_os_window on macOS

### DIFF
--- a/kitty/main.py
+++ b/kitty/main.py
@@ -18,7 +18,7 @@ from .constants import (
     is_wayland, kitty_exe, logo_data_file
 )
 from .fast_data_types import (
-    GLFW_IBEAM_CURSOR, GLFW_MOD_SUPER, create_os_window, free_font_data,
+    GLFW_IBEAM_CURSOR, create_os_window, free_font_data,
     glfw_init, glfw_terminate, load_png_data, set_custom_cursor,
     set_default_window_icon, set_options
 )
@@ -95,10 +95,6 @@ def init_glfw(opts, debug_keyboard=False):
     return glfw_module
 
 
-def prefer_cmd_shortcuts(x):
-    return x[0] == GLFW_MOD_SUPER
-
-
 def get_new_os_window_trigger(opts):
     new_os_window_trigger = None
     if is_macos:
@@ -108,8 +104,8 @@ def get_new_os_window_trigger(opts):
                 new_os_window_shortcuts.append(k)
         if new_os_window_shortcuts:
             from .fast_data_types import cocoa_set_new_window_trigger
-            new_os_window_shortcuts.sort(key=prefer_cmd_shortcuts, reverse=True)
-            for candidate in new_os_window_shortcuts:
+            # Reverse list so that later defined keyboard shortcts take priority over earlier defined ones
+            for candidate in reversed(new_os_window_shortcuts):
                 if cocoa_set_new_window_trigger(candidate[0], candidate[2]):
                     new_os_window_trigger = candidate
                     break


### PR DESCRIPTION
On macOS the keyboard shortcuts are visible in the menu bar. When the keyboard shortcut is used, the corresponding menu bar item flashes to indicate which action was just executed.
kitty allows defining multiple keyboard shortcuts for the same action but macOS allows only one, so kitty needs to decide which one should be handled by macOS. Currently it chooses the first keyboard shortcut with only the command key as a modifier key or the first shortcut when there are no shortcuts with only the command key as a modifier.
When a user tries to set their own keyboard shortcut (and doesn't use `clear_all_shortcuts yes`), this won't change the shortcut displayed in the menu bar since the first (default) shortcut with the command key is <kbd>⌘</kbd>+<kbd>n</kbd>.
I think simply choosing the last defined keyboard shortcut is better. This will even allow the user to specify modifier keys other than the command key while still changing the shortcut in the menu bar. This change will not change the default behaviour because all the macOS specific keyboard shortcuts are defined after the non-macOS specific ones.