### PR TITLE
Set default update interval to 0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ class Options(argparse.Namespace):
     extra_logging: List[str] = []
     extra_include_dirs: List[str] = []
     link_time_optimization: bool = 'KITTY_NO_LTO' not in os.environ
-    update_check_interval: float = 24
+    update_check_interval: float = 0
     egl_library: Optional[str] = os.getenv('KITTY_EGL_LIBRARY')
     startup_notification_library: Optional[str] = os.getenv('KITTY_STARTUP_NOTIFICATION_LIBRARY')
     canberra_library: Optional[str] = os.getenv('KITTY_CANBERRA_LIBRARY')
@@ -1083,10 +1083,10 @@ def package(args: Options, bundle_type: str) -> None:
     shutil.copytree('kittens', os.path.join(libdir, 'kittens'), ignore=src_ignore)
     if for_freeze:
         shutil.copytree('kitty_tests', os.path.join(libdir, 'kitty_tests'))
-    if args.update_check_interval != 24.0:
+    if args.update_check_interval != 0.0:
         with open(os.path.join(libdir, 'kitty/config_data.py'), 'r+', encoding='utf-8') as f:
             raw = f.read()
-            nraw = raw.replace("update_check_interval', 24", "update_check_interval', {}".format(args.update_check_interval), 1)
+            nraw = raw.replace("update_check_interval', 0", "update_check_interval', {}".format(args.update_check_interval), 1)
             if nraw == raw:
                 raise SystemExit('Failed to change the value of update_check_interval')
             f.seek(0), f.truncate(), f.write(nraw)


### PR DESCRIPTION
I believe that any kind of "opt-out" mechanism that connects to a remote resource is an anti-feature.

Automatic updates (or update detection) is a useful feature, but it is only a *feature* and users should be aware of its existence if it is turned on.
By making it an "opt-out" mechanism, you are effectively misleading users who assume that terminal emulators do not (by default) have a built-in phone-home mechanism.

Please do not contribute to the normalization of surveillance in GNU/Linux software.