### PR TITLE
Fix double free and memory leak

### DIFF
--- a/kitty/macos_process_info.c
+++ b/kitty/macos_process_info.c
@@ -248,7 +248,7 @@ error:
     if (procargs != NULL)
         free(procargs);
     if (procenv != NULL)
-        free(procargs);
+        free(procenv);
     return NULL;
 }
 


### PR DESCRIPTION
Found with the Clang Static Analyzer.
This is a copy & paste error. This bug was introduced in 72e2307c16e777e24d35e7c6c72788f5e2f26850 in Jul 2018.