### PR TITLE
Add headless mode

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -204,7 +204,8 @@ class Boss:
                 os_window_id = create_os_window(
                         initial_window_size_func(size_data, self.cached_values),
                         pre_show_callback,
-                        self.args.title or appname, wname or self.args.name or wclass, wclass)
+                        self.args.title or appname, wname or self.args.name or wclass, wclass,
+                        self.args.start_as == 'headless')
         tm = TabManager(os_window_id, self.opts, self.args, startup_session)
         self.os_window_map[os_window_id] = tm
         return os_window_id

--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -655,7 +655,7 @@ can also be specified in :file:`kitty.conf`.
 --start-as
 type=choices
 default=normal
-choices=normal,fullscreen,maximized,minimized
+choices=normal,fullscreen,maximized,minimized,headless
 Control how the initial kitty window is created.
 
 

--- a/kitty/complete.py
+++ b/kitty/complete.py
@@ -260,7 +260,7 @@ def complete_kitty_cli_arg(ans: Completions, opt: Optional[OptionDict], prefix: 
         complete_files_and_dirs(ans, prefix, files_group_name='Directories', predicate=os.path.isdir)
     elif dest == 'start_as':
         k = 'Start as'
-        ans.match_groups[k] = {x: x for x in 'normal,fullscreen,maximized,minimized'.split(',') if x.startswith(prefix)}
+        ans.match_groups[k] = {x: x for x in 'normal,fullscreen,maximized,minimized,headless'.split(',') if x.startswith(prefix)}
         ans.no_space_groups.add(k)
     elif dest == 'listen_on':
         if ':' not in prefix:

--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -533,6 +533,7 @@ def create_os_window(
     title: str,
     wm_class_name: str,
     wm_class_class: str,
+    headless: bool = False,
     load_programs: Optional[Callable[[bool], None]] = None,
     x: int = -1,
     y: int = -1

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -544,8 +544,9 @@ static PyObject*
 create_os_window(PyObject UNUSED *self, PyObject *args) {
     int x = -1, y = -1;
     char *title, *wm_class_class, *wm_class_name;
+    bool headless = false;
     PyObject *load_programs = NULL, *get_window_size, *pre_show_callback;
-    if (!PyArg_ParseTuple(args, "OOsss|Oii", &get_window_size, &pre_show_callback, &title, &wm_class_name, &wm_class_class, &load_programs, &x, &y)) return NULL;
+    if (!PyArg_ParseTuple(args, "OOsss|pOii", &get_window_size, &pre_show_callback, &title, &wm_class_name, &wm_class_class, &headless, &load_programs, &x, &y)) return NULL;
 
     static bool is_first_window = true;
     if (is_first_window) {
@@ -630,7 +631,7 @@ create_os_window(PyObject UNUSED *self, PyObject *args) {
         if (pret == NULL) return NULL;
         Py_DECREF(pret);
         if (x != -1 && y != -1) glfwSetWindowPos(glfw_window, x, y);
-        glfwShowWindow(glfw_window);
+        if (!headless) glfwShowWindow(glfw_window);
     }
     if (is_first_window) {
         PyObject *ret = PyObject_CallFunction(load_programs, "O", is_semi_transparent ? Py_True : Py_False);
@@ -950,6 +951,7 @@ change_os_window_state(PyObject *self UNUSED, PyObject *args) {
     if (!w || !w->handle) Py_RETURN_NONE;
     if (strcmp(state, "maximized") == 0) glfwMaximizeWindow(w->handle);
     else if (strcmp(state, "minimized") == 0) glfwIconifyWindow(w->handle);
+    else if (strcmp(state, "headless") == 0) glfwHideWindow(w->handle);
     else { PyErr_SetString(PyExc_ValueError, "Unknown window state"); return NULL; }
     Py_RETURN_NONE;
 }

--- a/kitty/main.py
+++ b/kitty/main.py
@@ -134,7 +134,8 @@ def _run_app(opts: OptionsStub, args: CLIOptions, bad_lines: Sequence[BadLine] =
                     run_app.initial_window_size_func(get_os_window_sizing_data(opts), cached_values),
                     pre_show_callback,
                     args.title or appname, args.name or args.cls or appname,
-                    args.cls or appname, load_all_shaders)
+                    args.cls or appname, args.start_as == 'headless', load_all_shaders)
+
         boss = Boss(opts, args, cached_values, new_os_window_trigger)
         boss.start(window_id)
         if bad_lines:

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -855,6 +855,8 @@ PYWRAP1(focus_os_window) {
     int also_raise = 1;
     PA("K|p", &os_window_id, &also_raise);
     WITH_OS_WINDOW(os_window_id)
+        if (os_window->handle && !glfwGetWindowAttrib(os_window->handle, GLFW_VISIBLE)) glfwShowWindow(os_window->handle);
+
         if (!os_window->is_focused) focus_os_window(os_window, also_raise);
         Py_RETURN_TRUE;
     END_WITH_OS_WINDOW


### PR DESCRIPTION
This would allow users to run commands in the context of a running kitty instance without showing a window.

Use cases:
1. Prepare an entire session with windows/tabs and show it all at once
```shell
kitty -o allow_remote_control=yes --listen-on unix:/tmp/kitty --start-as headless
kitty @ --to unix:/tmp/kitty launch htop
kitty @ --to unix:/tmp/kitty launch webserver
kitty @ --to unix:/tmp/kitty focus-window --match title:htop  # this will show the window
```
2. Extract information about kitty configuration using kittens
```python
# /tmp/kitten.py

from kittens.tui.handler import result_handler
from pprint import pprint

def main():
    return ""

@result_handler(no_ui=True)
def handle_result(args, res, target_window_id, boss):
    pprint(boss.opts.keymap)
```
```shell
kitty -o allow_remote_control=yes --listen-on unix:/tmp/kitty --start-as headless
kitty @ --to unix:/tmp/kitty kitten /tmp/kitten.py
```
3. Quake style terminal started as hidden at boot

*Have something like this run at boot (crontab/launchd)*
```shell
kitty --title=quake \
  -o initial_window_width=$(system_profiler SPDisplaysDataType | grep 'Resolution:' | head -n 1 | awk '{ print $2 }') \
  -o initial_window_height=400 \
  -o allow_remote_control=yes \
  --listen-on unix:/tmp/quake_kitty \
  --start-as headless
```
-----
*Bind this to a hotkey through something like skhd/karabiner/BetterTouchTool*
```shell
kitty @ --to unix:/tmp/quake_kitty focus-window
```
