### PR TITLE
Add flag to Layout to enforce drawing a border

### DIFF
--- a/kitty/layout.py
+++ b/kitty/layout.py
@@ -208,6 +208,7 @@ class Layout:  # {{{
 
     name: Optional[str] = None
     needs_window_borders = True
+    must_draw_borders = False
     needs_all_windows = False
     layout_opts = LayoutOpts({})
     only_active_window_visible = False

--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -231,7 +231,7 @@ class Tab:  # {{{
                 windows=visible_windows, active_window=w,
                 current_layout=self.current_layout, extra_blank_rects=tm.blank_rects,
                 padding_width=self.padding_width, border_width=self.border_width,
-                draw_window_borders=self.current_layout.needs_window_borders and len(visible_windows) > 1
+                draw_window_borders=self.current_layout.needs_window_borders and len(visible_windows) > 1 or self.current_layout.must_draw_borders
             )
             if w is not None:
                 w.change_titlebar_color()


### PR DESCRIPTION
Layout.must_draw_borders = True enforces drawing of a border even
though only a single window is visible. See #2531.

Here how it could be used in the `zoom_toggle.py` kitten in order to indicate that window is zoomed:
```python3
def main(args):
    pass

from kitty.layout import Stack
from kittens.tui.handler import result_handler
@result_handler(no_ui=True)
def handle_result(args, answer, target_window_id, boss):
    tab = boss.active_tab
    if tab is not None:
        if tab.current_layout.name == 'stack':
            tab.last_used_layout()
        else:
            try:
                Stack.must_draw_borders = True
                tab.goto_layout('stack')
            finally:
                Stack.must_draw_borders = False
```