### PR TITLE
Use consistent quotes and dashes in html docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,6 +109,9 @@ rst_prolog = '''
 
 '''.replace('VERSION', str_version)
 
+# Do not convert quotes and dashes to typographical symbols
+smartquotes = False
+
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
I played around with reproducible builds (#1155) again as it became a discussed topic again 🙂 

While doing so, I noticed that when we generate docs, it produces slightly different html files on different locales, in some cases html files would contain fancy Unicode dashes and typographical quotes, and in others not. 

I have a feeling that in practice nobody would care which quotes and dashes we use, so I'd just fix them to always be regular ASCII symbols, if that's okay with you?