### PR TITLE
Do not overwrite EDITOR variable

### DIFF
--- a/kitty/main.py
+++ b/kitty/main.py
@@ -275,15 +275,14 @@ def expand_listen_on(listen_on: str, from_config_file: bool) -> str:
 
 
 def setup_environment(opts: OptionsStub, cli_opts: CLIOptions) -> None:
-    if opts.editor == '.':
+    editor = opts.editor
+    if editor == '.':
         editor = get_editor_from_env(os.environ)
         if not editor:
             shell_env = read_shell_environment(opts)
             editor = get_editor_from_env(shell_env)
-        if editor:
-            os.environ['EDITOR'] = editor
-    else:
-        os.environ['EDITOR'] = opts.editor
+    if editor and 'EDITOR' not in os.environ:
+        os.environ['EDITOR'] = editor
     from_config_file = False
     if not cli_opts.listen_on and opts.listen_on.startswith('unix:'):
         cli_opts.listen_on = opts.listen_on


### PR DESCRIPTION
The current startup logic will overwrite the `EDITOR` variable in the case
that both `EDITOR` and `VISUAL` are defined. This is because `get_editor_from_env`
checks `VISUAL` before `EDITOR`, but `setup_environment` overwrites `EDITOR` in
either case.

This change simply adds a check to only define the `EDITOR` variable in
the case that it's not already set.

I'm not totally clear why the `EDITOR` variable needs to be set at all; I'm guessing it's because the config file is not available after the application has been started, so the environment is used to store the value for later. However, the current implementation has a problem, because the `get_editor_from_env` function checks `VISUAL` first, so if the config file has an `editor` setting, that won't be used if the `VISUAL` variable is defined. An easy fix would be to have the `get_editor_from_env` function check for `KITTY_EDITOR` before `VISUAL` or `EDITOR`, and have `setup_environment` update `KITTY_EDITOR` instead of `EDITOR`.

The reason I noticed this issue was because I set the following values:
``` sh
VISUAL='nvim`
EDITOR='nvim -e'
```

However, kitty was changing them to be:
``` sh
VISUAL='nvim'
EDITOR='/usr/bin/nvim'
```