### PR TITLE
Bugfix exception when executing marker functions

### DIFF
--- a/kitty/marks.py
+++ b/kitty/marks.py
@@ -89,5 +89,5 @@ def marker_from_spec(ftype, spec, flags):
         path = spec
         if not os.path.isabs(path):
             path = os.path.join(config_dir, path)
-        return marker_from_function(runpy.run_path(path, run_name='__marker__').marker)
+        return marker_from_function(runpy.run_path(path, run_name='__marker__')["marker"])
     raise ValueError('Unknown marker type: {}'.format(ftype))


### PR DESCRIPTION
Fixes the exception below that happened for function-markers:
```
Traceback (most recent call last):
  File "/usr/bin/../lib/kitty/kitty/boss.py", line 540, in dispatch_special_key
    return self.dispatch_action(key_action)
  File "/usr/bin/../lib/kitty/kitty/boss.py", line 612, in dispatch_action
    passthrough = f(*key_action.args)
  File "/usr/bin/../lib/kitty/kitty/window.py", line 615, in toggle_marker
    self.screen.set_marker(marker_from_spec(ftype, spec, flags))
  File "/usr/bin/../lib/kitty/kitty/marks.py", line 92, in marker_from_spec
    return marker_from_function(runpy.run_path(path, run_name='__marker__').marker)
```