### PR TITLE
Replace all instances of EnvironmentError with OSError

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -657,7 +657,7 @@ class Boss:
         with suppress(Exception):
             s.connect(address)
             s.sendall(b'c')
-            with suppress(EnvironmentError):
+            with suppress(OSError):
                 s.shutdown(socket.SHUT_RDWR)
             s.close()
 

--- a/kitty/child.py
+++ b/kitty/child.py
@@ -51,7 +51,7 @@ else:
             try:
                 with open('/proc/' + x + '/stat', 'rb') as f:
                     raw = f.read().decode('utf-8')
-            except EnvironmentError:
+            except OSError:
                 continue
             try:
                 q = int(raw.split(' ', 5)[4])

--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -233,7 +233,7 @@ def print_help_for_seq(seq, usage, message, appname):
     screen_size = screen_size_function()
     try:
         linesz = min(screen_size().cols, 76)
-    except EnvironmentError:
+    except OSError:
         linesz = 76
     blocks = []
     a = blocks.append

--- a/kitty/conf/utils.py
+++ b/kitty/conf/utils.py
@@ -80,7 +80,7 @@ def parse_line(line, type_map, special_handling, ans, all_keys, base_path_for_in
                 _parse(include, type_map, special_handling, ans, all_keys)
         except FileNotFoundError:
             log_error('Could not find included config file: {}, ignoring'.format(val))
-        except EnvironmentError:
+        except OSError:
             log_error('Could not read from included config file: {}, ignoring'.format(val))
         return
     if all_keys is not None and key not in all_keys:

--- a/kitty/data-types.c
+++ b/kitty/data-types.c
@@ -58,9 +58,9 @@ static PyObject*
 redirect_std_streams(PyObject UNUSED *self, PyObject *args) {
     char *devnull = NULL;
     if (!PyArg_ParseTuple(args, "s", &devnull)) return NULL;
-    if (freopen(devnull, "r", stdin) == NULL) return PyErr_SetFromErrno(PyExc_EnvironmentError);
-    if (freopen(devnull, "w", stdout) == NULL) return PyErr_SetFromErrno(PyExc_EnvironmentError);
-    if (freopen(devnull, "w", stderr) == NULL)  return PyErr_SetFromErrno(PyExc_EnvironmentError);
+    if (freopen(devnull, "r", stdin) == NULL) return PyErr_SetFromErrno(PyExc_OSError);
+    if (freopen(devnull, "w", stdout) == NULL) return PyErr_SetFromErrno(PyExc_OSError);
+    if (freopen(devnull, "w", stderr) == NULL)  return PyErr_SetFromErrno(PyExc_OSError);
     Py_RETURN_NONE;
 }
 

--- a/kitty/main.py
+++ b/kitty/main.py
@@ -67,14 +67,14 @@ def talk_to_instance(args):
 
     data = json.dumps(data, ensure_ascii=False).encode('utf-8')
     single_instance.socket.sendall(data)
-    with suppress(EnvironmentError):
+    with suppress(OSError):
         single_instance.socket.shutdown(socket.SHUT_RDWR)
     single_instance.socket.close()
 
     if args.wait_for_single_instance_window_close:
         conn = notify_socket.accept()[0]
         conn.recv(1)
-        with suppress(EnvironmentError):
+        with suppress(OSError):
             conn.shutdown(socket.SHUT_RDWR)
         conn.close()
 

--- a/kitty/remote_control.py
+++ b/kitty/remote_control.py
@@ -68,7 +68,7 @@ class SocketIO:
 
     def __exit__(self, *a):
         import socket
-        with suppress(EnvironmentError):  # on some OSes such as macOS the socket is already closed at this point
+        with suppress(OSError):  # on some OSes such as macOS the socket is already closed at this point
             self.socket.shutdown(socket.SHUT_RDWR)
         self.socket.close()
 

--- a/kitty/session.py
+++ b/kitty/session.py
@@ -143,7 +143,7 @@ def create_sessions(opts, args=None, special_window=None, cwd_from=None, respect
         try:
             with open(default_session) as f:
                 session_data = f.read()
-        except EnvironmentError:
+        except OSError:
             log_error('Failed to read from session file, ignoring: {}'.format(default_session))
         else:
             yield from parse_session(session_data, opts, getattr(args, 'title', None))

--- a/kitty/shell.py
+++ b/kitty/shell.py
@@ -23,7 +23,7 @@ match_commands = tuple(sorted(all_commands + ('exit', 'help', 'quit')))
 def init_readline(readline):
     try:
         readline.read_init_file()
-    except EnvironmentError:
+    except OSError:
         if not is_macos:
             raise
     if 'libedit' in readline.__doc__:

--- a/kitty/update_check.py
+++ b/kitty/update_check.py
@@ -109,7 +109,7 @@ def update_check(timer_id=None):
             kitty_exe(), '+runpy',
             'from kitty.update_check import run_worker; run_worker()'
         ], stdout=subprocess.PIPE)
-    except EnvironmentError as e:
+    except OSError as e:
         log_error('Failed to run kitty for update check, with error: {}'.format(e))
         return False
     monitor_pid(p.pid)

--- a/kitty/utils.py
+++ b/kitty/utils.py
@@ -260,10 +260,10 @@ class startup_notification_handler:
 
 
 def remove_socket_file(s, path=None):
-    with suppress(EnvironmentError):
+    with suppress(OSError):
         s.close()
     if path:
-        with suppress(EnvironmentError):
+        with suppress(OSError):
             os.unlink(path)
 
 
@@ -287,7 +287,7 @@ def single_instance_unix(name):
         fd = os.open(path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC | os.O_CLOEXEC)
         try:
             fcntl.lockf(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except EnvironmentError as err:
+        except OSError as err:
             if err.errno in (errno.EAGAIN, errno.EACCES):
                 # Client
                 s = socket.socket(family=socket.AF_UNIX)
@@ -298,7 +298,7 @@ def single_instance_unix(name):
         s = socket.socket(family=socket.AF_UNIX)
         try:
             s.bind(socket_path)
-        except EnvironmentError as err:
+        except OSError as err:
             if err.errno in (errno.EADDRINUSE, errno.EEXIST):
                 os.unlink(socket_path)
                 s.bind(socket_path)
@@ -322,7 +322,7 @@ def single_instance(group_id=None):
     addr = '\0' + name
     try:
         s.bind(addr)
-    except EnvironmentError as err:
+    except OSError as err:
         if err.errno == errno.ENOENT:
             return single_instance_unix(name)
         if err.errno == errno.EADDRINUSE:

--- a/logo/make.py
+++ b/logo/make.py
@@ -17,7 +17,7 @@ def abspath(x):
 def run(*args):
     try:
         subprocess.check_call(args)
-    except EnvironmentError:
+    except OSError:
         raise SystemExit('You are missing the {} program needed to generate the kitty logo'.format(args[0]))
 
 

--- a/setup.py
+++ b/setup.py
@@ -333,7 +333,7 @@ SPECIAL_SOURCES = {
 def newer(dest, *sources):
     try:
         dtime = os.path.getmtime(dest)
-    except EnvironmentError:
+    except OSError:
         return True
     for s in sources:
         with suppress(FileNotFoundError):

--- a/update-on-ubuntu
+++ b/update-on-ubuntu
@@ -17,9 +17,9 @@ if False:
     os.makedirs(dest)
     os.chdir(dest)
     dest = os.path.expanduser('~/.local/bin/kitty')
-    with suppress(EnvironmentError):
+    with suppress(OSError):
         os.remove(dest)
-    with suppress(EnvironmentError):
+    with suppress(OSError):
         os.makedirs(os.path.dirname(dest))
     subprocess.check_call(['tar', 'xJf', tarball])
     os.symlink(os.path.abspath('bin/kitty'), dest)


### PR DESCRIPTION
According to the text just above https://docs.python.org/3/library/exceptions.html#EnvironmentError, `EnvironmentError` has been an alias of `OSError` since Python 3.3. Replacing it makes the code more consistent since `OSError` is used in other places in the code too.