### PR TITLE
remove text stating that  window decoration setting is macOS only

### DIFF
--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -819,8 +819,8 @@ and one, with zero being fully faded).
 opt('hide_window_decorations', 'no',
     option_type='hide_window_decorations', ctype='uint',
     long_text='''
-Hide the window decorations (title-bar and window borders) with :code:`yes`. On
-macOS, :code:`titlebar-only` can be used to only hide the titlebar. Whether this
+Hide the window decorations (title-bar and window borders) with :code:`yes`.
+:code:`titlebar-only` can be used to only hide the titlebar. Whether this
 works and exactly what effect it has depends on the window manager/operating
 system. Note that the effects of changing this setting when reloading config
 are undefined.


### PR DESCRIPTION
This is small, but I think valuable. 

I've been using Kitty for years and never thought to try the `titlebar-only` on my linux machines because the docs imply that it's macOS exclusive. However I accidentally loaded a mac config on linux earlier and it worked like a charm and I've switched my linux config to use it as well without issue.

I think given that the rest of the text block is already qualifying that this settings behavior is dependent on platform/WM, it's reasonable and safe to remove this small bit of text. 