### PR TITLE
shell.nix: add new dependencies for building the documentation

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -33,6 +33,10 @@ mkShell rec {
     ncurses
     pkg-config
     sphinx
+    furo
+    sphinx-copybutton
+    sphinxext-opengraph
+    sphinx-inline-tabs
   ] ++ optionals stdenv.isDarwin [
     imagemagick
     libicns  # For the png2icns tool.

--- a/shell.nix
+++ b/shell.nix
@@ -7,6 +7,7 @@ let
   inherit (darwin.apple_sdk.frameworks) Cocoa CoreGraphics Foundation IOKit Kernel OpenGL;
   harfbuzzWithCoreText = harfbuzz.override { withCoreText = stdenv.isDarwin; };
 in
+with python3Packages;
 mkShell rec {
   buildInputs = [
     harfbuzzWithCoreText
@@ -29,17 +30,18 @@ mkShell rec {
   ] ++ checkInputs;
 
   nativeBuildInputs = [
-    pkgconfig python3Packages.sphinx ncurses
+    ncurses
+    pkg-config
+    sphinx
   ] ++ optionals stdenv.isDarwin [
     imagemagick
     libicns  # For the png2icns tool.
-    installShellFiles
   ];
 
   propagatedBuildInputs = optional stdenv.isLinux libGL;
 
   checkInputs = [
-    python3Packages.pillow
+    pillow
   ];
 
   # Causes build failure due to warning when using Clang


### PR DESCRIPTION
As promised in https://github.com/kovidgoyal/kitty/commit/f787a377c3a32563cef19c603ff0ec76eedcfb46#commitcomment-53677490, I finished packaging all the new dependencies for building the documentation a few days ago. They are now in the unstable channel.
Sorry that it took so long, I had some trouble packaging furo because I did not realise that furo needs an additional build step running gulp to build some CSS and JavaScript files when fetching directly from GitHub. I'm now just using the version from PyPI.
I also made a few other changes, most notably renaming pkgconfig to pkg-config since it was renamed in Nixpkgs as well.