### PR TITLE
Let kitty_exe() search in linux-package and kitty.app as well

### DIFF
--- a/kitty/constants.py
+++ b/kitty/constants.py
@@ -64,16 +64,20 @@ class WindowGeometry(NamedTuple):
 def kitty_exe() -> str:
     rpath = sys._xoptions.get('bundle_exe_dir')
     if not rpath:
-        items = filter(None, os.environ.get('PATH', '').split(os.pathsep))
+        items = os.environ.get('PATH', '').split(os.pathsep) + [
+            os.path.join(base, 'launcher'),
+            os.path.join(os.path.dirname(base), 'linux-package', 'bin'),
+            os.path.join(os.path.dirname(base), 'kitty.app', 'Contents', 'MacOS'),
+        ]
         seen: Set[str] = set()
-        for candidate in items:
+        for candidate in filter(None, items):
             if candidate not in seen:
                 seen.add(candidate)
                 if os.access(os.path.join(candidate, 'kitty'), os.X_OK):
                     rpath = candidate
                     break
         else:
-            rpath = os.path.join(base, 'launcher')
+            raise SystemExit('kitty binary not found')
     return os.path.join(rpath, 'kitty')
 
 

--- a/kitty/constants.py
+++ b/kitty/constants.py
@@ -73,7 +73,7 @@ def kitty_exe() -> str:
                     rpath = candidate
                     break
         else:
-            rpath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'launcher')
+            rpath = os.path.join(base, 'launcher')
     return os.path.join(rpath, 'kitty')
 
 
@@ -146,7 +146,7 @@ def wakeup() -> None:
         b.child_monitor.wakeup()
 
 
-base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+base_dir = os.path.dirname(base)
 terminfo_dir = os.path.join(base_dir, 'terminfo')
 logo_data_file = os.path.join(base_dir, 'logo', 'kitty.rgba')
 logo_png_file = os.path.join(base_dir, 'logo', 'kitty.png')


### PR DESCRIPTION
Fixes https://github.com/kovidgoyal/kitty/issues/2881.

This allows executing the tests after building only the linux-package or kitty.app.
`kitty_exe()` will also exit now if kitty could not be found. Is that good or could it be a problem?