### PR TITLE
Add missing newline in debug print

### DIFF
--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -634,7 +634,7 @@ mouse_event(int button, int modifiers, int action) {
     bool in_tab_bar;
     unsigned int window_idx = 0;
     Window *w = NULL;
-    debug("%s mouse_button: %d %s", action == GLFW_RELEASE ? "\x1b[32mRelease\x1b[m" : (button < 0 ? "\x1b[36mMove\x1b[m" : "\x1b[31mPress\x1b[m"), button, format_mods(modifiers));
+    debug("%s mouse_button: %d %s\n", action == GLFW_RELEASE ? "\x1b[32mRelease\x1b[m" : (button < 0 ? "\x1b[36mMove\x1b[m" : "\x1b[31mPress\x1b[m"), button, format_mods(modifiers));
     if (global_state.active_drag_in_window) {
         if (button == -1) {  // drag move
             w = window_for_id(global_state.active_drag_in_window);


### PR DESCRIPTION
When none of the other debug prints below were executed, this debug print would keep appending to the current line, leading to an unreadable mess.
Adding a newline at the end of the debug string is the easiest fix but you may find it desirable to instead keep some of the current behaviour where a second debug print appends to the same line from this debug output, in which case the proper fix is to print a new line whenever none of the other debug statements were executed. But this would be not as simple and introduce more complexity.