### PR TITLE
ibus's dbus name owner changed detection

### DIFF
--- a/glfw/ibus_glfw.c
+++ b/glfw/ibus_glfw.c
@@ -168,11 +168,7 @@ ibus_on_owner_change(DBusConnection* conn UNUSED, DBusMessage* msg, void* user_d
         }
 
         _GLFWIBUSData* ibus = (_GLFWIBUSData*) user_data;
-        if (strcmp(new_owner, "") == 0) {
-            ibus->ok = false;
-        } else {
-            ibus->ok = true;
-        }
+        ibus->ok = strcmp(new_owner, "") != 0;
 
         return DBUS_HANDLER_RESULT_HANDLED;
 


### PR DESCRIPTION
fcitx5 works fine with kitty, except that when you restart fcitx5, kitty stop working with fcitx5, because the dbus_connection_get_is_connected(ibus->conn) in #check_connection is always true when you use fcitx5.
this patch add a dbus name owner changed detection to detect the online status of ibus, in case the ibus backend uses the session bus, like fcitx5.