### PR TITLE
Gamma correct blending in cell fragment shading

### DIFF
--- a/kitty/cell_fragment.glsl
+++ b/kitty/cell_fragment.glsl
@@ -33,14 +33,19 @@ in float colored_sprite;
 
 out vec4 final_color;
 
+const float gamma = 1.8;
+const vec3 gamma3 = vec3(gamma);
+const vec3 invGamma3 = vec3(1.0/gamma);
+
 // Util functions {{{
 vec4 alpha_blend(vec3 over, float over_alpha, vec3 under, float under_alpha) {
     // Alpha blend two colors returning the resulting color pre-multiplied by its alpha
     // and its alpha.
     // See https://en.wikipedia.org/wiki/Alpha_compositing
     float alpha = mix(under_alpha, 1.0f, over_alpha);
-    vec3 combined_color = mix(under * under_alpha, over, over_alpha);
+    vec3 combined_color = pow(mix(pow(under, gamma3) * under_alpha, pow(over, gamma3), over_alpha), invGamma3);
     return vec4(combined_color, alpha);
+
 }
 
 vec3 premul_blend(vec3 over, float over_alpha, vec3 under) {


### PR DESCRIPTION
I switched to Kitty recently and while I think that it's a very nice replacement for my previous terminal (I like specially that many things just work out of the box and that it's easy to configure, kudos for that), I wasn't immediately convinced about the rendering quality of small fonts (event despite I have a high DPI display).
The vertical strokes are specially problematic as the intensity is not uniform. Here you have a close up, where it can be seen what I mean:
![Screenshot from 2021-02-12 15-41-38](https://user-images.githubusercontent.com/791427/107782027-df846200-6d48-11eb-9712-313f273c4ad9.png)

To my eyes, the `n`, the `h` and the `u` are too blurry on the left stroke.

I thought there could be an explanation for it in the implementation of the alpha blending so I dig in the code and I found it is indeed the problem. In order to get high quality rendering, the alpha blending function needs to be gamma corrected (this video explains very well what this is about: https://youtu.be/LKnqECcg6Gw).

After implementing the correction, the rendering looks a lot better to me. Here you have a few screenshots for comparison:

Font size 9.0
* master
![Screenshot from 2021-02-12 14-55-23](https://user-images.githubusercontent.com/791427/107782194-0fcc0080-6d49-11eb-81a3-f478fe682a79.png)
* branch
![Screenshot from 2021-02-12 14-54-09](https://user-images.githubusercontent.com/791427/107782203-135f8780-6d49-11eb-8d10-4e20d762b972.png)

Font size 7.0
* master
![Screenshot from 2021-02-12 14-55-52](https://user-images.githubusercontent.com/791427/107782221-19556880-6d49-11eb-97c8-bc97b97304a3.png)
* branch
![Screenshot from 2021-02-12 14-55-47](https://user-images.githubusercontent.com/791427/107782232-1c505900-6d49-11eb-96a9-4b748acb9d03.png)

In terms of performance, I've used this snippet to compare master vs this branch:
```
$ time python -c "for i in range(1000000): print(i, 'let me repeat myself ' * 5)"
```
I haven't done a scientific comparison, but a few repetitions show that essentially there's no noticeable difference.

The PR is a draft because there are other other blending functions in the same file that would require changes in the prototype and I didn't want to get down that rabbit hole without knowing if there's any interest upstream. It would also make sense to make the gamma value a configuration option.

This fix may be specially interesting for people complaining about the lack of support for bitmap fonts. I tested in the HD display of my laptop and font sizes even smaller that 7.0 look decent.