### PR TITLE
fixed docs on how to use showkey on macOs

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -234,18 +234,8 @@ the :sc:`send_text <send_text>` you can use the ``showkey`` utility. Run::
     showkey -a
 
 Then press the key you want to emulate. On macOS, this utility is currently not
-available. The manual way to figure it out is:
-
-    1. Look up your key's decimal value in the table at the bottom of `this
-       page <http://ascii-table.com/ansi-escape-sequences.php>`_ or any
-       ANSI escape sequence table. There are different modifiers for :kbd:`ctrl`,
-       :kbd:`alt`, etc. For e.g., for :kbd:`ctrl+s`, find the ``S`` row and look at
-       the third column value, ``19``.
-
-    2. Convert the decimal value to hex with ``kitty +runpy "print(hex(19))"``.
-       This shows the hex value, ``13`` in this case.
-
-    3. Use ``\x(hexval)`` in your ``send_text`` command in kitty. So in this example, ``\x13``
+available, but you can get something similar grabbing and compiling this 
+`gist <https://gist.github.com/rprichard/9b05a488439455e6e41fd73e5bfa8c15>`.
 
 How do I open a new window or tab with the same working directory as the current window?
 --------------------------------------------------------------------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -234,7 +234,7 @@ the :sc:`send_text <send_text>` you can use the ``showkey`` utility. Run::
     showkey -a
 
 Then press the key you want to emulate. On macOS, this utility is currently not
-available, but you can get something similar grabbing and compiling this 
+available, but you can get something similar grabbing and compiling this
 `gist <https://gist.github.com/rprichard/9b05a488439455e6e41fd73e5bfa8c15>`.
 
 How do I open a new window or tab with the same working directory as the current window?


### PR DESCRIPTION
The method used to map keys on macOs depended on aa site like http://ascii-table.com/ansi-escape-sequences.php , but that is now down and I couldn't find any other alternatives. On the other hand, I was able to find this  one file implementation of `showkey` that works on macOs: https://gist.github.com/rprichard/9b05a488439455e6e41fd73e5bfa8c15
It would be ideal if it could be part of kitty, but in the absence of that, updating the docs is the next best thing.