### PR TITLE
Make paths to libraries configurable at build time

### DIFF
--- a/glfw/glfw.py
+++ b/glfw/glfw.py
@@ -6,7 +6,7 @@ import json
 import os
 import re
 import sys
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 _plat = sys.platform.lower()
 is_linux = 'linux' in _plat
@@ -19,6 +19,7 @@ class Env:
     cppflags: List[str] = []
     cflags: List[str] = []
     ldflags: List[str] = []
+    library_paths: Dict[str, List[str]] = {}
     ldpaths: List[str] = []
     ccver: Tuple[int, int]
 
@@ -32,13 +33,13 @@ class Env:
 
     def __init__(
         self, cc: str = '', cppflags: List[str] = [], cflags: List[str] = [], ldflags: List[str] = [],
-        ldpaths: Optional[List[str]] = None, ccver: Tuple[int, int] = (0, 0)
+        library_paths: Dict[str, List[str]] = {}, ldpaths: Optional[List[str]] = None, ccver: Tuple[int, int] = (0, 0)
     ):
-        self.cc, self.cppflags, self.cflags, self.ldflags, self.ldpaths = cc, cppflags, cflags, ldflags, [] if ldpaths is None else ldpaths
-        self.ccver = ccver
+        self.cc, self.cppflags, self.cflags, self.ldflags, self.library_paths = cc, cppflags, cflags, ldflags, library_paths
+        self.ldpaths, self.ccver = [] if ldpaths is None else ldpaths, ccver
 
     def copy(self) -> 'Env':
-        ans = Env(self.cc, list(self.cppflags), list(self.cflags), list(self.ldflags), list(self.ldpaths), self.ccver)
+        ans = Env(self.cc, list(self.cppflags), list(self.cflags), list(self.ldflags), dict(self.library_paths), list(self.ldpaths), self.ccver)
         ans.all_headers = list(self.all_headers)
         ans.sources = list(self.sources)
         ans.wayland_packagedir = self.wayland_packagedir

--- a/kitty/desktop.c
+++ b/kitty/desktop.c
@@ -34,10 +34,14 @@ init_x11_startup_notification(PyObject UNUSED *self, PyObject *args) {
         done = true;
 
         const char* libnames[] = {
+#if defined(_KITTY_STARTUP_NOTIFICATION_LIBRARY)
+            _KITTY_STARTUP_NOTIFICATION_LIBRARY,
+#else
             "libstartup-notification-1.so",
             // some installs are missing the .so symlink, so try the full name
             "libstartup-notification-1.so.0",
             "libstartup-notification-1.so.0.0.0",
+#endif
             NULL
         };
         for (int i = 0; libnames[i]; i++) {
@@ -113,10 +117,14 @@ load_libcanberra(void) {
     if (done) return;
     done = true;
     const char* libnames[] = {
+#if defined(_KITTY_CANBERRA_LIBRARY)
+        _KITTY_CANBERRA_LIBRARY,
+#else
         "libcanberra.so",
         // some installs are missing the .so symlink, so try the full name
         "libcanberra.so.0",
         "libcanberra.so.0.2.5",
+#endif
         NULL
     };
     for (int i = 0; libnames[i]; i++) {


### PR DESCRIPTION
Don't merge this yet.
I'm trying to make the paths to `libEGL.so.1`, `libstartup-notification-1.so` and `libcanberra.so` configurable during build time. This is useful for nix since all paths to libraries are hardcoded in the binary for reproducibility and look like `/nix/store/rcli75fxa9x8raklf19kp0hfcyjc0kfn-libGL-1.2.0/lib/libEGL.so.1`. See https://github.com/NixOS/nixpkgs/blob/b16a5e2847b4e78a29be9fb2d157706f4ca84083/pkgs/applications/misc/kitty/default.nix and the parent directory for how this is done currently.
To change the paths, I want to define preprocessor variables containing a string with the path. I'd like to use the `SPECIAL_SOURCES` dict. Can I move the definition of `SPECIAL_SOURCES` into the function where it is used? I could then pass in the paths as arguments to the function. Do you see a better alternative?