### PR TITLE
Fix repeated version notifications

### DIFF
--- a/kitty/update_check.py
+++ b/kitty/update_check.py
@@ -90,7 +90,9 @@ def save_notification(version: Version) -> None:
     for version in sorted(notified_versions):
         n = notified_versions[version]
         lines.append('{},{},{}'.format(
-            '.'.join(map(str, n.version)), n.time_of_last_notification, n.count))
+            '.'.join(map(str, n.version)),
+            n.time_of_last_notification,
+            n.notification_count))
     atomic_save('\n'.join(lines).encode('utf-8'), version_notification_log())
 
 


### PR DESCRIPTION
Without this fix the file with the list of notifications looks like this:
```
0.19.0,1601899026.4373078,<built-in method count of Notification object at 0x7f8c582193b0>
```
which ends up notifying about a new version all the time.