### PR TITLE
Add new option `detect_urls` to check for URLs under the mouse cursor

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -520,6 +520,9 @@ def url_prefixes(x: str) -> Tuple[str, ...]:
 o('url_prefixes', 'http https file ftp', option_type=url_prefixes, long_text=_('''
 The set of URL prefixes to look for when detecting a URL under the mouse cursor.'''))
 
+o('detect_urls', True, long_text=_('''
+Detect URL under the mouse cursor.  If disabled URLs are still clickable.'''))
+
 
 def copy_on_select(raw: str) -> str:
     q = raw.lower()

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -368,7 +368,9 @@ HANDLER(handle_move_event) {
     bool in_left_half_of_cell = false;
     if (!cell_for_pos(w, &x, &y, &in_left_half_of_cell, global_state.callback_os_window)) return;
     Screen *screen = w->render_data.screen;
-    detect_url(screen, x, y);
+    if(OPT(detect_urls)) {
+        detect_url(screen, x, y);
+    }
     bool mouse_cell_changed = x != w->mouse_pos.cell_x || y != w->mouse_pos.cell_y;
     bool cell_half_changed = in_left_half_of_cell != w->mouse_pos.in_left_half_of_cell;
     w->mouse_pos.cell_x = x; w->mouse_pos.cell_y = y;

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -705,6 +705,7 @@ PYWRAP1(set_options) {
     S(pointer_shape_when_grabbed, pointer_shape);
     S(default_pointer_shape, pointer_shape);
     S(pointer_shape_when_dragging, pointer_shape);
+    S(detect_urls, PyObject_IsTrue);
 
     GA(tab_bar_style);
     global_state.tab_bar_hidden = PyUnicode_CompareWithASCIIString(ret, "hidden") == 0 ? true: false;

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -72,6 +72,7 @@ typedef struct {
         UrlPrefix *values;
         size_t num, max_prefix_len;
     } url_prefixes;
+    bool detect_urls;
 } Options;
 
 typedef struct {


### PR DESCRIPTION
Enabled by default add new option `detect_urls` that will allow you
contorl if kitty should detect URLs under the mouse cursor.  If disabled
the URLs are still clickable with open_url_modifiers.

In the almost the same spirt of #1828 but doesn't change current
funcationalty and makes the user opt. in.