### PR TITLE
Always show the macOS New OS Window menu item

### DIFF
--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -253,14 +253,12 @@ cocoa_create_global_menu(void) {
                 keyEquivalent:@","]
                     setTarget:global_menu_target];
 
-    if (new_window_key[0]) {
-        NSMenuItem* new_os_window_menu_item =
-            [appMenu addItemWithTitle:@"New OS window"
-                               action:@selector(new_os_window:)
-                        keyEquivalent:@(new_window_key)];
-        [new_os_window_menu_item setKeyEquivalentModifierMask:new_window_mods];
-        [new_os_window_menu_item setTarget:global_menu_target];
-    }
+    NSMenuItem* new_os_window_menu_item =
+        [appMenu addItemWithTitle:@"New OS window"
+                           action:@selector(new_os_window:)
+                    keyEquivalent:@(new_window_key)];
+    [new_os_window_menu_item setKeyEquivalentModifierMask:new_window_mods];
+    [new_os_window_menu_item setTarget:global_menu_target];
 
 
     [appMenu addItemWithTitle:[NSString stringWithFormat:@"Hide %@", app_name]


### PR DESCRIPTION
When there is no keyboard shortcut for a new OS window, the macOS menu item should still exist, it should just not have a keyboard shortcut.