### PR TITLE
Remove EGL and OSMesa struct member macros

### DIFF
--- a/glfw/cocoa_platform.h
+++ b/glfw/cocoa_platform.h
@@ -96,8 +96,6 @@ typedef VkResult (APIENTRY *PFN_vkCreateMetalSurfaceEXT)(VkInstance,const VkMeta
 #include "posix_thread.h"
 #include "cocoa_joystick.h"
 #include "nsgl_context.h"
-#include "egl_context.h"
-#include "osmesa_context.h"
 
 #define _glfw_dlopen(name) dlopen(name, RTLD_LAZY | RTLD_LOCAL)
 #define _glfw_dlclose(handle) dlclose(handle)

--- a/glfw/egl_context.h
+++ b/glfw/egl_context.h
@@ -147,10 +147,6 @@ typedef EGLSurface (EGLAPIENTRY * PFNEGLCREATEPLATFORMWINDOWSURFACEEXTPROC)(EGLD
 #define eglGetPlatformDisplayEXT _glfw.egl.GetPlatformDisplayEXT
 #define eglCreatePlatformWindowSurfaceEXT _glfw.egl.CreatePlatformWindowSurfaceEXT
 
-#define _GLFW_EGL_CONTEXT_STATE            _GLFWcontextEGL egl
-#define _GLFW_EGL_LIBRARY_CONTEXT_STATE    _GLFWlibraryEGL egl
-
-
 // EGL-specific per-context data
 //
 typedef struct _GLFWcontextEGL

--- a/glfw/internal.h
+++ b/glfw/internal.h
@@ -198,6 +198,9 @@ typedef void (APIENTRY * PFN_vkVoidFunction)(void);
  #error "No supported window creation API selected"
 #endif
 
+#include "egl_context.h"
+#include "osmesa_context.h"
+
 #define remove_i_from_array(array, i, count) { \
     (count)--; \
     if ((i) < (count)) { \
@@ -392,9 +395,9 @@ struct _GLFWcontext
     // This is defined in the context API's context.h
     _GLFW_PLATFORM_CONTEXT_STATE
     // This is defined in egl_context.h
-    _GLFW_EGL_CONTEXT_STATE;
+    _GLFWcontextEGL egl;
     // This is defined in osmesa_context.h
-    _GLFW_OSMESA_CONTEXT_STATE;
+    _GLFWcontextOSMesa osmesa;
 };
 
 // Window and context structure
@@ -613,9 +616,9 @@ struct _GLFWlibrary
     // This is defined in the platform's joystick.h
     _GLFW_PLATFORM_LIBRARY_JOYSTICK_STATE
     // This is defined in egl_context.h
-    _GLFW_EGL_LIBRARY_CONTEXT_STATE;
+    _GLFWlibraryEGL egl;
     // This is defined in osmesa_context.h
-    _GLFW_OSMESA_LIBRARY_CONTEXT_STATE;
+    _GLFWlibraryOSMesa osmesa;
 };
 
 // Global state shared between compilation units of GLFW

--- a/glfw/null_platform.h
+++ b/glfw/null_platform.h
@@ -35,8 +35,6 @@
 #define _GLFW_PLATFORM_CURSOR_STATE
 #define _GLFW_PLATFORM_LIBRARY_CONTEXT_STATE
 
-#include "egl_context.h"
-#include "osmesa_context.h"
 #include "posix_time.h"
 #include "posix_thread.h"
 #include "null_joystick.h"

--- a/glfw/osmesa_context.h
+++ b/glfw/osmesa_context.h
@@ -54,10 +54,6 @@ typedef GLFWglproc (GLAPIENTRY * PFN_OSMesaGetProcAddress)(const char*);
 #define OSMesaGetDepthBuffer _glfw.osmesa.GetDepthBuffer
 #define OSMesaGetProcAddress _glfw.osmesa.GetProcAddress
 
-#define _GLFW_OSMESA_CONTEXT_STATE              _GLFWcontextOSMesa osmesa
-#define _GLFW_OSMESA_LIBRARY_CONTEXT_STATE      _GLFWlibraryOSMesa osmesa
-
-
 // OSMesa-specific per-context data
 //
 typedef struct _GLFWcontextOSMesa

--- a/glfw/wl_platform.h
+++ b/glfw/wl_platform.h
@@ -50,8 +50,6 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
 #endif
 #include "backend_utils.h"
 #include "xkb_glfw.h"
-#include "egl_context.h"
-#include "osmesa_context.h"
 #include "wl_cursors.h"
 
 #include "wayland-xdg-shell-client-protocol.h"

--- a/glfw/x11_platform.h
+++ b/glfw/x11_platform.h
@@ -153,8 +153,6 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR)(Vk
 
 #include "posix_thread.h"
 #include "glx_context.h"
-#include "egl_context.h"
-#include "osmesa_context.h"
 #if defined(__linux__)
 #include "linux_joystick.h"
 #else


### PR DESCRIPTION
From upstream: https://github.com/glfw/glfw/commit/bcb85581896910c7205596cc4eec9b16d8b7e565.