### PR TITLE
macOS: re-add deprecated notification API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -213,7 +213,8 @@ def get_sanitize_args(cc: str, ccver: Tuple[int, int]) -> List[str]:
 
 def test_compile(cc: str, *cflags: str, src: Optional[str] = None) -> bool:
     src = src or 'int main(void) { return 0; }'
-    p = subprocess.Popen([cc] + list(cflags) + ['-x', 'c', '-o', os.devnull, '-'], stdin=subprocess.PIPE)
+    p = subprocess.Popen([cc] + list(cflags) + ['-x', 'c', '-o', os.devnull, '-'],
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, stdin=subprocess.PIPE)
     stdin = p.stdin
     assert stdin is not None
     try:
@@ -336,8 +337,12 @@ def kitty_env() -> Env:
     if is_macos:
         platform_libs = [
             '-framework', 'CoreText', '-framework', 'CoreGraphics',
-            '-framework', 'UserNotifications'
         ]
+        user_notifications_framework = first_successful_compile(ans.cc, '-framework UserNotifications')
+        if user_notifications_framework != '':
+            platform_libs.extend(shlex.split(user_notifications_framework))
+        else:
+            cppflags.append('-DKITTY_USE_DEPRECATED_MACOS_NOTIFICATION_API')
         # Apple deprecated OpenGL in Mojave (10.14) silence the endless
         # warnings about it
         cppflags.append('-DGL_SILENCE_DEPRECATION')


### PR DESCRIPTION
Please don't merge this yet.

This PR adds the deprecated macOS notification API again, so that notifications work when compiling from source without code signing. It was removed in 4e3c6e52aad41b9deb98d052c806f4a84846b782.

What did you mean by "compile time version detection" in https://github.com/kovidgoyal/kitty/pull/2876#issuecomment-697109685? Simply check if the macOS version is 10.15 (Catalina) or lower and then use the old API? But I think it would be useful to be able to use this API as long as it's still only deprecated and not removed. Do you have an idea, how this could be done best?