### PR TITLE
macOS: add ability to show subtitles in notifications

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1569,7 +1569,7 @@ class Boss:
         from .notify import notify
         now = monotonic()
         ident = f'test-notify-{now}'
-        notify(f'Test {now}', f'At: {now}', identifier=ident)
+        notify(f'Test {now}', f'At: {now}', identifier=ident, subtitle=f'Test subtitle {now}')
 
     def notification_activated(self, identifier: str, window_id: int, focus: bool, report: bool) -> None:
         w = self.window_id_map.get(window_id)

--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -520,6 +520,7 @@ def cocoa_send_notification(
     identifier: Optional[str],
     title: str,
     body: Optional[str],
+    subtitle: Optional[str],
 ) -> None:
     pass
 

--- a/kitty/notify.py
+++ b/kitty/notify.py
@@ -20,9 +20,10 @@ if is_macos:
         timeout: int = 5000,
         application: str = 'kitty',
         icon: bool = True,
-        identifier: Optional[str] = None
+        identifier: Optional[str] = None,
+        subtitle: Optional[str] = None,
     ) -> None:
-        cocoa_send_notification(identifier, title, body)
+        cocoa_send_notification(identifier, title, body, subtitle)
 
 else:
 
@@ -48,7 +49,8 @@ else:
         timeout: int = -1,
         application: str = 'kitty',
         icon: bool = True,
-        identifier: Optional[str] = None
+        identifier: Optional[str] = None,
+        subtitle: Optional[str] = None,
     ) -> None:
         icf = ''
         if icon is True:


### PR DESCRIPTION
This used to be implemented before 4e3c6e52aad41b9deb98d052c806f4a84846b782, when the now deprecated notifications framework was still being used.
Implement it again for feature parity, since my next PR will re-add the old notifications framework.

Note that I don't know how to actually test this, since it apparently requires signing and notarization, which I can't do.
Since this isn't actually used anywhere yet, do you think we should just leave this feature out?
Also, should I implement it in `kitty/notify.py` and in `send_test_notification()` as well?
How do you call `send_test_notification()` when testing? Which command do you use?