### PR TITLE
macOS: Fix change font size keyboard shortcut

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -1475,8 +1475,7 @@ k('next_layout', 'kitty_mod+l', 'next_layout', _('Next layout'))
 g('shortcuts.fonts')  # {{{
 k('increase_font_size', 'kitty_mod+equal', 'change_font_size all +2.0', _('Increase font size'))
 if is_macos:
-    k('increase_font_size', 'cmd+plus', 'change_font_size all +2.0', _('Increase font size'), add_to_docs=False)
-    k('increase_font_size', 'cmd+shift+equal', 'change_font_size all +2.0', _('Increase font size'), add_to_docs=False)
+    k('increase_font_size', 'cmd+equal', 'change_font_size all +2.0', _('Increase font size'), add_to_docs=False)
 k('decrease_font_size', 'kitty_mod+minus', 'change_font_size all -2.0', _('Decrease font size'))
 if is_macos:
     k('decrease_font_size', 'cmd+minus', 'change_font_size all -2.0', _('Decrease font size'), add_to_docs=False)


### PR DESCRIPTION
Fixes #2839.

I can't find any definitive MacOS keyboard shortcuts for changing application font size but from most applications it seems that `cmd+equal` and `cmd+minus` are mapped to increasing and decreasing, respectively. Some applications, like Chrome, also allow you to use the shift key as well but this doesn't seem to be across the board and without shift seems more common. Considering that some people might want to map `cmd+shift+minus|equal` to other actions I think it makes sense to not include these as a default mapping without being surprising.