### PR TITLE
GLFW: Cocoa: Fix potential leak of CFNumber object

### DIFF
--- a/glfw/cocoa_monitor.m
+++ b/glfw/cocoa_monitor.m
@@ -279,14 +279,20 @@ static double getFallbackRefreshRate(CGDirectDisplayID displayID)
                                             CFSTR("IOFBCurrentPixelCount"),
                                             kCFAllocatorDefault,
                                             kNilOptions);
-        if (!clockRef || !countRef)
-            break;
 
         uint32_t clock = 0, count = 0;
-        CFNumberGetValue(clockRef, kCFNumberIntType, &clock);
-        CFNumberGetValue(countRef, kCFNumberIntType, &count);
-        CFRelease(clockRef);
-        CFRelease(countRef);
+
+        if (clockRef)
+        {
+            CFNumberGetValue(clockRef, kCFNumberIntType, &clock);
+            CFRelease(clockRef);
+        }
+
+        if (countRef)
+        {
+            CFNumberGetValue(countRef, kCFNumberIntType, &count);
+            CFRelease(countRef);
+        }
 
         if (clock > 0 && count > 0)
             refreshRate = clock / (double) count;


### PR DESCRIPTION
From upstream: https://github.com/glfw/glfw/commit/a2674a903434b7dfc0b0bcc5d0b479da417367ff.