### PR TITLE
Fix upwards selection not being cleared when lines change

### DIFF
--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -373,8 +373,10 @@ selection_has_screen_line(const Selections *selections, const int y) {
     for (size_t i = 0; i < selections->count; i++) {
         const Selection *s = selections->items + i;
         if (!is_selection_empty(s)) {
-            int top = (int)s->start.y - s->start_scrolled_by;
-            int bottom = (int)s->end.y - s->end_scrolled_by;
+            int start = (int)s->start.y - s->start_scrolled_by;
+            int end = (int)s->end.y - s->end_scrolled_by;
+            int top = MIN(start, end);
+            int bottom = MAX(start, end);
             if (top <= y && y <= bottom) return true;
         }
     }


### PR DESCRIPTION
When selecting text by dragging upwards, the "end" of the selection is above the "start". This causes the `selection_has_screen_line()` to never return `true` in this case.
In practice this bug causes the selection to not be cleared when the screen contents under the selection change if it was made by dragging upwards.

Please double-check that `s->start_scrolled_by` and `s->end_scrolled_by` don't need to be subtracted from `top` and `bottom` instead as I'm not sure.