### PR TITLE
Add two more build-time dependencies to the docs

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -30,7 +30,7 @@ Build-time dependencies:
     * gcc or clang
     * pkg-config
     * For building on Linux in addition to the above dependencies you might also need to install the ``-dev`` packages for:
-      ``libdbus-1-dev``, ``libxcursor-dev``, ``libxrandr-dev``, ``libxi-dev``, ``libxinerama-dev``, ``libgl1-mesa-dev``, ``libxkbcommon-x11-dev``, ``libfontconfig-dev``, and ``libpython3-dev``,
+      ``libdbus-1-dev``, ``libxcursor-dev``, ``libxrandr-dev``, ``libxi-dev``, ``libxinerama-dev``, ``libgl1-mesa-dev``, ``libxkbcommon-x11-dev``, ``libfontconfig-dev``, ``libx11-xcb-dev``, ``liblcms2-dev``, and ``libpython3-dev``,
       if they are not already installed by your distro.
 
 Install and run from source


### PR DESCRIPTION
I needed to install these to get `make` to work on a clean checkout. I think they should be in this list, although the error message from `make` is certainly plenty clear.