### PR TITLE
Remove outdated Python version check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1176,8 +1176,6 @@ def option_parser() -> argparse.ArgumentParser:  # {{{
 
 def main() -> None:
     global verbose
-    if sys.version_info < (3, 5):
-        raise SystemExit('python >= 3.5 required')
     args = option_parser().parse_args(namespace=Options())
     verbose = args.verbose > 0
     args.prefix = os.path.abspath(args.prefix)


### PR DESCRIPTION
The Python version is already checked at the top of the file. That check was added in 81a58186c6fae2de7bb4d7c7a3dc1a418d2b3d03.