### PR TITLE
Allow drawing images below cells w/background

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -335,7 +335,8 @@ placed in the same location with different z-index values will be blended if
 they are semi-transparent. You can specify z-index values using the ``z`` key.
 Negative z-index values mean that the images will be drawn under the text. This
 allows rendering of text on top of images. Negative z-index values below
-INT32_MIN/2 will be drawn under the background.
+INT32_MIN/2 (-1073741824) will be drawn under cells with non-default background
+colors.
 
 Deleting images
 ---------------------

--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -334,7 +334,8 @@ Finally, you can specify the image *z-index*, i.e. the vertical stacking order. 
 placed in the same location with different z-index values will be blended if
 they are semi-transparent. You can specify z-index values using the ``z`` key.
 Negative z-index values mean that the images will be drawn under the text. This
-allows rendering of text on top of images.
+allows rendering of text on top of images. Negative z-index values below
+INT32_MIN/2 will be drawn under the background.
 
 Deleting images
 ---------------------
@@ -417,7 +418,7 @@ Key      Value                 Default    Description
 ``Y``    Positive integer      ``0``      The y-offset within the first cell at which to start displaying the image
 ``c``    Positive integer      ``0``      The number of columns to display the image over
 ``r``    Positive integer      ``0``      The number of rows to display the image over
-``z``    Integer               ``0``      The *z-index* vertical stacking order of the image
+``z``    32-bit integer        ``0``      The *z-index* vertical stacking order of the image
 **Keys for deleting images**
 -----------------------------------------------------------
 ``d``    Single character.     ``a``      What to delete.

--- a/kitty/cell_fragment.glsl
+++ b/kitty/cell_fragment.glsl
@@ -129,18 +129,19 @@ void main() {
 #endif
 
 #if (defined(DEFAULTBG) || defined(BACKGROUND))
+    float bgfac = 1-float(equal(background, defaultbg));
 #if defined(DEFAULTBG)
-    if (background == defaultbg)
-#elif defined(BACKGROUND)
-    if (background != defaultbg)
+    bgfac += 1;
 #endif
 #if defined(TRANSPARENT)
-    final_color = vec4(background.rgb * bg_alpha, bg_alpha);
+    final_color = vec4(bgfac * background.rgb * bg_alpha, bg_alpha * bgfac);
 #else
-    final_color = vec4(background.rgb, 1.0f);
+#if defined(DEFAULTBG)
+    final_color = vec4(bgfac * background.rgb, 1.0f);
+#else
+    final_color = vec4(bgfac * background.rgb, 1.0f * bgfac);
 #endif
-    else
-    final_color = vec4(0);
+#endif
 #endif
 
 #ifdef FOREGROUND

--- a/kitty/cell_fragment.glsl
+++ b/kitty/cell_fragment.glsl
@@ -13,6 +13,7 @@
 #ifdef NEEDS_BACKROUND
 in vec3 background;
 in vec3 defaultbg;
+in float bgfac;
 #if defined(TRANSPARENT) || defined(SPECIAL)
 in float bg_alpha;
 #endif
@@ -129,10 +130,6 @@ void main() {
 #endif
 
 #if (defined(DEFAULTBG) || defined(BACKGROUND))
-    float bgfac = 1-float(equal(background, defaultbg));
-#if defined(DEFAULTBG)
-    bgfac += 1;
-#endif
 #if defined(TRANSPARENT)
     final_color = vec4(bgfac * background.rgb * bg_alpha, bg_alpha * bgfac);
 #else

--- a/kitty/cell_vertex.glsl
+++ b/kitty/cell_vertex.glsl
@@ -46,6 +46,7 @@ const uvec2 cell_pos_map[] = uvec2[4](
 #ifdef NEEDS_BACKROUND
 out vec3 background;
 out vec3 defaultbg;
+out float bgfac;
 #if defined(TRANSPARENT) || defined(SPECIAL)
 out float bg_alpha;
 #endif
@@ -201,6 +202,10 @@ void main() {
 #if defined(BACKGROUND) || defined(DEFAULTBG)
     background = bg;
     defaultbg = to_color(colors[2], default_colors[bg_index]);
+    bgfac = 1-float(equal(background, defaultbg));
+#if defined(DEFAULTBG)
+    bgfac += 1;
+#endif
 #endif
 
 #if defined(TRANSPARENT)

--- a/kitty/cell_vertex.glsl
+++ b/kitty/cell_vertex.glsl
@@ -35,7 +35,7 @@ const uvec2 cell_pos_map[] = uvec2[4](
 // }}}
 
 
-#if defined(SIMPLE) || defined(BACKGROUND) || defined(SPECIAL)
+#if defined(SIMPLE) || defined(BACKGROUND) || defined(SPECIAL) || defined(DEFAULTBG)
 #define NEEDS_BACKROUND
 #endif
 
@@ -45,6 +45,7 @@ const uvec2 cell_pos_map[] = uvec2[4](
 
 #ifdef NEEDS_BACKROUND
 out vec3 background;
+out vec3 defaultbg;
 #if defined(TRANSPARENT) || defined(SPECIAL)
 out float bg_alpha;
 #endif
@@ -197,8 +198,9 @@ void main() {
     // Background {{{
 #ifdef NEEDS_BACKROUND
 
-#if defined(BACKGROUND)
+#if defined(BACKGROUND) || defined(DEFAULTBG)
     background = bg;
+    defaultbg = to_color(colors[2], default_colors[bg_index]);
 #endif
 
 #if defined(TRANSPARENT)

--- a/kitty/graphics.c
+++ b/kitty/graphics.c
@@ -544,7 +544,9 @@ grman_update_layers(GraphicsManager *self, unsigned int scrolled_by, float scree
     if (!self->layers_dirty) return false;
     self->layers_dirty = false;
     size_t i, j;
-    self->num_of_negative_refs = 0; self->num_of_positive_refs = 0;
+    self->num_of_below_refs = 0;
+    self->num_of_negative_refs = 0;
+    self->num_of_positive_refs = 0;
     Image *img; ImageRef *ref;
     ImageRect r;
     float screen_width = dx * num_cols, screen_height = dy * num_rows;
@@ -565,7 +567,12 @@ grman_update_layers(GraphicsManager *self, unsigned int scrolled_by, float scree
         if (ref->num_cols > 0) r.right = screen_left + (ref->start_column + (int32_t)ref->num_cols) * dx;
         else r.right = r.left + screen_width * (float)ref->src_width / screen_width_px;
 
-        if (ref->z_index < 0) self->num_of_negative_refs++; else self->num_of_positive_refs++;
+        if (ref->z_index < ((int32_t)INT32_MIN/2))
+            self->num_of_below_refs++;
+        else if (ref->z_index < 0)
+            self->num_of_negative_refs++;
+        else
+            self->num_of_positive_refs++;
         ensure_space_for(self, render_data, ImageRenderData, self->count + 1, capacity, 64, true);
         ImageRenderData *rd = self->render_data + self->count;
         zero_at_ptr(rd);

--- a/kitty/graphics.h
+++ b/kitty/graphics.h
@@ -72,7 +72,8 @@ typedef struct {
     size_t count, capacity;
     ImageRenderData *render_data;
     bool layers_dirty;
-    size_t num_of_negative_refs, num_of_positive_refs;
+    // The number of images below MIN_ZINDEX / 2, then the number of refs between MIN_ZINDEX / 2 and -1 inclusive, then the number of refs above 0 inclusive.
+    size_t num_of_below_refs, num_of_negative_refs, num_of_positive_refs;
     unsigned int last_scrolled_by;
     size_t used_storage;
 } GraphicsManager;

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -15,7 +15,7 @@ from .constants import (
     ScreenGeometry, WindowGeometry, appname, get_boss, wakeup
 )
 from .fast_data_types import (
-    BLIT_PROGRAM, CELL_BG_PROGRAM, CELL_FG_PROGRAM, CELL_PROGRAM,
+    BLIT_PROGRAM, CELL_BG_PROGRAM, CELL_DEFAULT_BG_PROGRAM, CELL_FG_PROGRAM, CELL_PROGRAM,
     CELL_SPECIAL_PROGRAM, CSI, DCS, DECORATION, DIM,
     GRAPHICS_ALPHA_MASK_PROGRAM, GRAPHICS_PREMULT_PROGRAM, GRAPHICS_PROGRAM,
     OSC, REVERSE, SCROLL_FULL, SCROLL_LINE, SCROLL_PAGE, STRIKETHROUGH, Screen,
@@ -63,6 +63,7 @@ def load_shader_programs(semi_transparent=False):
     for which, p in {
             'SIMPLE': CELL_PROGRAM,
             'BACKGROUND': CELL_BG_PROGRAM,
+            'DEFAULTBG': CELL_DEFAULT_BG_PROGRAM,
             'SPECIAL': CELL_SPECIAL_PROGRAM,
             'FOREGROUND': CELL_FG_PROGRAM,
     }.items():


### PR DESCRIPTION
This is part 1 of solving #163.

It allows users to draw an image below cells that might have a background, thus:

![2020-01-10-200813_2560x1401_scrot](https://user-images.githubusercontent.com/838783/72199214-14522580-3474-11ea-953b-8d11b0ad2ba5.png)

The image is .25 opacity, while the window is .8 opacity, with a video below.

The next steps, after this is accepted, is to add a configuration option for background images, whether to tile or scale, and perhaps even an opacity for convenience (we might expect users are too lazy to just use GIMP to add the appropriate alpha channel). Now that the rendering is all figured out, all I need to do for that is add a new slot to `GraphicsManager` (graphics.h), and add the appropriate calls in the appropriate places, below CELL_DEFAULT_BG_PROGRAM but above CELL_BG_PROGRAM, similar to what I've done in this commit.