### PR TITLE
Add support for the standard MacOS emoji keyboard command.

### DIFF
--- a/kitty/config_data.py
+++ b/kitty/config_data.py
@@ -1575,6 +1575,8 @@ g('shortcuts.misc')  # {{{
 k('toggle_fullscreen', 'kitty_mod+f11', 'toggle_fullscreen', _('Toggle fullscreen'))
 k('toggle_maximized', 'kitty_mod+f10', 'toggle_maximized', _('Toggle maximized'))
 k('input_unicode_character', 'kitty_mod+u', 'kitten unicode_input', _('Unicode input'))
+if is_macos:
+    k('input_unicode_character', 'cmd+ctrl+space', 'kitten unicode_input', _('Unicode input'), add_to_docs=False)
 k('edit_config_file', 'kitty_mod+f2', 'edit_config_file', _('Edit config file'))
 if is_macos:
     k('edit_config_file', 'cmd+,', 'edit_config_file', _('Edit config file'), add_to_docs=False)


### PR DESCRIPTION
MacOS utilizes the `cmd+ctrl+space` command to display the emoji keyboard. As a new user that has heavily adopted the usage of emoji in everyday life, I struggled to figure out how to display the emoji keyboard. 

After a lot of due-diligence (which included searching the repository), I finally found the `input_unicode_character` command, which calls the `unicode_input` kitten. I was then able to add support to my configuration file, and now it works off from muscle memory.

```conf
map cmd+ctrl+space input_unicode_character
```

While the `unicode_input` kitten is not identical to the emoji keyboard provided by MacOS, it still is the primary way to access emoji, and I wanted to pay-it-forward so that future MacOS users can migrate even easier.

Knowing what I know now, and re-referencing the website, I was able to find [mention of the `unicode_input` option](https://sw.kovidgoyal.net/kitty/conf.html?highlight=unicode_input#miscellaneous). However, as someone that never references them as Unicode-based input, and instead calls them emoji, this was overlooked. It's not very evident as a new user [doing a search](https://sw.kovidgoyal.net/kitty/search.html?q=emoji&check_keywords=yes&area=default) about how to access them. Is there a way I could also assist in helping update the documentation to call out the emoji-based support?

![i want to help - clueless.gif](https://dl.dropboxusercontent.com/s/0xvy46nf58acti3/i+want+to+help+-+clueless.gif)