### PR TITLE
Fixes Incorrect Index Behavior in Unicode Name Selector

### DIFF
--- a/kittens/unicode_input/main.py
+++ b/kittens/unicode_input/main.py
@@ -175,7 +175,7 @@ class Table:
         self.codepoints = codepoints
         self.mode = mode
         self.layout_dirty = True
-        self.current_idx = current_idx
+        self.current_idx = current_idx if current_idx < len(codepoints) else 0
 
     def codepoint_at_hint(self, hint: str) -> int:
         return self.codepoints[decode_hint(hint)]
@@ -330,7 +330,7 @@ class UnicodeInput(Handler):
                 codepoints = codepoints_matching_search(tuple(words))
         if q != self.last_updated_code_point_at:
             self.last_updated_code_point_at = q
-            self.table.set_codepoints(codepoints or [], self.mode, iindex_word if iindex_word < len(codepoints) else 0)
+            self.table.set_codepoints(codepoints or [], self.mode, iindex_word)
 
     def update_current_char(self) -> None:
         self.update_codepoints()


### PR DESCRIPTION
The bases for the index were being decoded as base 16, despite being displayed as base 36 (0-9, a-z). This fix makes it so typing 'search string .index' returns the unicode char at the expected index, based on what is displayed by the program. The previous behavior was that to enter the symbol that is displayed at index 18, you would actually have to type `.2c`, since `18 base 36` = `2c base 16`. This fix makes it so to type the symbol at index 18, you type `.18`, which seems more reasonable

It also slightly changes the behavior. Before, only the selected result would appear. For example, musical note `musical note .18` would only show a single result (with index 0 always), since there was only a single result at index 18. Now, searching by index doesn't remove codepoints/results, it simply highlights the result at the correct index for you.

This is my first PR to this project, so sorry if I've violated any coding styles. I will say I'm not particularly happy with how I handled the iindex_word variable in the update_codepoints function, nor am I sure that it's totally sane to set the index as part of set_codepoints. Since setting the index to 0 was a side effect of set_codepoints before, I figured it was okay.

That said, I just wanted to submit something that works :)

Fixes #3221 