### PR TITLE
DRYer

### DIFF
--- a/kitty/keys.py
+++ b/kitty/keys.py
@@ -120,16 +120,18 @@ control_codes.update({
     for i, k in
     enumerate(range(defines.GLFW_KEY_A, defines.GLFW_KEY_RIGHT_BRACKET + 1))
 })
-control_codes[defines.GLFW_KEY_GRAVE_ACCENT] = (0,)
-control_codes[defines.GLFW_KEY_UNDERSCORE] = (0,)
-control_codes[defines.GLFW_KEY_SPACE] = (0,)
-control_codes[defines.GLFW_KEY_2] = (0,)
+
+
+def multi_assign(dictionary, keys, value):
+    dictionary.update(dict.fromkeys(keys, value))
+
+
+multi_assign(control_codes, (defines.GLFW_KEY_2, defines.GLFW_KEY_GRAVE_ACCENT, defines.GLFW_KEY_UNDERSCORE, defines.GLFW_KEY_SPACE), (0,))
 control_codes[defines.GLFW_KEY_3] = (27,)
 control_codes[defines.GLFW_KEY_4] = (28,)
 control_codes[defines.GLFW_KEY_5] = (29,)
-control_codes[defines.GLFW_KEY_6] = control_codes[defines.GLFW_KEY_CIRCUMFLEX] = (30,)
-control_codes[defines.GLFW_KEY_7] = (31,)
-control_codes[defines.GLFW_KEY_SLASH] = (31,)
+multi_assign(control_codes, (defines.GLFW_KEY_6, defines.GLFW_KEY_CIRCUMFLEX), (30,))
+multi_assign(control_codes, (defines.GLFW_KEY_7, defines.GLFW_KEY_SLASH), (31,))
 control_codes[defines.GLFW_KEY_8] = (127,)
 
 rmkx_key_map = smkx_key_map.copy()


### PR DESCRIPTION
Inspired by e0c66ea5ba3e0bd1b375c05a9450b2d3ead412b6.

The line with `GLFW_KEY_2`, `GLFW_KEY_GRAVE_ACCENT`, `GLFW_KEY_UNDERSCORE` and `GLFW_KEY_SPACE` got very long, so I wrote a little method to assign one value to multiple keys, which makes the line shorter. Is this a good idea? It might still be too long, I'll break up the line if the CI complains.