### PR TITLE
Add #compdef comment to zsh completion

### DIFF
--- a/kitty/complete.py
+++ b/kitty/complete.py
@@ -61,7 +61,8 @@ def remote_control_command_names() -> Tuple[str, ...]:
 
 
 completion_scripts = {
-    'zsh': '''
+    'zsh': '''#compdef kitty
+
 _kitty() {
     local src
     # Send all words up to the word the cursor is currently on


### PR DESCRIPTION
This will allow adding completions without using `kitty + complete setup zsh | source /dev/stdin` by piping the code into a file named `_kitty` in a directory in `$fpath` instead of piping to `source`. This is especially handy for package managers that package kitty.
See https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org.
The `compdef _kitty kitty` line at the end doesn't seem to have any ill effects when using the completion code in a completion function file. When piping the code to `source` like before, the added line should be interpreted as a comment and be ignored.