### PR TITLE
Made powerline tab_bar_style have different display options

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -907,6 +907,11 @@ entries to this list.
 o('tab_separator', '"{}"'.format(default_tab_separator), option_type=tab_separator, long_text=_('''
 The separator between tabs in the tab bar when using :code:`separator` as the :opt:`tab_bar_style`.'''))
 
+o('tab_powerline_style', 'angled', option_type=choices('angled', 'slanted', 'round'), long_text=_('''
+The powerline separator style between tabs in the tab bar when using :code:`powerline`
+as the :opt:`tab_bar_style`, can be one of: :code:`angled`, :code:`slanted`, or :code:`round`.
+'''))
+
 
 def tab_activity_symbol(x: str) -> Optional[str]:
     if x == 'none':

--- a/kitty/tab_bar.py
+++ b/kitty/tab_bar.py
@@ -42,6 +42,7 @@ class DrawData(NamedTuple):
     title_template: str
     active_title_template: Optional[str]
     tab_activity_symbol: Optional[str]
+    powerline_style: str
 
 
 def as_rgb(x: int) -> int:
@@ -186,13 +187,22 @@ def draw_tab_with_powerline(draw_data: DrawData, screen: Screen, tab: TabBarData
     inactive_bg = as_rgb(color_as_int(draw_data.inactive_bg))
     default_bg = as_rgb(color_as_int(draw_data.default_bg))
 
+    separator_symbol = ''
+    separator_alt_symbol = ''
+    if draw_data.powerline_style == 'slanted':
+        separator_symbol = ''
+        separator_alt_symbol = '╱'
+    elif draw_data.powerline_style == 'round':
+        separator_symbol = ''
+        separator_alt_symbol = ''
+
     min_title_length = 1 + 2
 
     if screen.cursor.x + min_title_length >= screen.columns:
         screen.cursor.x -= 2
         screen.cursor.bg = default_bg
         screen.cursor.fg = inactive_bg
-        screen.draw('   ')
+        screen.draw('{}   '.format(separator_symbol))
         return screen.cursor.x
 
     start_draw = 2
@@ -200,7 +210,7 @@ def draw_tab_with_powerline(draw_data: DrawData, screen: Screen, tab: TabBarData
         screen.cursor.x -= 2
         screen.cursor.fg = inactive_bg
         screen.cursor.bg = tab_bg
-        screen.draw(' ')
+        screen.draw('{} '.format(separator_symbol))
         screen.cursor.fg = tab_fg
     elif screen.cursor.x == 0:
         screen.cursor.bg = tab_bg
@@ -224,9 +234,9 @@ def draw_tab_with_powerline(draw_data: DrawData, screen: Screen, tab: TabBarData
             screen.cursor.bg = default_bg
         else:
             screen.cursor.bg = inactive_bg
-        screen.draw('')
+        screen.draw(separator_symbol)
     else:
-        screen.draw(' ')
+        screen.draw(' {}'.format(separator_alt_symbol))
 
     end = screen.cursor.x
     if end < screen.columns:
@@ -273,7 +283,8 @@ class TabBar:
             self.opts.inactive_tab_foreground, self.opts.inactive_tab_background,
             self.opts.tab_bar_background or self.opts.background, self.opts.tab_title_template,
             self.opts.active_tab_title_template,
-            self.opts.tab_activity_symbol
+            self.opts.tab_activity_symbol,
+            self.opts.tab_powerline_style
         )
         if self.opts.tab_bar_style == 'separator':
             self.draw_func = draw_tab_with_separator


### PR DESCRIPTION
I added options for powerline tab_bar_style to not just have the default angled symbol.
The three options are angled, slanted, and rounded.
I've attached some screenshots using the following config:

    include ayu.conf

    background_opacity 0.85

    enable_audio_bell no

    font_family     MesloLGS NF

    tab_bar_style           powerline
    #tab_powerline_style     angled
    #tab_powerline_style     slanted
    #tab_powerline_style     round
    tab_bar_edge            top
    active_tab_foreground   #3D424D
    active_tab_background   #39BAE6
    active_tab_font_style   bold-italic
    inactive_tab_foreground #B3B1AD
    inactive_tab_background #3D424D
    inactive_tab_font_style normal

![angled1](https://user-images.githubusercontent.com/4364508/108957799-ba8cca80-7637-11eb-9b8e-304dac53b190.jpg)
![angled2](https://user-images.githubusercontent.com/4364508/108957802-ba8cca80-7637-11eb-8092-115340b2d995.jpg)
![angled3](https://user-images.githubusercontent.com/4364508/108957803-ba8cca80-7637-11eb-9fef-ae2d0a5e3050.jpg)
![round1](https://user-images.githubusercontent.com/4364508/108957804-bb256100-7637-11eb-8120-f10d045f6492.jpg)
![round2](https://user-images.githubusercontent.com/4364508/108957806-bb256100-7637-11eb-8115-76fa20cc2577.jpg)
![round3](https://user-images.githubusercontent.com/4364508/108957807-bb256100-7637-11eb-90d7-257828bd7358.jpg)
![slanted1](https://user-images.githubusercontent.com/4364508/108957808-bb256100-7637-11eb-899a-19c0a4cff91a.jpg)
![slanted2](https://user-images.githubusercontent.com/4364508/108957809-bbbdf780-7637-11eb-8289-cb634334329a.jpg)
![slanted3](https://user-images.githubusercontent.com/4364508/108957963-ef991d00-7637-11eb-9cce-08455214c97e.jpg)