### PR TITLE
terminfo: add Smulx for underline extensions

### DIFF
--- a/kitty/terminfo.py
+++ b/kitty/terminfo.py
@@ -231,6 +231,8 @@ string_capabilities = {
     'smso': r'\E[7m',
     # Enter underline mode
     'smul': r'\E[4m',
+    # Enter extended Kitty underline mode
+    'Smulx': r'\E[4:%p1%dm',
     # Enter strikethrough mode
     'smxx': r'\E[9m',
     # Clear all tab stops


### PR DESCRIPTION
WezTerm has support for the Kitty underline extensions, and is shipping the `Smulx` terminfo variable. Lots more info is available [here](https://github.com/wez/wezterm/issues/415). I believe this terminfo definition to be correct according to the spec at https://sw.kovidgoyal.net/kitty/protocol-extensions.html#colored-and-styled-underlines.