### PR TITLE
Add padding options for around the tab bar - Transfer from config_data.py

### DIFF
--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -688,6 +688,7 @@ opt('window_margin_width', '0',
 The window margin (in pts) (blank area outside the border). A single value sets
 all four sides. Two values set the vertical and horizontal sides. Three values
 set top, horizontal and bottom. Four values set top, right, bottom and left.
+For margins with tab bar, see tab_bar_margin_height.
 '''
     )
 
@@ -709,6 +710,7 @@ The window padding (in pts) (blank area between the text and the window border).
 A single value sets all four sides. Two values set the vertical and horizontal
 sides. Three values set top, horizontal and bottom. Four values set top, right,
 bottom and left.
+For padding with tab bar, see tab_bar_margin_height.
 '''
     )
 
@@ -812,6 +814,25 @@ opt('tab_bar_edge', 'bottom',
 opt('tab_bar_margin_width', '0.0',
     option_type='positive_float',
     long_text='The margin to the left and right of the tab bar (in pts)'
+    )
+
+opt('tab_bar_margin_height', '0.0',
+    option_type='positive_float',
+    long_text='''
+The margin to the top or bottom of the tab bar (in pts). If tab_bar_style is hidden, this value has no effect.
+If the number of tabs is less than tab_bar_min_tabs and retain_tab_bar_margin_height is set on, this is the distance
+between the top of the os window and the point where the padding/margin set through window_margin_width/window_padding_width takes over.
+If the number of tabs is greater than tab_bar_min_tabs, there is the top/bottom of the os window, a padding of tab_bar_margin_height,
+the tab bar (which takes a height of one character cell), the padding/margin (set through window_margin_width or window_padding_width), and
+then the shell prompt. (or the bottom of the field if tab_bar_edge is set to bottom)
+'''
+    )
+
+opt('retain_tab_bar_margin_height', 'no',
+    option_type='to_bool', ctype='bool',
+    long_text='''
+Retain tab_bar_margin_height when the number of tabs is too few to trigger the tab bar.
+'''
     )
 
 opt('tab_bar_style', 'fade',

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -1095,6 +1095,9 @@ class Parser:
     def resize_in_steps(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['resize_in_steps'] = to_bool(val)
 
+    def retain_tab_bar_margin_height(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        ans['retain_tab_bar_margin_height'] = to_bool(val)
+
     def scrollback_fill_enlarged_window(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['scrollback_fill_enlarged_window'] = to_bool(val)
 
@@ -1148,6 +1151,9 @@ class Parser:
 
     def tab_bar_edge(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['tab_bar_edge'] = tab_bar_edge(val)
+
+    def tab_bar_margin_height(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        ans['tab_bar_margin_height'] = positive_float(val)
 
     def tab_bar_margin_width(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['tab_bar_margin_width'] = positive_float(val)

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -386,6 +386,7 @@ option_names = (  # {{{
  'resize_debounce_time',
  'resize_draw_strategy',
  'resize_in_steps',
+ 'retain_tab_bar_margin_height',
  'scrollback_fill_enlarged_window',
  'scrollback_lines',
  'scrollback_pager',
@@ -402,6 +403,7 @@ option_names = (  # {{{
  'tab_activity_symbol',
  'tab_bar_background',
  'tab_bar_edge',
+ 'tab_bar_margin_height',
  'tab_bar_margin_width',
  'tab_bar_min_tabs',
  'tab_bar_style',
@@ -770,6 +772,7 @@ class Options:
     resize_debounce_time: float = 0.1
     resize_draw_strategy: int = 0
     resize_in_steps: bool = False
+    retain_tab_bar_margin_height: bool = False
     scrollback_fill_enlarged_window: bool = False
     scrollback_lines: int = 2000
     scrollback_pager: typing.List[str] = ['less', '--chop-long-lines', '--RAW-CONTROL-CHARS', '+INPUT_LINE_NUMBER']
@@ -785,6 +788,7 @@ class Options:
     tab_activity_symbol: typing.Optional[str] = None
     tab_bar_background: typing.Optional[kitty.rgb.Color] = None
     tab_bar_edge: int = 3
+    tab_bar_margin_height: float = 0
     tab_bar_margin_width: float = 0
     tab_bar_min_tabs: int = 2
     tab_bar_style: choices_for_tab_bar_style = 'fade'

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -468,26 +468,43 @@ add_borders_rect(id_type os_window_id, id_type tab_id, uint32_t left, uint32_t t
 
 void
 os_window_regions(OSWindow *os_window, Region *central, Region *tab_bar) {
-    if (!OPT(tab_bar_hidden) && os_window->num_tabs >= OPT(tab_bar_min_tabs)) {
+    if (OPT(tab_bar_hidden)) {
+        zero_at_ptr(tab_bar);
+        central->left = 0; central->top = 0; central->right = os_window->viewport_width - 1;
+        central->bottom = os_window->viewport_height - 1;
+    } else if (os_window->num_tabs >= OPT(tab_bar_min_tabs)) {
         switch(OPT(tab_bar_edge)) {
             case TOP_EDGE:
-                central->left = 0; central->top = os_window->fonts_data->cell_height; central->right = os_window->viewport_width - 1;
+                central->left = 0; central->top = os_window->fonts_data->cell_height + pt_to_px(OPT(tab_bar_margin_height), os_window->id); central->right = os_window->viewport_width - 1;
                 central->bottom = os_window->viewport_height - 1;
-                tab_bar->left = central->left; tab_bar->right = central->right; tab_bar->top = 0;
+                tab_bar->left = central->left; tab_bar->right = central->right; tab_bar->top = pt_to_px(OPT(tab_bar_margin_height), os_window->id);
                 tab_bar->bottom = central->top - 1;
                 break;
             default:
                 central->left = 0; central->top = 0; central->right = os_window->viewport_width - 1;
-                central->bottom = os_window->viewport_height - os_window->fonts_data->cell_height - 1;
+                central->bottom = os_window->viewport_height - os_window->fonts_data->cell_height - pt_to_px(OPT(tab_bar_margin_height), os_window->id) - 1;
                 tab_bar->left = central->left; tab_bar->right = central->right; tab_bar->top = central->bottom + 1;
                 tab_bar->bottom = os_window->viewport_height - 1;
                 break;
+        }
+    } else if (OPT(retain_tab_bar_margin_height)) {
+        switch(OPT(tab_bar_edge)) {
+          case TOP_EDGE:
+            zero_at_ptr(tab_bar);
+            central->left = 0; central->top = pt_to_px(OPT(tab_bar_margin_height), os_window->id); central->right = os_window->viewport_width - 1;
+            central->bottom = os_window->viewport_height - 1;
+            break;
+          default:
+            zero_at_ptr(tab_bar);
+            central->left = 0; central->top = 0; central->right = os_window->viewport_width - 1;
+            central->bottom = os_window->viewport_height - pt_to_px(OPT(tab_bar_margin_height), os_window->id);
+            break;
         }
     } else {
         zero_at_ptr(tab_bar);
         central->left = 0; central->top = 0; central->right = os_window->viewport_width - 1;
         central->bottom = os_window->viewport_height - 1;
-    }
+      }
 }
 
 void
@@ -664,6 +681,8 @@ PYWRAP1(set_options) {
     S(macos_hide_from_tasks, PyObject_IsTrue);
     S(macos_thicken_font, PyFloat_AsFloat);
     S(tab_bar_min_tabs, PyLong_AsUnsignedLong);
+    S(tab_bar_margin_height, PyFloat_AsFloat);
+    S(retain_tab_bar_margin_height, PyObject_IsTrue);
     S(disable_ligatures, PyLong_AsLong);
     S(force_ltr, PyObject_IsTrue);
     S(resize_draw_strategy, PyLong_AsLong);

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -53,6 +53,8 @@ typedef struct {
     float inactive_text_alpha;
     Edge tab_bar_edge;
     unsigned long tab_bar_min_tabs;
+    float tab_bar_margin_height;
+    bool retain_tab_bar_margin_height;
     DisableLigature disable_ligatures;
     bool force_ltr;
     ResizeDrawStrategy resize_draw_strategy;

--- a/kitty/tab_bar.py
+++ b/kitty/tab_bar.py
@@ -257,7 +257,9 @@ class TabBar:
         self.os_window_id = os_window_id
         self.num_tabs = 1
         opts = get_options()
+        self.tab_bar_edge = opts.tab_bar_edge
         self.margin_width = pt_to_px(opts.tab_bar_margin_width, self.os_window_id)
+        self.margin_height = pt_to_px(opts.tab_bar_margin_height, self.os_window_id)
         self.cell_width, cell_height = cell_size_for_window(self.os_window_id)
         self.data_buffer_size = 0
         self.laid_out_once = False
@@ -325,6 +327,7 @@ class TabBar:
         if tab_bar.width < 2:
             return
         self.cell_width = cell_width
+        self.cell_height = cell_height
         s = self.screen
         viewport_width = max(4 * cell_width, tab_bar.width - 2 * self.margin_width)
         ncells = viewport_width // cell_width
@@ -334,10 +337,26 @@ class TabBar:
         margin = (viewport_width - ncells * cell_width) // 2 + self.margin_width
         self.window_geometry = g = WindowGeometry(
             margin, tab_bar.top, viewport_width - margin, tab_bar.bottom, s.columns, s.lines)
-        if margin > 0:
-            self.blank_rects = (Rect(0, g.top, g.left, g.bottom + 1), Rect(g.right - 1, g.top, viewport_width, g.bottom + 1))
-        else:
-            self.blank_rects = ()
+
+        if self.tab_bar_edge == 1: #top
+            if margin > 0 and self.margin_height > 0:
+                self.blank_rects = (Rect(0, g.top, g.left, g.bottom + 1), Rect(g.right - 1, g.top, viewport_width, g.bottom + 1), Rect(0, 0, viewport_width - 1, g.top))
+            elif margin > 0:
+                self.blank_rects = (Rect(0, g.top, g.left, g.bottom + 1), Rect(g.right - 1, g.top, viewport_width, g.bottom + 1))
+            elif self.margin_height > 0:
+                self.blank_rects = (Rect(0, 0, viewport_width - 1, g.top))
+            else:
+                self.blank_rects = ()
+        else: #tab_bar_edge == 3, bottom
+            if margin > 0 and self.margin_height > 0:
+                self.blank_rects = (Rect(0, g.top, g.left, g.bottom + 1), Rect(g.right - 1, g.top, viewport_width, g.bottom + 1), Rect(0, g.top + self.cell_height, viewport_width - 1, vh))
+            elif margin > 0:
+                self.blank_rects = (Rect(0, g.top, g.left, g.bottom + 1), Rect(g.right - 1, g.top, viewport_width, g.bottom + 1))
+            elif self.margin_height > 0:
+                self.blank_rects = (Rect(0, g.top + self.cell_height, viewport_width - 1, vh))
+            else:
+                self.blank_rects = ()
+                
         self.screen_geometry = sg = calculate_gl_geometry(g, vw, vh, cell_width, cell_height)
         set_tab_bar_render_data(self.os_window_id, sg.xstart, sg.ystart, sg.dx, sg.dy, self.screen)
 


### PR DESCRIPTION
See [3436](https://github.com/kovidgoyal/kitty/pull/3436)

Tab bar padding no longer functions after moving to the new python options schema

pt_to_px may have something to do with it, as replacing the call to pt_to_px  on line 478 with a constant number causes that number of pixels padding between the top of the window and the tab bar. (also, `printf("%ld", pt_to_px(OPT(tab_bar_margin_height), os_window->id);` does not print anything

EDIT: Not pt_to_px, but the problem lies in OPT(tab_bar_margin_height)