### PR TITLE
Omit final tab separator

### DIFF
--- a/kitty/tab_bar.py
+++ b/kitty/tab_bar.py
@@ -84,7 +84,7 @@ def draw_tab_with_separator(draw_data: DrawData, screen: Screen, tab: TabBarData
     screen.cursor.fg = 0
     if not is_last:
         screen.cursor.bg = as_rgb(color_as_int(draw_data.inactive_bg))
-    screen.draw(draw_data.sep)
+        screen.draw(draw_data.sep)
     screen.cursor.bg = 0
     return end
 


### PR DESCRIPTION
This makes tab separators only drawn between the tabs.

Relates to #2616