### PR TITLE
Sextants: fix arithmetic mistake that broke 🬓, 🬦, 🬧

### DIFF
--- a/kitty/fonts/box_drawing.py
+++ b/kitty/fonts/box_drawing.py
@@ -955,7 +955,7 @@ for i in range(256):
 
 c = 0x1fb00
 for i in range(1, 63):
-    if i in (20, 40):
+    if i in (21, 42):
         continue
     box_chars[chr(c)] = [p(sextant, which=i)]
     c += 1


### PR DESCRIPTION
The scheme used in draw_sextant works well enough, but the
feed was broken. 21 and 42 need to be skipped, not 20 and
40. Without this change, the following glyphs are broken:

U+1FB13 BLOCK SEXTANT-35 🬓 renders as LEFT HALF
U+1FB26 BLOCK SEXTANT-46 🬦 renders as SEXTANT-146
U+1FB27 BLOCK SEXTANT-146 🬧 renders as RIGHT HALF

With this change, the entirety of the sextant block works
correctly. Found debugging the Notcurses sextant blitter:
https://github.com/dankamongmen/notcurses/issues/1112

Closes #3106 