### PR TITLE
On Mac OS, set $WINDOWID to OS's window number

### DIFF
--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -390,6 +390,12 @@ cocoa_focus_window(void *w) {
     [window makeKeyWindow];
 }
 
+long
+cocoa_window_number(void *w) {
+    NSWindow *window = (NSWindow*)w;
+    return [window windowNumber];
+}
+
 size_t
 cocoa_get_workspace_ids(void *w, size_t *workspace_ids, size_t array_sz) {
     NSWindow *window = (NSWindow*)w;

--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -781,6 +781,10 @@ def x11_window_id(os_window_id: int) -> int:
     pass
 
 
+def cocoa_window_id(os_window_id: int) -> int:
+    pass
+
+
 def swap_tabs(os_window_id: int, a: int, b: int) -> None:
     pass
 

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -1045,15 +1045,18 @@ x11_window_id(PyObject UNUSED *self, PyObject *os_wid) {
     return Py_BuildValue("l", (long)glfwGetX11Window(w->handle));
 }
 
-#ifdef __APPLE__
 static PyObject*
 cocoa_window_id(PyObject UNUSED *self, PyObject *os_wid) {
     OSWindow *w = find_os_window(os_wid);
     if (!w) { PyErr_SetString(PyExc_ValueError, "No OSWindow with the specified id found"); return NULL; }
     if (!glfwGetCocoaWindow) { PyErr_SetString(PyExc_RuntimeError, "Failed to load glfwGetCocoaWindow"); return NULL; }
+#ifdef __APPLE__
     return Py_BuildValue("l", (long)cocoa_window_number(glfwGetCocoaWindow(w->handle)));
-}
+#else
+    PyErr_SetString(PyExc_RuntimeError, "cocoa_window_id() is only supported on Mac");
+    return NULL;
 #endif
+}
 
 static PyObject*
 get_primary_selection(PYNOARG) {
@@ -1236,9 +1239,7 @@ static PyMethodDef module_methods[] = {
 #ifndef __APPLE__
     METHODB(dbus_send_notification, METH_VARARGS),
 #endif
-#ifdef __APPLE__
     METHODB(cocoa_window_id, METH_O),
-#endif
     {"glfw_init", (PyCFunction)glfw_init, METH_VARARGS, ""},
     {"glfw_terminate", (PyCFunction)glfw_terminate, METH_NOARGS, ""},
     {"glfw_get_physical_dpi", (PyCFunction)glfw_get_physical_dpi, METH_NOARGS, ""},

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -1039,18 +1039,18 @@ find_os_window(PyObject *os_wid) {
 
 static PyObject*
 x11_window_id(PyObject UNUSED *self, PyObject *os_wid) {
-    if (!glfwGetX11Window) { PyErr_SetString(PyExc_RuntimeError, "Failed to load glfwGetX11Window"); return NULL; }
     OSWindow *w = find_os_window(os_wid);
     if (!w) { PyErr_SetString(PyExc_ValueError, "No OSWindow with the specified id found"); return NULL; }
+    if (!glfwGetX11Window) { PyErr_SetString(PyExc_RuntimeError, "Failed to load glfwGetX11Window"); return NULL; }
     return Py_BuildValue("l", (long)glfwGetX11Window(w->handle));
 }
 
 #ifdef __APPLE__
 static PyObject*
 cocoa_window_id(PyObject UNUSED *self, PyObject *os_wid) {
-    if (!glfwGetCocoaWindow) { PyErr_SetString(PyExc_RuntimeError, "Failed to load glfwGetCocoaWindow"); return NULL; }
     OSWindow *w = find_os_window(os_wid);
     if (!w) { PyErr_SetString(PyExc_ValueError, "No OSWindow with the specified id found"); return NULL; }
+    if (!glfwGetCocoaWindow) { PyErr_SetString(PyExc_RuntimeError, "Failed to load glfwGetCocoaWindow"); return NULL; }
     return Py_BuildValue("l", (long)cocoa_window_number(glfwGetCocoaWindow(w->handle)));
 }
 #endif

--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -17,7 +17,7 @@ from .child import Child
 from .cli_stub import CLIOptions
 from .constants import appname, is_macos, is_wayland
 from .fast_data_types import (
-    add_tab, attach_window, detach_window, get_boss, mark_tab_bar_dirty,
+    add_tab, attach_window, cocoa_window_id, detach_window, get_boss, mark_tab_bar_dirty,
     next_window_id, remove_tab, remove_window, ring_bell, set_active_tab,
     set_active_window, swap_tabs, sync_os_window_title, x11_window_id
 )
@@ -283,7 +283,13 @@ class Tab:  # {{{
         if env:
             fenv.update(env)
         fenv['KITTY_WINDOW_ID'] = str(next_window_id())
-        if not is_macos and not is_wayland():
+        if is_macos:
+            try:
+                fenv['WINDOWID'] = str(cocoa_window_id(self.os_window_id))
+            except Exception:
+                import traceback
+                traceback.print_exc()
+        elif not is_wayland():
             try:
                 fenv['WINDOWID'] = str(x11_window_id(self.os_window_id))
             except Exception:


### PR DESCRIPTION
The API used is rather plain, not private or suspicious.  (I did research, though, and AFAICT, private APIs will pass the notary, but Apple threatened that they wouldn't when they first introduced the notary, so ... ??.) 

I'm running this locally, and the window ids are stable and agree with yabai's window numbers (apparently in spite of the vague comment in `windowNumber`'s documentation):

```
jfelice@C02X421DJHD4 src 
$ echo $WINDOWID
20273

jfelice@C02X421DJHD4 src 
$ yabai -m query --windows --window | jq '.id'
20273
```

I chose to reuse the `WINDOWID` variable because it seems like the same purpose and it is possible that some scripts might now work on Mac OS.

Let me know about any code quality issues, and I'll fix them up.

(See #2552 and koekeishiya/yabai#625)