### PR TITLE
Remove unnecessary condition

### DIFF
--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -536,7 +536,7 @@ cleanup() {
 
     if (dockMenu) [dockMenu release];
     dockMenu = nil;
-    if (notification_activated_callback) Py_CLEAR(notification_activated_callback);
+    Py_CLEAR(notification_activated_callback);
     drain_pending_notifications(NO);
     free(notification_queue.notifications);
     notification_queue.notifications = NULL;


### PR DESCRIPTION
According to the python documentation, `Py_CLEAR()` has no effect when the argument is `NULL`, see https://docs.python.org/3/c-api/refcounting.html#c.Py_CLEAR.

In case you were planning to release a new version in the next couple days, could you please wait til this weekend, when I will have made all the PRs that I would like to include in the next version?