### PR TITLE
Fix wrong kittenname in documentation

### DIFF
--- a/docs/kittens/hyperlinked_grep.rst
+++ b/docs/kittens/hyperlinked_grep.rst
@@ -34,7 +34,7 @@ you use some editor other than vim, you should adjust the
 
 Finally, add an alias to your shell's rc files to invoke the kitten as ``hg``::
 
-    alias hg='kitty +kitten hyperlink_grep'
+    alias hg='kitty +kitten hyperlinked_grep'
 
 
 You can now run searches with::


### PR DESCRIPTION
It's called `hyperlinked_grep` not `hyperlink_grep`.