### PR TITLE
Remove redundant code

### DIFF
--- a/kitty/freetype.c
+++ b/kitty/freetype.c
@@ -319,11 +319,11 @@ cell_metrics(PyObject *s, unsigned int* cell_width, unsigned int* cell_height, u
     if (OPT(adjust_baseline_px) != 0) baseline_offset = OPT(adjust_baseline_px);
     else if (OPT(adjust_baseline_frac) != 0) baseline_offset = (int)(*cell_height * OPT(adjust_baseline_frac));
     *baseline = font_units_to_pixels_y(self, self->ascender);
-    *underline_position = MIN(*cell_height - 1, (unsigned int)MAX(0, font_units_to_pixels_y(self, MAX(0, self->ascender - self->underline_position))));
+    *underline_position = MIN(*cell_height - 1, (unsigned int)font_units_to_pixels_y(self, MAX(0, self->ascender - self->underline_position)));
     *underline_thickness = MAX(1, font_units_to_pixels_y(self, self->underline_thickness));
 
     if (self->strikethrough_position != 0) {
-      *strikethrough_position = MIN(*cell_height - 1, (unsigned int)MAX(0, font_units_to_pixels_y(self, MAX(0, self->ascender - self->strikethrough_position))));
+      *strikethrough_position = MIN(*cell_height - 1, (unsigned int)font_units_to_pixels_y(self, MAX(0, self->ascender - self->strikethrough_position)));
     } else {
       *strikethrough_position = (unsigned int)floor(*baseline * 0.65);
     }


### PR DESCRIPTION
Remove `MAX(0, ...)` introduced in #3734 and no longer needed as of 0fb2f38