### PR TITLE
Add old xterm code for alternate screen mode

### DIFF
--- a/kitty/modes.h
+++ b/kitty/modes.h
@@ -69,6 +69,7 @@
 
 // Alternate screen buffer
 #define ALTERNATE_SCREEN  (1049 << 5)
+#define OLD_ALTERNATE_SCREEN  (47 << 5)
 
 // Bracketed paste mode
 // https://cirw.in/blog/bracketed-paste

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -728,6 +728,7 @@ set_mode_from_const(Screen *self, unsigned int mode, bool val) {
             self->cursor->blink = val;
             break;
         case ALTERNATE_SCREEN:
+        case OLD_ALTERNATE_SCREEN:
             if (val && self->linebuf == self->main_linebuf) screen_toggle_screen_buffer(self);
             else if (!val && self->linebuf != self->main_linebuf) screen_toggle_screen_buffer(self);
             break;


### PR DESCRIPTION
This fixes [#2870](https://github.com/kovidgoyal/kitty/issues/2870#issue-663362790), according to [this manual](https://www.gnu.org/software/screen/manual/screen.html) screen mode 47 is the old xterm code for alternate screen. (1049 being the new one). This fixes the issue but I'm unsure why 47 was deprecated in the first place.