### PR TITLE
Add note clarifying icat won't work with tmux [take 2]

### DIFF
--- a/docs/kittens/icat.rst
+++ b/docs/kittens/icat.rst
@@ -23,8 +23,7 @@ Then you can simply use ``icat image.png`` to view images.
 
 .. note::
 
-    ``icat`` uses terminal features that are incompatible with screen multiplexers
-    such as `tmux` and `screen`.
+    kitty's image display protocol may not work when used within a terminal multiplxer such as ``screen`` or ``tmux``, depending on whether the multiplxer has added support for it or not
 
 
 .. program:: kitty +kitten icat

--- a/docs/kittens/icat.rst
+++ b/docs/kittens/icat.rst
@@ -21,6 +21,11 @@ Then you can simply use ``icat image.png`` to view images.
     `ImageMagick <https://www.imagemagick.org>`_ must be installed for ``icat`` to
     work.
 
+.. note::
+
+    ``icat`` uses terminal features that are incompatible with screen multiplexers
+    such as `tmux` and `screen`.
+
 
 .. program:: kitty +kitten icat
 


### PR DESCRIPTION
When using icat with tmux we get the following:

```
$ kitty icat ~/Pictures/fc.jpg 
Terminal does not support reporting screen sizes via the TIOCGWINSZ ioctl
```

In #2597 this was confirmed to generally be a limitation of terminal multiplexers and adding support in kitty would add too much maintenance overhead.  We document this for users.