### PR TITLE
Kitten hints: Add new IP (matches v4 and v6) type

### DIFF
--- a/kittens/hints/main.py
+++ b/kittens/hints/main.py
@@ -325,6 +325,14 @@ def functions_for(args: HintsCLIOptions) -> Tuple[str, List[PostprocessorFunc]]:
         pattern = '(?m)^\\s*(.+)[\\s\0]*$'
     elif args.type == 'hash':
         pattern = '[0-9a-f]{7,128}'
+    elif args.type == 'ip':
+        pattern = (
+            # # IPv4 with no validation
+            r"((?:\d{1,3}\.){3}\d{1,3}"
+            r"|"
+            # # IPv6 with no validation
+            r"(?:[a-fA-F0-9]{0,4}:){2,7}[a-fA-F0-9]{1,4})"
+        )
     elif args.type == 'word':
         chars = args.word_characters
         if chars is None:
@@ -482,7 +490,7 @@ programs.
 
 --type
 default=url
-choices=url,regex,path,line,hash,word,linenum,hyperlink
+choices=url,regex,path,line,hash,word,linenum,hyperlink,ip
 The type of text to search for. A value of :code:`linenum` is special, it looks
 for error messages using the pattern specified with :option:`--regex`, which
 must have the named groups, :code:`path` and :code:`line`. If not specified,

--- a/kitty_tests/hints.py
+++ b/kitty_tests/hints.py
@@ -48,8 +48,9 @@ class TestHints(BaseTest):
             ('2001:DB8::FF00:42:8329', ['2001:DB8::FF00:42:8329']),
             ('0000:0000:0000:0000:0000:0000:0000:0001', ['0000:0000:0000:0000:0000:0000:0000:0001']),
             ('::1', ['::1']),
-            # The regex doesn't check for validity
-            ('255.255.255.256', ['255.255.255.256']),
+            # Invalid IPs won't match
+            ('255.255.255.256', []),
+            (':1', []),
         )
 
         for testcase, expected in testcases:

--- a/kitty_tests/hints.py
+++ b/kitty_tests/hints.py
@@ -30,3 +30,30 @@ class TestHints(BaseTest):
         t('link:{}[xxx]'.format(u), u)
         t('`xyz <{}>`_.'.format(u), u)
         t('<a href="{}">moo'.format(u), u)
+
+    def test_ip_hints(self):
+        from kittens.hints.main import parse_hints_args, functions_for, mark, convert_text
+        args = parse_hints_args(['--type', 'ip'])[0]
+        pattern, post_processors = functions_for(args)
+
+        def create_marks(text, cols=60):
+            text = convert_text(text, cols)
+            return tuple(mark(pattern, post_processors, text, args))
+
+        testcases = (
+            ('100.64.0.0', ['100.64.0.0']),
+            ('2001:0db8:0000:0000:0000:ff00:0042:8329', ['2001:0db8:0000:0000:0000:ff00:0042:8329']),
+            ('2001:db8:0:0:0:ff00:42:8329', ['2001:db8:0:0:0:ff00:42:8329']),
+            ('2001:db8::ff00:42:8329', ['2001:db8::ff00:42:8329']),
+            ('2001:DB8::FF00:42:8329', ['2001:DB8::FF00:42:8329']),
+            ('0000:0000:0000:0000:0000:0000:0000:0001', ['0000:0000:0000:0000:0000:0000:0000:0001']),
+            ('::1', ['::1']),
+            # The regex doesn't check for validity
+            ('255.255.255.256', ['255.255.255.256']),
+        )
+
+        for testcase, expected in testcases:
+            with self.subTest(testcase=testcase, expected=expected):
+                marks = create_marks(testcase)
+                ips = [m.text for m in marks]
+                self.ae(ips, expected)


### PR DESCRIPTION
This PR adds a new type for the hints kitten: IP.

This type matches both v4 and v6 IPs. Subnet mask notation (`ip/32`) is not supported, but could easily be added.

This PR contains two commits:

The first commit adds a very simple regex to match IPv4/IPv6 **with no validation** and tests that cover matching valid and invalid IPs.

The second commit adds validation by adding a postprocessor for the `ip` type, and a new exception called `InvalidMatch`, which can be raised by the postprocessor to ignore a given match. This postprocessor for `ip` makes use of the Python standard library's `ipaddress` module to validate the matched IPs. This commit also improves the previous test by adding a few testcases of invalid matches being ignored.

The bodies of the commit contain this information as well, but as for the reasoning behind doing the validation in Python: Validating IPs with regex (especially IPv6 with its multiple notations) is hard. There are some regex patterns you can find online for matching IPv6 and all its different notations, but they all have a thing in common: they're very long (the smallest I found was well over 400 characters), and complex.

For this PR, I decided on readability/simplicity, and using existing and tested Python code (`ipaddress`) over some complex regex to do the validation as well.

That being said, since the commits are separated, if you don't agree with this approach (or allowing postprocessors to "ignore" a match by raising `InvalidMatch`), it can simply be dropped, and just re-use the first commit which only adds the simply regex pattern (which can be replaced by the more complex ones that also perform validation) and a testcase for this new hints type.

---

As an aside, if you end up merging this, I would appreciate it if you add the `hacktoberfest-accepted` label to the PR (following [new restrictions to this year's Hacktoberfest](https://hacktoberfest.digitalocean.com/hacktoberfest-update)) so this PR counts towards that, but it's fine if you don't :+1: 