### PR TITLE
Implement HiDPI cursors on Wayland

### DIFF
--- a/glfw/source-info.json
+++ b/glfw/source-info.json
@@ -78,6 +78,7 @@
       "wl_init.c",
       "wl_monitor.c",
       "wl_window.c",
+      "wl_cursors.c",
       "posix_thread.c",
       "xkb_glfw.c",
       "dbus_glfw.c",

--- a/glfw/wl_cursors.c
+++ b/glfw/wl_cursors.c
@@ -1,0 +1,176 @@
+// Future devs supporting whatever Wayland protocol stabilizes for cursor selection: see _themeAdd.
+
+#include "wl_cursors.h"
+
+#include "internal.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef struct {
+    struct wl_cursor_theme *theme;
+    int                     px;
+    int                     refcount;
+} _themeData;
+
+struct _wlCursorThemeManager {
+    size_t count;
+    /** Pointer to the head of an unsorted array of themes with no sentinel.
+     *
+     * The lack of sort (and thus forcing a linear search) is intentional;
+     * in most cases, users are likely to have 1-2 different cursor sizes loaded.
+     * For those cases, we get no benefit from sorting and added constant overheads.
+     *
+     * Don't change this to a flexible array member becuase that complicates growing/shrinking.
+     */
+    _themeData *themes;
+};
+
+static void
+_themeInit(_themeData *dest, const char *name, int px) {
+    dest->px = px;
+    dest->refcount = 1;
+    if(_glfw.wl.shm) {
+        dest->theme = wl_cursor_theme_load(name, px, _glfw.wl.shm);
+        if(!dest->theme) {
+            _glfwInputError(GLFW_PLATFORM_ERROR,
+                        "Wayland: Unable to load cursor theme");
+        }
+    } else {
+        dest->theme = NULL;
+    }
+}
+
+static struct wl_cursor_theme*
+_themeAdd(int px, _wlCursorThemeManager *manager) {
+   ++manager->count;
+   _themeData *temp = realloc(manager->themes, sizeof(_themeData)*manager->count);
+   if(!temp) {
+       _glfwInputError(GLFW_OUT_OF_MEMORY,
+                       "OOM during cursor theme management.");
+       return NULL;
+   } else {
+       manager->themes = temp;
+       _themeInit(manager->themes + manager->count-1,
+                   getenv("XCURSOR_THEME"),
+                   px);
+       return manager->themes[manager->count-1].theme;
+   }
+}
+
+//WARNING: No input safety checks.
+static inline void _themeInc(_themeData
+                          *theme) {
+    ++(theme->refcount);
+}
+
+//WARNING: No input safety checks.
+// In particular, doesn't check if theme is actually managed by the manager.
+static void
+_themeDec(_themeData *theme, _wlCursorThemeManager *manager) {
+    if(--(theme->refcount) == 0) {
+        wl_cursor_theme_destroy(theme->theme);
+        if(--(manager->count) > 0) {
+            const _themeData *last_theme = (manager->themes)+(manager->count);
+            *theme = *last_theme;
+            _themeData *temp = realloc(manager->themes, (manager->count)*sizeof(_themeData));
+            //^ The chances of this failing are very slim, but one never knows.
+            if(temp) {
+                manager->themes = temp;
+            }
+            // We're shrinking here, so it's not catastrophic if realloc fails.
+        } else {
+            free(manager->themes);
+            manager->themes = NULL;
+        }
+    }
+}
+
+static _wlCursorThemeManager _default = {0, NULL};
+
+_wlCursorThemeManager*
+_wlCursorThemeManagerDefault() {
+    return &_default;
+}
+
+void
+_wlCursorThemeManagerDestroy(_wlCursorThemeManager *manager) {
+    if(manager) {
+        for(size_t i = 0; i < manager->count; ++i) {
+            wl_cursor_theme_destroy(manager->themes[i].theme);
+        }
+        free(manager->themes);
+    }
+}
+
+static struct wl_cursor_theme*
+_wlCursorThemeManagerGet(_wlCursorThemeManager *manager, int px) {
+    _themeData *themedata = NULL;
+    for(size_t i = 0; i < manager->count; ++i) {
+        _themeData
+    *temp = manager->themes+i;
+        if(temp->px == px) {
+            themedata = temp;
+            break;
+        }
+    }
+    if(themedata != NULL) {
+        _themeInc(themedata);
+        return themedata->theme;
+    } else {
+        return _themeAdd(px, manager);
+    }
+}
+
+struct wl_cursor_theme*
+_wlCursorThemeManage(_wlCursorThemeManager *manager, struct wl_cursor_theme *theme, int px) {
+    //WARNING: Multiple returns.
+    if(manager == NULL) {
+        return NULL;
+    }
+    if(theme != NULL) {
+        // Search for the provided theme in the manager.
+        _themeData *themedata = NULL;
+        for(size_t i = 0; i < manager->count; ++i) {
+            _themeData *temp = manager->themes+i;
+            if(temp->theme == theme) {
+                themedata = temp;
+                break;
+            }
+        }
+        if(themedata != NULL) {
+            // Search succeeded. Check if we can avoid unnecessary operations.
+            if(themedata->px == px) {
+                return theme;
+            } else {
+                _themeDec(themedata, manager);
+            }
+        } else {
+            _glfwInputError(GLFW_PLATFORM_ERROR,
+                            "Wayland internal: managed theme isn't in the provided manager");
+            return theme;
+            //^ This is probably the sanest behavior for this situation: do nothing.
+        }
+    }
+    if(px > 0) {
+        return _wlCursorThemeManagerGet(manager, px);
+    } else {
+        return NULL;
+    }
+}
+
+int
+_wlCursorPxFromScale(int scale) {
+    const char *envStr = getenv("XCURSOR_SIZE");
+    if(envStr != NULL) {
+        const int retval = atoi(envStr);
+        //^ atoi here is fine since 0 is an invalid value.
+        if(retval > 0 && retval <= INT_MAX/scale) {
+            return retval*scale;
+        }
+    }
+    return 32*scale;
+}

--- a/glfw/wl_cursors.c
+++ b/glfw/wl_cursors.c
@@ -37,7 +37,7 @@ _themeInit(_themeData *dest, const char *name, int px) {
         dest->theme = wl_cursor_theme_load(name, px, _glfw.wl.shm);
         if(!dest->theme) {
             _glfwInputError(GLFW_PLATFORM_ERROR,
-                        "Wayland: Unable to load cursor theme");
+                            "Wayland: Unable to load cursor theme");
         }
     } else {
         dest->theme = NULL;

--- a/glfw/wl_cursors.h
+++ b/glfw/wl_cursors.h
@@ -1,0 +1,31 @@
+// Declarations for a HiDPI-aware cursor theme manager.
+
+#include <wayland-cursor.h>
+
+typedef struct _wlCursorThemeManager _wlCursorThemeManager;
+
+/** Returns a pointer to a wlCursorThemeManagerInstance.
+ * Repeatedly calling this function will return the same instance.
+ * 
+ * The retrieved instance must be destroyed with _wlCursorThemeManagerDestroy.
+ */
+_wlCursorThemeManager* _wlCursorThemeManagerDefault(void);
+
+/** Set a wl_cursor_theme pointer variable to a pointer to a managed cursor theme.
+ * Pass the desired px as the third argument.
+ * Returns a pointer to a managed theme, or NULL if the desired px is 0 or an error occurs.
+ * 
+ * The passed theme pointer must either be NULL or a pointer to a theme managed by the passed manager.
+ * The provided pointer may be invalidated if it's non-NULL. 
+ */
+struct wl_cursor_theme*
+_wlCursorThemeManage(_wlCursorThemeManager*, struct wl_cursor_theme*, int);
+
+/** Helper method to determine the appropriate size in pixels for a given scale.
+ * 
+ * Reads XCURSOR_SIZE if it's set and is valid, else defaults to 32*scale.
+ */
+
+void _wlCursorThemeManagerDestroy(_wlCursorThemeManager*);
+ 
+int _wlCursorPxFromScale(int);

--- a/glfw/wl_platform.h
+++ b/glfw/wl_platform.h
@@ -76,7 +76,10 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
 #define _GLFW_PLATFORM_CONTEXT_STATE
 #define _GLFW_PLATFORM_LIBRARY_CONTEXT_STATE
 
-struct wl_cursor_image {
+#include "wl_cursors.h"
+//^ Includes <wayland-cursor.h>
+
+/**struct wl_cursor_image {
     uint32_t width;
     uint32_t height;
     uint32_t hotspot_x;
@@ -87,7 +90,7 @@ struct wl_cursor {
     unsigned int image_count;
     struct wl_cursor_image** images;
     char* name;
-};
+};*/
 typedef struct wl_cursor_theme* (* PFN_wl_cursor_theme_load)(const char*, int, struct wl_shm*);
 typedef void (* PFN_wl_cursor_theme_destroy)(struct wl_cursor_theme*);
 typedef struct wl_cursor* (* PFN_wl_cursor_theme_get_cursor)(struct wl_cursor_theme*, const char*);
@@ -148,6 +151,7 @@ typedef struct _GLFWwindowWayland
 
     _GLFWcursor*                currentCursor;
     double                      cursorPosX, cursorPosY;
+    struct wl_cursor_theme*     cursorTheme;
 
     char*                       title;
     char                        appId[256];
@@ -236,7 +240,6 @@ typedef struct _GLFWlibraryWayland
     int                         compositorVersion;
     int                         seatVersion;
 
-    struct wl_cursor_theme*     cursorTheme;
     struct wl_surface*          cursorSurface;
     GLFWCursorShape             cursorPreviousShape;
     uint32_t                    pointerSerial;
@@ -278,6 +281,8 @@ typedef struct _GLFWlibraryWayland
     size_t dataOffersCounter;
     _GLFWWaylandDataOffer dataOffers[8];
     char* primarySelectionString;
+
+    _wlCursorThemeManager*      cursorThemeManager;
 } _GLFWlibraryWayland;
 
 // Wayland-specific per-monitor data
@@ -291,8 +296,7 @@ typedef struct _GLFWmonitorWayland
     int                         x;
     int                         y;
     int                         scale;
-
-} _GLFWmonitorWayland;
+ } _GLFWmonitorWayland;
 
 // Wayland-specific per-cursor data
 //
@@ -303,6 +307,10 @@ typedef struct _GLFWcursorWayland
     int                         width, height;
     int                         xhot, yhot;
     int                         currentImage;
+    /** The scale of the cursor, or 0 if the cursor should be loaded late, or -1 if the cursor variable itself is unused. */
+    int                         scale;
+    /** Cursor shape stored to allow late cursor loading in setCursorImage. */
+    GLFWCursorShape             shape;
 } _GLFWcursorWayland;
 
 
@@ -310,5 +318,5 @@ void _glfwAddOutputWayland(uint32_t name, uint32_t version);
 void _glfwSetupWaylandDataDevice(void);
 void _glfwSetupWaylandPrimarySelectionDevice(void);
 void animateCursorImage(id_type timer_id, void *data);
-struct wl_cursor* _glfwLoadCursor(GLFWCursorShape);
+struct wl_cursor* _glfwLoadCursor(GLFWCursorShape, struct wl_cursor_theme*);
 void destroy_data_offer(_GLFWWaylandDataOffer*);

--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -1455,8 +1455,6 @@ static bool isPointerLocked(_GLFWwindow* window)
 
 void _glfwPlatformSetCursor(_GLFWwindow* window, _GLFWcursor* cursor)
 {
-    struct wl_cursor* defaultCursor;
-
     if (!_glfw.wl.pointer)
         return;
 
@@ -1477,15 +1475,8 @@ void _glfwPlatformSetCursor(_GLFWwindow* window, _GLFWcursor* cursor)
             setCursorImage(window, &cursor->wl);
         else
         {
-            defaultCursor = _glfwLoadCursor(GLFW_ARROW_CURSOR, window->wl.cursorTheme);
-            if (!defaultCursor) return;
-            _GLFWcursorWayland cursorWayland = {
-                defaultCursor,
-                NULL,
-                0, 0,
-                0, 0,
-                0
-            };
+            _GLFWcursorWayland cursorWayland = {0};
+            cursorWayland.shape = GLFW_ARROW_CURSOR;
             setCursorImage(window, &cursorWayland);
         }
     }


### PR DESCRIPTION
Free time is a fickle thing, isn't it?

These commits implement properly-scaled cursors on Wayland compositors with HiDPI support, addressing #2647/#2669. It implements a reference-counting manager for cursor themes (which can probably be extended to manage `wl_cursor` instances later), and changes some of the Wayland-specific platform code to use the new manager to acquire themes with the required pixel sizes.

I tried to be as surgical as possible in my implementation, which lead to a couple of questionable design choices that I'd prefer to be upfront about:

* The semantics of the `cursor` variable in `_GLFWcursorWayland` have changed. `NULL` no longer means that `buffer` and its associated variables should be used instead. Instead, the `scale` variable stores the relevant information (see the attached comment). I've tried to find the spots where this would be an issue, but won't claim it's impossible that I've overlooked something.
* Actually loading a default cursor is delayed in most cases until `setCursorImage` gets called. Loading can fail, and `setCursorImage` handles this quietly, which in the worst case may result in a null pointer dereference. **If you folks have a preference on what way this failure should be handled instead, please let me know.** As a tangent, setting `XCURSOR_THEME` to an invalid value doesn't produce this issue for me (on sway).
* Managed cursor themes are pointed to by each window instance, not each monitor instance. This is probably the smallest problem of the bunch, especially given the possibilities for per-window custom cursors that this opens up.