### PR TITLE
Use one space on each side in tab_separator

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -781,7 +781,7 @@ Note that this does not currently work on Wayland.
 # }}}
 
 g('tabbar')   # {{{
-default_tab_separator = ' ┇'
+default_tab_separator = ' ┇ '
 
 
 def tab_separator(x: str) -> str:


### PR DESCRIPTION
This makes the separator in the tab bar symmetrical with equal spacing on both sides.

Do you agree that it looks better with equal spacing, or do you prefer keeping the default as is?

With this change:
![image](https://user-images.githubusercontent.com/601966/80791379-bd429e80-8b91-11ea-98cf-fb4c320a8abf.png)

Relates to #2616