### PR TITLE
Add tab_switch_strategy option 'right'

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -880,11 +880,12 @@ o('tab_bar_min_tabs', 2, option_type=tab_bar_min_tabs, long_text=_('''
 The minimum number of tabs that must exist before the tab bar is shown
 '''))
 
-o('tab_switch_strategy', 'previous', option_type=choices('previous', 'left', 'last'), long_text=_('''
+o('tab_switch_strategy', 'previous', option_type=choices('previous', 'left', 'right', 'last'), long_text=_('''
 The algorithm to use when switching to a tab when the current tab is closed.
 The default of :code:`previous` will switch to the last used tab. A value of
 :code:`left` will switch to the tab to the left of the closed tab. A value
-of :code:`last` will switch to the right-most tab.
+of :code:`right` will switch to the tab to the right of the closed tab.
+A value of :code:`last` will switch to the right-most tab.
 '''))
 
 

--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -721,6 +721,8 @@ class TabManager:  # {{{
                         break
         elif self.opts.tab_switch_strategy == 'left':
             next_active_tab = max(0, self.active_tab_idx - 1)
+        elif self.opts.tab_switch_strategy == 'right':
+            next_active_tab = min(self.active_tab_idx, len(self.tabs) - 1)
 
         if next_active_tab < 0:
             next_active_tab = max(0, min(self.active_tab_idx, len(self.tabs) - 1))


### PR DESCRIPTION
Add tab_switch_strategy option 'right' to switch to the tab to the right of the closed tab, as in Firefox, Safari, and Chrome.