### PR TITLE
Fix Clang warning

### DIFF
--- a/kitty/lineops.h
+++ b/kitty/lineops.h
@@ -64,7 +64,7 @@ left_shift_line(Line *line, index_type at, index_type num) {
         COPY_CELL(line, i + num, line, i);
     }
     const CellAttrs empty = {.width=1};
-    const CellAttrs zero = {0};
+    const CellAttrs zero = {{0}};
     if (at < line->xnum && line->gpu_cells[at].attrs.width != 1) {
         line->cpu_cells[at].ch = BLANK_CHAR;
         line->cpu_cells[at].hyperlink_id = 0;


### PR DESCRIPTION
Without this, Clang would complain:
```
In file included from kitty/fonts.c:9:
In file included from kitty/fonts.h:9:
kitty/lineops.h:67:29: error: suggest braces around initialization of subobject
      [-Werror,-Wmissing-braces]
    const CellAttrs zero = {0};
                            ^
                            {}
```

Please check, that this is actually the correct fix.