### PR TITLE
Add macos_hide_titlebar to option_names

### DIFF
--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -367,6 +367,7 @@ option_names = (  # {{{
  'listen_on',
  'macos_custom_beam_cursor',
  'macos_hide_from_tasks',
+ 'macos_hide_titlebar',
  'macos_option_as_alt',
  'macos_quit_when_last_window_closed',
  'macos_show_window_title_in',


### PR DESCRIPTION
As pointed out in https://github.com/fladson/vim-kitty/pull/12, the `option_names` list is missing the `macos_hide_titlebar` option.

`vim-kitty` is using that for generating the syntax file, just for context.

The `no_op` action is also not being returned by `kitty.actions import get_all_actions`, can you point me out the direction to also add it?