### PR TITLE
Fix shell.nix error with stdenv.lib.getLib

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -48,7 +48,7 @@ mkShell rec {
   shellHook = if stdenv.isDarwin then ''
     export KITTY_NO_LTO=
   '' else ''
-    export KITTY_EGL_LIBRARY='${stdenv.lib.getLib libGL}/lib/libEGL.so.1'
+    export KITTY_EGL_LIBRARY='${lib.getLib libGL}/lib/libEGL.so.1'
     export KITTY_STARTUP_NOTIFICATION_LIBRARY='${libstartup_notification}/lib/libstartup-notification-1.so'
     export KITTY_CANBERRA_LIBRARY='${libcanberra}/lib/libcanberra.so'
   '';


### PR DESCRIPTION
NOTE - I know very very little about nix. But, when I tried to do `nix shell`, I got an error that `stdenv.lib.getLib` did not exist. It _seems_ like this is the right fix (and it runs without errors!) but please verify.