### PR TITLE
Allow quoted args to toggle_marker

### DIFF
--- a/kitty/config.py
+++ b/kitty/config.py
@@ -298,11 +298,12 @@ def parse_marker_spec(ftype: str, parts: Sequence[str]) -> Tuple[str, Union[str,
 
 @func_with_args('toggle_marker')
 def toggle_marker(func: str, rest: str) -> FuncArgsType:
+    import shlex
     parts = rest.split(maxsplit=1)
     if len(parts) != 2:
         raise ValueError('{} is not a valid marker specification'.format(rest))
     ftype, spec = parts
-    parts = spec.split()
+    parts = shlex.split(spec)
     return func, list(parse_marker_spec(ftype, parts))
 
 


### PR DESCRIPTION
[Mapping a key](https://sw.kovidgoyal.net/kitty/marks.html#creating-markers-dynamically) to create marks dynamically, and attempting to create a mark such as `text 1 'a b'` results in an error: 
![before](https://user-images.githubusercontent.com/20690/106336908-e9dd3100-625d-11eb-996d-e56f9a3fb636.png)

This PR allows quoted marks to be created from `map` keybindings : 
![after](https://user-images.githubusercontent.com/20690/106337039-30cb2680-625e-11eb-9915-e9ae6876df7e.png)
