### PR TITLE
Allow empty or blank space tab_separator

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -795,12 +795,12 @@ default_tab_separator = ' ┇'
 
 
 def tab_separator(x: str) -> str:
+    if not x.strip():
+        x = ('\xa0' * len(x)) if x else default_tab_separator
     for q in '\'"':
         if x.startswith(q) and x.endswith(q):
             x = x[1:-1]
             break
-    if not x.strip():
-        x = ('\xa0' * len(x)) if x else default_tab_separator
     return x
 
 


### PR DESCRIPTION
This modifies `tab_separator` config so that blank spaces or empty separators are allowed. For example, `tab_separator ""` will display tabs like

<img width="243" alt="Screen Shot 2020-06-12 at 10 26 08 PM" src="https://user-images.githubusercontent.com/5923395/84560796-f9722e80-acfb-11ea-9266-28cceceea83b.png">

 `default_tab_separator` is still used if no value is provided for `tab_separator`.