### PR TITLE
Allow for C compilers that are indirectly invoked

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ def cc_version() -> Tuple[str, Tuple[int, int]]:
                 cc = 'clang'
             else:
                 cc = 'cc'
-    raw = subprocess.check_output([cc, '-dumpversion']).decode('utf-8')
+    raw = subprocess.check_output(cc.split() + ['-dumpversion']).decode('utf-8')
     ver_ = raw.strip().split('.')[:2]
     try:
         if len(ver_) == 1:


### PR DESCRIPTION
This will allow for programs that expose a C compiler behind an argument
like `zig cc` or utilities that expect a C Compiler to be given as an
argument, like `ccache gcc` or any combination of the two `ccache zig cc`

