### PR TITLE
Disjunct codepoint ranges

### DIFF
--- a/kitty/fonts/render.py
+++ b/kitty/fonts/render.py
@@ -96,6 +96,14 @@ def merge_ranges(a: Range, b: Range, priority_map: Dict[Tuple[int, int], int]) -
 
 
 def coalesce_symbol_maps(maps: Dict[Tuple[int, int], str]) -> Dict[Tuple[int, int], str]:
+    ### NOTE https://docs.python.org/3/library/stdtypes.html?highlight=dict#mapping-types-dict:
+    # Changed in version 3.7: Dictionary order is guaranteed to be insertion order. This behavior was an
+    # implementation detail of CPython from 3.6.
+    print( '^22333198^', f"maps             {maps           }" )
+    print( '^22333198^', f"type( maps )     {type( maps )   }" )
+    import sys
+    print( '^22333198^', f"sys.version   {sys.version }" )
+    # print( '^22333198^', f"sorted( maps )   {sorted( maps ) }" )
     if not maps:
         return maps
     priority_map = {r: i for i, r in enumerate(maps.keys())}
@@ -105,6 +113,9 @@ def coalesce_symbol_maps(maps: Dict[Tuple[int, int], str]) -> Dict[Tuple[int, in
     for i in range(1, len(ranges)):
         r = ranges[i]
         ans[-1:] = list(merge_ranges(ans[-1], r, priority_map))
+    print( '^22333198^', f"ans              {ans            }" )
+    print( '^22333198^', f"priority_map     {priority_map   }" )
+    print( '^22333198^', f"ranges           {ranges         }" )
     return dict(ans)
 
 

--- a/kitty/interlap/interlap.py
+++ b/kitty/interlap/interlap.py
@@ -114,15 +114,21 @@ class Lap( Immutable ):
   def size( me ) -> int: return sum( ( s.size for s in me.segments ), 0 )
 
 #-----------------------------------------------------------------------------------------------------------
-def new_segment( lohi: gen_segment ) -> Segment:
+def new_segment( lohi: gen_segment = None, *, lo: int = None, hi: int = None ) -> Segment:
   if isinstance( lohi, Segment ): return lohi
-  if len( lohi ) != 2:
-    raise InterlapValueError( f"^E7986^ expected a tuple of length 2, got one with length {len( lohi )}")
-  lo, hi = lohi
+  if lohi is None:
+    if not isinstance( lo, int ): raise InterlapValueError( f"^E342^ illegal arguments: lohi: {lohi}, lo: {lo}, hi: {hi}" )
+    if not isinstance( hi, int ): raise InterlapValueError( f"^E345^ illegal arguments: lohi: {lohi}, lo: {lo}, hi: {hi}" )
+  else:
+    if lo != None: raise InterlapValueError( f"^E342^ illegal arguments: lohi: {lohi}, lo: {lo}, hi: {hi}" )
+    if hi != None: raise InterlapValueError( f"^E345^ illegal arguments: lohi: {lohi}, lo: {lo}, hi: {hi}" )
+    if len( lohi ) != 2:
+      raise InterlapValueError( f"^E348^ expected a tuple of length 2, got one with length {len( lohi )}: lohi: {lohi}")
+    lo, hi = lohi
   #.........................................................................................................
-  # if not isinstance( lo, int ): throw( f"expected an integer, got a {type( lo )}" ) # unreachable?
-  # if not isinstance( hi, int ): throw( f"expected an integer, got a {type( hi )}" ) # unreachable?
-  if not lo <= hi: raise InterlapValueError( f"^E8319^ expected lo <= hi, got {lo} and {hi}" )
+  # if not isinstance( lo, int ): raise InterlapValueError( f"^E300^ expected an integer, got a {type( lo )}" ) # unreachable?
+  # if not isinstance( hi, int ): raise InterlapValueError( f"^E300^ expected an integer, got a {type( hi )}" ) # unreachable?
+  if not lo <= hi: raise InterlapValueError( f"^E351^ expected lo <= hi, got {lo} and {hi}" )
   #.........................................................................................................
   return Segment( lo, hi, )
 

--- a/kitty/interlap/interlap.py
+++ b/kitty/interlap/interlap.py
@@ -42,7 +42,7 @@ gen_segment     = Union[ 'Segment', bi_int, ]
 #-----------------------------------------------------------------------------------------------------------
 class Immutable:
   def __setattr__( me, *P: Any ) -> None:
-    raise InterlapKeyError( "^E7653^ forbidden to set attribute on immutable" )
+    raise InterlapKeyError( "^E333^ forbidden to set attribute on immutable" )
 
 #-----------------------------------------------------------------------------------------------------------
 @total_ordering
@@ -95,7 +95,7 @@ class Lap( Immutable ):
   #---------------------------------------------------------------------------------------------------------
   def __lt__( me, other: Any ) -> bool:
     if not isinstance( other, Lap ):
-      raise InterlapValueError( f"^E1732^ unable to compare a Lap with a {type( other )}" )
+      raise InterlapValueError( f"^E339^ unable to compare a Lap with a {type( other )}" )
     if me.segments == other.segments: return False
     length = min( len( me ), len( other ) )
     if length == 0:

--- a/kitty/interlap/interlap.py
+++ b/kitty/interlap/interlap.py
@@ -1,0 +1,253 @@
+
+
+#-----------------------------------------------------------------------------------------------------------
+# from _testing import C
+# from _testing import debug
+# from _testing import urge
+# from _testing import help
+# from typing import NamedTuple
+from typing import Union
+from typing import Tuple
+from typing import Iterable
+from typing import List
+from typing import Any
+# from typing import NoReturn
+# from typing import NewType
+# from math import inf
+from functools import total_ordering
+
+#-----------------------------------------------------------------------------------------------------------
+class InterlapError( Exception ): pass
+class InterlapKeyError( KeyError, InterlapError ): pass
+class InterlapValueError( ValueError, InterlapError ): pass
+
+
+#-----------------------------------------------------------------------------------------------------------
+def isa( T: Any, x: Any ) -> Any:
+  ### thx to https://stackoverflow.com/a/49471187/7568091 ###
+  ### TAINT This is much more complicated than it should be ###
+  if getattr( T, '__origin__', None ) == Union: return isinstance( x, T.__args__ )
+  return isinstance( x, T )
+
+#-----------------------------------------------------------------------------------------------------------
+### TAINT https://mypy.readthedocs.io/en/latest/cheat_sheet_py3.html#miscellaneous forward reference ###
+# intinf          = Union[ int, inf, ]
+# intinf          = Union[ int, str ]
+# Lap             = Tuple[ Segment ]
+# opt_gen_segment = Union[ gen_segment, None, ]
+bi_int          = Tuple[ int, int ]
+gen_segment     = Union[ 'Segment', bi_int, ]
+
+
+#-----------------------------------------------------------------------------------------------------------
+class Immutable:
+  def __setattr__( me, *P: Any ) -> None:
+    raise InterlapKeyError( "^E7653^ forbidden to set attribute on immutable" )
+
+#-----------------------------------------------------------------------------------------------------------
+@total_ordering
+class Segment( Immutable ):
+  # __slots__ = [ 'lo', 'hi', ]
+
+  #---------------------------------------------------------------------------------------------------------
+  def __init__( me, lo: int, hi: int ) -> None:
+    me.lo: int
+    me.hi: int
+    me.__dict__[ 'lo' ] = lo
+    me.__dict__[ 'hi' ] = hi
+
+  #---------------------------------------------------------------------------------------------------------
+  def __iter__( me ) -> Iterable: yield me
+  def __repr__( me ) -> str: return f"{me.__class__.__name__}( {me.lo}, {me.hi} )"
+
+  #---------------------------------------------------------------------------------------------------------
+  def __lt__( me, other: Any ) -> bool:
+    if not isinstance( other, Segment ):
+      raise InterlapValueError( f"^E3786^ unable to compare a Segment with a {type( other )}" )
+    return ( me.lo < other.lo ) or ( me.hi < other.hi ) # type: ignore
+
+  #---------------------------------------------------------------------------------------------------------
+  def __eq__( me, other: Any ) -> bool:
+    if not isinstance( other, Segment ): return False
+    return ( me.lo == other.lo ) and ( me.hi == other.hi )
+
+  #---------------------------------------------------------------------------------------------------------
+  @property
+  def size( me ) -> int: return me.hi - me.lo + 1
+
+
+#-----------------------------------------------------------------------------------------------------------
+@total_ordering
+class Lap( Immutable ):
+
+  #---------------------------------------------------------------------------------------------------------
+  def __init__( me, segments: Iterable[ Segment, ] = () ):
+    me.segments: Tuple[ Segment, ]
+    me.__dict__[ 'segments' ] = tuple( segments )
+
+  #---------------------------------------------------------------------------------------------------------
+  def __repr__(     me            ) -> str:       return f"Lap( {repr( me.segments )} )"
+  def __iter__(     me            ) -> Iterable:  return iter( me.segments )
+  def __len__(      me            ) -> int:       return len( me.segments )
+  def __getitem__(  me, idx: int  ) -> Segment:   return me.segments[ idx ]
+
+  #---------------------------------------------------------------------------------------------------------
+  def __lt__( me, other: Any ) -> bool:
+    if not isinstance( other, Lap ):
+      raise InterlapValueError( f"^E1732^ unable to compare a Lap with a {type( other )}" )
+    if me.segments == other.segments: return False
+    length = min( len( me ), len( other ) )
+    if length == 0:
+      if len( me ) == 0: return True
+      return False
+    for idx in range( 0, length ): # type: ignore
+      if me.segments[ idx ] < other.segments[ idx ]: return True # type: ignore
+    return False
+
+  #---------------------------------------------------------------------------------------------------------
+  def __eq__( me, other: Any ) -> bool:
+    if not isinstance( other, Lap ): return False
+    return me.segments == other.segments
+
+  #---------------------------------------------------------------------------------------------------------
+  @property
+  def size( me ) -> int: return sum( ( s.size for s in me.segments ), 0 )
+
+#-----------------------------------------------------------------------------------------------------------
+def new_segment( lohi: gen_segment ) -> Segment:
+  if isinstance( lohi, Segment ): return lohi
+  if len( lohi ) != 2:
+    raise InterlapValueError( f"^E7986^ expected a tuple of length 2, got one with length {len( lohi )}")
+  lo, hi = lohi
+  #.........................................................................................................
+  # if not isinstance( lo, int ): throw( f"expected an integer, got a {type( lo )}" ) # unreachable?
+  # if not isinstance( hi, int ): throw( f"expected an integer, got a {type( hi )}" ) # unreachable?
+  if not lo <= hi: raise InterlapValueError( f"^E8319^ expected lo <= hi, got {lo} and {hi}" )
+  #.........................................................................................................
+  return Segment( lo, hi, )
+
+#-----------------------------------------------------------------------------------------------------------
+def new_lap( *P: gen_segment ) -> Lap: return merge_segments( *P ) # type: ignore
+
+
+#===========================================================================================================
+#
+#-----------------------------------------------------------------------------------------------------------
+# class A:
+# @classmethod ... def segments_are_disjunct( cls, ... )
+def segments_are_disjunct( me: gen_segment, other: gen_segment ) -> bool:
+  """Two segments are disjunct iff they have no point in common."""
+  return _segments_are_disjunct( new_segment( me ), new_segment( other ) )
+
+#-----------------------------------------------------------------------------------------------------------
+def segments_overlap( me: gen_segment, other: gen_segment ) -> bool:
+  """Two segments overlap iff they have at least one point in common."""
+  return _segments_overlap( new_segment( me ), new_segment( other ) )
+
+#-----------------------------------------------------------------------------------------------------------
+def segments_are_adjacent( me: gen_segment, other: gen_segment ) -> bool:
+  """Two segments are adjacent if the upper bound of the one directly precedes the lower bound of the
+  other."""
+  return _segments_are_adjacent( new_segment( me ), new_segment( other ) )
+
+#-----------------------------------------------------------------------------------------------------------
+def merge_segments( *P: gen_segment ) -> Lap:
+  if len( P ) == 0: return Lap()
+  if len( P ) == 1: return Lap( ( new_segment( P[ 0 ] ), ) )
+  if len( P ) == 2: return Lap( _merge_two_segments( new_segment( P[ 0 ] ), new_segment( P[ 1 ] ) ) )
+  return Lap( _merge_segments( *P ) )
+
+#-----------------------------------------------------------------------------------------------------------
+def subtract_segments( *P: gen_segment ) -> Lap:
+  if len( P ) == 0: return Lap()
+  if len( P ) == 1: return Lap( ( new_segment( P[ 0 ] ), ) )
+  if len( P ) == 2: return Lap( _subtract_two_segments( new_segment( P[ 0 ] ), new_segment( P[ 1 ] ) ) )
+  me, *others               = P
+  me                        = new_segment( me )
+  others: List[ Segment, ]  = _merge_segments( *others )
+  # urge( '^334^', f"others {others}" )
+  R: List[ Segment, ]       = []
+  idx                       = -1
+  last_idx                  = len( others ) - 1
+  leftovers:  List[ Segment, ]
+  other:      Segment
+  while True:
+    idx      += +1
+    if idx > last_idx: break
+    other     = others[ idx ]
+    leftovers = _subtract_two_segments( me, other )
+    if len( leftovers ) == 0:
+      continue
+    if len( leftovers ) == 1:
+      me = leftovers[ 0 ]
+    else:
+      R  += leftovers[ 0 : len( leftovers ) - 1 ] ### TAINT use negative index ###
+      me  = leftovers[ -1 ]
+    # help( "^443^", idx, f"me {me}", f"other {other}", f"leftovers {leftovers}", f"R {R}" )
+  R.append( me )
+  R.sort()
+  return Lap( R )
+
+#-----------------------------------------------------------------------------------------------------------
+def _subtract_two_segments( a: Segment, b: Segment ) -> List[ Segment, ]:
+  if segments_are_disjunct( a, b ):  return [ a, ]
+  if a == b:            return []
+  if b.lo <= a.lo:
+    if b.hi >= a.hi: return []
+    return [ Segment( b.hi + 1, a.hi ), ]
+  if b.hi >= a.hi:
+    return [ Segment( a.lo, b.lo - 1 ), ]
+  return [ Segment( a.lo, b.lo - 1 ), Segment( b.hi + 1, a.hi ), ]
+
+
+#===========================================================================================================
+#
+#-----------------------------------------------------------------------------------------------------------
+def _segments_are_disjunct( me: Segment, other: Segment ) -> bool:
+  return ( me.hi < other.lo ) or ( other.hi < me.lo )
+
+#-----------------------------------------------------------------------------------------------------------
+def _segments_overlap( me: Segment, other: Segment ) -> bool:
+  return not ( ( me.hi < other.lo ) or ( other.hi < me.lo ) )
+
+#-----------------------------------------------------------------------------------------------------------
+def _segments_are_adjacent( me: Segment, other: Segment ) -> bool:
+  return ( me.hi + 1 == other.lo ) or ( other.hi + 1 == me.lo )
+
+#-----------------------------------------------------------------------------------------------------------
+def _merge_segments( *P: gen_segment ) -> List[ Segment ]:
+  if len( P ) == 0: return []
+  if len( P ) == 1: return [ new_segment( P[ 0 ] ), ]
+  if len( P ) == 2: return _merge_two_segments( new_segment( P[ 0 ] ), new_segment( P[ 1 ] ) )
+  segments      = [ new_segment( s ) for s in P ]
+  segments.sort()
+  reference, \
+  segments      = segments[ 0 ], segments[ 1 : ]
+  R             = []
+  idx           = -1
+  last_idx      = len( segments ) - 1
+  while True:
+    idx += +1
+    if idx > last_idx: break
+    segment = segments[ idx ]
+    if segment == reference: continue
+    merged_segments = _merge_two_segments( reference, segment )
+    if len( merged_segments ) > 1:
+      R.append( merged_segments[ 0 ] )
+      reference = merged_segments[ 1 ]
+      continue
+    reference = merged_segments[ 0 ]
+  R.append( reference )
+  return R
+
+#-----------------------------------------------------------------------------------------------------------
+def _merge_two_segments( a: Segment, b: Segment ) -> List[ Segment ]:
+  if a.lo > b.lo: a, b = b, a
+  if b.lo > a.hi + 1: return [ a, b, ]
+  return [ new_segment( ( a.lo, max( a.hi, b.hi ), ) ), ]
+
+
+############################################################################################################
+if __name__ == '__main__':
+  pass
+  # test()

--- a/kitty/interlap/interlap.py
+++ b/kitty/interlap/interlap.py
@@ -59,11 +59,12 @@ class Segment( Immutable ):
   #---------------------------------------------------------------------------------------------------------
   def __iter__( me ) -> Iterable: yield me
   def __repr__( me ) -> str: return f"{me.__class__.__name__}( {me.lo}, {me.hi} )"
+  def __hash__( me ) -> int: return hash( ( me.lo, me.hi, ) )
 
   #---------------------------------------------------------------------------------------------------------
   def __lt__( me, other: Any ) -> bool:
     if not isinstance( other, Segment ):
-      raise InterlapValueError( f"^E3786^ unable to compare a Segment with a {type( other )}" )
+      raise InterlapValueError( f"^E336^ unable to compare a Segment with a {type( other )}" )
     return ( me.lo < other.lo ) or ( me.hi < other.hi ) # type: ignore
 
   #---------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request if accepted will change the behavior of `kitty/fonts/render.py#coalesce_symbol_maps()` such that codepoint ranges configured with the `symbol_map` directive are made free of overlaps (conflicting codepoints). 

Assuming that the input argument `maps: Dict[ Tuple[ int, int, ], str, ]` preserves ordering of its entries as given in the configuration file (which it should as of Python3.6), disjunct codepoint ranges are computed such that entries in the configuration file that come *later* are given *higher* precedence than those that come *earlier*; this is in keeping with current practices in the field (cf. JavaScript's `Object.assign()`; CSS declarations) and desirable because defaults defined by the system and the application come (at least notionally) earlier than the choices defined by the user.

To illustrate, when a user has configured

```
symbol_map      U+3000-U+30ff                  Sun-ExtA
symbol_map      U+300a-U+300b                  NanumMyeongjo
```

this will result in and be indistinguishable from a configuration given as 

```
symbol_map      U+3000-U+3009                  Sun-ExtA
symbol_map      U+300a-U+300b                  NanumMyeongjo
symbol_map      U+300c-U+30ff                  Sun-ExtA
```

where all ranges are disjunct (and are, hence, independent of ordering, which is a nice property). This will work with arbitrary numbers of overlapping segments and is seen as beneficial since it allows users to configure their choices in brad strokes at fist, then refining them as seen fit, without any need to manually compute and remove any overlapping parts.

There are tests for the range arithmetics in https://github.com/loveencounterflow/hengist/blob/master/dev/kitty-font-config-writer-kfcw/python/tests.py; if deemed necessary, I could look into incorporating them into the Kitty testing lineup. Other than that, I have visually tested various configurations and am reasonably sure everything works as expected.
