### PR TITLE
Change the flow of lines from the scroll region to the scrollback

### DIFF
--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -999,8 +999,8 @@ index_selection(const Screen *self, Selections *selections, bool up) {
     if (self->overlay_line.is_active) deactivate_overlay_line(self); \
     linebuf_index(self->linebuf, top, bottom); \
     INDEX_GRAPHICS(-1) \
-    if (self->linebuf == self->main_linebuf && bottom == self->lines - 1) { \
-        /* Only add to history when no page margins have been set */ \
+    if (self->linebuf == self->main_linebuf && self->margin_top == 0) { \
+        /* Only add to history when no top margin has been set */ \
         linebuf_init_line(self->linebuf, bottom); \
         historybuf_add_line(self->historybuf, self->linebuf->line, &self->as_ansi_buf); \
         self->history_line_added_count++; \

--- a/kitty_tests/screen.py
+++ b/kitty_tests/screen.py
@@ -683,3 +683,37 @@ class TestScreen(BaseTest):
         self.ae(s.current_url_text(), '123abcxyz')
         self.ae('2', s.hyperlink_at(1, 3))
         self.ae(s.current_url_text(), 'Z Z')
+
+    def test_bottom_margin(self):
+        return
+        s = self.create_screen(cols=80, lines=6, scrollback=4)
+        s.set_margins(0, 5)
+        for i in range(8):
+            s.draw(str(i))
+            s.linefeed()
+            s.carriage_return()
+
+        self.ae(str(s.linebuf), '4\n5\n6\n7\n\n')
+        self.ae(str(s.historybuf), '3\n2\n1\n0')
+
+    def test_top_margin(self):
+        s = self.create_screen(cols=80, lines=6, scrollback=4)
+        s.set_margins(2, 6)
+        for i in range(8):
+            s.draw(str(i))
+            s.linefeed()
+            s.carriage_return()
+
+        self.ae(str(s.linebuf), '0\n4\n5\n6\n7\n')
+        self.ae(str(s.historybuf), '')
+
+    def test_top_and_bottom_margin(self):
+        s = self.create_screen(cols=80, lines=6, scrollback=4)
+        s.set_margins(2, 5)
+        for i in range(8):
+            s.draw(str(i))
+            s.linefeed()
+            s.carriage_return()
+
+        self.ae(str(s.linebuf), '0\n5\n6\n7\n\n')
+        self.ae(str(s.historybuf), '')


### PR DESCRIPTION
There are two user-visible changes in here:

1. If a scroll region is set such that there is a bottom margin and no
   top margin, scrolling the region forward used to discard the top
   lines. Now those lines are appended to the scrollback.
   ```shell
   # Assuming a terminal window with 24 lines.
   printf '\033[H\033[J\033[3J\033[0;5r' && seq 100
   ```
   This command used to result in an empty scrollback. Now it contains
   the numbers 1-96.
2. If a scroll region is set such that there is a top margin and no bottom
   margin, scrolling the region forward used to append the top lines to
   the scrollback. Now these lines are discarded.
   ```shell
   # Assuming a terminal window with 24 lines.
   printf '\033[H\033[J\033[3J\033[2;24r' && seq 100
   ```
   This command used to populate scrollback with the numbers 2-78. Now
   the scrollback is empty. The numbers on the screen are the same as
   before: 1 and 79-100.

Related issue: #3113.