### PR TITLE
chore(logo): add missing attribution

### DIFF
--- a/logo/attribution.txt
+++ b/logo/attribution.txt
@@ -1,0 +1,8 @@
+Attribution
+###########
+
+- Name: macOS Big Sur Icon Template
+- Author: Václav Vančura
+- Source: https://www.figma.com/community/file/857303226040719059
+- License: https://creativecommons.org/licenses/by/4.0/
+- Modification: Replaced the template logo with kitty's


### PR DESCRIPTION
The Big Sur template includes a CC BY 4.0 license, hence the attribution with the details of the change.

Add attribution for the new logo in https://github.com/kovidgoyal/kitty/pull/3548.

I hope this looks okay?