### PR TITLE
GLFW: Make joystick platform code init on demand

### DIFF
--- a/glfw/cocoa_init.m
+++ b/glfw/cocoa_init.m
@@ -669,8 +669,6 @@ int _glfwPlatformInit(void)
     if (!initializeTIS())
         return false;
 
-    _glfwInitJoysticksNS();
-
     _glfwPollMonitorsNS();
     return true;
 
@@ -723,7 +721,6 @@ void _glfwPlatformTerminate(void)
     free(_glfw.ns.clipboardString);
 
     _glfwTerminateNSGL();
-    _glfwTerminateJoysticksNS();
 
     } // autoreleasepool
 }

--- a/glfw/cocoa_joystick.h
+++ b/glfw/cocoa_joystick.h
@@ -44,7 +44,3 @@ typedef struct _GLFWjoystickNS
     CFMutableArrayRef   hats;
 } _GLFWjoystickNS;
 
-
-void _glfwInitJoysticksNS(void);
-void _glfwTerminateJoysticksNS(void);
-

--- a/glfw/cocoa_joystick.m
+++ b/glfw/cocoa_joystick.m
@@ -296,7 +296,7 @@ static void removeCallback(void* context UNUSED,
 
 // Initialize joystick interface
 //
-void _glfwInitJoysticksNS(void)
+bool _glfwPlatformInitJoysticks(void)
 {
     CFMutableArrayRef matching;
     const long usages[] =
@@ -315,7 +315,7 @@ void _glfwInitJoysticksNS(void)
     if (!matching)
     {
         _glfwInputError(GLFW_PLATFORM_ERROR, "Cocoa: Failed to create array");
-        return;
+        return false;
     }
 
     for (size_t i = 0;  i < sizeof(usages) / sizeof(long);  i++)
@@ -370,19 +370,23 @@ void _glfwInitJoysticksNS(void)
     // Execute the run loop once in order to register any initially-attached
     // joysticks
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
+    return true;
 }
 
 // Close all opened joystick handles
 //
-void _glfwTerminateJoysticksNS(void)
+void _glfwPlatformTerminateJoysticks(void)
 {
     int jid;
 
     for (jid = 0;  jid <= GLFW_JOYSTICK_LAST;  jid++)
         closeJoystick(_glfw.joysticks + jid);
 
-    CFRelease(_glfw.ns.hidManager);
-    _glfw.ns.hidManager = NULL;
+    if (_glfw.ns.hidManager)
+    {
+        CFRelease(_glfw.ns.hidManager);
+        _glfw.ns.hidManager = NULL;
+    }
 }
 
 

--- a/glfw/cocoa_joystick.m
+++ b/glfw/cocoa_joystick.m
@@ -291,11 +291,9 @@ static void removeCallback(void* context UNUSED,
 
 
 //////////////////////////////////////////////////////////////////////////
-//////                       GLFW internal API                      //////
+//////                       GLFW platform API                      //////
 //////////////////////////////////////////////////////////////////////////
 
-// Initialize joystick interface
-//
 bool _glfwPlatformInitJoysticks(void)
 {
     CFMutableArrayRef matching;
@@ -373,8 +371,6 @@ bool _glfwPlatformInitJoysticks(void)
     return true;
 }
 
-// Close all opened joystick handles
-//
 void _glfwPlatformTerminateJoysticks(void)
 {
     int jid;
@@ -389,10 +385,6 @@ void _glfwPlatformTerminateJoysticks(void)
     }
 }
 
-
-//////////////////////////////////////////////////////////////////////////
-//////                       GLFW platform API                      //////
-//////////////////////////////////////////////////////////////////////////
 
 int _glfwPlatformPollJoystick(_GLFWjoystick* js, int mode)
 {

--- a/glfw/glfw3.h
+++ b/glfw/glfw3.h
@@ -1202,7 +1202,6 @@ typedef enum {
  */
 #define GLFW_ANGLE_PLATFORM_TYPE    0x00050002
 #define GLFW_DEBUG_KEYBOARD         0x00050003
-#define GLFW_ENABLE_JOYSTICKS       0x00050004
 /*! @brief macOS specific init hint.
  *
  *  macOS specific [init hint](@ref GLFW_COCOA_CHDIR_RESOURCES_hint).

--- a/glfw/init.c
+++ b/glfw/init.c
@@ -55,7 +55,6 @@ static _GLFWinitconfig _glfwInitHints =
     true,      // hat buttons
     GLFW_ANGLE_PLATFORM_TYPE_NONE, // ANGLE backend
     false,     // debug keyboard
-    true,      // enable joystick
     {
         true,  // macOS menu bar
         true   // macOS bundle chdir
@@ -276,9 +275,6 @@ GLFWAPI void glfwInitHint(int hint, int value)
 {
     switch (hint)
     {
-        case GLFW_ENABLE_JOYSTICKS:
-            _glfwInitHints.enableJoysticks = value;
-            return;
         case GLFW_JOYSTICK_HAT_BUTTONS:
             _glfwInitHints.hatButtons = value;
             return;

--- a/glfw/init.c
+++ b/glfw/init.c
@@ -92,6 +92,7 @@ static void terminate(void)
     _glfw.mappingCount = 0;
 
     _glfwTerminateVulkan();
+    _glfwPlatformTerminateJoysticks();
     _glfwPlatformTerminate();
 
     _glfw.initialized = false;

--- a/glfw/input.c
+++ b/glfw/input.c
@@ -44,6 +44,22 @@
 #define _GLFW_JOYSTICK_BUTTON   2
 #define _GLFW_JOYSTICK_HATBIT   3
 
+// Initializes the platform joystick API if it has not been already
+//
+static bool initJoysticks(void)
+{
+    if (!_glfw.joysticksInitialized)
+    {
+        if (!_glfwPlatformInitJoysticks())
+        {
+            _glfwPlatformTerminateJoysticks();
+            return false;
+        }
+    }
+
+    return _glfw.joysticksInitialized = true;
+}
+
 // Finds a mapping based on joystick GUID
 //
 static _GLFWmapping* findMapping(const char* guid)
@@ -1101,6 +1117,9 @@ GLFWAPI int glfwJoystickPresent(int jid)
         return false;
     }
 
+    if (!initJoysticks())
+        return false;
+
     js = _glfw.joysticks + jid;
     if (!js->present)
         return false;
@@ -1125,6 +1144,9 @@ GLFWAPI const float* glfwGetJoystickAxes(int jid, int* count)
         _glfwInputError(GLFW_INVALID_ENUM, "Invalid joystick ID %i", jid);
         return NULL;
     }
+
+    if (!initJoysticks())
+        return NULL;
 
     js = _glfw.joysticks + jid;
     if (!js->present)
@@ -1154,6 +1176,9 @@ GLFWAPI const unsigned char* glfwGetJoystickButtons(int jid, int* count)
         _glfwInputError(GLFW_INVALID_ENUM, "Invalid joystick ID %i", jid);
         return NULL;
     }
+
+    if (!initJoysticks())
+        return NULL;
 
     js = _glfw.joysticks + jid;
     if (!js->present)
@@ -1188,6 +1213,9 @@ GLFWAPI const unsigned char* glfwGetJoystickHats(int jid, int* count)
         return NULL;
     }
 
+    if (!initJoysticks())
+        return NULL;
+
     js = _glfw.joysticks + jid;
     if (!js->present)
         return NULL;
@@ -1214,6 +1242,9 @@ GLFWAPI const char* glfwGetJoystickName(int jid)
         return NULL;
     }
 
+    if (!initJoysticks())
+        return NULL;
+
     js = _glfw.joysticks + jid;
     if (!js->present)
         return NULL;
@@ -1238,6 +1269,9 @@ GLFWAPI const char* glfwGetJoystickGUID(int jid)
         _glfwInputError(GLFW_INVALID_ENUM, "Invalid joystick ID %i", jid);
         return NULL;
     }
+
+    if (!initJoysticks())
+        return NULL;
 
     js = _glfw.joysticks + jid;
     if (!js->present)
@@ -1284,6 +1318,10 @@ GLFWAPI void* glfwGetJoystickUserPointer(int jid)
 GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun cbfun)
 {
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+
+    if (!initJoysticks())
+        return NULL;
+
     _GLFW_SWAP_POINTERS(_glfw.callbacks.joystick, cbfun);
     return cbfun;
 }
@@ -1363,6 +1401,9 @@ GLFWAPI int glfwJoystickIsGamepad(int jid)
         return false;
     }
 
+    if (!initJoysticks())
+        return false;
+
     js = _glfw.joysticks + jid;
     if (!js->present)
         return false;
@@ -1387,6 +1428,9 @@ GLFWAPI const char* glfwGetGamepadName(int jid)
         _glfwInputError(GLFW_INVALID_ENUM, "Invalid joystick ID %i", jid);
         return NULL;
     }
+
+    if (!initJoysticks())
+        return NULL;
 
     js = _glfw.joysticks + jid;
     if (!js->present)
@@ -1419,6 +1463,9 @@ GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state)
         _glfwInputError(GLFW_INVALID_ENUM, "Invalid joystick ID %i", jid);
         return false;
     }
+
+    if (!initJoysticks())
+        return false;
 
     js = _glfw.joysticks + jid;
     if (!js->present)

--- a/glfw/internal.h
+++ b/glfw/internal.h
@@ -574,6 +574,7 @@ struct _GLFWlibrary
     _GLFWmonitor**      monitors;
     int                 monitorCount;
 
+    bool                joysticksInitialized;
     _GLFWjoystick       joysticks[GLFW_JOYSTICK_LAST + 1];
     _GLFWmapping*       mappings;
     int                 mappingCount;
@@ -667,6 +668,8 @@ void _glfwPlatformSetPrimarySelectionString(const char* string);
 const char* _glfwPlatformGetPrimarySelectionString(void);
 #endif
 
+bool _glfwPlatformInitJoysticks(void);
+void _glfwPlatformTerminateJoysticks(void);
 int _glfwPlatformPollJoystick(_GLFWjoystick* js, int mode);
 void _glfwPlatformUpdateGamepadGUID(char* guid);
 

--- a/glfw/internal.h
+++ b/glfw/internal.h
@@ -276,7 +276,6 @@ struct _GLFWinitconfig
     bool          hatButtons;
     int           angleType;
     bool          debugKeyboard;
-    bool          enableJoysticks;
     struct {
         bool      menubar;
         bool      chdir;

--- a/glfw/linux_joystick.c
+++ b/glfw/linux_joystick.c
@@ -266,7 +266,7 @@ static int compareJoysticks(const void* fp, const void* sp)
 
 // Initialize joystick interface
 //
-bool _glfwInitJoysticksLinux(void)
+bool _glfwPlatformInitJoysticks(void)
 {
     const char* dirname = "/dev/input";
 
@@ -322,7 +322,7 @@ bool _glfwInitJoysticksLinux(void)
 
 // Close all opened joystick handles
 //
-void _glfwTerminateJoysticksLinux(void)
+void _glfwPlatformTerminateJoysticks(void)
 {
     int jid;
 
@@ -333,14 +333,13 @@ void _glfwTerminateJoysticksLinux(void)
             closeJoystick(js);
     }
 
-    regfree(&_glfw.linjs.regex);
-
     if (_glfw.linjs.inotify > 0)
     {
         if (_glfw.linjs.watch > 0)
             inotify_rm_watch(_glfw.linjs.inotify, _glfw.linjs.watch);
 
         close(_glfw.linjs.inotify);
+        regfree(&_glfw.linjs.regex);
     }
 }
 

--- a/glfw/linux_joystick.h
+++ b/glfw/linux_joystick.h
@@ -55,7 +55,4 @@ typedef struct _GLFWlibraryLinux
     bool                    dropped;
 } _GLFWlibraryLinux;
 
-
-bool _glfwInitJoysticksLinux(void);
-void _glfwTerminateJoysticksLinux(void);
 void _glfwDetectJoystickConnectionLinux(void);

--- a/glfw/null_joystick.c
+++ b/glfw/null_joystick.c
@@ -33,6 +33,15 @@
 //////                       GLFW platform API                      //////
 //////////////////////////////////////////////////////////////////////////
 
+int _glfwPlatformInitJoysticks(void)
+{
+    return true;
+}
+
+void _glfwPlatformTerminateJoysticks(void)
+{
+}
+
 int _glfwPlatformPollJoystick(_GLFWjoystick* js UNUSED, int mode UNUSED)
 {
     return false;

--- a/glfw/wl_init.c
+++ b/glfw/wl_init.c
@@ -771,11 +771,6 @@ int _glfwPlatformInit(void)
     // Sync so we got all initial output events
     wl_display_roundtrip(_glfw.wl.display);
 
-#ifdef __linux__
-    if (!_glfwInitJoysticksLinux())
-        return false;
-#endif
-
     if (!_glfw.wl.wmBase)
     {
         _glfwInputError(GLFW_PLATFORM_ERROR,
@@ -799,9 +794,6 @@ int _glfwPlatformInit(void)
 
 void _glfwPlatformTerminate(void)
 {
-#ifdef __linux__
-    _glfwTerminateJoysticksLinux();
-#endif
     _glfwTerminateEGL();
     if (_glfw.wl.egl.handle)
     {

--- a/glfw/wl_init.c
+++ b/glfw/wl_init.c
@@ -772,10 +772,8 @@ int _glfwPlatformInit(void)
     wl_display_roundtrip(_glfw.wl.display);
 
 #ifdef __linux__
-    if (_glfw.hints.init.enableJoysticks) {
-        if (!_glfwInitJoysticksLinux())
-            return false;
-    }
+    if (!_glfwInitJoysticksLinux())
+        return false;
 #endif
 
     if (!_glfw.wl.wmBase)

--- a/glfw/x11_init.c
+++ b/glfw/x11_init.c
@@ -654,12 +654,10 @@ int _glfwPlatformInit(void)
     _glfw.x11.hiddenCursorHandle = createHiddenCursor();
 
 #if defined(__linux__)
-    if (_glfw.hints.init.enableJoysticks) {
-        if (!_glfwInitJoysticksLinux())
-            return false;
-        if (_glfw.linjs.inotify > 0)
-            addWatch(&_glfw.x11.eventLoopData, "joystick", _glfw.linjs.inotify, POLLIN, 1, NULL, NULL);
-    }
+    if (!_glfwInitJoysticksLinux())
+        return false;
+    if (_glfw.linjs.inotify > 0)
+        addWatch(&_glfw.x11.eventLoopData, "joystick", _glfw.linjs.inotify, POLLIN, 1, NULL, NULL);
 #endif
 
     _glfwPollMonitorsX11();

--- a/glfw/x11_init.c
+++ b/glfw/x11_init.c
@@ -653,13 +653,6 @@ int _glfwPlatformInit(void)
     _glfw.x11.helperWindowHandle = createHelperWindow();
     _glfw.x11.hiddenCursorHandle = createHiddenCursor();
 
-#if defined(__linux__)
-    if (!_glfwInitJoysticksLinux())
-        return false;
-    if (_glfw.linjs.inotify > 0)
-        addWatch(&_glfw.x11.eventLoopData, "joystick", _glfw.linjs.inotify, POLLIN, 1, NULL, NULL);
-#endif
-
     _glfwPollMonitorsX11();
     return true;
 }
@@ -738,9 +731,6 @@ void _glfwPlatformTerminate(void)
     _glfwTerminateEGL();
     _glfwTerminateGLX();
 
-#if defined(__linux__)
-    _glfwTerminateJoysticksLinux();
-#endif
     finalizePollData(&_glfw.x11.eventLoopData);
 }
 

--- a/glfw/x11_window.c
+++ b/glfw/x11_window.c
@@ -2653,7 +2653,7 @@ _glfwDispatchX11Events(void) {
     unsigned dispatched = 0;
 
 #if defined(__linux__)
-    if (_glfw.hints.init.enableJoysticks) _glfwDetectJoystickConnectionLinux();
+    _glfwDetectJoystickConnectionLinux();
 #endif
     dispatched += dispatch_x11_queued_events(XEventsQueued(_glfw.x11.display, QueuedAfterFlush));
 

--- a/glfw/x11_window.c
+++ b/glfw/x11_window.c
@@ -2653,7 +2653,8 @@ _glfwDispatchX11Events(void) {
     unsigned dispatched = 0;
 
 #if defined(__linux__)
-    _glfwDetectJoystickConnectionLinux();
+    if (_glfw.joysticksInitialized)
+        _glfwDetectJoystickConnectionLinux();
 #endif
     dispatched += dispatch_x11_queued_events(XEventsQueued(_glfw.x11.display, QueuedAfterFlush));
 

--- a/kitty/glfw-wrapper.h
+++ b/kitty/glfw-wrapper.h
@@ -940,7 +940,6 @@ typedef enum {
  */
 #define GLFW_ANGLE_PLATFORM_TYPE    0x00050002
 #define GLFW_DEBUG_KEYBOARD         0x00050003
-#define GLFW_ENABLE_JOYSTICKS       0x00050004
 /*! @brief macOS specific init hint.
  *
  *  macOS specific [init hint](@ref GLFW_COCOA_CHDIR_RESOURCES_hint).

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -814,9 +814,6 @@ glfw_init(PyObject UNUSED *self, PyObject *args) {
     if (err) { PyErr_SetString(PyExc_RuntimeError, err); return NULL; }
     glfwSetErrorCallback(error_callback);
     glfwInitHint(GLFW_DEBUG_KEYBOARD, debug_keyboard);
-    // Joysticks cause slow startup on some linux systems, see
-    // https://github.com/kovidgoyal/kitty/issues/830
-    glfwInitHint(GLFW_ENABLE_JOYSTICKS, 0);
     OPT(debug_keyboard) = debug_keyboard != 0;
 #ifdef __APPLE__
     glfwInitHint(GLFW_COCOA_CHDIR_RESOURCES, 0);


### PR DESCRIPTION
This PR removes our custom `GLFW_ENABLE_JOYSTICKS` GLFW init hint and replaces it with the new lazy joystick initialisation from upstream.