### PR TITLE
GLFW: X11: Make libX11 dynamically loaded

### DIFF
--- a/glfw/glfw.py
+++ b/glfw/glfw.py
@@ -79,7 +79,7 @@ def init_env(env: Env, pkg_config: Callable, at_least_version: Callable, test_co
         at_least_version('xkbcommon', 0, 5)
 
     if module == 'x11':
-        for dep in 'x11 xrandr xinerama xcursor xkbcommon xkbcommon-x11 x11-xcb dbus-1'.split():
+        for dep in 'xrandr xinerama xcursor xkbcommon xkbcommon-x11 x11-xcb dbus-1'.split():
             ans.cflags.extend(pkg_config(dep, '--cflags-only-I'))
             ans.ldpaths.extend(pkg_config(dep, '--libs'))
 

--- a/glfw/x11_init.c
+++ b/glfw/x11_init.c
@@ -31,8 +31,6 @@
 #include "internal.h"
 #include "backend_utils.h"
 
-#include <X11/Xresource.h>
-
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
@@ -612,6 +610,114 @@ Cursor _glfwCreateCursorX11(const GLFWimage* image, int xhot, int yhot)
 
 int _glfwPlatformInit(void)
 {
+#if defined(__CYGWIN__)
+    _glfw.x11.xlib.handle = _glfw_dlopen("libX11-6.so");
+#else
+    _glfw.x11.xlib.handle = _glfw_dlopen("libX11.so.6");
+#endif
+    if (!_glfw.x11.xlib.handle)
+    {
+        _glfwInputError(GLFW_PLATFORM_ERROR, "X11: Failed to load Xlib");
+        return false;
+    }
+
+    glfw_dlsym(_glfw.x11.xlib.AllocClassHint, _glfw.x11.xlib.handle, "XAllocClassHint");
+    glfw_dlsym(_glfw.x11.xlib.AllocSizeHints, _glfw.x11.xlib.handle, "XAllocSizeHints");
+    glfw_dlsym(_glfw.x11.xlib.AllocWMHints, _glfw.x11.xlib.handle, "XAllocWMHints");
+    glfw_dlsym(_glfw.x11.xlib.ChangeProperty, _glfw.x11.xlib.handle, "XChangeProperty");
+    glfw_dlsym(_glfw.x11.xlib.ChangeWindowAttributes, _glfw.x11.xlib.handle, "XChangeWindowAttributes");
+    glfw_dlsym(_glfw.x11.xlib.CheckIfEvent, _glfw.x11.xlib.handle, "XCheckIfEvent");
+    glfw_dlsym(_glfw.x11.xlib.CheckTypedWindowEvent, _glfw.x11.xlib.handle, "XCheckTypedWindowEvent");
+    glfw_dlsym(_glfw.x11.xlib.CloseDisplay, _glfw.x11.xlib.handle, "XCloseDisplay");
+    glfw_dlsym(_glfw.x11.xlib.CloseIM, _glfw.x11.xlib.handle, "XCloseIM");
+    glfw_dlsym(_glfw.x11.xlib.ConvertSelection, _glfw.x11.xlib.handle, "XConvertSelection");
+    glfw_dlsym(_glfw.x11.xlib.CreateColormap, _glfw.x11.xlib.handle, "XCreateColormap");
+    glfw_dlsym(_glfw.x11.xlib.CreateFontCursor, _glfw.x11.xlib.handle, "XCreateFontCursor");
+    glfw_dlsym(_glfw.x11.xlib.CreateIC, _glfw.x11.xlib.handle, "XCreateIC");
+    glfw_dlsym(_glfw.x11.xlib.CreateWindow, _glfw.x11.xlib.handle, "XCreateWindow");
+    glfw_dlsym(_glfw.x11.xlib.DefineCursor, _glfw.x11.xlib.handle, "XDefineCursor");
+    glfw_dlsym(_glfw.x11.xlib.DeleteContext, _glfw.x11.xlib.handle, "XDeleteContext");
+    glfw_dlsym(_glfw.x11.xlib.DeleteProperty, _glfw.x11.xlib.handle, "XDeleteProperty");
+    glfw_dlsym(_glfw.x11.xlib.DestroyIC, _glfw.x11.xlib.handle, "XDestroyIC");
+    glfw_dlsym(_glfw.x11.xlib.DestroyWindow, _glfw.x11.xlib.handle, "XDestroyWindow");
+    glfw_dlsym(_glfw.x11.xlib.EventsQueued, _glfw.x11.xlib.handle, "XEventsQueued");
+    glfw_dlsym(_glfw.x11.xlib.FilterEvent, _glfw.x11.xlib.handle, "XFilterEvent");
+    glfw_dlsym(_glfw.x11.xlib.FindContext, _glfw.x11.xlib.handle, "XFindContext");
+    glfw_dlsym(_glfw.x11.xlib.Flush, _glfw.x11.xlib.handle, "XFlush");
+    glfw_dlsym(_glfw.x11.xlib.Free, _glfw.x11.xlib.handle, "XFree");
+    glfw_dlsym(_glfw.x11.xlib.FreeColormap, _glfw.x11.xlib.handle, "XFreeColormap");
+    glfw_dlsym(_glfw.x11.xlib.FreeCursor, _glfw.x11.xlib.handle, "XFreeCursor");
+    glfw_dlsym(_glfw.x11.xlib.FreeEventData, _glfw.x11.xlib.handle, "XFreeEventData");
+    glfw_dlsym(_glfw.x11.xlib.GetErrorText, _glfw.x11.xlib.handle, "XGetErrorText");
+    glfw_dlsym(_glfw.x11.xlib.GetEventData, _glfw.x11.xlib.handle, "XGetEventData");
+    glfw_dlsym(_glfw.x11.xlib.GetICValues, _glfw.x11.xlib.handle, "XGetICValues");
+    glfw_dlsym(_glfw.x11.xlib.GetIMValues, _glfw.x11.xlib.handle, "XGetIMValues");
+    glfw_dlsym(_glfw.x11.xlib.GetInputFocus, _glfw.x11.xlib.handle, "XGetInputFocus");
+    glfw_dlsym(_glfw.x11.xlib.GetKeyboardMapping, _glfw.x11.xlib.handle, "XGetKeyboardMapping");
+    glfw_dlsym(_glfw.x11.xlib.GetScreenSaver, _glfw.x11.xlib.handle, "XGetScreenSaver");
+    glfw_dlsym(_glfw.x11.xlib.GetSelectionOwner, _glfw.x11.xlib.handle, "XGetSelectionOwner");
+    glfw_dlsym(_glfw.x11.xlib.GetVisualInfo, _glfw.x11.xlib.handle, "XGetVisualInfo");
+    glfw_dlsym(_glfw.x11.xlib.GetWMNormalHints, _glfw.x11.xlib.handle, "XGetWMNormalHints");
+    glfw_dlsym(_glfw.x11.xlib.GetWindowAttributes, _glfw.x11.xlib.handle, "XGetWindowAttributes");
+    glfw_dlsym(_glfw.x11.xlib.GetWindowProperty, _glfw.x11.xlib.handle, "XGetWindowProperty");
+    glfw_dlsym(_glfw.x11.xlib.GrabPointer, _glfw.x11.xlib.handle, "XGrabPointer");
+    glfw_dlsym(_glfw.x11.xlib.IconifyWindow, _glfw.x11.xlib.handle, "XIconifyWindow");
+    glfw_dlsym(_glfw.x11.xlib.InitThreads, _glfw.x11.xlib.handle, "XInitThreads");
+    glfw_dlsym(_glfw.x11.xlib.InternAtom, _glfw.x11.xlib.handle, "XInternAtom");
+    glfw_dlsym(_glfw.x11.xlib.LookupString, _glfw.x11.xlib.handle, "XLookupString");
+    glfw_dlsym(_glfw.x11.xlib.MapRaised, _glfw.x11.xlib.handle, "XMapRaised");
+    glfw_dlsym(_glfw.x11.xlib.MapWindow, _glfw.x11.xlib.handle, "XMapWindow");
+    glfw_dlsym(_glfw.x11.xlib.MoveResizeWindow, _glfw.x11.xlib.handle, "XMoveResizeWindow");
+    glfw_dlsym(_glfw.x11.xlib.MoveWindow, _glfw.x11.xlib.handle, "XMoveWindow");
+    glfw_dlsym(_glfw.x11.xlib.NextEvent, _glfw.x11.xlib.handle, "XNextEvent");
+    glfw_dlsym(_glfw.x11.xlib.OpenDisplay, _glfw.x11.xlib.handle, "XOpenDisplay");
+    glfw_dlsym(_glfw.x11.xlib.OpenIM, _glfw.x11.xlib.handle, "XOpenIM");
+    glfw_dlsym(_glfw.x11.xlib.PeekEvent, _glfw.x11.xlib.handle, "XPeekEvent");
+    glfw_dlsym(_glfw.x11.xlib.Pending, _glfw.x11.xlib.handle, "XPending");
+    glfw_dlsym(_glfw.x11.xlib.QueryExtension, _glfw.x11.xlib.handle, "XQueryExtension");
+    glfw_dlsym(_glfw.x11.xlib.QueryPointer, _glfw.x11.xlib.handle, "XQueryPointer");
+    glfw_dlsym(_glfw.x11.xlib.RaiseWindow, _glfw.x11.xlib.handle, "XRaiseWindow");
+    glfw_dlsym(_glfw.x11.xlib.ResizeWindow, _glfw.x11.xlib.handle, "XResizeWindow");
+    glfw_dlsym(_glfw.x11.xlib.ResourceManagerString, _glfw.x11.xlib.handle, "XResourceManagerString");
+    glfw_dlsym(_glfw.x11.xlib.SaveContext, _glfw.x11.xlib.handle, "XSaveContext");
+    glfw_dlsym(_glfw.x11.xlib.SelectInput, _glfw.x11.xlib.handle, "XSelectInput");
+    glfw_dlsym(_glfw.x11.xlib.SendEvent, _glfw.x11.xlib.handle, "XSendEvent");
+    glfw_dlsym(_glfw.x11.xlib.SetClassHint, _glfw.x11.xlib.handle, "XSetClassHint");
+    glfw_dlsym(_glfw.x11.xlib.SetErrorHandler, _glfw.x11.xlib.handle, "XSetErrorHandler");
+    glfw_dlsym(_glfw.x11.xlib.SetICFocus, _glfw.x11.xlib.handle, "XSetICFocus");
+    glfw_dlsym(_glfw.x11.xlib.SetInputFocus, _glfw.x11.xlib.handle, "XSetInputFocus");
+    glfw_dlsym(_glfw.x11.xlib.SetLocaleModifiers, _glfw.x11.xlib.handle, "XSetLocaleModifiers");
+    glfw_dlsym(_glfw.x11.xlib.SetScreenSaver, _glfw.x11.xlib.handle, "XSetScreenSaver");
+    glfw_dlsym(_glfw.x11.xlib.SetSelectionOwner, _glfw.x11.xlib.handle, "XSetSelectionOwner");
+    glfw_dlsym(_glfw.x11.xlib.SetWMHints, _glfw.x11.xlib.handle, "XSetWMHints");
+    glfw_dlsym(_glfw.x11.xlib.SetWMNormalHints, _glfw.x11.xlib.handle, "XSetWMNormalHints");
+    glfw_dlsym(_glfw.x11.xlib.SetWMProtocols, _glfw.x11.xlib.handle, "XSetWMProtocols");
+    glfw_dlsym(_glfw.x11.xlib.SupportsLocale, _glfw.x11.xlib.handle, "XSupportsLocale");
+    glfw_dlsym(_glfw.x11.xlib.Sync, _glfw.x11.xlib.handle, "XSync");
+    glfw_dlsym(_glfw.x11.xlib.TranslateCoordinates, _glfw.x11.xlib.handle, "XTranslateCoordinates");
+    glfw_dlsym(_glfw.x11.xlib.UndefineCursor, _glfw.x11.xlib.handle, "XUndefineCursor");
+    glfw_dlsym(_glfw.x11.xlib.UngrabPointer, _glfw.x11.xlib.handle, "XUngrabPointer");
+    glfw_dlsym(_glfw.x11.xlib.UnmapWindow, _glfw.x11.xlib.handle, "XUnmapWindow");
+    glfw_dlsym(_glfw.x11.xlib.UnsetICFocus, _glfw.x11.xlib.handle, "XUnsetICFocus");
+    glfw_dlsym(_glfw.x11.xlib.VisualIDFromVisual, _glfw.x11.xlib.handle, "XVisualIDFromVisual");
+    glfw_dlsym(_glfw.x11.xlib.WarpPointer, _glfw.x11.xlib.handle, "XWarpPointer");
+    glfw_dlsym(_glfw.x11.xkb.FreeKeyboard, _glfw.x11.xlib.handle, "XkbFreeKeyboard");
+    glfw_dlsym(_glfw.x11.xkb.FreeNames, _glfw.x11.xlib.handle, "XkbFreeNames");
+    glfw_dlsym(_glfw.x11.xkb.GetMap, _glfw.x11.xlib.handle, "XkbGetMap");
+    glfw_dlsym(_glfw.x11.xkb.GetNames, _glfw.x11.xlib.handle, "XkbGetNames");
+    glfw_dlsym(_glfw.x11.xkb.GetState, _glfw.x11.xlib.handle, "XkbGetState");
+    glfw_dlsym(_glfw.x11.xkb.KeycodeToKeysym, _glfw.x11.xlib.handle, "XkbKeycodeToKeysym");
+    glfw_dlsym(_glfw.x11.xkb.QueryExtension, _glfw.x11.xlib.handle, "XkbQueryExtension");
+    glfw_dlsym(_glfw.x11.xkb.SelectEventDetails, _glfw.x11.xlib.handle, "XkbSelectEventDetails");
+    glfw_dlsym(_glfw.x11.xkb.SetDetectableAutoRepeat, _glfw.x11.xlib.handle, "XkbSetDetectableAutoRepeat");
+    glfw_dlsym(_glfw.x11.xrm.DestroyDatabase, _glfw.x11.xlib.handle, "XrmDestroyDatabase");
+    glfw_dlsym(_glfw.x11.xrm.GetResource, _glfw.x11.xlib.handle, "XrmGetResource");
+    glfw_dlsym(_glfw.x11.xrm.GetStringDatabase, _glfw.x11.xlib.handle, "XrmGetStringDatabase");
+    glfw_dlsym(_glfw.x11.xrm.Initialize, _glfw.x11.xlib.handle, "XrmInitialize");
+    glfw_dlsym(_glfw.x11.xrm.UniqueQuark, _glfw.x11.xlib.handle, "XrmUniqueQuark");
+    glfw_dlsym(_glfw.x11.xlib.utf8LookupString, _glfw.x11.xlib.handle, "Xutf8LookupString");
+    glfw_dlsym(_glfw.x11.xlib.utf8SetWMProperties, _glfw.x11.xlib.handle, "Xutf8SetWMProperties");
+
     XInitThreads();
     XrmInitialize();
 
@@ -730,6 +836,12 @@ void _glfwPlatformTerminate(void)
     //       cleanup callbacks that get called by that function
     _glfwTerminateEGL();
     _glfwTerminateGLX();
+
+    if (_glfw.x11.xlib.handle)
+    {
+        _glfw_dlclose(_glfw.x11.xlib.handle);
+        _glfw.x11.xlib.handle = NULL;
+    }
 
     finalizePollData(&_glfw.x11.eventLoopData);
 }

--- a/glfw/x11_platform.h
+++ b/glfw/x11_platform.h
@@ -34,6 +34,7 @@
 #include <X11/Xlib.h>
 #include <X11/keysym.h>
 #include <X11/Xatom.h>
+#include <X11/Xresource.h>
 #include <X11/Xcursor/Xcursor.h>
 
 // The xcb library is needed to work with libxkb
@@ -57,6 +58,190 @@
 // The libxkb library is used for improved keyboard support
 #include "xkb_glfw.h"
 #include "backend_utils.h"
+
+typedef XClassHint* (* PFN_XAllocClassHint)(void);
+typedef XSizeHints* (* PFN_XAllocSizeHints)(void);
+typedef XWMHints* (* PFN_XAllocWMHints)(void);
+typedef int (* PFN_XChangeProperty)(Display*,Window,Atom,Atom,int,int,const unsigned char*,int);
+typedef int (* PFN_XChangeWindowAttributes)(Display*,Window,unsigned long,XSetWindowAttributes*);
+typedef Bool (* PFN_XCheckIfEvent)(Display*,XEvent*,Bool(*)(Display*,XEvent*,XPointer),XPointer);
+typedef Bool (* PFN_XCheckTypedWindowEvent)(Display*,Window,int,XEvent*);
+typedef int (* PFN_XCloseDisplay)(Display*);
+typedef Status (* PFN_XCloseIM)(XIM);
+typedef int (* PFN_XConvertSelection)(Display*,Atom,Atom,Atom,Window,Time);
+typedef Colormap (* PFN_XCreateColormap)(Display*,Window,Visual*,int);
+typedef Cursor (* PFN_XCreateFontCursor)(Display*,unsigned int);
+typedef XIC (* PFN_XCreateIC)(XIM,...);
+typedef Window (* PFN_XCreateWindow)(Display*,Window,int,int,unsigned int,unsigned int,unsigned int,int,unsigned int,Visual*,unsigned long,XSetWindowAttributes*);
+typedef int (* PFN_XDefineCursor)(Display*,Window,Cursor);
+typedef int (* PFN_XDeleteContext)(Display*,XID,XContext);
+typedef int (* PFN_XDeleteProperty)(Display*,Window,Atom);
+typedef void (* PFN_XDestroyIC)(XIC);
+typedef int (* PFN_XDestroyWindow)(Display*,Window);
+typedef int (* PFN_XEventsQueued)(Display*,int);
+typedef Bool (* PFN_XFilterEvent)(XEvent*,Window);
+typedef int (* PFN_XFindContext)(Display*,XID,XContext,XPointer*);
+typedef int (* PFN_XFlush)(Display*);
+typedef int (* PFN_XFree)(void*);
+typedef int (* PFN_XFreeColormap)(Display*,Colormap);
+typedef int (* PFN_XFreeCursor)(Display*,Cursor);
+typedef void (* PFN_XFreeEventData)(Display*,XGenericEventCookie*);
+typedef int (* PFN_XGetErrorText)(Display*,int,char*,int);
+typedef Bool (* PFN_XGetEventData)(Display*,XGenericEventCookie*);
+typedef char* (* PFN_XGetICValues)(XIC,...);
+typedef char* (* PFN_XGetIMValues)(XIM,...);
+typedef int (* PFN_XGetInputFocus)(Display*,Window*,int*);
+typedef KeySym* (* PFN_XGetKeyboardMapping)(Display*,KeyCode,int,int*);
+typedef int (* PFN_XGetScreenSaver)(Display*,int*,int*,int*,int*);
+typedef Window (* PFN_XGetSelectionOwner)(Display*,Atom);
+typedef XVisualInfo* (* PFN_XGetVisualInfo)(Display*,long,XVisualInfo*,int*);
+typedef Status (* PFN_XGetWMNormalHints)(Display*,Window,XSizeHints*,long*);
+typedef Status (* PFN_XGetWindowAttributes)(Display*,Window,XWindowAttributes*);
+typedef int (* PFN_XGetWindowProperty)(Display*,Window,Atom,long,long,Bool,Atom,Atom*,int*,unsigned long*,unsigned long*,unsigned char**);
+typedef int (* PFN_XGrabPointer)(Display*,Window,Bool,unsigned int,int,int,Window,Cursor,Time);
+typedef Status (* PFN_XIconifyWindow)(Display*,Window,int);
+typedef Status (* PFN_XInitThreads)(void);
+typedef Atom (* PFN_XInternAtom)(Display*,const char*,Bool);
+typedef int (* PFN_XLookupString)(XKeyEvent*,char*,int,KeySym*,XComposeStatus*);
+typedef int (* PFN_XMapRaised)(Display*,Window);
+typedef int (* PFN_XMapWindow)(Display*,Window);
+typedef int (* PFN_XMoveResizeWindow)(Display*,Window,int,int,unsigned int,unsigned int);
+typedef int (* PFN_XMoveWindow)(Display*,Window,int,int);
+typedef int (* PFN_XNextEvent)(Display*,XEvent*);
+typedef Display* (* PFN_XOpenDisplay)(const char*);
+typedef XIM (* PFN_XOpenIM)(Display*,XrmDatabase*,char*,char*);
+typedef int (* PFN_XPeekEvent)(Display*,XEvent*);
+typedef int (* PFN_XPending)(Display*);
+typedef Bool (* PFN_XQueryExtension)(Display*,const char*,int*,int*,int*);
+typedef Bool (* PFN_XQueryPointer)(Display*,Window,Window*,Window*,int*,int*,int*,int*,unsigned int*);
+typedef int (* PFN_XRaiseWindow)(Display*,Window);
+typedef int (* PFN_XResizeWindow)(Display*,Window,unsigned int,unsigned int);
+typedef char* (* PFN_XResourceManagerString)(Display*);
+typedef int (* PFN_XSaveContext)(Display*,XID,XContext,const char*);
+typedef int (* PFN_XSelectInput)(Display*,Window,long);
+typedef Status (* PFN_XSendEvent)(Display*,Window,Bool,long,XEvent*);
+typedef int (* PFN_XSetClassHint)(Display*,Window,XClassHint*);
+typedef XErrorHandler (* PFN_XSetErrorHandler)(XErrorHandler);
+typedef void (* PFN_XSetICFocus)(XIC);
+typedef int (* PFN_XSetInputFocus)(Display*,Window,int,Time);
+typedef char* (* PFN_XSetLocaleModifiers)(const char*);
+typedef int (* PFN_XSetScreenSaver)(Display*,int,int,int,int);
+typedef int (* PFN_XSetSelectionOwner)(Display*,Atom,Window,Time);
+typedef int (* PFN_XSetWMHints)(Display*,Window,XWMHints*);
+typedef void (* PFN_XSetWMNormalHints)(Display*,Window,XSizeHints*);
+typedef Status (* PFN_XSetWMProtocols)(Display*,Window,Atom*,int);
+typedef Bool (* PFN_XSupportsLocale)(void);
+typedef int (* PFN_XSync)(Display*,Bool);
+typedef Bool (* PFN_XTranslateCoordinates)(Display*,Window,Window,int,int,int*,int*,Window*);
+typedef int (* PFN_XUndefineCursor)(Display*,Window);
+typedef int (* PFN_XUngrabPointer)(Display*,Time);
+typedef int (* PFN_XUnmapWindow)(Display*,Window);
+typedef void (* PFN_XUnsetICFocus)(XIC);
+typedef VisualID (* PFN_XVisualIDFromVisual)(Visual*);
+typedef int (* PFN_XWarpPointer)(Display*,Window,Window,int,int,unsigned int,unsigned int,int,int);
+typedef void (* PFN_XrmDestroyDatabase)(XrmDatabase);
+typedef Bool (* PFN_XrmGetResource)(XrmDatabase,const char*,const char*,char**,XrmValue*);
+typedef XrmDatabase (* PFN_XrmGetStringDatabase)(const char*);
+typedef void (* PFN_XrmInitialize)(void);
+typedef XrmQuark (* PFN_XrmUniqueQuark)(void);
+typedef int (* PFN_Xutf8LookupString)(XIC,XKeyPressedEvent*,char*,int,KeySym*,Status*);
+typedef void (* PFN_Xutf8SetWMProperties)(Display*,Window,const char*,const char*,char**,int,XSizeHints*,XWMHints*,XClassHint*);
+#define XAllocClassHint _glfw.x11.xlib.AllocClassHint
+#define XAllocSizeHints _glfw.x11.xlib.AllocSizeHints
+#define XAllocWMHints _glfw.x11.xlib.AllocWMHints
+#define XChangeProperty _glfw.x11.xlib.ChangeProperty
+#define XChangeWindowAttributes _glfw.x11.xlib.ChangeWindowAttributes
+#define XCheckIfEvent _glfw.x11.xlib.CheckIfEvent
+#define XCheckTypedWindowEvent _glfw.x11.xlib.CheckTypedWindowEvent
+#define XCloseDisplay _glfw.x11.xlib.CloseDisplay
+#define XCloseIM _glfw.x11.xlib.CloseIM
+#define XConvertSelection _glfw.x11.xlib.ConvertSelection
+#define XCreateColormap _glfw.x11.xlib.CreateColormap
+#define XCreateFontCursor _glfw.x11.xlib.CreateFontCursor
+#define XCreateIC _glfw.x11.xlib.CreateIC
+#define XCreateWindow _glfw.x11.xlib.CreateWindow
+#define XDefineCursor _glfw.x11.xlib.DefineCursor
+#define XDeleteContext _glfw.x11.xlib.DeleteContext
+#define XDeleteProperty _glfw.x11.xlib.DeleteProperty
+#define XDestroyIC _glfw.x11.xlib.DestroyIC
+#define XDestroyWindow _glfw.x11.xlib.DestroyWindow
+#define XEventsQueued _glfw.x11.xlib.EventsQueued
+#define XFilterEvent _glfw.x11.xlib.FilterEvent
+#define XFindContext _glfw.x11.xlib.FindContext
+#define XFlush _glfw.x11.xlib.Flush
+#define XFree _glfw.x11.xlib.Free
+#define XFreeColormap _glfw.x11.xlib.FreeColormap
+#define XFreeCursor _glfw.x11.xlib.FreeCursor
+#define XFreeEventData _glfw.x11.xlib.FreeEventData
+#define XGetErrorText _glfw.x11.xlib.GetErrorText
+#define XGetEventData _glfw.x11.xlib.GetEventData
+#define XGetICValues _glfw.x11.xlib.GetICValues
+#define XGetIMValues _glfw.x11.xlib.GetIMValues
+#define XGetInputFocus _glfw.x11.xlib.GetInputFocus
+#define XGetKeyboardMapping _glfw.x11.xlib.GetKeyboardMapping
+#define XGetScreenSaver _glfw.x11.xlib.GetScreenSaver
+#define XGetSelectionOwner _glfw.x11.xlib.GetSelectionOwner
+#define XGetVisualInfo _glfw.x11.xlib.GetVisualInfo
+#define XGetWMNormalHints _glfw.x11.xlib.GetWMNormalHints
+#define XGetWindowAttributes _glfw.x11.xlib.GetWindowAttributes
+#define XGetWindowProperty _glfw.x11.xlib.GetWindowProperty
+#define XGrabPointer _glfw.x11.xlib.GrabPointer
+#define XIconifyWindow _glfw.x11.xlib.IconifyWindow
+#define XInitThreads _glfw.x11.xlib.InitThreads
+#define XInternAtom _glfw.x11.xlib.InternAtom
+#define XLookupString _glfw.x11.xlib.LookupString
+#define XMapRaised _glfw.x11.xlib.MapRaised
+#define XMapWindow _glfw.x11.xlib.MapWindow
+#define XMoveResizeWindow _glfw.x11.xlib.MoveResizeWindow
+#define XMoveWindow _glfw.x11.xlib.MoveWindow
+#define XNextEvent _glfw.x11.xlib.NextEvent
+#define XOpenDisplay _glfw.x11.xlib.OpenDisplay
+#define XOpenIM _glfw.x11.xlib.OpenIM
+#define XPeekEvent _glfw.x11.xlib.PeekEvent
+#define XPending _glfw.x11.xlib.Pending
+#define XQueryExtension _glfw.x11.xlib.QueryExtension
+#define XQueryPointer _glfw.x11.xlib.QueryPointer
+#define XRaiseWindow _glfw.x11.xlib.RaiseWindow
+#define XResizeWindow _glfw.x11.xlib.ResizeWindow
+#define XResourceManagerString _glfw.x11.xlib.ResourceManagerString
+#define XSaveContext _glfw.x11.xlib.SaveContext
+#define XSelectInput _glfw.x11.xlib.SelectInput
+#define XSendEvent _glfw.x11.xlib.SendEvent
+#define XSetClassHint _glfw.x11.xlib.SetClassHint
+#define XSetErrorHandler _glfw.x11.xlib.SetErrorHandler
+#define XSetICFocus _glfw.x11.xlib.SetICFocus
+#define XSetInputFocus _glfw.x11.xlib.SetInputFocus
+#define XSetLocaleModifiers _glfw.x11.xlib.SetLocaleModifiers
+#define XSetScreenSaver _glfw.x11.xlib.SetScreenSaver
+#define XSetSelectionOwner _glfw.x11.xlib.SetSelectionOwner
+#define XSetWMHints _glfw.x11.xlib.SetWMHints
+#define XSetWMNormalHints _glfw.x11.xlib.SetWMNormalHints
+#define XSetWMProtocols _glfw.x11.xlib.SetWMProtocols
+#define XSupportsLocale _glfw.x11.xlib.SupportsLocale
+#define XSync _glfw.x11.xlib.Sync
+#define XTranslateCoordinates _glfw.x11.xlib.TranslateCoordinates
+#define XUndefineCursor _glfw.x11.xlib.UndefineCursor
+#define XUngrabPointer _glfw.x11.xlib.UngrabPointer
+#define XUnmapWindow _glfw.x11.xlib.UnmapWindow
+#define XUnsetICFocus _glfw.x11.xlib.UnsetICFocus
+#define XVisualIDFromVisual _glfw.x11.xlib.VisualIDFromVisual
+#define XWarpPointer _glfw.x11.xlib.WarpPointer
+#define XkbFreeKeyboard _glfw.x11.xkb.FreeKeyboard
+#define XkbFreeNames _glfw.x11.xkb.FreeNames
+#define XkbGetMap _glfw.x11.xkb.GetMap
+#define XkbGetNames _glfw.x11.xkb.GetNames
+#define XkbGetState _glfw.x11.xkb.GetState
+#define XkbKeycodeToKeysym _glfw.x11.xkb.KeycodeToKeysym
+#define XkbQueryExtension _glfw.x11.xkb.QueryExtension
+#define XkbSelectEventDetails _glfw.x11.xkb.SelectEventDetails
+#define XkbSetDetectableAutoRepeat _glfw.x11.xkb.SetDetectableAutoRepeat
+#define XrmDestroyDatabase _glfw.x11.xrm.DestroyDatabase
+#define XrmGetResource _glfw.x11.xrm.GetResource
+#define XrmGetStringDatabase _glfw.x11.xrm.GetStringDatabase
+#define XrmInitialize _glfw.x11.xrm.Initialize
+#define XrmUniqueQuark _glfw.x11.xrm.UniqueQuark
+#define Xutf8LookupString _glfw.x11.xlib.utf8LookupString
+#define Xutf8SetWMProperties _glfw.x11.xlib.utf8SetWMProperties
 
 typedef XRRCrtcGamma* (* PFN_XRRAllocGamma)(int);
 typedef void (* PFN_XRRFreeCrtcInfo)(XRRCrtcInfo*);
@@ -291,6 +476,100 @@ typedef struct _GLFWlibraryX11
 
     // XRM database atom
     Atom            RESOURCE_MANAGER;
+
+    struct {
+        void*       handle;
+        PFN_XAllocClassHint AllocClassHint;
+        PFN_XAllocSizeHints AllocSizeHints;
+        PFN_XAllocWMHints AllocWMHints;
+        PFN_XChangeProperty ChangeProperty;
+        PFN_XChangeWindowAttributes ChangeWindowAttributes;
+        PFN_XCheckIfEvent CheckIfEvent;
+        PFN_XCheckTypedWindowEvent CheckTypedWindowEvent;
+        PFN_XCloseDisplay CloseDisplay;
+        PFN_XCloseIM CloseIM;
+        PFN_XConvertSelection ConvertSelection;
+        PFN_XCreateColormap CreateColormap;
+        PFN_XCreateFontCursor CreateFontCursor;
+        PFN_XCreateIC CreateIC;
+        PFN_XCreateWindow CreateWindow;
+        PFN_XDefineCursor DefineCursor;
+        PFN_XDeleteContext DeleteContext;
+        PFN_XDeleteProperty DeleteProperty;
+        PFN_XDestroyIC DestroyIC;
+        PFN_XDestroyWindow DestroyWindow;
+        PFN_XEventsQueued EventsQueued;
+        PFN_XFilterEvent FilterEvent;
+        PFN_XFindContext FindContext;
+        PFN_XFlush Flush;
+        PFN_XFree Free;
+        PFN_XFreeColormap FreeColormap;
+        PFN_XFreeCursor FreeCursor;
+        PFN_XFreeEventData FreeEventData;
+        PFN_XGetErrorText GetErrorText;
+        PFN_XGetEventData GetEventData;
+        PFN_XGetICValues GetICValues;
+        PFN_XGetIMValues GetIMValues;
+        PFN_XGetInputFocus GetInputFocus;
+        PFN_XGetKeyboardMapping GetKeyboardMapping;
+        PFN_XGetScreenSaver GetScreenSaver;
+        PFN_XGetSelectionOwner GetSelectionOwner;
+        PFN_XGetVisualInfo GetVisualInfo;
+        PFN_XGetWMNormalHints GetWMNormalHints;
+        PFN_XGetWindowAttributes GetWindowAttributes;
+        PFN_XGetWindowProperty GetWindowProperty;
+        PFN_XGrabPointer GrabPointer;
+        PFN_XIconifyWindow IconifyWindow;
+        PFN_XInitThreads InitThreads;
+        PFN_XInternAtom InternAtom;
+        PFN_XLookupString LookupString;
+        PFN_XMapRaised MapRaised;
+        PFN_XMapWindow MapWindow;
+        PFN_XMoveResizeWindow MoveResizeWindow;
+        PFN_XMoveWindow MoveWindow;
+        PFN_XNextEvent NextEvent;
+        PFN_XOpenDisplay OpenDisplay;
+        PFN_XOpenIM OpenIM;
+        PFN_XPeekEvent PeekEvent;
+        PFN_XPending Pending;
+        PFN_XQueryExtension QueryExtension;
+        PFN_XQueryPointer QueryPointer;
+        PFN_XRaiseWindow RaiseWindow;
+        PFN_XResizeWindow ResizeWindow;
+        PFN_XResourceManagerString ResourceManagerString;
+        PFN_XSaveContext SaveContext;
+        PFN_XSelectInput SelectInput;
+        PFN_XSendEvent SendEvent;
+        PFN_XSetClassHint SetClassHint;
+        PFN_XSetErrorHandler SetErrorHandler;
+        PFN_XSetICFocus SetICFocus;
+        PFN_XSetInputFocus SetInputFocus;
+        PFN_XSetLocaleModifiers SetLocaleModifiers;
+        PFN_XSetScreenSaver SetScreenSaver;
+        PFN_XSetSelectionOwner SetSelectionOwner;
+        PFN_XSetWMHints SetWMHints;
+        PFN_XSetWMNormalHints SetWMNormalHints;
+        PFN_XSetWMProtocols SetWMProtocols;
+        PFN_XSupportsLocale SupportsLocale;
+        PFN_XSync Sync;
+        PFN_XTranslateCoordinates TranslateCoordinates;
+        PFN_XUndefineCursor UndefineCursor;
+        PFN_XUngrabPointer UngrabPointer;
+        PFN_XUnmapWindow UnmapWindow;
+        PFN_XUnsetICFocus UnsetICFocus;
+        PFN_XVisualIDFromVisual VisualIDFromVisual;
+        PFN_XWarpPointer WarpPointer;
+        PFN_Xutf8LookupString utf8LookupString;
+        PFN_Xutf8SetWMProperties utf8SetWMProperties;
+    } xlib;
+
+    struct {
+        PFN_XrmDestroyDatabase DestroyDatabase;
+        PFN_XrmGetResource GetResource;
+        PFN_XrmGetStringDatabase GetStringDatabase;
+        PFN_XrmInitialize Initialize;
+        PFN_XrmUniqueQuark UniqueQuark;
+    } xrm;
 
     struct {
         bool        available;

--- a/glfw/xkb_glfw.h
+++ b/glfw/xkb_glfw.h
@@ -34,6 +34,18 @@
 
 #include "ibus_glfw.h"
 
+#ifdef _GLFW_X11
+typedef void (* PFN_XkbFreeKeyboard)(XkbDescPtr,unsigned int,Bool);
+typedef void (* PFN_XkbFreeNames)(XkbDescPtr,unsigned int,Bool);
+typedef XkbDescPtr (* PFN_XkbGetMap)(Display*,unsigned int,unsigned int);
+typedef Status (* PFN_XkbGetNames)(Display*,unsigned int,XkbDescPtr);
+typedef Status (* PFN_XkbGetState)(Display*,unsigned int,XkbStatePtr);
+typedef KeySym (* PFN_XkbKeycodeToKeysym)(Display*,KeyCode,int,int);
+typedef Bool (* PFN_XkbQueryExtension)(Display*,int*,int*,int*,int*,int*);
+typedef Bool (* PFN_XkbSelectEventDetails)(Display*,unsigned int,unsigned int,unsigned long,unsigned long);
+typedef Bool (* PFN_XkbSetDetectableAutoRepeat)(Display*,Bool,Bool*);
+#endif
+
 typedef struct {
     struct xkb_state*       state;
     struct xkb_state*       clean_state;
@@ -74,6 +86,15 @@ typedef struct {
     int                     errorBase;
     int                     major;
     int                     minor;
+    PFN_XkbFreeKeyboard FreeKeyboard;
+    PFN_XkbFreeNames FreeNames;
+    PFN_XkbGetMap GetMap;
+    PFN_XkbGetNames GetNames;
+    PFN_XkbGetState GetState;
+    PFN_XkbKeycodeToKeysym KeycodeToKeysym;
+    PFN_XkbQueryExtension QueryExtension;
+    PFN_XkbSelectEventDetails SelectEventDetails;
+    PFN_XkbSetDetectableAutoRepeat SetDetectableAutoRepeat;
 #endif
 
 } _GLFWXKBData;


### PR DESCRIPTION
From upstream: https://github.com/glfw/glfw/commit/a0a5cc57dff620f97428168a2580714bebc22381.

I moved some of the `typedef`s to `glfw/xkb_glfw.h` because that's where a certain `struct` is located in kitty (but not in GLFW). GLFW has the `typedef`s in `src/x11_platform.h`. Is putting the typedefs in that file a good solution or do you see a better one? I tried including `src/x11_platform.h` but that didn't work out well.
Please also check that I removed the correct library from the list of libraries to link against and that no other libraries should be removed.