### PR TITLE
Add MacOS menu option to close window

### DIFF
--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -395,6 +395,10 @@ cocoa_create_global_menu(void) {
     NSMenu* windowMenu = [[NSMenu alloc] initWithTitle:@"Window"];
     [windowMenuItem setSubmenu:windowMenu];
 
+    [windowMenu addItemWithTitle:@"Close"
+                          action:@selector(performClose:)
+                   keyEquivalent:@"w"];
+
     [windowMenu addItemWithTitle:@"Minimize"
                           action:@selector(performMiniaturize:)
                    keyEquivalent:@"m"];


### PR DESCRIPTION
I often find that I accidentally hit Cmd-W when coding, and accidentally close the window, sometimes losing changes, and often just having to deal with the pain of recovering swap files. MacOS allows you to overwrite the shortcuts for an app, but it seems like it's only if the command is explicitly in one of the menus.

For example, I am able to create a new shortcut for "Quit kitty" so that I don't accidentally quit the entire application, but I am not able to do it for "Close" since there is not a dedicated menu option for it.

Other applications I have looked at have it in the "Window" menu tab and call it "Close", so the UX will be similar enough to other MacOS applications.