### PR TITLE
GLFW: Fix typo in GLFWwindowmaximizefun documentation

### DIFF
--- a/glfw/glfw3.h
+++ b/glfw/glfw3.h
@@ -1502,7 +1502,7 @@ typedef void (* GLFWwindowiconifyfun)(GLFWwindow*,int);
  *  @endcode
  *
  *  @param[in] window The window that was maximized or restored.
- *  @param[in] iconified `true` if the window was maximized, or
+ *  @param[in] maximized `true` if the window was maximized, or
  *  `false` if it was restored.
  *
  *  @sa @ref window_maximize

--- a/kitty/glfw-wrapper.h
+++ b/kitty/glfw-wrapper.h
@@ -1240,7 +1240,7 @@ typedef void (* GLFWwindowiconifyfun)(GLFWwindow*,int);
  *  @endcode
  *
  *  @param[in] window The window that was maximized or restored.
- *  @param[in] iconified `true` if the window was maximized, or
+ *  @param[in] maximized `true` if the window was maximized, or
  *  `false` if it was restored.
  *
  *  @sa @ref window_maximize


### PR DESCRIPTION
From upstream: https://github.com/glfw/glfw/commit/1ed1489831e32337c13fbcbac2c2562ac4163bd3.