### PR TITLE
Use T_PYSSIZET for GraphicsManager.image_count

### DIFF
--- a/kitty/graphics.c
+++ b/kitty/graphics.c
@@ -939,7 +939,7 @@ static PyMethodDef methods[] = {
 };
 
 static PyMemberDef members[] = {
-    {"image_count", T_UINT, offsetof(GraphicsManager, image_count), 0, "image_count"},
+    {"image_count", T_PYSSIZET, offsetof(GraphicsManager, image_count), 0, "image_count"},
     {NULL},
 };
 


### PR DESCRIPTION
`GraphicsManager.image_count` is declared as a `size_t`, so the Python type needs to be the same width.  On 64-bit big-endian architectures, this mismatch was showing up as test failures:

    ======================================================================
    FAIL: test_gr_delete (kitty_tests.graphics.TestGraphics)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/<<PKGBUILDDIR>>/kitty_tests/graphics.py", line 319, in test_gr_delete
        self.ae(len(layers(s)), 0), self.ae(s.grman.image_count, 1)
        ch = 20
        cw = 10
        delete = <function TestGraphics.test_gr_delete.<locals>.delete at 0x3ffb7fc38b0>
        dx = 0.2
        dy = 0.4
        layers = <function put_helpers.<locals>.layers at 0x3ffb77709d0>
        put_image = <function put_helpers.<locals>.put_image at 0x3ffb77708b0>
        put_ref = <function put_helpers.<locals>.put_ref at 0x3ffb7770940>
        rect_eq = <function put_helpers.<locals>.rect_eq at 0x3ffb7770a60>
        s = <fast_data_types.Screen object at 0x1b60df0>
        self = <kitty_tests.graphics.TestGraphics testMethod=test_gr_delete>
    AssertionError: 0 != 1