### PR TITLE
Update example fontconfig

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -182,7 +182,7 @@ following :file:`~/.config/fontconfig/fonts.conf`::
     <?xml version="1.0"?>
     <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
     <fontconfig>
-    <match target="font">
+    <match target="scan">
         <test name="family">
             <string>Your Font Family Name</string>
         </test>


### PR DESCRIPTION
In fontconfig version `2:2.13.91+48+gfcb0420-2` from the Arch Linux extra repository (which is what I am using), the target must be set to `scan` for the `spacing` value to be successfully overwritten. I am unsure about other versions.