### PR TITLE
Fix tab_bar_background not being respected

### DIFF
--- a/kitty/tab_bar.py
+++ b/kitty/tab_bar.py
@@ -179,12 +179,8 @@ class TabBar:
         self.data_buffer_size = 0
         self.laid_out_once = False
         self.dirty = True
-        self.screen = s = Screen(None, 1, 10, 0, self.cell_width, cell_height)
-        s.color_profile.update_ansi_color_table(build_ansi_color_table(opts))
-        s.color_profile.set_configured_colors(
-            color_as_int(opts.inactive_tab_foreground),
-            color_as_int(opts.background)
-        )
+        self.screen = Screen(None, 1, 10, 0, self.cell_width, cell_height)
+        self.screen.color_profile.update_ansi_color_table(build_ansi_color_table(opts))
         self.blank_rects: Tuple[Rect, ...] = ()
         sep = opts.tab_separator
         self.trailing_spaces = self.leading_spaces = 0
@@ -208,6 +204,10 @@ class TabBar:
             self.opts.tab_bar_background or self.opts.background, self.opts.tab_title_template,
             self.opts.active_tab_title_template
         )
+        self.screen.color_profile.set_configured_colors(
+            color_as_int(self.draw_data.inactive_fg),
+            color_as_int(self.draw_data.default_bg)
+        )
         if self.opts.tab_bar_style == 'separator':
             self.draw_func = draw_tab_with_separator
         elif self.opts.tab_bar_style == 'powerline':
@@ -228,8 +228,8 @@ class TabBar:
         elif 'background' in spec and not self.opts.tab_bar_background:
             self.draw_data = self.draw_data._replace(default_bg=color_from_int(spec['background']))
         self.screen.color_profile.set_configured_colors(
-                spec.get('inactive_tab_foreground', color_as_int(self.opts.inactive_tab_foreground)),
-                spec.get('inactive_tab_background', color_as_int(self.opts.inactive_tab_background))
+            color_as_int(self.draw_data.inactive_fg),
+            color_as_int(self.draw_data.default_bg)
         )
 
     def layout(self) -> None:


### PR DESCRIPTION
Hi! After update to v0.17.0 my tab bar changed from:

![image](https://user-images.githubusercontent.com/15367354/77565079-61b72e00-6ecc-11ea-94e8-628524d3500f.png)

to:

![image](https://user-images.githubusercontent.com/15367354/77565142-785d8500-6ecc-11ea-9a87-78ae5d57a554.png)

By looking through the changelog I found that it was commit 0d87b8fac5168171493cb0d8cef85d60e564c0b0 which broke my configuration. Looks like while that commit did fix #2464, it broke `powerline` and `separator` tab bar styles. Fortunately, the fix was simple enough and now `tab_bar_background` is treated as specified in the documentation.

P. S. I fixed my specific configuration by copying the color from `inactive_tab_background` to `tab_bar_background`. Since my changes to tab bar rendering were insignificant (in other words: part of my config for tab bar isn't much different from the default configuration) I think that this fix is worthwhile including in the default configuration.