### PR TITLE
icat: fix exception thrown if stdin is None

### DIFF
--- a/kittens/icat/main.py
+++ b/kittens/icat/main.py
@@ -506,7 +506,7 @@ def main(args: List[str] = sys.argv) -> None:
     if not sys.stdout.isatty():
         sys.stdout = open(os.ctermid(), 'w')
     stdin_data = None
-    if cli_opts.stdin == 'yes' or (not sys.stdin.isatty() and cli_opts.stdin == 'detect'):
+    if cli_opts.stdin == 'yes' or (cli_opts.stdin == 'detect' and sys.stdin is not None and not sys.stdin.isatty()):
         stdin_data = sys.stdin.buffer.read()
         if stdin_data:
             items.insert(0, stdin_data)


### PR DESCRIPTION
Currently, if icat is invoked with stdin closed, it will throw `AttributeError: 'NoneType' object has no attribute 'isatty'`.
This happens even if `--stdin=no` is given at command line. Try for instance in bash:
```bash
kitty +kitten icat --stdin=no <image_file> <&-
```

This PR fixes it so:
 - if `--stdin=no` is given, `sys.stdin` is not even queried
 - if `--stdin=detect` is given and `sys.stdin` is None, it will behave as if `--stdin=no` was given