### PR TITLE
Fixed marks grouping and coloring for simultaneous multi marks definition

### DIFF
--- a/kitty/config.py
+++ b/kitty/config.py
@@ -311,7 +311,7 @@ def parse_marker_spec(ftype: str, parts: Sequence[str]) -> Tuple[str, Union[str,
 def toggle_marker(func: str, rest: str) -> FuncArgsType:
     parts = rest.split(maxsplit=1)
     if len(parts) != 2:
-        raise ValueError('{} if not a valid marker specification'.format(rest))
+        raise ValueError('{} is not a valid marker specification'.format(rest))
     ftype, spec = parts
     parts = spec.split()
     return func, list(parse_marker_spec(ftype, parts))

--- a/kitty/marks.py
+++ b/kitty/marks.py
@@ -56,7 +56,7 @@ def marker_from_multiple_regex(regexes: Iterable[Tuple[int, str]], flags: int = 
         for match in pat.finditer(text):
             left.value = match.start()
             right.value = match.end() - 1
-            grp = next(k for k, v in match.groupdict().items())
+            grp = match.lastgroup
             color.value = color_map[grp]
             yield
 


### PR DESCRIPTION
This PR fixes an issue with multiple simultaneous mark groups defined. The issue exists on a latest Kitty version and on top of the master branch. If I try to define several marks simultaneously in any available approach I got a text colored just by one color and that color just corresponds to a first mark group in the making definition.

**Steps to reproduce:**
1. `echo -e 'WARN\nERROR\nFAIL'`
2. `kitty @ create-marker regex 1 FAIL 2 ERR  3 WARN`

All three words should have different colors but all of them just colored as the `FAIL` word by the color of the first group in the applied marking definition.

**Bellow screenshots demonstrate the issue:**
![Screenshot from 2020-05-18 06-52-20](https://user-images.githubusercontent.com/14666676/82173423-e07d8580-98d5-11ea-8448-1a4eb815cb16.png)
![Screenshot from 2020-05-18 06-51-21](https://user-images.githubusercontent.com/14666676/82173425-e3787600-98d5-11ea-9f03-c1cbb5b5cc58.png)

**With the PR fix:**
![Screenshot from 2020-05-18 07-08-22](https://user-images.githubusercontent.com/14666676/82173592-7f09e680-98d6-11ea-965b-5e2a76fcdfb5.png)

**P.S: And thanks for the great project!** :rocket: 