### PR TITLE
graphics-protocol: delete duplicate table entry

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -421,7 +421,6 @@ Value of ``d``       Meaning
 ``n`` or ``N``       Delete newest image with the specified number, specified using the ``I`` key. If you specify a ``p`` key for the
                      placement id as well, then only the placement with the specified number and placement id will be deleted.
 ``c`` or ``C``       Delete all placements that intersect with the current cursor position.
-``c`` or ``C``       Delete all placements that intersect with the current cursor position.
 ``p`` or ``P``       Delete all placements that intersect a specific cell, the cell is specified using the ``x`` and ``y`` keys
 ``q`` or ``Q``       Delete all placements that intersect a specific cell having a specific z-index. The cell and z-index is specified using the ``x``, ``y`` and ``z`` keys.
 ``x`` or ``X``       Delete all placements that intersect the specified column, specified using the ``x`` key.


### PR DESCRIPTION
This entry was duplicated, so I purged the copy. Perhaps it was meant to be something else, though, for which documentation is lacking?