### PR TITLE
Add note clarifying that icat won't work with tmux

### DIFF
--- a/docs/kittens/icat.rst
+++ b/docs/kittens/icat.rst
@@ -21,6 +21,11 @@ Then you can simply use ``icat image.png`` to view images.
     `ImageMagick <https://www.imagemagick.org>`_ must be installed for ``icat`` to
     work.
 
+.. note::
+
+    ``icat`` uses terminal features that are incompatible with screen multiplexers
+    such as `tmux` and `screen`.
+
 
 .. program:: kitty +kitten icat
 


### PR DESCRIPTION
When using icat with tmux we get the following:

```
$ kitty icat ~/Pictures/fc.jpg 
Terminal does not support reporting screen sizes via the TIOCGWINSZ ioctl
```

I found a suggestion[1] this is due to limitations between kitty and tmux, so I'm raising this PR to either confirm this is the case and make it clear in the documentation, or to have it rejected so an issue can be raised to address the feature.

1: https://unix.stackexchange.com/a/484776/41996