### PR TITLE
When running a background process, always inherit env

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1221,6 +1221,8 @@ class Boss:
         cwd_from: Optional[int] = None
     ) -> None:
         import subprocess
+        if env:
+            env = {**os.environ, **env}
         if cwd_from:
             with suppress(Exception):
                 cwd = cwd_of_process(cwd_from)


### PR DESCRIPTION
subprocess.Popen inherits the current environment if you pass env=None,
but only sets the environment you pass when you pass something else.
This causes an issue with using launch with --stdin-source and
--type=background, e.g. that DISPLAY is not set so you can't launch
graphical processes. Therefore, we have to include os.environ when we
pass an env to Popen.

Fixes #3602