### PR TITLE
Add some notes to graphics protocol docs

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -194,15 +194,16 @@ Compression
 ~~~~~~~~~~~~~
 
 The client can send compressed image data to the terminal emulator, by specifying the
-``o`` key. Currently, only zlib based deflate compression is supported, which is specified using
-``o=z``. For example::
+``o`` key. Currently, only RFC1950-style zlib based deflate compression is
+supported, which is specified using ``o=z``. For example::
 
     <ESC>_Gf=24,s=10,v=20,o=z;<payload><ESC>\
 
 This is the same as the example from the RGB data section, except that the
-payload is now compressed using deflate. The terminal emulator will decompress
-it before rendering. You can specify compression for any format. The terminal
-emulator will decompress before interpreting the pixel data.
+payload is now compressed using deflate (this occurs prior to base64-encoding).
+The terminal emulator will decompress it before rendering. You can specify
+compression for any format. The terminal emulator will decompress before
+interpreting the pixel data.
 
 
 The transmission medium


### PR DESCRIPTION
Clarify that RFC1950-style zlib-wrapped deflate (as opposed to RFC1951-style raw deflate) payloads are sent in the graphics protocol, and that base64 encoding follows compression (implied by remarks elsewhere, but go ahead and make it explicit here).

BTW, I'd consider a new flag to indicate that base64 encoding is not being used. You already provide a means to detect support for the graphics protocol; if I've verified that, we pretty much know I can handle arbitrary characters, right? Maybe I'm missing something.

Overall, I like this protocol much, much more than Sixel, especially the attention paid to the z-axis.