### PR TITLE
Register to bus when connect to ibus.

### DIFF
--- a/glfw/ibus_glfw.c
+++ b/glfw/ibus_glfw.c
@@ -269,7 +269,7 @@ setup_connection(_GLFWIBUSData *ibus) {
         ibus->conn = NULL;
     }
     debug("Connecting to IBUS daemon @ %s for IME input management\n", ibus->address);
-    ibus->conn = glfw_dbus_connect_to(ibus->address, "Failed to connect to the IBUS daemon, with error", "ibus", false);
+    ibus->conn = glfw_dbus_connect_to(ibus->address, "Failed to connect to the IBUS daemon, with error", "ibus", true);
     if (!ibus->conn) return false;
     free((void*)ibus->input_ctx_path); ibus->input_ctx_path = NULL;
     if (!glfw_dbus_call_method_with_reply(


### PR DESCRIPTION
This is required when the actual dbus is not from ibus but session bus.
This may happen when other run a shim layer for ibus, or ibus is
running with flatpak mode.