### PR TITLE
[macos] - Add "Secure Keyboard Entry" menu item

### DIFF
--- a/glfw/glfw.py
+++ b/glfw/glfw.py
@@ -89,7 +89,7 @@ def init_env(env: Env, pkg_config: Callable, pkg_version: Callable, at_least_ver
 
     elif module == 'cocoa':
         ans.cppflags.append('-DGL_SILENCE_DEPRECATION')
-        for f_ in 'Cocoa IOKit CoreFoundation CoreVideo'.split():
+        for f_ in 'Cocoa Carbon IOKit CoreFoundation CoreVideo'.split():
             ans.ldpaths.extend(('-framework', f_))
 
     elif module == 'wayland':

--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -397,6 +397,12 @@ cocoa_create_global_menu(void) {
 
     [appMenu addItem:[NSMenuItem separatorItem]];
 
+    [[appMenu addItemWithTitle:@"Secure Keyboard Entry"
+                        action:@selector(toggleSecureInput:)
+                 keyEquivalent:@"s"]
+        setKeyEquivalentModifierMask:NSEventModifierFlagOption | NSEventModifierFlagCommand];
+    [appMenu addItem:[NSMenuItem separatorItem]];
+
     [appMenu addItemWithTitle:[NSString stringWithFormat:@"Quit %@", app_name]
                        action:@selector(terminate:)
                 keyEquivalent:@"q"];


### PR DESCRIPTION
Hi there 👋 

I was missing the "Secure Keyboard Entry" functionality, so here you go 🚀 
Mostly based/copied from https://github.com/gnachman/iTerm2/blob/master/sources/iTermSecureKeyboardEntryController.m

Toggled by `Command-Option-S`

![image](https://user-images.githubusercontent.com/616057/114189829-4aba7100-9953-11eb-970f-ae56f81bdd74.png)