### PR TITLE
Changing "match target" to "font"

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -179,7 +179,7 @@ following :file:`~/.config/fontconfig/fonts.conf`::
     <?xml version="1.0"?>
     <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
     <fontconfig>
-    <match target="scan">
+    <match target="font">
         <test name="family">
             <string>Your Font Family Name</string>
         </test>


### PR DESCRIPTION
As suggested in #2516, changing "match target" to "font" in the fonts.conf file.