### PR TITLE
X11: Fix BadMatch focusing a window on non-EWMH WM

### DIFF
--- a/glfw/x11_window.c
+++ b/glfw/x11_window.c
@@ -2255,7 +2255,7 @@ void _glfwPlatformFocusWindow(_GLFWwindow* window)
 {
     if (_glfw.x11.NET_ACTIVE_WINDOW)
         sendEventToWM(window, _glfw.x11.NET_ACTIVE_WINDOW, 1, 0, 0, 0, 0);
-    else
+    else if (_glfwPlatformWindowVisible(window))
     {
         XRaiseWindow(_glfw.x11.display, window->x11.handle);
         XSetInputFocus(_glfw.x11.display, window->x11.handle,


### PR DESCRIPTION
From upstream: https://github.com/glfw/glfw/commit/aa5e31356178de43d42f43f48914a62c25033f4b.