### PR TITLE
Fix Clang Static Analyzer complaining about Apple coding conventions

### DIFF
--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -307,17 +307,17 @@ cocoa_send_notification(PyObject *self UNUSED, PyObject *args) {
 
 @implementation ServiceProvider
 
-- (void)openTab:(NSPasteboard*)pasteboard
+- (BOOL)openTab:(NSPasteboard*)pasteboard
         userData:(NSString *) UNUSED userData error:(NSError **) UNUSED error {
-    [self openFilesFromPasteboard:pasteboard type:NEW_TAB_WITH_WD];
+    return [self openFilesFromPasteboard:pasteboard type:NEW_TAB_WITH_WD];
 }
 
-- (void)openOSWindow:(NSPasteboard*)pasteboard
+- (BOOL)openOSWindow:(NSPasteboard*)pasteboard
         userData:(NSString *) UNUSED userData  error:(NSError **) UNUSED error {
-    [self openFilesFromPasteboard:pasteboard type:NEW_OS_WINDOW_WITH_WD];
+    return [self openFilesFromPasteboard:pasteboard type:NEW_OS_WINDOW_WITH_WD];
 }
 
-- (void)openFilesFromPasteboard:(NSPasteboard *)pasteboard type:(int)type {
+- (BOOL)openFilesFromPasteboard:(NSPasteboard *)pasteboard type:(int)type {
     NSDictionary *options = @{ NSPasteboardURLReadingFileURLsOnlyKey: @YES };
     NSArray *filePathArray = [pasteboard readObjectsForClasses:[NSArray arrayWithObject:[NSURL class]] options:options];
     for (NSURL *url in filePathArray) {
@@ -330,6 +330,7 @@ cocoa_send_notification(PyObject *self UNUSED, PyObject *args) {
             set_cocoa_pending_action(type, [path UTF8String]);
         }
     }
+    return YES;
 }
 
 @end


### PR DESCRIPTION
The error message was: "Method accepting NSError** should have a non-void return value to indicate whether or not an error occurred".