### PR TITLE
wayland: Minor rework of error handling in handleEvents

### DIFF
--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -762,15 +762,9 @@ handleEvents(monotonic_t timeout)
     EVDBG("starting handleEvents(%.2f)", monotonic_t_to_s_double(timeout));
 
     while (wl_display_prepare_read(display) != 0) {
-        while(1) {
-            int num_dispatched = wl_display_dispatch_pending(display);
-            if (num_dispatched < 0) {
-                if (errno == EAGAIN) continue;
-                int last_error = wl_display_get_error(display);
-                if (last_error) abortOnFatalError(last_error);
-                return;
-            }
-            break;
+        if (wl_display_dispatch_pending(display) == -1) {
+            abortOnFatalError(wl_display_get_error(display));
+            return;
         }
     }
 

--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -768,7 +768,6 @@ handleEvents(monotonic_t timeout)
             if (num_dispatched < 0) {
                 if (errno == EAGAIN) continue;
                 int last_error = wl_display_get_error(display);
-                wl_display_cancel_read(display);
                 if (last_error) abortOnFatalError(last_error);
                 return;
             }

--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -763,7 +763,6 @@ handleEvents(monotonic_t timeout)
 
     while (wl_display_prepare_read(display) != 0) {
         while(1) {
-            errno = 0;
             int num_dispatched = wl_display_dispatch_pending(display);
             if (num_dispatched < 0) {
                 if (errno == EAGAIN) continue;
@@ -778,7 +777,6 @@ handleEvents(monotonic_t timeout)
     // If an error different from EAGAIN happens, we have likely been
     // disconnected from the Wayland session, try to handle that the best we
     // can.
-    errno = 0;
     if (wl_display_flush(display) < 0 && errno != EAGAIN)
     {
         wl_display_cancel_read(display);

--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -763,7 +763,7 @@ handleEvents(monotonic_t timeout)
 
     while (wl_display_prepare_read(display) != 0) {
         if (wl_display_dispatch_pending(display) == -1) {
-            abortOnFatalError(wl_display_get_error(display));
+            abortOnFatalError(errno);
             return;
         }
     }

--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -782,8 +782,8 @@ handleEvents(monotonic_t timeout)
     errno = 0;
     if (wl_display_flush(display) < 0 && errno != EAGAIN)
     {
-        abortOnFatalError(errno);
         wl_display_cancel_read(display);
+        abortOnFatalError(errno);
         return;
     }
 


### PR DESCRIPTION
This PR contains a few minor changes to the wayland loop, each in their own commit:

1. Ensure that wl_display_cancel_read is called immediately on error.
2. Ensure that wl_display_cancel_read is only called if wl_display_prepare_read has succeeded.
3. Simplify wl_display_dispatch_pending error handling, as it does not return EAGAIN.
4. Avoid unnecessarily clearing errno before calls to wayland, as errno will be overwritten if an error occurs.
5. Use errno for both calls to abortOnFatalError, instead of errno for one and wl_display_get_error for the other.