### PR TITLE
macOS: Fix detection for notification API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -343,7 +343,10 @@ def kitty_env() -> Env:
         platform_libs = [
             '-framework', 'CoreText', '-framework', 'CoreGraphics',
         ]
-        user_notifications_framework = first_successful_compile(ans.cc, '-framework UserNotifications')
+        test_program_src = '''#include <UserNotifications/UserNotifications.h>
+        int main(void) { return 0; }\n'''
+        user_notifications_framework = first_successful_compile(ans.cc, ' -framework UserNotifications',
+                                                                src=test_program_src, lang='objective-c')
         if user_notifications_framework:
             platform_libs.extend(shlex.split(user_notifications_framework))
         else:


### PR DESCRIPTION
For some reason it can happen that the `UserNotifications` framework exists but the `UserNotifications/UserNotifications.h` header doesn't.
The temporary directory is needed because clang would try to write to `/dev/null.d`, which would obviously fail.
Closes #3042.