### PR TITLE
Document default layouts order

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -224,11 +224,11 @@ using the :sc:`new_window` key combination.
 
 Currently, there are five layouts available,
 
-* **Stack** -- Only a single maximized window is shown at a time
-* **Tall** -- One window is shown full height on the left, the rest of the windows are shown one below the other on the right
 * **Fat** -- One window is shown full width on the top, the rest of the windows are shown side-by-side on the bottom
 * **Grid** -- All windows are shown in a grid
 * **Horizontal** -- All windows are shown side-by-side
+* **Stack** -- Only a single maximized window is shown at a time
+* **Tall** -- One window is shown full height on the left, the rest of the windows are shown one below the other on the right
 * **Vertical** -- All windows are shown one below the other
 
 You can switch between layouts using the :sc:`next_layout` key combination. You can

--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -608,7 +608,8 @@ def to_layout_names(raw):
 o('enabled_layouts', '*', option_type=to_layout_names, long_text=_('''
 The enabled window layouts. A comma separated list of layout names. The special
 value :code:`all` means all layouts. The first listed layout will be used as the
-startup layout. For a list of available layouts, see the :ref:`layouts`.
+startup layout. Default configuration is :code:`'fat,grid,horizontal,stack,tall,vertical'`.
+For a list of available layouts, see the :ref:`layouts`.
 '''))
 
 o('window_resize_step_cells', 2, option_type=positive_int, long_text=_('''


### PR DESCRIPTION
Hey,

That's a rather important piece of information [you've provided](https://github.com/kovidgoyal/kitty/issues/2258#issuecomment-573272518) in #2258.

I think it's worth documenting 😉

Also, list layouts in the documentation in the order they actually appear to make it less confusing like it was to me 😅

Cheers!