### PR TITLE
U+1fb3e: upper middle left to lower center🭉🬾

### DIFF
--- a/kitty/fonts/box_drawing.py
+++ b/kitty/fonts/box_drawing.py
@@ -889,7 +889,7 @@ box_chars: Dict[str, List[Callable]] = {
 
     '🬼': [p(smooth_mosaic, a=(0, 0.75), b=(0.5, 1))],
     '🬽': [p(smooth_mosaic, a=(0, 0.75), b=(1, 1))],
-    '🬾': [p(smooth_mosaic, a=(0, 0.5), b=(0.5, 1))],
+    '🬾': [p(smooth_mosaic, a=(0, 0.25), b=(0.5, 1))],
     '🬿': [p(smooth_mosaic, a=(0, 0.5), b=(1, 1))],
     '🭀': [p(smooth_mosaic, a=(0, 0), b=(0.5, 1))],
 


### PR DESCRIPTION
should have probably just put this with #3855, sorry. 
