### PR TITLE
Make hyperlinked_grep kitten respect context options

### DIFF
--- a/kittens/hyperlinked_grep/main.py
+++ b/kittens/hyperlinked_grep/main.py
@@ -29,7 +29,7 @@ def main() -> None:
     write: Callable[[bytes], None] = cast(Callable[[bytes], None], sys.stdout.buffer.write)
     sgr_pat = re.compile(br'\x1b\[.*?m')
     osc_pat = re.compile(b'\x1b\\].*?\x1b\\\\')
-    num_pat = re.compile(b'^(\\d+):')
+    num_pat = re.compile(b'^(\\d+)[:\\-]')
 
     in_result: bytes = b''
     hostname = socket.gethostname().encode('utf-8')
@@ -46,6 +46,8 @@ def main() -> None:
                 m = num_pat.match(clean_line)
                 if m is not None:
                     write_hyperlink(write, in_result, line, frag=m.group(1))
+                else:
+                    write(line)
             else:
                 if line.strip():
                     path = quote_from_bytes(os.path.abspath(clean_line)).encode('utf-8')


### PR DESCRIPTION
I want to start using the `hyperlinked_grep` kitten, but it currently ignores the context options, which I use frequently. Some sample expected output:

```
$ rg -C 1 'write_hyperlink' kittens
kittens/hyperlinked_grep/main.py
14-
15:def write_hyperlink(write: Callable[[bytes], None], url: bytes, line: bytes, frag: bytes = b'') -> None:
16-    text = b'\033]8;;' + url
--
47-                if m is not None:
48:                    write_hyperlink(write, in_result, line, frag=m.group(1))
49-                else:
--
54-                    in_result = b'file://' + hostname + path
55:                    write_hyperlink(write, in_result, line)
56-                else:
```

But the kitten does not output context:

```
$ kitty +kitten hyperlinked_grep -C 1 'write_hyperlink' kittens
15:def write_hyperlink(write: Callable[[bytes], None], url: bytes, line: bytes, frag: bytes = b'') -> None:
48:                    write_hyperlink(write, in_result, line, frag=m.group(1))
55:                    write_hyperlink(write, in_result, line)
```

Here, I fix the `num_pat` regex so that context lines are hyperlinked. I also also add a case so that any non-matching lines (like the `--` separators) are still output without hyperlinks.