### PR TITLE
Add support for png2icns as an alternative to iconutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -861,7 +861,7 @@ def create_macos_app_icon(where: str = 'Resources') -> None:
     iconset_dir = os.path.abspath(os.path.join('logo', appname + '.iconset'))
     subprocess.check_call([
         'iconutil', '-c', 'icns', iconset_dir, '-o',
-        os.path.join(where, os.path.basename(iconset_dir).partition('.')[0] + '.icns')
+        os.path.join(where, appname + '.icns')
     ])
 
 

--- a/setup.py
+++ b/setup.py
@@ -858,10 +858,10 @@ def macos_info_plist() -> bytes:
 
 
 def create_macos_app_icon(where: str = 'Resources') -> None:
-    logo_dir = os.path.abspath(os.path.join('logo', appname + '.iconset'))
+    iconset_dir = os.path.abspath(os.path.join('logo', appname + '.iconset'))
     subprocess.check_call([
-        'iconutil', '-c', 'icns', logo_dir, '-o',
-        os.path.join(where, os.path.basename(logo_dir).partition('.')[0] + '.icns')
+        'iconutil', '-c', 'icns', iconset_dir, '-o',
+        os.path.join(where, os.path.basename(iconset_dir).partition('.')[0] + '.icns')
     ])
 
 

--- a/setup.py
+++ b/setup.py
@@ -859,10 +859,23 @@ def macos_info_plist() -> bytes:
 
 def create_macos_app_icon(where: str = 'Resources') -> None:
     iconset_dir = os.path.abspath(os.path.join('logo', appname + '.iconset'))
-    subprocess.check_call([
-        'iconutil', '-c', 'icns', iconset_dir, '-o',
-        os.path.join(where, appname + '.icns')
-    ])
+    icns_dir = os.path.join(where, appname + '.icns')
+    try:
+        subprocess.check_call([
+            'iconutil', '-c', 'icns', iconset_dir, '-o', icns_dir
+        ])
+    except FileNotFoundError:
+        print(error('iconutil not found') + ', using png2icns (without retina support) to convert the logo', file=sys.stderr)
+        subprocess.check_call([
+            'png2icns', icns_dir
+        ] + [os.path.join(iconset_dir, logo) for logo in [
+            # png2icns does not support retina icons, so only pass the non-retina icons
+            'icon_16x16.png',
+            'icon_32x32.png',
+            'icon_128x128.png',
+            'icon_256x256.png',
+            'icon_512x512.png',
+        ]])
 
 
 def create_minimal_macos_bundle(args: Options, where: str) -> None:


### PR DESCRIPTION
png2icns is used when building kitty with nix because iconutil seems to be closed-source. They currently patch the build system to use png2icns: https://github.com/NixOS/nixpkgs/blob/569d6d0fb11b0d3a26e565c61f3dbef15a5c1348/pkgs/applications/misc/kitty/png2icns.patch. It would be nice if kitty would support using png2icns without patching.
libicns also has an iconutil clone called icnsutil in the source tree but the last release is from 2012, which does not include this utility yet.
I'm printing a warning message because png2icns does not provide the same functionality as iconutil (no retina support). Is this a good way of printing the warning message or is there a better way to do this?