### PR TITLE
fix(window): inactive window border fix

### DIFF
--- a/kitty/layout.py
+++ b/kitty/layout.py
@@ -549,7 +549,7 @@ class Layout:  # {{{
 
     def minimal_borders(self, windows: WindowList, active_window: Optional[WindowType], needs_borders_map: Dict[int, bool]) -> Generator[Borders, None, None]:
         for w in windows:
-            if (w is active_window and draw_active_borders) or w.needs_attention:
+            if w is not active_window or draw_active_borders or w.needs_attention:
                 yield all_borders
             else:
                 yield no_borders


### PR DESCRIPTION
I'm really not sure of what I'm doing here so please double check :)
But it seems that in commit f7eef3f456f7ca38044355b88cd6ffe45cd91061 the `if` statement got "inverted" and in doing so a typo cause the condition to fail.

For reference this is the change (from f7eef3f456f7ca38044355b88cd6ffe45cd91061):
```diff
-            if w is active_window and not draw_active_borders and not w.needs_attention:
-                yield no_borders
-            else:
+            if (w is active_window and draw_active_borders) or w.needs_attention:
                 yield all_borders
+            else:
+                yield no_borders
```

The `if` initially being `A && !B && !C` it should have been translated to `!A || B || C` when inverted. That's what this fix does.

Fixes #2474.