### PR TITLE
Fix installation docs

### DIFF
--- a/docs/binary.rst
+++ b/docs/binary.rst
@@ -44,7 +44,7 @@ particular desktop, but it should work for most major desktop environments.
     # your PATH)
     ln -s ~/.local/kitty.app/bin/kitty ~/.local/bin/
     # Place the kitty.desktop file somewhere it can be found by the OS
-    cp ~/.local/kitty.app/share/applications/kitty.desktop ~/.local/share/applications
+    cp ~/.local/kitty.app/share/applications/kitty.desktop ~/.local/share/applications/
     # Update the path to the kitty icon in the kitty.desktop file
     sed -i "s|Icon=kitty|Icon=/home/$USER/.local/kitty.app/share/icons/hicolor/256x256/apps/kitty.png|g" ~/.local/share/applications/kitty.desktop
 


### PR DESCRIPTION
Added `/` at the applications, otherwise applications may be considered a file if the directory is not present. The addition of `/` also ensures user knows that he/she needs to create new directory if it is not present.