### PR TITLE
Generate u[6789] with terminfo.py

### DIFF
--- a/kitty/terminfo.py
+++ b/kitty/terminfo.py
@@ -262,6 +262,15 @@ string_capabilities = {
     # Set RGB background color (non-standard used by neovim)
     'setrgbb': r'\E[48:2:%p1%d:%p2%d:%p3%dm',
 
+    # The following entries are for compatibility with xterm,
+    # and shell scripts using e.g. `tput u7` to emit a CPR escape
+    # See https://invisible-island.net/ncurses/terminfo.src.html
+    # and INTERPRETATION OF USER CAPABILITIES
+    'u6': r'\E[%i%d;%dR',
+    'u7': r'\E[6n',
+    'u8': r'\E[?%[;0123456789]c',
+    'u9': r'\E[c',
+
     # The following are entries that we don't use
     # # turn on blank mode, (characters invisible)
     # 'invis': r'\E[8m',
@@ -401,6 +410,10 @@ termcap_aliases.update({
     'fs': 'fsl',
     'ds': 'dsl',
 
+    'u6': 'u6',
+    'u7': 'u7',
+    'u8': 'u8',
+    'u9': 'u9',
 
     # 'ut': 'bce',
     # 'ds': 'dsl',


### PR DESCRIPTION
Should not hurt anything, it's just documenting kitty's existing VT220 compatibility.

I had some third-party bash scripts fail, since they were using
 `echo -ne "$(tput u7)"`
vs a direct
`echo -ne '\e[6n'`
¯\\\_(ツ)\_/¯

I got the terminfo strings from:
```
$ infocmp -q1 xterm | grep -oP '(?<=\t)u[0-9]=.+'
u6=\E[%i%d;%dR,
u7=\E[6n,
u8=\E[?%[;0123456789]c,
u9=\E[c,
```