### PR TITLE
shell.nix: add dependency on librsync

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,7 @@ mkShell rec {
     harfbuzzWithCoreText
     ncurses
     lcms2
+    librsync
   ] ++ optionals stdenv.isDarwin [
     Cocoa
     CoreGraphics


### PR DESCRIPTION
The dependency on librsync was introduced in f0fab80f5b9dec2c8eafc995fb9bdd7818bcb2ce.