### PR TITLE
Update comment to remove legacy way of starting kitty

### DIFF
--- a/kitty/keys.py
+++ b/kitty/keys.py
@@ -387,7 +387,7 @@ def generate_key_table_impl(w):
 
 
 def generate_key_table():
-    # To run this, use: python3 . +runpy "from kitty.keys import *; generate_key_table()"
+    # To run this, use: ./kitty/launcher/kitty +runpy "from kitty.keys import *; generate_key_table()"
     import os
     from functools import partial
     with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'keys.h'), 'w') as f:


### PR DESCRIPTION
Since 9135387cfa141e9ec27271bc41d5b6c43da90197 kitty should not be started with `python3 .` anymore.