### PR TITLE
fix allocation typo

### DIFF
--- a/kitty/graphics.c
+++ b/kitty/graphics.c
@@ -306,7 +306,7 @@ png_path_to_bitmap(const char* path, uint8_t** data, unsigned int* width, unsign
     unsigned char *buf = malloc(capacity);
     if (!buf) { log_error("Out of memory reading PNG file at: %s", path); fclose(fp); return false; }
     while (!feof(fp)) {
-        if (pos - capacity < 1024) {
+        if (capacity - pos < 1024) {
             capacity *= 2;
             unsigned char *new_buf = realloc(buf, capacity);
             if (!new_buf) {


### PR DESCRIPTION
Fortunately, this only affected performance, not memory safety.

The length parameter of `fread` properly prevented a buffer overflow, but a typo in the allocation condition required the buffer to be entirely filled before allocating more memory. This is because the condition `pos - capacity` underflows when `pos < capacity`, causing `pos - capacity < 1024` to be false unless `pos == capacity`.

---

Thank you for writing this terminal emulator! I appreciate all the effort you put into maintaining it, so I thought I'd contribute back when I noticed something odd :-)