### PR TITLE
Guard active_tab_idx setter when current idx is desired idx

### DIFF
--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -631,8 +631,11 @@ class TabManager:  # {{{
             old_active_tab = None
         else:
             assert old_active_tab is not None
+            new_active_tab_idx = max(0, min(val, len(self.tabs) - 1))
+            if self._active_tab_idx == new_active_tab_idx:
+                return
             add_active_id_to_history(self.active_tab_history, old_active_tab.id)
-        self._active_tab_idx = max(0, min(val, len(self.tabs) - 1))
+        self._active_tab_idx = new_active_tab_idx
         try:
             new_active_tab: Optional[Tab] = self.tabs[self._active_tab_idx]
         except Exception:


### PR DESCRIPTION
Firstly, thanks for creating kitty!

The motivation behind this diff is I want to be able to detach the current window into a new tab and then go back to the previous tab from which the window was detached (`detach_window new-tab` and then `goto_tab -1`).

The current behavior is after detaching a window into a new tab, `goto_tab -1` resolves to the current tab and no tab switching is performed.

My understanding is that this is due to `TabManager.@active_tab_idx.setter` being invoked twice in `Boss._move_window_to` [here](https://github.com/kovidgoyal/kitty/blob/887347106ddecc27ecc577d74b8116bd7e7e27da/kitty/boss.py#L1691) and [here](https://github.com/kovidgoyal/kitty/blob/887347106ddecc27ecc577d74b8116bd7e7e27da/kitty/boss.py#L1714) (via [`Boss.detach_window`](https://github.com/kovidgoyal/kitty/blob/887347106ddecc27ecc577d74b8116bd7e7e27da/kitty/boss.py#L1770)).

The call paths are:
- `TabManager.new_tab -> TabManager._set_active_tab -> TabManager.@active_tab_idx.setter`
- `Tab.make_active -> TabManager.set_active_tab -> TabManager.set_active_tab_idx -> TabManager._set_active_tab -> TabManager.@active_tab_idx.setter`

This diff intends to short circuit setting `TabManager._active_tab_idx` and updating `TabManager.active_tab_history` if they would be updated with the current tab so that the "true" history is preserved.

---

Alternatively, we may avoid the second call to `TabManager.@active_tab_idx.setter` by changing `TabManager.new_tab` or `Tab.make_active` or introducing a variant of them/inlining their logic specifically for `Boss._move_window_to` - the former feels like a larger scope change. I'm open to other approaches for solving this problem. Let me know if there are any test suites that would benefit from being updated. I validated this change with a `KITTY_DEVELOP_FROM` instance and by running `./test.py`.