### PR TITLE
X11: Fix setting the clipboard string to itself

### DIFF
--- a/glfw/x11_window.c
+++ b/glfw/x11_window.c
@@ -2735,8 +2735,9 @@ void _glfwPlatformSetCursor(_GLFWwindow* window, _GLFWcursor* cursor UNUSED)
 
 void _glfwPlatformSetClipboardString(const char* string)
 {
+    char* copy = _glfw_strdup(string);
     free(_glfw.x11.clipboardString);
-    _glfw.x11.clipboardString = _glfw_strdup(string);
+    _glfw.x11.clipboardString = copy;
 
     XSetSelectionOwner(_glfw.x11.display,
                        _glfw.x11.CLIPBOARD,


### PR DESCRIPTION
From upstream: https://github.com/glfw/glfw/commit/0c27ed1d0ef36672f0ef28d86bf8e108cc6e379d.