### PR TITLE
cache_dir(): allow symlinks along path to target directory

### DIFF
--- a/kitty/constants.py
+++ b/kitty/constants.py
@@ -111,6 +111,7 @@ def cache_dir() -> str:
     else:
         candidate = os.environ.get('XDG_CACHE_HOME', '~/.cache')
         candidate = os.path.join(os.path.expanduser(candidate), appname)
+    candidate = os.path.realpath(candidate)
     os.makedirs(candidate, exist_ok=True)
     return candidate
 


### PR DESCRIPTION
Without this, a symlink at the cache directory results in an error along these lines:

```python
[schwarzgerat](0) $ kitty
[136 14:49:36.346668] Traceback (most recent call last):
  File "/home/dank/src/kitty/kitty/launcher/../../kitty/main.py", line 336, in main
    _main()
  File "/home/dank/src/kitty/kitty/launcher/../../kitty/main.py", line 329, in _main
    run_app(opts, cli_opts, bad_lines)
  File "/home/dank/src/kitty/kitty/launcher/../../kitty/main.py", line 176, in __call__
    _run_app(opts, args, bad_lines)
  File "/home/dank/src/kitty/kitty/launcher/../../kitty/main.py", line 147, in _run_app
    with cached_values_for(run_app.cached_values_name) as cached_values:
  File "/usr/lib/python3.9/contextlib.py", line 117, in __enter__
    return next(self.gen)
  File "/home/dank/src/kitty/kitty/launcher/../../kitty/config.py", line 762, in cached_values_for
    cached_path = os.path.join(cache_dir(), name + '.json')
  File "/home/dank/src/kitty/kitty/launcher/../../kitty/types.py", line 84, in __call__
    self._cached_result = self.__wrapped__()
  File "/home/dank/src/kitty/kitty/launcher/../../kitty/constants.py", line 114, in cache_dir
    os.makedirs(candidate, exist_ok=True)
  File "/usr/lib/python3.9/os.py", line 225, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/home/dank/.cache/kitty'

[schwarzgerat](1) $
```

I am not a Python expert, or really even well-versed in the language, but this seems reasonable.