### PR TITLE
mention kitten_alias in hits documentation

### DIFF
--- a/docs/kittens/hints.rst
+++ b/docs/kittens/hints.rst
@@ -92,4 +92,12 @@ look it up in the Google dictionary.
 Command Line Interface
 -------------------------
 
+Remember, kitten command line options can be made permanent by putting
+a :ref:`kitten_alias` in the config file. For example you can change
+the order of hinting characters used with::
+
+    kitten_alias hints hints --alphabet qfjdkslaureitywovmcxzpq1234567890
+
+Generally, options can be used from command line this:
+
 .. include:: ../generated/cli-kitten-hints.rst


### PR DESCRIPTION
No idea, if I correctly referenced this part of the documentation `https://sw.kovidgoyal.net/kitty/conf.html#opt-kitty.kitten_alias` with:

```
:ref:`kitten_alias` 
```