### PR TITLE
Fixed issue with a cwd for kitty_mod+h scroll buffer viewer

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -800,7 +800,7 @@ class Boss:
         tab = self.active_tab
         if tab is not None:
             tab.new_special_window(
-                SpecialWindow(cmd, data, _('History'), overlay_for=window.id),
+                SpecialWindow(cmd, data, _('History'), overlay_for=window.id, cwd=window.cwd_of_child),
                 copy_colors_from=self.active_window
                 )
 


### PR DESCRIPTION
There is an issue with ability to save scroll buffer from a default less
scroll buffer viewer by just typing relative path to an output file,
because the running less instance inherits cwd from Kitty's cwd
instead of cwd of active window.

How to reproduce:
  1. Start Kitty.
  2. Go to some place.
  3. Press 'kitty_mod+h'
  4. Press 's' and you'll see a less prompt like 'log file:'
  5. Type a just file name without any path and press Enter then press 'q'
  6. See that there is no such file in a current shell directory.