### PR TITLE
Use less contrasting color for powerline alt separator

### DIFF
--- a/kitty/rgb.py
+++ b/kitty/rgb.py
@@ -12,6 +12,16 @@ class Color(NamedTuple):
     green: int
     blue: int
 
+    def luminance(self) -> float:
+        return 0.299 * self.red + 0.587 * self.green + 0.114 * self.blue
+
+    def contrast(self, other: 'Color') -> float:
+        a = self.luminance()
+        b = other.luminance()
+        if a < b:
+            a, b = b, a
+        return (a + 0.05) / (b + 0.05)
+
 
 def alpha_blend_channel(top_color: int, bottom_color: int, alpha: float) -> int:
     return int(alpha * top_color + (1 - alpha) * bottom_color)

--- a/kitty/tab_bar.py
+++ b/kitty/tab_bar.py
@@ -234,6 +234,15 @@ def draw_tab_with_powerline(draw_data: DrawData, screen: Screen, tab: TabBarData
             screen.cursor.bg = inactive_bg
         screen.draw(separator_symbol)
     else:
+        if tab_bg == default_bg:
+            pass
+        elif tab_bg == tab_fg:
+            screen.cursor.fg = default_bg
+        else:
+            c1 = draw_data.inactive_bg.contrast(draw_data.default_bg)
+            c2 = draw_data.inactive_bg.contrast(draw_data.inactive_fg)
+            if c1 < c2:
+                screen.cursor.fg = default_bg
         screen.draw(f' {separator_alt_symbol}')
 
     end = screen.cursor.x


### PR DESCRIPTION
This change makes it so that when using powerline-style tab bars, and
if the `tab_bar_background`, `inactive_tab_background` and
`inactive_tab_foreground` are all different, the separator between
inactive tabs uses the less contrasting color between the inactive
foreground, and the tab bar background.

This fixes #3664.