### PR TITLE
Avoid incrementing hidden cursors' images

### DIFF
--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -738,7 +738,7 @@ static bool createXdgSurface(_GLFWwindow* window)
 static void
 incrementCursorImage(_GLFWwindow* window)
 {
-    if (window && window->wl.decorations.focus == mainWindow) {
+    if (window && window->wl.decorations.focus == mainWindow && window->cursorMode != GLFW_CURSOR_HIDDEN) {
         _GLFWcursor* cursor = window->wl.currentCursor;
         if (cursor && cursor->wl.cursor)
         {


### PR DESCRIPTION
This is actually a quick bugfix: animated mouse cursors on Wayland currently do not hide when using any nonzero value for `mouse_hide_wait`. They hide for one frame of animation, then immediately reappear. This fixes that.