### PR TITLE
Prevent subpixel rendering on box drawn corners

### DIFF
--- a/kitty/fonts/box_drawing.py
+++ b/kitty/fonts/box_drawing.py
@@ -478,11 +478,11 @@ def rectircle_equations(
     if left_quadrants:
         def x(t: float) -> float:
             xterm = 1 - pow(t, yexp)
-            return cell_width - abs(a * pow(xterm, xexp)) - adjust_left_quadrant
+            return math.floor(cell_width - abs(a * pow(xterm, xexp)) - adjust_left_quadrant)
     else:
         def x(t: float) -> float:
             xterm = 1 - pow(t, yexp)
-            return abs(a * pow(xterm, xexp))
+            return math.ceil(abs(a * pow(xterm, xexp)))
 
     return x, y
 


### PR DESCRIPTION
Firstly, I want to thank you @kovidgoyal for your patience and help; I really appreciate all the work you do on Kitty! ❤️

Given the discussion at https://github.com/kovidgoyal/kitty/issues/3409#issuecomment-803767623...

>You basically want to change the values returned by the lower x() function by a delta. Play with it and see what happens, though in my testing, the current code is optimal across all cell sizes.

I agree that the rectircle equation is correct/perfect, but I found that the cause of the seemingly-misaligned corners (especially on the right side) is due to subpixel rendering when the `x()` functions return certain floats / decimals on certain displays.  I found that applying `math.floor()` to the left quadrant, and `math.ceil()` to the right quadrant prevents subpixel rendering issues at every font size and cell_width I tried.  Here are screenshot examples, before and after my change...

### Before

This can be extremely subtle, but if you look at where the corner meets the vertical side, there is a subpixel rendering issue causing it to look ever-so-slightly misaligned (at least on both of my displays in MacOS here):

![CleanShot 2021-03-25 at 00 08 42](https://user-images.githubusercontent.com/5187394/112417591-50cb1380-8cfe-11eb-9a48-6e900a45a2f0.png)

### After

After this `math.floor()` and `math.ceil()` change, I cannot reproduce this subpixel rendering error at any font size or cell width:

![CleanShot 2021-03-25 at 00 09 49](https://user-images.githubusercontent.com/5187394/112417682-79530d80-8cfe-11eb-9fff-448a27b34cc0.png)