### PR TITLE
Fix buffer size calculation for open_cache_file_without_tmpfile.

### DIFF
--- a/kitty/disk-cache.c
+++ b/kitty/disk-cache.c
@@ -84,11 +84,11 @@ new(PyTypeObject *type, PyObject UNUSED *args, PyObject UNUSED *kwds) {
 static int
 open_cache_file_without_tmpfile(const char *cache_path) {
     int fd = -1;
-    static const char *template = "%s/disk-cache-XXXXXXXXXXXX";
-    const size_t sz = strlen(cache_path) + sizeof(template) + 4;
+    static const char template[] = "%s/disk-cache-XXXXXXXXXXXX";
+    const size_t sz = strlen(cache_path) + sizeof(template) - 2;
     FREE_AFTER_FUNCTION char *buf = calloc(1, sz);
     if (!buf) { errno = ENOMEM; return -1; }
-    snprintf(buf, sz - 1, template, cache_path);
+    snprintf(buf, sz, template, cache_path);
     while (fd < 0) {
         fd = mkostemp(buf, O_CLOEXEC);
         if (fd > -1 || errno != EINTR) break;


### PR DESCRIPTION
tl;dr: The calculation of `sz` in `open_cache_file_without_tmpfile` is incorrect because it uses `sizeof(template)` which is a `char*` (not a `char[]`), resulting in a platform-dependent and effectively always too-small value for `sz`.

I've recently been trying out kitty on a WSL 1 debian installation and discovered that the graphics protocol wasn't working. First, the call to `open` using `O_TMPFILE` was returning `EISDIR` which seems to result from a WSL emulation bug. To work around this, I tried using the fallback `open_cache_file_without_tmpfile` but discovered that `mkostemp` was also failing, this time with `EINVAL`.

After poking around in the debugger, I discovered that the calculation of `sz` (which is passed to `snprintf` to limit the number of characters written) is incorrect:

```
static const char *template = "%s/disk-cache-XXXXXXXXXXXX";
const size_t sz = strlen(cache_path) + sizeof(template) + 4;
```

`template` is a `char*` so `sizeof(template)` is platform-dependent (8 on most 64-bit hosts), so even with the `+ 4` it ends up being too small. The end result is that after the `snprintf` on line 91, `buf` does not actually contain the required `XXXXXX` characters.

This patch changes the type of `template` to `const char[]` so that `sizeof` computes the full size of the array (including the null terminator) as expected and updates the `sz` calculation to account for the replaced `%s` pattern (hence `- 2`). Finally, we pass the full size into `snprintf` to ensure the last template character is not overwritten by the null terminator--POSIX only requires 6 suffix `X` characters so this is not strictly necessary but the omission of the last `X` seems potentially confusing.

I have tested this manually but I'm not familiar enough with the `kitty` test infrastructure to suggest an automated test (and testing seems to be complicated by the fact that `open_cache_file_without_tmpfile` is selected at compile time based on the macros defined by system headers).