### PR TITLE
Fixed confirm_os_window_close bug introduced in commit 7bf83603c8ad6a

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,7 +12,7 @@ To update |kitty|, :doc:`follow the instructions <binary>`.
 - Tall and Fat layouts: Add a ``mirrored`` option to put the full size window
   on the opposite edge of the screen (:iss:`2654`)
 
-- Add an option :opt:`confirm_on_os_window_close` to ask for confirmation
+- Add an option :opt:`confirm_os_window_close` to ask for confirmation
   when closing an OS window with multiple kitty windows.
 
 - Add a new mappable ``quit`` action to quit kitty completely.

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -732,7 +732,7 @@ class Boss:
 
     def confirm_os_window_close(self, os_window_id: int) -> None:
         tm = self.os_window_map.get(os_window_id)
-        if tm is None or self.opts.confirm_os_window_close <= tm.number_of_windows:
+        if tm is None or self.opts.confirm_os_window_close > tm.number_of_windows:
             mark_os_window_for_close(os_window_id)
             return
         if tm is not None:
@@ -768,7 +768,7 @@ class Boss:
         num = 0
         for q in self.os_window_map.values():
             num += q.number_of_windows
-        if self.opts.confirm_os_window_close <= num or tm is None:
+        if self.opts.confirm_os_window_close > num or tm is None:
             set_application_quit_request(IMPERATIVE_CLOSE_REQUESTED)
             return
         if current_application_quit_request() == CLOSE_BEING_CONFIRMED:


### PR DESCRIPTION
The `confirm_os_window_close` parameter set to 1 has no effect on current master branch.
Current implementation works like **"starting from a number allow close without confirmation"** but
I suspect should be **"a minimum allowed to close without confirmation"**.