### PR TITLE
GLFW: Wayland: Fix partial framebuffer size retrieval

### DIFF
--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -1081,8 +1081,10 @@ void _glfwPlatformGetFramebufferSize(_GLFWwindow* window,
                                      int* width, int* height)
 {
     _glfwPlatformGetWindowSize(window, width, height);
-    *width *= window->wl.scale;
-    *height *= window->wl.scale;
+    if (width)
+        *width *= window->wl.scale;
+    if (height)
+        *height *= window->wl.scale;
 }
 
 void _glfwPlatformGetWindowFrameSize(_GLFWwindow* window,


### PR DESCRIPTION
From upstream: https://github.com/glfw/glfw/commit/5f60c22cfa5c3d62e2cb2f281fd057384fc58f54.