### PR TITLE
U+1fb3f: upper middle left to lower right 🭊🬿

### DIFF
--- a/kitty/fonts/box_drawing.py
+++ b/kitty/fonts/box_drawing.py
@@ -890,7 +890,7 @@ box_chars: Dict[str, List[Callable]] = {
     '🬼': [p(smooth_mosaic, a=(0, 0.75), b=(0.5, 1))],
     '🬽': [p(smooth_mosaic, a=(0, 0.75), b=(1, 1))],
     '🬾': [p(smooth_mosaic, a=(0, 0.5), b=(0.5, 1))],
-    '🬿': [p(smooth_mosaic, a=(0, 0.5), b=(1, 1))],
+    '🬿': [p(smooth_mosaic, a=(0, 0.25), b=(1, 1))],
     '🭀': [p(smooth_mosaic, a=(0, 0), b=(0.5, 1))],
 
     '🭁': [p(smooth_mosaic, a=(0, 0.25), b=(0.5, 0))],


### PR DESCRIPTION
Fix U+1FB3F so that it matches its mirrored glyph U+1FB4A.

before:

![2021-07-22-182325_38x38_scrot](https://user-images.githubusercontent.com/143473/126716923-1cb82bb9-7a31-4d78-ad76-0b30b9c6cd8d.png)

after:

![2021-07-22-182348_38x40_scrot](https://user-images.githubusercontent.com/143473/126716938-b6840869-df30-4e42-b400-baf6948208cb.png)
