### PR TITLE
Remove call to release on an automatically memory managed object

### DIFF
--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -258,7 +258,6 @@ cocoa_create_global_menu(void) {
         [new_os_window_menu_item setKeyEquivalentModifierMask:new_window_mods];
         [new_os_window_menu_item setTarget:global_menu_target];
         [appMenu addItem:new_os_window_menu_item];
-        [s release];
     }
 
 


### PR DESCRIPTION
This call even reliably caused a crash for code I was trying to develop.