### PR TITLE
Better build system output when stdout is not a tty

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -485,8 +485,10 @@ def parallel_run(items: List[Command]) -> None:
             num += 1
             if verbose:
                 print(' '.join(compile_cmd.cmd))
-            else:
+            elif sys.stdout.isatty():
                 print('\r\x1b[K[{}/{}] {}'.format(num, total, compile_cmd.desc), end='')
+            else:
+                print('[{}/{}] {}'.format(num, total, compile_cmd.desc), flush=True)
             printed = True
             w = subprocess.Popen(compile_cmd.cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
             workers[w.pid] = compile_cmd, w


### PR DESCRIPTION
When piping the output of `setup.py` to another program, that program cannot usually deal with escape sequences well. To fix this, output the compilation progress on new lines instead of overwriting the current line.