### PR TITLE
Use f-string instead of format for tab_title templates

### DIFF
--- a/kitty/tab_bar.py
+++ b/kitty/tab_bar.py
@@ -54,14 +54,18 @@ def draw_title(draw_data: DrawData, screen: Screen, tab: TabBarData, index: int)
         screen.cursor.fg = draw_data.bell_fg
         screen.draw('🔔 ')
         screen.cursor.fg = fg
-    layout_name = tab.layout_name
-    num_windows = tab.num_windows
     template = draw_data.title_template
-    title = tab.title
     if tab.is_active and draw_data.active_title_template is not None:
         template = draw_data.active_title_template
     try:
-        title = eval(f"f'{template}'")
+        eval_locals = {
+            'index': index,
+            'layout_name': tab.layout_name,
+            'num_windows': tab.num_windows,
+            'title': tab.title
+        }
+        compiled_template = compile('f"""' + template + '"""', '<tab_template>', 'eval')
+        title = eval(compiled_template, {'__builtins__': {}}, eval_locals)
     except Exception as e:
         if template not in template_failures:
             template_failures.add(template)

--- a/kitty/tab_bar.py
+++ b/kitty/tab_bar.py
@@ -54,11 +54,14 @@ def draw_title(draw_data: DrawData, screen: Screen, tab: TabBarData, index: int)
         screen.cursor.fg = draw_data.bell_fg
         screen.draw('🔔 ')
         screen.cursor.fg = fg
+    layout_name = tab.layout_name
+    num_windows = tab.num_windows
     template = draw_data.title_template
+    title = tab.title
     if tab.is_active and draw_data.active_title_template is not None:
         template = draw_data.active_title_template
     try:
-        title = template.format(title=tab.title, index=index, layout_name=tab.layout_name, num_windows=tab.num_windows)
+        title = eval(f"f'{template}'")
     except Exception as e:
         if template not in template_failures:
             template_failures.add(template)


### PR DESCRIPTION
The documentation for v0.17.4 states this about the `tab_title_template`:

> Note that formatting is done by Python’s string formatting machinery, so you can use, for instance, {layout_name[:2].upper()} to show only the first two letters of the layout name, upper-cased.

However, because the templating uses String `.format`, this generates an error:

```
Invalid tab title template: "{layout_name[:2].upper()}" with error: string indices must be integers
```

If instead we used an f-string, we could fulfill the promise of the docs.

I'm fairly new to Python, so not sure if there is a more direct / safer way to pass a variable to an f-string.