### PR TITLE
Fix compilation on macOS 10.12

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -32,6 +32,12 @@
 #include <float.h>
 #include <string.h>
 
+#if (MAC_OS_X_VERSION_MAX_ALLOWED < 101300)
+#define NSControlStateValueOn NSOnState
+#define NSControlStateValueOff NSOffState
+#define NSControlStateValueMixed NSMixedState
+#endif
+
 
 static uint32_t
 vk_code_to_functional_key_code(uint8_t key_code) {  // {{{


### PR DESCRIPTION
The constants `NSControlStateValueOn`, `NSControlStateValueOff` and `NSControlStateValueMixed` are only available for macOS 10.13 or above according to https://developer.apple.com/documentation/appkit/nscontrolstatevalueon?language=objc.
Without this commit, compilation fails with this message:
```
glfw/cocoa_window.m:1537:28: error: use of undeclared identifier 'NSControlStateValueOn'
              item.state = NSControlStateValueOn;
                           ^
glfw/cocoa_window.m:1539:28: error: use of undeclared identifier 'NSControlStateValueMixed'
              item.state = NSControlStateValueMixed;
                           ^
glfw/cocoa_window.m:1542:47: error: use of undeclared identifier 'NSControlStateValueOn'
          item.state = controller.isDesired ? NSControlStateValueOn : NSControlStateValueOff;
                                              ^
glfw/cocoa_window.m:1542:71: error: use of undeclared identifier 'NSControlStateValueOff'
          item.state = controller.isDesired ? NSControlStateValueOn : NSControlStateValueOff;
                                                                      ^
```
To fix this, simply redefine the constants to use the old and now deprecated constants on older macOS versions.

The code that causes this was introduced in 98519bf326834a126e89489a6a221ff21fab100f.

@multi I'd like to test that this actually works when I compile the code with this patch on my machine. Could you please tell me how to do that?
@kovidgoyal Please wait with merging this PR until I can test it.