### PR TITLE
GLFW: Wayland: Fix scroll offsets being inverted

### DIFF
--- a/glfw/wl_init.c
+++ b/glfw/wl_init.c
@@ -337,9 +337,9 @@ static void pointerHandleAxis(void* data UNUSED,
            axis == WL_POINTER_AXIS_VERTICAL_SCROLL);
 
     if (axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL)
-        x = wl_fixed_to_double(value) * -1;
+        x = -wl_fixed_to_double(value);
     else if (axis == WL_POINTER_AXIS_VERTICAL_SCROLL)
-        y = wl_fixed_to_double(value) * -1;
+        y = -wl_fixed_to_double(value);
 
     _glfwInputScroll(window, x, y, 1, _glfw.wl.xkb.states.modifiers);
 }


### PR DESCRIPTION
From upstream: https://github.com/glfw/glfw/commit/f760b124ca849d99effbedb91fb8d10a828aea00.

This commit does not actually change any behaviour, it merely makes the code style of the two lines more similar to the new upstream code.