### PR TITLE
Premultiply resizing text with the alpha value

### DIFF
--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -633,7 +633,7 @@ draw_resizing_text(OSWindow *w) {
     snprintf(text, sizeof(text), "%u x %u cells", width / w->fonts_data->cell_width, height / w->fonts_data->cell_height);
     StringCanvas rendered = render_simple_text(w->fonts_data, text);
     if (rendered.canvas) {
-        draw_centered_alpha_mask(w->gvao_idx, width, height, rendered.width, rendered.height, rendered.canvas);
+        draw_centered_alpha_mask(w->is_semi_transparent, w->gvao_idx, width, height, rendered.width, rendered.height, rendered.canvas);
         free(rendered.canvas);
     }
 }

--- a/kitty/graphics_fragment.glsl
+++ b/kitty/graphics_fragment.glsl
@@ -1,5 +1,6 @@
 #version GLSL_VERSION
-#define ALPHA_TYPE
+#define NOT_ALPHA_MASK
+#define NOT_PREMULT
 
 uniform sampler2D image;
 #ifdef ALPHA_MASK
@@ -27,7 +28,11 @@ vec3 color_to_vec(uint c) {
 void main() {
     color = texture(image, texcoord);
 #ifdef ALPHA_MASK
+#ifdef PREMULT
+    color = vec4(color_to_vec(fg) * color.r, color.r);
+#else
     color = vec4(color_to_vec(fg), color.r);
+#endif
 #else
     color.a *= inactive_text_alpha;
 #ifdef PREMULT

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -214,7 +214,7 @@ ssize_t create_graphics_vao(void);
 ssize_t create_border_vao(void);
 bool send_cell_data_to_gpu(ssize_t, ssize_t, float, float, float, float, Screen *, OSWindow *);
 void draw_cells(ssize_t, ssize_t, float, float, float, float, Screen *, OSWindow *, bool, bool);
-void draw_centered_alpha_mask(ssize_t gvao_idx, size_t screen_width, size_t screen_height, size_t width, size_t height, uint8_t *canvas);
+void draw_centered_alpha_mask(bool is_semi_transparent, ssize_t gvao_idx, size_t screen_width, size_t screen_height, size_t width, size_t height, uint8_t *canvas);
 void update_surface_size(int, int, uint32_t);
 void free_texture(uint32_t*);
 void send_image_to_gpu(uint32_t*, const void*, int32_t, int32_t, bool, bool);

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -17,7 +17,7 @@ from .constants import (
 from .fast_data_types import (
     BLIT_PROGRAM, CELL_BG_PROGRAM, CELL_FG_PROGRAM, CELL_PROGRAM,
     CELL_SPECIAL_PROGRAM, CSI, DCS, DECORATION, DIM,
-    GRAPHICS_ALPHA_MASK_PROGRAM, GRAPHICS_PREMULT_PROGRAM, GRAPHICS_PROGRAM,
+    GRAPHICS_ALPHA_MASK_PROGRAM, GRAPHICS_ALPHA_MASK_PREMULT_PROGRAM, GRAPHICS_PREMULT_PROGRAM, GRAPHICS_PROGRAM,
     OSC, REVERSE, SCROLL_FULL, SCROLL_LINE, SCROLL_PAGE, STRIKETHROUGH, Screen,
     add_window, cell_size_for_window, compile_program, get_clipboard_string,
     init_cell_program, set_clipboard_string, set_titlebar_color,
@@ -82,12 +82,17 @@ def load_shader_programs(semi_transparent=False):
             ff = ff.replace('#define USE_SELECTION_FG', '#define DONT_USE_SELECTION_FG')
         compile_program(p, vv, ff)
     v, f = load_shaders('graphics')
-    for which, p in {
-            'SIMPLE': GRAPHICS_PROGRAM,
-            'PREMULT': GRAPHICS_PREMULT_PROGRAM,
-            'ALPHA_MASK': GRAPHICS_ALPHA_MASK_PROGRAM,
+    for (alpha_mask, premult), p in {
+            (False, False): GRAPHICS_PROGRAM,
+            (False, True): GRAPHICS_PREMULT_PROGRAM,
+            (True, False): GRAPHICS_ALPHA_MASK_PROGRAM,
+            (True, True): GRAPHICS_ALPHA_MASK_PREMULT_PROGRAM,
     }.items():
-        ff = f.replace('ALPHA_TYPE', which)
+        ff = f
+        if alpha_mask:
+            ff = ff.replace('#define NOT_ALPHA_MASK', '#define ALPHA_MASK')
+        if premult:
+            ff = ff.replace('#define NOT_PREMULT', '#define PREMULT')
         compile_program(p, v, ff)
     init_cell_program()
 


### PR DESCRIPTION
The resizing text needs to be premultiplied or the anti-aliasing will look wrong. The issue seems to be more pronounced on grey to white backgrounds.
To reproduce the issue start kitty with `kitty --config NONE -o background_opacity=0.3 -o resize_draw_strategy=size -o foreground=#899` and resize the window.
`graphics_fragment.glsl` has `#define ALPHA_TYPE` at the top, which will be replaced by one of `SIMPLE`, `PREMULT` or `ALPHA_MASK` compile time, so it is impossible to define both `PREMULT` and `ALPHA_MASK` at the same time. This is why I premultiply in the `#ifdef ALPHA_MASK`.

Without this fix:
![before](https://user-images.githubusercontent.com/15217907/71357436-1e27ed80-2586-11ea-9ef7-20c1a3a582dd.png)
With:
![after](https://user-images.githubusercontent.com/15217907/71357447-254efb80-2586-11ea-8b57-ebdb5f7bd2ed.png)
The text is hard to read because of the poor contrast between the text color and the wallpaper but this is expected. I chose this combination of colours because it was fairly easy to see the anti-aliasing issue.
Please double-check that you can reproduce the issue on your machine.