### PR TITLE
Use pip3 instead of pip for CI

### DIFF
--- a/.github/workflows/ci.py
+++ b/.github/workflows/ci.py
@@ -40,7 +40,7 @@ def install_deps():
     if is_bundle:
         install_bundle()
     else:
-        run('pip install Pillow pygments')
+        run('pip3 install Pillow pygments')
 
 
 def build_kitty():


### PR DESCRIPTION
There was a warning when the CI executed the "macOS Brew" job:
```
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
```
To fix this, use pip3 instead of pip.