### PR TITLE
ibus: Add support for ForwardKeyEvent signal

### DIFF
--- a/glfw/xkb_glfw.c
+++ b/glfw/xkb_glfw.c
@@ -842,6 +842,19 @@ glfw_xkb_key_from_ime(_GLFWIBUSKeyEvent *ev, bool handled_by_ime, bool failed) {
       last_handled_press_keycode = ev->glfw_ev.native_key;
 }
 
+void
+glfw_xkb_forwarded_key_from_ime(xkb_keysym_t keysym, unsigned int glfw_mods) {
+    _GLFWwindow *w = _glfwFocusedWindow();
+    if (w && w->callbacks.keyboard) {
+        GLFWkeyevent fake_ev = {.action = GLFW_PRESS};
+        fake_ev.native_key = keysym;
+        fake_ev.key = glfw_key_for_sym(keysym);
+        fake_ev.mods = glfw_mods;
+        fake_ev.ime_state = GLFW_IME_NONE;
+        w->callbacks.keyboard((GLFWwindow*) w, &fake_ev);
+    }
+}
+
 static bool
 is_switch_layout_key(xkb_keysym_t xkb_sym) {
     return xkb_sym == XKB_KEY_ISO_First_Group || xkb_sym == XKB_KEY_ISO_Last_Group || xkb_sym == XKB_KEY_ISO_Next_Group || xkb_sym == XKB_KEY_ISO_Prev_Group || xkb_sym == XKB_KEY_Mode_switch;

--- a/glfw/xkb_glfw.h
+++ b/glfw/xkb_glfw.h
@@ -98,3 +98,4 @@ void glfw_xkb_handle_key_event(_GLFWwindow *window, _GLFWXKBData *xkb, xkb_keyco
 int glfw_xkb_keysym_from_name(const char *name, bool case_sensitive);
 void glfw_xkb_update_ime_state(_GLFWwindow *w, _GLFWXKBData *xkb, const GLFWIMEUpdateEvent *ev);
 void glfw_xkb_key_from_ime(_GLFWIBUSKeyEvent *ev, bool handled_by_ime, bool failed);
+void glfw_xkb_forwarded_key_from_ime(xkb_keysym_t keysym, unsigned int glfw_mods);


### PR DESCRIPTION
The ForwardKeyEvent ibus signal is used to maintain ordering between CommitText events and non-IME key events.
The ordering is important for Korean IMEs, where it automatically commits text whenever a character is fully composed. This is different from Chinese/Japanese IMEs, where user manually presses a key to commit each word.

Without this patch, kitty can't handle non-IME key events when used with ibus-hangul, which utilizes ForwardKeyEvent signal.

Without ForwardKeyEvent:
```
key | sequence of events from application's view
r   | UpdatePreeditText 'ㄱ'
k   | UpdatePreeditText '가'
1   | (receives the reply to ProcessKeyEvent call: "native_key: 0x31 release: 0 handled: 0")
    | -> UpdatePreeditText ''
    | -> CommitText '가'
```
Application receives "1가", which is incorrect.

With ForwardKeyEvent:
```
key | sequence of events from application's view
r   | UpdatePreeditText 'ㄱ'
k   | UpdatePreeditText '가'
1   | (receives the reply to ProcessKeyEvent call: "native_key: 0x31 release: 0 handled: 1", and kitty discards the event)
    | -> UpdatePreeditText ''
    | -> CommitText '가'
    | -> ForwardKeyEvent keysym=0x31("1")
```
Application receives "가1", which is correct.

Relevant ibus-hangul github issue to implement ForwardKeyEvent: https://github.com/libhangul/ibus-hangul/issues/42
Relevant changes in Qt to handle ForwardKeyEvent: https://codereview.qt-project.org/c/qt/qtbase/+/212179, https://codereview.qt-project.org/c/qt/qtbase/+/255587