### PR TITLE
Make is_arm predicate work on macos

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ is_freebsd = 'freebsd' in _plat
 is_netbsd = 'netbsd' in _plat
 is_dragonflybsd = 'dragonfly' in _plat
 is_bsd = is_freebsd or is_netbsd or is_dragonflybsd or is_openbsd
-is_arm = platform.processor() == 'arm'
+is_arm = platform.processor() == 'arm' or platform.machine() == 'arm64'
 Env = glfw.Env
 env = Env()
 PKGCONFIG = os.environ.get('PKGCONFIG_EXE', 'pkg-config')


### PR DESCRIPTION
just a small change- on current arm macOS, it seems that python's `platform.processor()` lies. This should make the build work correctly on apple silicon.

I added another conditional because i'm assuming is_arm isn't just for apple, and assuming other platforms behave better.

```
[00:04:03][pjjw@loon:~/src/kitty(master)]$ file /usr/bin/python3
/usr/bin/python3: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64e:Mach-O 64-bit executable arm64e]
/usr/bin/python3 (for architecture x86_64):	Mach-O 64-bit executable x86_64
/usr/bin/python3 (for architecture arm64e):	Mach-O 64-bit executable arm64e
[00:04:29][pjjw@loon:~/src/kitty(master)]$ arch -arm64e /usr/bin/python3
Python 3.8.2 (default, Nov  4 2020, 21:23:28) 
[Clang 12.0.0 (clang-1200.0.32.28)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import platform
>>> platform.processor()
'i386'
>>> platform.machine()
'arm64'
>>> ^D
[00:04:56][pjjw@loon:~/src/kitty(master)]$ arch -x86_64 /usr/bin/python3
Python 3.8.2 (default, Nov  4 2020, 21:23:28) 
[Clang 12.0.0 (clang-1200.0.32.28)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import platform
>>> platform.processor()
'i386'
>>> platform.machine()
'x86_64'
```