### PR TITLE
macOS: add menu items for new_window and close_window

### DIFF
--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -997,6 +997,8 @@ process_global_state(void *data) {
             if (cocoa_pending_actions & NEXT_TAB) { call_boss(next_tab, NULL); }
             if (cocoa_pending_actions & PREVIOUS_TAB) { call_boss(previous_tab, NULL); }
             if (cocoa_pending_actions & DETACH_TAB) { call_boss(detach_tab, NULL); }
+            if (cocoa_pending_actions & NEW_WINDOW) { call_boss(new_window, NULL); }
+            if (cocoa_pending_actions & CLOSE_WINDOW) { call_boss(close_window, NULL); }
             if (cocoa_pending_actions_data.wd) {
                 if (cocoa_pending_actions & NEW_OS_WINDOW_WITH_WD) { call_boss(new_os_window_with_wd, "s", cocoa_pending_actions_data.wd); }
                 if (cocoa_pending_actions & NEW_TAB_WITH_WD) { call_boss(new_tab_with_wd, "s", cocoa_pending_actions_data.wd); }

--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -88,6 +88,8 @@ PENDING(close_tab, CLOSE_TAB)
 PENDING(new_tab, NEW_TAB)
 PENDING(next_tab, NEXT_TAB)
 PENDING(previous_tab, PREVIOUS_TAB)
+PENDING(new_window, NEW_WINDOW)
+PENDING(close_window, CLOSE_WINDOW)
 
 - (void)open_kitty_website_url:(id)sender {
     (void)sender;
@@ -115,7 +117,7 @@ typedef struct {
 } GlobalShortcut;
 typedef struct {
     GlobalShortcut new_os_window, close_os_window, close_tab, edit_config_file;
-    GlobalShortcut previous_tab, next_tab, new_tab;
+    GlobalShortcut previous_tab, next_tab, new_tab, new_window, close_window;
 } GlobalShortcuts;
 static GlobalShortcuts global_shortcuts;
 
@@ -129,6 +131,7 @@ cocoa_set_global_shortcut(PyObject *self UNUSED, PyObject *args) {
 #define Q(x) if (strcmp(name, #x) == 0) gs = &global_shortcuts.x
     Q(new_os_window); else Q(close_os_window); else Q(close_tab); else Q(edit_config_file);
     else Q(new_tab); else Q(next_tab); else Q(previous_tab);
+    else Q(new_window); else Q(close_window);
 #undef Q
     if (gs == NULL) { PyErr_SetString(PyExc_KeyError, "Unknown shortcut name"); return NULL; }
     int cocoa_mods;
@@ -415,9 +418,11 @@ cocoa_create_global_menu(void) {
     [shellMenuItem setSubmenu:shellMenu];
     MENU_ITEM(shellMenu, @"New OS Window", new_os_window);
     MENU_ITEM(shellMenu, @"New Tab", new_tab);
+    MENU_ITEM(shellMenu, @"New Window", new_window);
     [shellMenu addItem:[NSMenuItem separatorItem]];
     MENU_ITEM(shellMenu, @"Close OS Window", close_os_window);
     MENU_ITEM(shellMenu, @"Close Tab", close_tab);
+    MENU_ITEM(shellMenu, @"Close Window", close_window);
     [shellMenu release];
 
     NSMenuItem* windowMenuItem =

--- a/kitty/main.py
+++ b/kitty/main.py
@@ -135,7 +135,8 @@ def set_x11_window_icon() -> None:
 def _run_app(opts: OptionsStub, args: CLIOptions, bad_lines: Sequence[BadLine] = ()) -> None:
     global_shortcuts: Dict[str, SingleKey] = {}
     if is_macos:
-        for ac in ('new_os_window', 'close_os_window', 'close_tab', 'edit_config_file', 'previous_tab', 'next_tab', 'new_tab'):
+        for ac in ('new_os_window', 'close_os_window', 'close_tab', 'edit_config_file', 'previous_tab',
+                   'next_tab', 'new_tab', 'new_window', 'close_window'):
             val = get_macos_shortcut_for(opts, ac)
             if val is not None:
                 global_shortcuts[ac] = val

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -271,7 +271,9 @@ typedef enum {
     NEXT_TAB = 128,
     PREVIOUS_TAB = 256,
     DETACH_TAB = 512,
-    OPEN_FILE = 1024
+    OPEN_FILE = 1024,
+    NEW_WINDOW = 2048,
+    CLOSE_WINDOW = 4096,
 } CocoaPendingAction;
 void set_cocoa_pending_action(CocoaPendingAction action, const char*);
 #endif


### PR DESCRIPTION
As promised in #3647.
Please double-check that I made the changes in exactly the right places, not in too few places and not in too many. I basically just searched the code base for an already existing shortcut and then replicated the appropriate looking code for the new shortcuts.
Should I sort the shortcuts in the code into a particular order or just append to the end like I did now?
I successfully tested this change.