### PR TITLE
Fix fake scroll when scrolling in unfocused kitty window

### DIFF
--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -303,7 +303,6 @@ void enter_event(void);
 void mouse_event(int, int, int);
 void focus_in_event(void);
 void scroll_event(double, double, int, int);
-void fake_scroll(int, bool);
 void set_special_key_combo(int glfw_key, int mods, bool is_native);
 void on_key_input(GLFWkeyevent *ev);
 void request_window_attention(id_type, bool);

--- a/kitty/keys.c
+++ b/kitty/keys.c
@@ -203,8 +203,7 @@ on_key_input(GLFWkeyevent *ev) {
 }
 
 void
-fake_scroll(int amount, bool upwards) {
-    Window *w = active_window();
+fake_scroll(Window *w, int amount, bool upwards) {
     if (!w) return;
     int key = upwards ? GLFW_KEY_UP : GLFW_KEY_DOWN;
     while (amount-- > 0) {

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -698,7 +698,7 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags, int modifiers) {
                 }
             }
         } else {
-            fake_scroll(abs(s), upwards);
+            fake_scroll(w, abs(s), upwards);
         }
     }
 }

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -277,3 +277,4 @@ void stop_main_loop(void);
 void os_window_update_size_increments(OSWindow *window);
 void set_os_window_title_from_window(Window *w, OSWindow *os_window);
 void update_os_window_title(OSWindow *os_window);
+void fake_scroll(Window *w, int amount, bool upwards);


### PR DESCRIPTION
I'm working on a little bug fix. Unfortunately I can't figure out how to get it to compile because I need to pass a pointer to a `Window` to `fake_scroll()` but I can't do that since `Window` is not defined in `kitty/data-types.h`. I can't import `state.h` in `data-types.h` because `state.h` already imports `data-types.h`. I can't put `fake_scroll()` into `kitty/mouse.c` because `send_key_to_child()` is not defined there. Can you please help me find a way to make this work? Maybe making `send_key_to_child()` available in `kitty/mouse.c`?