### PR TITLE
Process pending resize events before sizing viewport on startup

### DIFF
--- a/glfw/window.c
+++ b/glfw/window.c
@@ -286,6 +286,10 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
 #ifndef _GLFW_WAYLAND
             if (wndconfig.focused)
                 _glfwPlatformFocusWindow(window);
+#else
+            // HACK: process any immediate resize events to prevent flickering on
+            // startup, before we install any handlers.
+            _glfwPlatformWaitEventsTimeout(ms_double_to_monotonic_t(5));
 #endif
         }
     }


### PR DESCRIPTION
Addresses #2447.

This commit processes pending resize events after `glfwCreateWindow`, so that `glfwGetFramebufferSize` returns the correct size for viewport sizing.

This fixes flickering visible when starting kitty in a tiling window manager like sway.

I've imported `glfwPollEvents` and supporting functions from `glfw` master.