### PR TITLE
Heuristic to find hyper and meta on wayland

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -64,6 +64,13 @@ Variables that influence kitty behavior
    Same as :envvar:`VISUAL`. Used if :envvar:`VISUAL` is not set.
 
 
+.. envvar:: KITTY_WAYLAND_DETECT_MODIFIERS
+
+   When set to a non-empty value, kitty attempts to autodiscover XKB
+   modifiers under Wayland. It is possible for the autodiscovery to
+   fail; the default Wayland XKB mappings are used in this case.
+
+
 Variables that kitty sets when running child programs
 
 .. envvar:: LANG

--- a/docs/keyboard-protocol.rst
+++ b/docs/keyboard-protocol.rst
@@ -145,8 +145,8 @@ Modifiers
 This protocol supports six modifier keys, :kbd:`shift, alt, ctrl, super, hyper
 and meta` as well as :kbd:`num_lock and caps_lock`. Here :kbd:`super` is either
 the *Windows/Linux* key or the *Cmd* key on mac keyboards. :kbd:`hyper` and
-:kbd:`meta` are typically present only on X11 based systems with special XKB
-rules. Modifiers are encoded as a bit field with::
+:kbd:`meta` are typically present only on X11/Wayland based systems with
+special XKB rules. Modifiers are encoded as a bit field with::
 
     shift     0b1         (1)
     alt       0b10        (2)

--- a/glfw/xkb_glfw.c
+++ b/glfw/xkb_glfw.c
@@ -515,15 +515,17 @@ static int local_modifier_mapping(_GLFWXKBData *xkb) {
         }
     }
 
+    if ( algorithm.failed )
+        debug( "Wayland modifier autodetection algorithm failed; using defaults\n" );
     return !algorithm.failed;
 }
 
 static void
 glfw_xkb_update_masks(_GLFWXKBData *xkb) {
     // Should find better solution under Wayland
-    // See https://github.com/kovidgoyal/kitty/pull/3430 for discussion
+    // See https://github.com/kovidgoyal/kitty/pull/3943 for discussion
 
-    if ( !local_modifier_mapping( xkb ) ) {
+    if ( getenv( "KITTY_WAYLAND_DETECT_MODIFIERS" ) == NULL || !local_modifier_mapping( xkb ) ) {
 #define S( a ) xkb->a##Idx = XKB_MOD_INVALID; xkb->a##Mask = 0
         S(hyper); S(meta);
 #undef S

--- a/glfw/xkb_glfw.c
+++ b/glfw/xkb_glfw.c
@@ -439,7 +439,15 @@ static void modifier_mapping_algorithm( struct xkb_keymap *keymap, xkb_keycode_t
          * for each modifier in case there are some modifiers that are only present in
          * combination with others, but it is not worth the effort. */
         if ( num_keysyms == 1 && mods && ( mods & ( mods-1 ) ) == 0 ) {
-#define S2( k, a ) if ( ( keysyms[0] == XKB_KEY_##k##_L || keysyms[0] == XKB_KEY_##k##_R ) && !algorithm->a ) algorithm->a = mods
+#define S2( k, a )                                                      \
+            do {                                                        \
+                if ( keysyms[0] == XKB_KEY_##k##_L || keysyms[0] == XKB_KEY_##k##_R ) { \
+                    if ( !algorithm->a )                                \
+                        algorithm->a = mods;                            \
+                    else if ( algorithm->a != mods )                    \
+                        algorithm->failed = 1;                          \
+                }                                                       \
+            } while ( 0 )
 #define S1( k, a ) if ( ( keysyms[0] == XKB_KEY_##k ) && !algorithm->a ) algorithm->a = mods
             S2( Shift, shift );
             S2( Control, control );


### PR DESCRIPTION
Pull request 3430 created hyper and meta for X11, but could not support Wayland since xkbcommon does not provide a way to map virtual modifiers to real modifiers. This patch identifies modifiers for the common case of each mapped modifier generated by its own single key. If such modifiers are not found, it falls back to the current static mapping; the current static mapping does not support meta and hyper. Tested with a wayland session on Plasma Wayland desktop.

Example of supported xkb modifier maps with normal key mapping:

    modifier_map Shift  { Shift_L, Shift_R };
    modifier_map Lock   { Caps_Lock };
    modifier_map Control{ Control_L, Control_R };
    modifier_map Mod1   { Meta_L };
    modifier_map Mod2   { Alt_L };
    modifier_map Mod3   { Hyper_L };
    modifier_map Mod4   { Super_L, Super_R };

Example where the algorithm would fail since left and right map to different modifier keys:

    modifier_map Mod1   { Meta_L, Alt_L };
    modifier_map Mod2   { Meta_R, Alt_R };