### PR TITLE
tui line_edit: Set correct cursor position on end

### DIFF
--- a/kittens/tui/line_edit.py
+++ b/kittens/tui/line_edit.py
@@ -103,7 +103,7 @@ class LineEdit:
 
     def end(self):
         orig = self.cursor_pos
-        self.cursor_pos = wcswidth(self.current_input) + 1
+        self.cursor_pos = wcswidth(self.current_input)
         return self.cursor_pos != orig
 
     def on_key(self, key_event):


### PR DESCRIPTION
Previously, the cursor would end up one character after the last typed
character when pressing end in the unicode input kitten.