### PR TITLE
GLFW: Cocoa: Support some sim page joystick elements

### DIFF
--- a/glfw/cocoa_joystick.m
+++ b/glfw/cocoa_joystick.m
@@ -233,6 +233,19 @@ static void matchCallback(void* context UNUSED,
                     break;
             }
         }
+        else if (page == kHIDPage_Simulation)
+        {
+            switch (usage)
+            {
+                case kHIDUsage_Sim_Accelerator:
+                case kHIDUsage_Sim_Brake:
+                case kHIDUsage_Sim_Throttle:
+                case kHIDUsage_Sim_Rudder:
+                case kHIDUsage_Sim_Steering:
+                    target = axes;
+                    break;
+            }
+        }
         else if (page == kHIDPage_Button || page == kHIDPage_Consumer)
             target = buttons;
 


### PR DESCRIPTION
From upstream: https://github.com/glfw/glfw/commit/0d355379e070d094a6b9e0894f4fa51e00e1364f.