### PR TITLE
tabs.py::move_window_to_top fix

### DIFF
--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -440,9 +440,9 @@ class Tab:  # {{{
                     self.relayout()
 
     def move_window_to_top(self) -> None:
-        n = self.windows.num_groups
-        if n > 1:
-            self.move_window(1 - n)
+        n = self.windows._active_group_idx
+        if n > 0:
+            self.move_window(-n)
 
     def move_window_forward(self) -> None:
         self.move_window()


### PR DESCRIPTION
Proposed fix to make move_window_to_top keyboard shortcut work.