### PR TITLE
Make visual bell flash much more gentle

### DIFF
--- a/kitty/cell_vertex.glsl
+++ b/kitty/cell_vertex.glsl
@@ -220,7 +220,10 @@ void main() {
     draw_bg = 1;
 
 #if defined(BACKGROUND)
-    background = bg;
+    background = choose_color(visual_bell_intensity,
+        blend_softlight(color_to_vec(highlight_bg), bg),
+        bg
+    );
     // draw_bg_bitfield has bit 0 set to draw default bg cells and bit 1 set to draw non-default bg cells
     uint draw_bg_mask = uint(2 * cell_has_non_default_bg + (1 - cell_has_non_default_bg));
     draw_bg = step(1, float(draw_bg_bitfield & draw_bg_mask));

--- a/kitty/cell_vertex.glsl
+++ b/kitty/cell_vertex.glsl
@@ -134,10 +134,6 @@ float is_cursor(uint xi, uint y) {
     float x_equal = step(0.5, x1_equal + x2_equal);
     return step(2.0, x_equal + y_equal);
 }
-
-vec3 blend_softlight(vec3 base, vec3 blend) {
-    return (1.0 - 2.0 * blend) * base * base + 2.0 * blend * base;
-}
 // }}}
 
 
@@ -195,10 +191,6 @@ void main() {
     // Selection
     vec3 selection_color = color_to_vec(highlight_fg);
     foreground = choose_color(float(is_selected & ONE), selection_color, foreground);
-    foreground = choose_color(visual_bell_intensity * 0.5,
-        blend_softlight(color_to_vec(highlight_bg), foreground),
-        foreground
-    );
     decoration_fg = choose_color(float(is_selected & ONE), selection_color, decoration_fg);
 #endif
     // Underline and strike through (rendered via sprites)
@@ -247,12 +239,9 @@ void main() {
 
 #if defined(SPECIAL) || defined(SIMPLE)
     // Selection and cursor
+    bg = max(bg, choose_color(visual_bell_intensity, color_to_vec(highlight_bg), bg));
     bg = choose_color(float(is_selected & ONE), color_to_vec(highlight_bg), bg);
-    bg = choose_color(cell_has_block_cursor, color_to_vec(cursor_color), bg);
-    background = choose_color(visual_bell_intensity,
-        blend_softlight(color_to_vec(highlight_bg), bg),
-        bg
-    );
+    background = choose_color(cell_has_block_cursor, color_to_vec(cursor_color), bg);
 #if !defined(TRANSPARENT) && defined(SPECIAL)
     float is_special_cell = cell_has_block_cursor + float(is_selected & ONE);
     bg_alpha = step(0.5, is_special_cell);

--- a/kitty/cell_vertex.glsl
+++ b/kitty/cell_vertex.glsl
@@ -212,10 +212,7 @@ void main() {
     draw_bg = 1;
 
 #if defined(BACKGROUND)
-    background = choose_color(visual_bell_intensity,
-        blend_softlight(color_to_vec(highlight_bg), bg),
-        bg
-    );
+    background = bg;
     // draw_bg_bitfield has bit 0 set to draw default bg cells and bit 1 set to draw non-default bg cells
     uint draw_bg_mask = uint(2 * cell_has_non_default_bg + (1 - cell_has_non_default_bg));
     draw_bg = step(1, float(draw_bg_bitfield & draw_bg_mask));

--- a/kitty/cell_vertex.glsl
+++ b/kitty/cell_vertex.glsl
@@ -12,7 +12,7 @@
 
 // Inputs {{{
 layout(std140) uniform CellRenderData {
-    float xstart, ystart, dx, dy, sprite_dx, sprite_dy, background_opacity, cursor_text_uses_bg;
+    float xstart, ystart, dx, dy, sprite_dx, sprite_dy, background_opacity, cursor_text_uses_bg, visual_bell_intensity;
 
     uint default_fg, default_bg, highlight_fg, highlight_bg, cursor_color, cursor_text_color, url_color, url_style, inverted;
 
@@ -236,6 +236,7 @@ void main() {
 
 #if defined(SPECIAL) || defined(SIMPLE)
     // Selection and cursor
+    bg = max(bg, choose_color(visual_bell_intensity, color_to_vec(highlight_bg), bg));
     bg = choose_color(float(is_selected & ONE), color_to_vec(highlight_bg), bg);
     background = choose_color(cell_has_block_cursor, color_to_vec(cursor_color), bg);
 #if !defined(TRANSPARENT) && defined(SPECIAL)

--- a/kitty/cell_vertex.glsl
+++ b/kitty/cell_vertex.glsl
@@ -134,6 +134,10 @@ float is_cursor(uint xi, uint y) {
     float x_equal = step(0.5, x1_equal + x2_equal);
     return step(2.0, x_equal + y_equal);
 }
+
+vec3 blend_softlight(vec3 base, vec3 blend) {
+    return (1.0 - 2.0 * blend) * base * base + 2.0 * blend * base;
+}
 // }}}
 
 
@@ -191,6 +195,10 @@ void main() {
     // Selection
     vec3 selection_color = color_to_vec(highlight_fg);
     foreground = choose_color(float(is_selected & ONE), selection_color, foreground);
+    foreground = choose_color(visual_bell_intensity * 0.5,
+        blend_softlight(color_to_vec(highlight_bg), foreground),
+        foreground
+    );
     decoration_fg = choose_color(float(is_selected & ONE), selection_color, decoration_fg);
 #endif
     // Underline and strike through (rendered via sprites)
@@ -236,9 +244,12 @@ void main() {
 
 #if defined(SPECIAL) || defined(SIMPLE)
     // Selection and cursor
-    bg = max(bg, choose_color(visual_bell_intensity, color_to_vec(highlight_bg), bg));
     bg = choose_color(float(is_selected & ONE), color_to_vec(highlight_bg), bg);
-    background = choose_color(cell_has_block_cursor, color_to_vec(cursor_color), bg);
+    bg = choose_color(cell_has_block_cursor, color_to_vec(cursor_color), bg);
+    background = choose_color(visual_bell_intensity,
+        blend_softlight(color_to_vec(highlight_bg), bg),
+        bg
+    );
 #if !defined(TRANSPARENT) && defined(SPECIAL)
     float is_special_cell = cell_has_block_cursor + float(is_selected & ONE);
     bg_alpha = step(0.5, is_special_cell);

--- a/kitty/cell_vertex.glsl
+++ b/kitty/cell_vertex.glsl
@@ -12,7 +12,7 @@
 
 // Inputs {{{
 layout(std140) uniform CellRenderData {
-    float xstart, ystart, dx, dy, sprite_dx, sprite_dy, background_opacity, cursor_text_uses_bg, visual_bell_intensity;
+    float xstart, ystart, dx, dy, sprite_dx, sprite_dy, background_opacity, cursor_text_uses_bg;
 
     uint default_fg, default_bg, highlight_fg, highlight_bg, cursor_color, cursor_text_color, url_color, url_style, inverted;
 
@@ -236,7 +236,6 @@ void main() {
 
 #if defined(SPECIAL) || defined(SIMPLE)
     // Selection and cursor
-    bg = max(bg, choose_color(visual_bell_intensity, color_to_vec(highlight_bg), bg));
     bg = choose_color(float(is_selected & ONE), color_to_vec(highlight_bg), bg);
     background = choose_color(cell_has_block_cursor, color_to_vec(cursor_color), bg);
 #if !defined(TRANSPARENT) && defined(SPECIAL)

--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -596,7 +596,7 @@ prepare_to_render_os_window(OSWindow *os_window, monotonic_t now, unsigned int *
 }
 
 static inline void
-render_os_window(OSWindow *os_window, monotonic_t now, unsigned int active_window_id, color_type active_window_bg, unsigned int num_visible_windows, bool all_windows_have_same_bg) {
+render_os_window(OSWindow *os_window, unsigned int active_window_id, color_type active_window_bg, unsigned int num_visible_windows, bool all_windows_have_same_bg) {
     // ensure all pixels are cleared to background color at least once in every buffer
     if (os_window->clear_count++ < 3) blank_os_window(os_window);
     Tab *tab = os_window->tabs + os_window->active_tab;
@@ -618,8 +618,7 @@ render_os_window(OSWindow *os_window, monotonic_t now, unsigned int active_windo
             bool is_active_window = i == tab->active_window;
             draw_cells(WD.vao_idx, WD.gvao_idx, WD.xstart, WD.ystart, WD.dx * x_ratio, WD.dy * y_ratio, WD.screen, os_window, is_active_window, true);
             if (WD.screen->start_visual_bell_at != 0) {
-                monotonic_t bell_left = OPT(visual_bell_duration) - (now - WD.screen->start_visual_bell_at);
-                set_maximum_wait(bell_left);
+                set_maximum_wait(OPT(repaint_delay));
             }
             w->cursor_visible_at_last_render = WD.screen->cursor_render_info.is_visible; w->last_cursor_x = WD.screen->cursor_render_info.x; w->last_cursor_y = WD.screen->cursor_render_info.y; w->last_cursor_shape = WD.screen->cursor_render_info.shape;
         }
@@ -704,7 +703,7 @@ render(monotonic_t now, bool input_read) {
         if (prepare_to_render_os_window(w, now, &active_window_id, &active_window_bg, &num_visible_windows, &all_windows_have_same_bg)) needs_render = true;
         if (w->last_active_window_id != active_window_id || w->last_active_tab != w->active_tab || w->focused_at_last_render != w->is_focused) needs_render = true;
         if (w->render_calls < 3 && w->bgimage && w->bgimage->texture_id) needs_render = true;
-        if (needs_render) render_os_window(w, now, active_window_id, active_window_bg, num_visible_windows, all_windows_have_same_bg);
+        if (needs_render) render_os_window(w, active_window_id, active_window_bg, num_visible_windows, all_windows_have_same_bg);
         if (w->is_focused) change_menubar_title(w->window_title);
     }
     last_render_at = now;

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -1328,19 +1328,19 @@ screen_invert_colors(Screen *self) {
     return inverted;
 }
 
-float
+static inline float
 ease_out_cubic(float phase) {
     return 1.0f - powf(1.0f - phase, 3.0f);
 }
 
-float
+static inline float
 ease_in_out_cubic(float phase) {
     return phase < 0.5f ?
         4.0f * powf(phase, 3.0f) :
         1.0f - powf(-2.0f * phase + 2.0f, 3.0f) / 2.0f;
 }
 
-float
+static inline float
 visual_bell_intensity(float phase) {
     float peak = 0.2f;
     float fade = 1.0f - peak;

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -1324,12 +1324,43 @@ screen_use_latin1(Screen *self, bool on) {
 bool
 screen_invert_colors(Screen *self) {
     bool inverted = false;
+    if (self->modes.mDECSCNM) inverted = true;
+    return inverted;
+}
+
+float
+ease_out_cubic(float phase) {
+    return 1.0f - powf(1.0f - phase, 3.0f);
+}
+
+float
+ease_in_out_cubic(float phase) {
+    return phase < 0.5f ?
+        4.0f * powf(phase, 3.0f) :
+        1.0f - powf(-2.0f * phase + 2.0f, 3.0f) / 2.0f;
+}
+
+float
+visual_bell_intensity(float phase) {
+    float peak = 0.2f;
+    float fade = 1.0f - peak;
+    if (phase < peak)
+        return ease_out_cubic(phase / peak);
+    else
+        return ease_in_out_cubic((1.0f - phase) / fade);
+}
+
+float
+screen_visual_bell_intensity(Screen *self) {
     if (self->start_visual_bell_at > 0) {
-        if (monotonic() - self->start_visual_bell_at <= OPT(visual_bell_duration)) inverted = true;
+        monotonic_t progress = monotonic() - self->start_visual_bell_at;
+        monotonic_t duration = OPT(visual_bell_duration);
+        if (progress <= duration) {
+            return visual_bell_intensity((float)progress / duration);
+        }
         else self->start_visual_bell_at = 0;
     }
-    if (self->modes.mDECSCNM) inverted = inverted ? false : true;
-    return inverted;
+    return 0.0f;
 }
 
 void

--- a/kitty/screen.h
+++ b/kitty/screen.h
@@ -194,6 +194,7 @@ void screen_apply_selection(Screen *self, void *address, size_t size);
 bool screen_is_selection_dirty(Screen *self);
 bool screen_has_selection(Screen*);
 bool screen_invert_colors(Screen *self);
+float screen_visual_bell_intensity(Screen *self);
 void screen_update_cell_data(Screen *self, void *address, FONTS_DATA_HANDLE, bool cursor_has_moved);
 bool screen_is_cursor_visible(Screen *self);
 bool screen_selection_range_for_line(Screen *self, index_type y, index_type *start, index_type *end);

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -458,6 +458,21 @@ draw_tint(bool premult, Screen *screen, GLfloat xstart, GLfloat ystart, GLfloat 
     glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 }
 
+void
+draw_visual_bell_flash(GLfloat intensity, GLfloat xstart, GLfloat ystart, GLfloat w, GLfloat h, Screen *screen) {
+    glEnable(GL_BLEND);
+    // BLEND_PREMULT
+    glBlendFuncSeparate(GL_ONE, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
+    bind_program(TINT_PROGRAM);
+    color_type flash = colorprofile_to_color(screen->color_profile, screen->color_profile->overridden.highlight_bg, screen->color_profile->configured.highlight_bg);
+#define C(shift) ((((GLfloat)((flash >> shift) & 0xFF)) / 255.0f) * intensity * 0.5f)
+    glUniform4f(tint_program_layout.tint_color_location, C(16), C(8), C(0), intensity * 0.5f);
+#undef C
+    glUniform4f(tint_program_layout.edges_location, xstart, ystart - h, xstart + w, ystart);
+    glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+    glDisable(GL_BLEND);
+}
+
 static void
 draw_cells_interleaved(ssize_t vao_idx, ssize_t gvao_idx, Screen *screen, OSWindow *w, GLfloat xstart, GLfloat ystart, GLfloat width, GLfloat height) {
     glEnable(GL_BLEND);
@@ -649,6 +664,11 @@ draw_cells(ssize_t vao_idx, ssize_t gvao_idx, GLfloat xstart, GLfloat ystart, GL
         if (screen->grman->num_of_negative_refs || screen->grman->num_of_below_refs || has_bgimage(os_window)) draw_cells_interleaved(
                 vao_idx, gvao_idx, screen, os_window, xstart, ystart, w, h);
         else draw_cells_simple(vao_idx, gvao_idx, screen);
+    }
+
+    float intensity = screen_visual_bell_intensity(screen);
+    if (intensity > 0.0f) {
+        draw_visual_bell_flash((GLfloat)intensity, xstart, ystart, w, h, screen);
     }
 }
 // }}}

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -250,9 +250,9 @@ send_graphics_data_to_gpu(size_t image_count, ssize_t gvao_idx, const ImageRende
 }
 
 static inline void
-cell_update_uniform_block(ssize_t vao_idx, Screen *screen, int uniform_buffer, GLfloat xstart, GLfloat ystart, GLfloat dx, GLfloat dy, CursorRenderInfo *cursor, bool inverted, GLfloat visual_bell_intensity, OSWindow *os_window) {
+cell_update_uniform_block(ssize_t vao_idx, Screen *screen, int uniform_buffer, GLfloat xstart, GLfloat ystart, GLfloat dx, GLfloat dy, CursorRenderInfo *cursor, bool inverted, OSWindow *os_window) {
     struct CellRenderData {
-        GLfloat xstart, ystart, dx, dy, sprite_dx, sprite_dy, background_opacity, cursor_text_uses_bg, visual_bell_intensity;
+        GLfloat xstart, ystart, dx, dy, sprite_dx, sprite_dy, background_opacity, cursor_text_uses_bg;
 
         GLuint default_fg, default_bg, highlight_fg, highlight_bg, cursor_color, cursor_text_color, url_color, url_style, inverted;
 
@@ -295,7 +295,6 @@ cell_update_uniform_block(ssize_t vao_idx, Screen *screen, int uniform_buffer, G
     rd->sprite_dx = 1.0f / (float)x; rd->sprite_dy = 1.0f / (float)y;
     rd->inverted = inverted ? 1 : 0;
     rd->background_opacity = os_window->is_semi_transparent ? os_window->background_opacity : 1.0f;
-    rd->visual_bell_intensity = visual_bell_intensity;
 
 #define COLOR(name) colorprofile_to_color(screen->color_profile, screen->color_profile->overridden.name, screen->color_profile->configured.name)
     rd->default_fg = COLOR(default_fg); rd->default_bg = COLOR(default_bg); rd->highlight_fg = COLOR(highlight_fg); rd->highlight_bg = COLOR(highlight_bg);
@@ -618,9 +617,8 @@ void
 draw_cells(ssize_t vao_idx, ssize_t gvao_idx, GLfloat xstart, GLfloat ystart, GLfloat dx, GLfloat dy, Screen *screen, OSWindow *os_window, bool is_active_window, bool can_be_focused) {
     CELL_BUFFERS;
     bool inverted = screen_invert_colors(screen);
-    GLfloat intensity = (GLfloat)screen_visual_bell_intensity(screen);
 
-    cell_update_uniform_block(vao_idx, screen, uniform_buffer, xstart, ystart, dx, dy, &screen->cursor_render_info, inverted, intensity, os_window);
+    cell_update_uniform_block(vao_idx, screen, uniform_buffer, xstart, ystart, dx, dy, &screen->cursor_render_info, inverted, os_window);
 
     bind_vao_uniform_buffer(vao_idx, uniform_buffer, cell_program_layouts[CELL_PROGRAM].render_data.index);
     bind_vertex_array(vao_idx);

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -464,9 +464,11 @@ draw_visual_bell_flash(GLfloat intensity, GLfloat xstart, GLfloat ystart, GLfloa
     // BLEND_PREMULT
     glBlendFuncSeparate(GL_ONE, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
     bind_program(TINT_PROGRAM);
+    // TODO config option worth?
+    GLfloat attenuation = 0.4f;
     color_type flash = colorprofile_to_color(screen->color_profile, screen->color_profile->overridden.highlight_bg, screen->color_profile->configured.highlight_bg);
-#define C(shift) ((((GLfloat)((flash >> shift) & 0xFF)) / 255.0f) * intensity * 0.5f)
-    glUniform4f(tint_program_layout.tint_color_location, C(16), C(8), C(0), intensity * 0.5f);
+#define C(shift) ((((GLfloat)((flash >> shift) & 0xFF)) / 255.0f) * intensity * attenuation)
+    glUniform4f(tint_program_layout.tint_color_location, C(16), C(8), C(0), intensity * attenuation);
 #undef C
     glUniform4f(tint_program_layout.edges_location, xstart, ystart - h, xstart + w, ystart);
     glDrawArrays(GL_TRIANGLE_FAN, 0, 4);

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -250,9 +250,9 @@ send_graphics_data_to_gpu(size_t image_count, ssize_t gvao_idx, const ImageRende
 }
 
 static inline void
-cell_update_uniform_block(ssize_t vao_idx, Screen *screen, int uniform_buffer, GLfloat xstart, GLfloat ystart, GLfloat dx, GLfloat dy, CursorRenderInfo *cursor, bool inverted, OSWindow *os_window) {
+cell_update_uniform_block(ssize_t vao_idx, Screen *screen, int uniform_buffer, GLfloat xstart, GLfloat ystart, GLfloat dx, GLfloat dy, CursorRenderInfo *cursor, bool inverted, GLfloat visual_bell_intensity, OSWindow *os_window) {
     struct CellRenderData {
-        GLfloat xstart, ystart, dx, dy, sprite_dx, sprite_dy, background_opacity, cursor_text_uses_bg;
+        GLfloat xstart, ystart, dx, dy, sprite_dx, sprite_dy, background_opacity, cursor_text_uses_bg, visual_bell_intensity;
 
         GLuint default_fg, default_bg, highlight_fg, highlight_bg, cursor_color, cursor_text_color, url_color, url_style, inverted;
 
@@ -295,6 +295,7 @@ cell_update_uniform_block(ssize_t vao_idx, Screen *screen, int uniform_buffer, G
     rd->sprite_dx = 1.0f / (float)x; rd->sprite_dy = 1.0f / (float)y;
     rd->inverted = inverted ? 1 : 0;
     rd->background_opacity = os_window->is_semi_transparent ? os_window->background_opacity : 1.0f;
+    rd->visual_bell_intensity = visual_bell_intensity;
 
 #define COLOR(name) colorprofile_to_color(screen->color_profile, screen->color_profile->overridden.name, screen->color_profile->configured.name)
     rd->default_fg = COLOR(default_fg); rd->default_bg = COLOR(default_bg); rd->highlight_fg = COLOR(highlight_fg); rd->highlight_bg = COLOR(highlight_bg);
@@ -617,8 +618,9 @@ void
 draw_cells(ssize_t vao_idx, ssize_t gvao_idx, GLfloat xstart, GLfloat ystart, GLfloat dx, GLfloat dy, Screen *screen, OSWindow *os_window, bool is_active_window, bool can_be_focused) {
     CELL_BUFFERS;
     bool inverted = screen_invert_colors(screen);
+    GLfloat intensity = (GLfloat)screen_visual_bell_intensity(screen);
 
-    cell_update_uniform_block(vao_idx, screen, uniform_buffer, xstart, ystart, dx, dy, &screen->cursor_render_info, inverted, os_window);
+    cell_update_uniform_block(vao_idx, screen, uniform_buffer, xstart, ystart, dx, dy, &screen->cursor_render_info, inverted, intensity, os_window);
 
     bind_vao_uniform_buffer(vao_idx, uniform_buffer, cell_program_layouts[CELL_PROGRAM].render_data.index);
     bind_vertex_array(vao_idx);


### PR DESCRIPTION
Right now visual bell makes background flash sharply with bright white (when configured with darkish color theme). This causes eye strain, especially prominent in unlit environments.

This change makes background bounce smoothly between regular bg color and highlight (selection) bg color for the configured visual bell duration. Intensity is animated with cubic easing functions. It currently peaks at 20% of the duration, this is hardcoded.

---

Overall I acknowledge this change as quick and somewhat dirty starting point. For example I chose not to introduce any new configuration options yet. I'm wholly open to your suggestions on how to improve it.