### PR TITLE
macOS: fix spotlight search in help menu not working on some machines

### DIFF
--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -454,6 +454,7 @@ cocoa_create_global_menu(void) {
                          action:@selector(open_kitty_website_url:)
                   keyEquivalent:@"?"]
                       setTarget:global_menu_target];
+    [NSApp setHelpMenu:helpMenu];
     [helpMenu release];
 
     [bar release];


### PR DESCRIPTION
The spotlight search in the "Help" menu of the menu bar did not appear when the system language is set to a language other than English. macOS magically adds the search box when the text in that menu matches the translation of "Help" in the system language. On my German system for example replacing "Help" with "Hilfe" will make the search box appear again. This is however not a good solution for kitty as it would require implementing localization support for all languages. Removing `CFBundleAllowMixedLocalizations=True` from `setup.py` also brings back the search box but that may break the locale again. The line was added in  8818b5d8df686c0e340ef3d15a069bf54082d112 to fix an issue related to https://github.com/kovidgoyal/kitty/issues/1233.
Luckily I found a seemingly undocumented function that helps us out here, which does not rely the text comparison magic.