### PR TITLE
Remove GLFW_TRUE in comment

### DIFF
--- a/glfw/glfw3.h
+++ b/glfw/glfw3.h
@@ -4199,7 +4199,7 @@ GLFWAPI int glfwGetInputMode(GLFWwindow* window, int mode);
  *  GLFW_MOD_CAPS_LOCK bit set when the event was generated with Caps Lock on,
  *  and the @ref GLFW_MOD_NUM_LOCK bit when Num Lock was on.
  *
- *  If the mode is `GLFW_RAW_MOUSE_MOTION`, the value must be either `GLFW_TRUE`
+ *  If the mode is `GLFW_RAW_MOUSE_MOTION`, the value must be either `true`
  *  to enable raw (unscaled and unaccelerated) mouse motion when the cursor is
  *  disabled, or `false` to disable it.  If raw motion is not supported,
  *  attempting to set this will emit @ref GLFW_FEATURE_UNAVAILABLE.  Call @ref


### PR DESCRIPTION
In 55ad228166bc537e5e6508c2efac0e31bfd6d71b I forgot to replace `GLFW_TRUE` with `true` in a comment.