### PR TITLE
Properly evaluate /etc/issue placeholders

### DIFF
--- a/kitty/data-types.c
+++ b/kitty/data-types.c
@@ -226,6 +226,9 @@ extern bool init_mouse(PyObject *module);
 extern bool init_kittens(PyObject *module);
 extern bool init_logging(PyObject *module);
 extern bool init_png_reader(PyObject *module);
+#ifdef __unix__
+extern bool init_utmp(PyObject *module);
+#endif
 #ifdef __APPLE__
 extern int init_CoreText(PyObject *);
 extern bool init_cocoa(PyObject *module);
@@ -293,6 +296,9 @@ PyInit_fast_data_types(void) {
     if (!init_freetype_render_ui_text(m)) return NULL;
 #endif
     if (!init_fonts(m)) return NULL;
+#if defined(__unix__)
+    if (!init_utmp(m)) return NULL;
+#endif
 
     CellAttrs a;
 #define s(name, attr) { a.val = 0; a.attr = 1; PyModule_AddIntConstant(m, #name, shift_to_first_set_bit(a)); }

--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -1238,3 +1238,6 @@ def get_os_window_size(os_window_id: int) -> Optional[OSWindowSize]:
 
 def get_all_processes() -> Tuple[int, ...]:
     pass
+
+def num_users() -> int:
+    pass

--- a/kitty/utmp.c
+++ b/kitty/utmp.c
@@ -1,0 +1,50 @@
+#if defined(__unix__)
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <stdbool.h>
+
+#include <utmp.h>
+
+static PyObject*
+num_users(PyObject *const self, PyObject *const args) {
+    (void)self; (void)args;
+    size_t users = 0;
+    Py_BEGIN_ALLOW_THREADS
+#ifdef UTENT_REENTRANT
+    struct utmp *result = NULL;
+    struct utmp buffer = { 0, };
+    while (true) {
+        if (getutent_r(&buffer, &result) == -1) {
+            Py_BLOCK_THREADS
+            return PyErr_SetFromErrno(PyExc_OSError);
+        }
+        if (result == NULL) { break; }
+        if (result->ut_type == USER_PROCESS) { users++; }
+    }
+#else
+    struct utmp *ut;
+    setutent();
+    while ((ut = getutent())) {
+        if (ut->ut_type == USER_PROCESS) {
+            users++;
+        }
+    }
+    endutent();
+#endif
+    Py_END_ALLOW_THREADS
+    return PyLong_FromSize_t(users);
+}
+
+static PyMethodDef UtmpMethods[] = {
+    {"num_users", num_users, METH_NOARGS, "Get the number of users using UTMP data" },
+    { NULL, NULL, 0, NULL },
+};
+
+bool
+init_utmp(PyObject *module) {
+    // 0 = success
+    return PyModule_AddFunctions(module, UtmpMethods) == 0;
+}
+
+#endif

--- a/kitty_tests/utmp.py
+++ b/kitty_tests/utmp.py
@@ -1,0 +1,13 @@
+from sys import platform
+
+if platform in ('linux', 'linux2'):
+    import subprocess
+    import re
+    from kitty.fast_data_types import num_users
+    from . import BaseTest
+
+    class UTMPTest(BaseTest):
+        def test_num_users(self):
+            # who -q is the control
+            expected = subprocess.run(['who'], capture_output=True).stdout.decode('utf-8').count('\n')
+            self.ae(num_users(), expected)


### PR DESCRIPTION
Currently, in the debug_config page, the issue file looks really ugly because escape codes are not evaluated properly. For example, my issue looks like this:

![Screenshot_2021-10-04_20-51-15](https://user-images.githubusercontent.com/58113890/135957323-305203e3-26aa-44c3-8967-0856405a4a59.png)

The double backslashes are particularly bothersome.

Instead, since it's not that complicated to evaluate an issue file, just do that.

Note: this PR introduces another C method that is interfaced with from Python. I would appreciate if you took a look at that and made sure all was well with reference counting, GIL, and that kind of thing as I don't have much experience there.