### PR TITLE
Downgrade libstartup-notification-1.so non-existence to warning

### DIFF
--- a/kitty/desktop.c
+++ b/kitty/desktop.c
@@ -52,8 +52,8 @@ init_x11_startup_notification(PyObject UNUSED *self, PyObject *args) {
             if (libsn_handle) break;
         }
         if (libsn_handle == NULL) {
-            PyErr_Format(PyExc_OSError, "Failed to load %s with error: %s", libnames[0], dlerror());
-            return NULL;
+            log_error("Failed to load %s with error: %s", libnames[0], dlerror());
+            Py_RETURN_NONE;
         }
         dlerror();    /* Clear any existing error */
 #define F(name) LOAD_FUNC(libsn_handle, name)


### PR DESCRIPTION
I'm not sure how common this library actually is. On my system, an Arch
Linux system with 2,170 packages installed, including KDE (Plasma), I
didn't have it.

Googling around shows me that its purpose is just to show a loading
cursor when an application is loading. That sounds pretty Windows 98 to
me. I see how it could be useful, but certainly it's not an error not to
have this around.