### PR TITLE
Add shell.nix

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -78,6 +78,17 @@ you might have to rebuild the app.
    a self signed certificate, see for example, `here
    <https://stackoverflow.com/questions/27474751/how-can-i-codesign-an-app-without-being-in-the-mac-developer-program/27474942>`_.
 
+Build and run from source with Nix
+-------------------------------------------
+
+On NixOS or any other Linux or macOS system with the Nix package manager installed,
+execute ``nix-shell`` to create the correct environment to build kitty or use
+``nix-shell --pure`` instead to eliminate most of the influence of the outside system,
+e.g. globally installed packages. ``nix-shell`` will automatically fetch all required
+dependencies and make them available in the newly spawned shell.
+
+Then proceed with ``make`` or ``make app`` according to the platform specific instructions above.
+
 
 Note for Linux/macOS packagers
 ----------------------------------

--- a/setup.py
+++ b/setup.py
@@ -63,11 +63,11 @@ class Options(argparse.Namespace):
     for_freeze: bool = False
     libdir_name: str = 'lib'
     extra_logging: List[str] = []
-    link_time_optimization: bool = True
+    link_time_optimization: bool = 'KITTY_NO_LTO' not in os.environ
     update_check_interval: float = 24
-    egl_library: Optional[str] = None
-    startup_notification_library: Optional[str] = None
-    canberra_library: Optional[str] = None
+    egl_library: Optional[str] = os.getenv('KITTY_EGL_LIBRARY')
+    startup_notification_library: Optional[str] = os.getenv('KITTY_STARTUP_NOTIFICATION_LIBRARY')
+    canberra_library: Optional[str] = os.getenv('KITTY_CANBERRA_LIBRARY')
 
 
 class CompileKey(NamedTuple):

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,55 @@
+{ pkgs ? import <nixpkgs> { } }:
+with pkgs;
+
+let
+  inherit (lib) optional optionals;
+  inherit (xorg) libX11 libXrandr libXinerama libXcursor libXi libXext;
+  inherit (darwin.apple_sdk.frameworks) Cocoa CoreGraphics Foundation IOKit Kernel OpenGL;
+  harfbuzzWithCoreText = harfbuzz.override { withCoreText = stdenv.isDarwin; };
+in
+mkShell rec {
+  buildInputs = [
+    harfbuzzWithCoreText
+    ncurses
+    lcms2
+  ] ++ optionals stdenv.isDarwin [
+    Cocoa
+    CoreGraphics
+    Foundation
+    IOKit
+    Kernel
+    OpenGL
+    libpng
+    python3
+    zlib
+  ] ++ optionals stdenv.isLinux [
+    fontconfig libunistring libcanberra libX11
+    libXrandr libXinerama libXcursor libxkbcommon libXi libXext
+    wayland-protocols wayland dbus
+  ] ++ checkInputs;
+
+  nativeBuildInputs = [
+    pkgconfig python3Packages.sphinx ncurses
+  ] ++ optionals stdenv.isDarwin [
+    imagemagick
+    libicns  # For the png2icns tool.
+    installShellFiles
+  ];
+
+  propagatedBuildInputs = optional stdenv.isLinux libGL;
+
+  checkInputs = [
+    python3Packages.pillow
+  ];
+
+  # Causes build failure due to warning when using Clang
+  hardeningDisable = [ "strictoverflow" ];
+
+  shellHook = if stdenv.isDarwin then ''
+    export KITTY_NO_LTO=
+  '' else ''
+    export KITTY_EGL_LIBRARY='${stdenv.lib.getLib libGL}/lib/libEGL.so.1'
+    export KITTY_STARTUP_NOTIFICATION_LIBRARY='${libstartup_notification}/lib/libstartup-notification-1.so'
+    export KITTY_CANBERRA_LIBRARY='${libcanberra}/lib/libcanberra.so'
+  '';
+}


### PR DESCRIPTION
This makes it possible to execute `nix-shell` to create the correct environment to build kitty. Use `nix-shell --pure` to eliminate most of the influence of the outside system, e.g. globally installed packages.
This works on NixOS and any Linux or macOS system with the Nix package manager installed.
The build inputs are split into `buildInputs`, `nativeBuildInputs`, `propagatedBuildInputs` and `checkInputs` so it closely resembles https://github.com/NixOS/nixpkgs/blob/2bb3a9da24ca60d9f5bed69f679a1ec50dbdf997/pkgs/applications/terminal-emulators/kitty/default.nix. This makes it easy to port changes between the two files.

I tested that it works correctly with NixOS (both X11 and Wayland), Arch Linux with Nix installed (just X11) and macOS of course.
I first created this file a couple months back. It has been the main way I develop kitty on my machine for the past couple weeks but it's been a little annoying since I had to checkout this branch, then do `nix-shell` and then switch back to whatever I wanted to work on.
I think this will also be very useful for other contributors using Nix.
I hope you don't mind the extra file in the root directory of kitty.