### PR TITLE
Declare _glfwPlatformInitJoysticks() to return bool

### DIFF
--- a/glfw/null_joystick.c
+++ b/glfw/null_joystick.c
@@ -33,7 +33,7 @@
 //////                       GLFW platform API                      //////
 //////////////////////////////////////////////////////////////////////////
 
-int _glfwPlatformInitJoysticks(void)
+bool _glfwPlatformInitJoysticks(void)
 {
     return true;
 }


### PR DESCRIPTION
This patch declares _glfwPlatformInitJoysticks() to return bool which
matches its prototype in glfw/internal.h.

Without this patch, kitty is failing to build under FreeBSD with the following error:

```
gcc -MMD -DNDEBUG -D_GLFW_WAYLAND -D_GLFW_BUILD_DLL -Wextra -Wfloat-conversion -Wno-missing-field-initializers -Wall -Wstrict-prototypes -std=c11 -pedantic-errors -Werror -O3 -fwrapv -fstack-protector-strong -pipe -march=native -fvisibility=hidden -D_FORTIFY_SOURCE=2 -fPIC -flto -fPIC -pthread -I/usr/local/include -I/usr/local/include/libepoll-shim -I/usr/local/include -I/usr/local/include/libepoll-shim -I/usr/local/include -I/usr/local/include/dbus-1.0 -I/usr/local/lib/dbus-1.0/include -c glfw/null_joystick.c -o build/glfw-wayland-null_joystick.c.o
glfw/null_joystick.c:36:5: error: conflicting types for '_glfwPlatformInitJoysticks'
   36 | int _glfwPlatformInitJoysticks(void)
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from glfw/null_joystick.c:29:
glfw/internal.h:671:6: note: previous declaration of '_glfwPlatformInitJoysticks' was here
  671 | bool _glfwPlatformInitJoysticks(void);
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~
```