### PR TITLE
Use c99 instead of c11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -256,7 +256,7 @@ def init_env(
         cppflags.append('-DDEBUG_{}'.format(el.upper().replace('-', '_')))
     cflags_ = os.environ.get(
         'OVERRIDE_CFLAGS', (
-            '-Wextra {} -Wno-missing-field-initializers -Wall -Wstrict-prototypes -std=c11'
+            '-Wextra {} -Wno-missing-field-initializers -Wall -Wstrict-prototypes -std=c99'
             ' -pedantic-errors -Werror {} {} -fwrapv {} {} -pipe {} -fvisibility=hidden {}'
         ).format(
             float_conversion,


### PR DESCRIPTION
Kitty builds fine with c99. The switch to c11 was due to a bug in Harfbuzz 2 that was fixed in Harfbuzz 2.3.0. See #1196. This reverts f098e6c973c5b514edb6047546bdd90c0705332b.