### PR TITLE
Add `background_image_anchor`

### DIFF
--- a/kitty/bgimage_vertex.glsl
+++ b/kitty/bgimage_vertex.glsl
@@ -8,7 +8,7 @@
 #define tex_right 1
 #define tex_bottom 1
 
-uniform float rescaled;
+uniform float adjust_scale;
 uniform vec2 transform;  // [ pos_left_relative, pos_top_relative ]
 uniform vec4 sizes;  // [ window_width, window_height, image_width, image_height ]
 
@@ -29,7 +29,7 @@ const vec2 tex_map[] = vec2[4](
 
 
 float scaling_factor(int i) {
-    return rescaled * (sizes[i] / sizes[i + 2]) + (1 - rescaled);
+    return adjust_scale * (sizes[i] / sizes[i + 2]) + (1 - adjust_scale);
 }
 
 float position_divisor(int i) {

--- a/kitty/bgimage_vertex.glsl
+++ b/kitty/bgimage_vertex.glsl
@@ -8,7 +8,7 @@
 #define tex_right 1
 #define tex_bottom 1
 
-uniform float tiled;
+uniform float unscaled;
 uniform vec2 translate; // [ left, top ]
 uniform vec4 sizes;  // [ window_width, window_height, image_width, image_height ]
 
@@ -28,16 +28,12 @@ const vec2 tex_map[] = vec2[4](
 );
 
 
-float scale_factor(float window, float image) {
-    return window / image;
-}
-
-float tiling_factor(int i) {
-    return tiled * scale_factor(sizes[i], sizes[i + 2]) + (1 - tiled);
+float unscaling_factor(int i) {
+    return unscaled * (sizes[i] / sizes[i + 2]) + (1 - unscaled);
 }
 
 void main() {
     vec2 tex_coords = tex_map[gl_VertexID];
-    texcoord = vec2(tex_coords[0] * tiling_factor(0) - translate[0], tex_coords[1] * tiling_factor(1) - translate[1]);
+    texcoord = vec2(tex_coords[0] * unscaling_factor(0) - translate[0], tex_coords[1] * unscaling_factor(1) - translate[1]);
     gl_Position = vec4(pos_map[gl_VertexID], 0, 1);
 }

--- a/kitty/bgimage_vertex.glsl
+++ b/kitty/bgimage_vertex.glsl
@@ -9,6 +9,7 @@
 #define tex_bottom 1
 
 uniform float tiled;
+uniform vec2 translate; // [ left, top ]
 uniform vec4 sizes;  // [ window_width, window_height, image_width, image_height ]
 
 out vec2 texcoord;
@@ -37,6 +38,6 @@ float tiling_factor(int i) {
 
 void main() {
     vec2 tex_coords = tex_map[gl_VertexID];
-    texcoord = vec2(tex_coords[0] * tiling_factor(0), tex_coords[1] * tiling_factor(1));
+    texcoord = vec2(tex_coords[0] * tiling_factor(0) - translate[0], tex_coords[1] * tiling_factor(1) - translate[1]);
     gl_Position = vec4(pos_map[gl_VertexID], 0, 1);
 }

--- a/kitty/bgimage_vertex.glsl
+++ b/kitty/bgimage_vertex.glsl
@@ -8,8 +8,8 @@
 #define tex_right 1
 #define tex_bottom 1
 
-uniform float unscaled;
-uniform vec2 translate; // [ left, top ]
+uniform float rescaled;
+uniform vec2 transform;  // [ pos_left_relative, pos_top_relative ]
 uniform vec4 sizes;  // [ window_width, window_height, image_width, image_height ]
 
 out vec2 texcoord;
@@ -28,12 +28,16 @@ const vec2 tex_map[] = vec2[4](
 );
 
 
-float unscaling_factor(int i) {
-    return unscaled * (sizes[i] / sizes[i + 2]) + (1 - unscaled);
+float scaling_factor(int i) {
+    return rescaled * (sizes[i] / sizes[i + 2]) + (1 - rescaled);
+}
+
+float position_divisor(int i) {
+    return (sizes[i] - sizes[i + 2]) * transform[i] / sizes[i + 2];
 }
 
 void main() {
     vec2 tex_coords = tex_map[gl_VertexID];
-    texcoord = vec2(tex_coords[0] * unscaling_factor(0) - translate[0], tex_coords[1] * unscaling_factor(1) - translate[1]);
+    texcoord = vec2(tex_coords[0] * scaling_factor(0) - position_divisor(0), tex_coords[1] * scaling_factor(1) - position_divisor(1));
     gl_Position = vec4(pos_map[gl_VertexID], 0, 1);
 }

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1975,11 +1975,8 @@ class Boss:
 
         self.choose_entry('Choose an OS window to move the tab to', items, chosen)
 
-    def set_background_image(self, path: Optional[str], os_windows: Tuple[int, ...], configured: bool, layout: Optional[str]) -> None:
-        if layout:
-            set_background_image(path, os_windows, configured, layout)
-        else:
-            set_background_image(path, os_windows, configured)
+    def set_background_image(self, path: Optional[str], os_windows: Tuple[int, ...], configured: bool, layout: Optional[str], anchor: Optional[str]) -> None:
+        set_background_image(path, os_windows, configured, layout, anchor)
         for os_window_id in os_windows:
             self.default_bg_changed_for(os_window_id)
 

--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -65,7 +65,9 @@ typedef enum MouseTrackingProtocols { NORMAL_PROTOCOL, UTF8_PROTOCOL, SGR_PROTOC
 typedef enum MouseShapes { BEAM, HAND, ARROW } MouseShape;
 typedef enum { NONE, MENUBAR, WINDOW, ALL } WindowTitleIn;
 typedef enum { TILING, SCALED, MIRRORED, CLAMPED } BackgroundImageLayout;
-typedef enum { TOP_LEFT, TOP, TOP_RIGHT, LEFT, CENTER, RIGHT, BOTTOM_LEFT, BOTTOM, BOTTOM_RIGHT } BackgroundImageAnchor;
+typedef struct {
+    float x, y;
+} BackgroundImageAnchor;
 
 #define MAX_CHILDREN 512
 #define BLANK_CHAR 0

--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -65,7 +65,7 @@ typedef enum MouseTrackingProtocols { NORMAL_PROTOCOL, UTF8_PROTOCOL, SGR_PROTOC
 typedef enum MouseShapes { BEAM, HAND, ARROW } MouseShape;
 typedef enum { NONE, MENUBAR, WINDOW, ALL } WindowTitleIn;
 typedef enum { TILING, SCALED, MIRRORED, CLAMPED } BackgroundImageLayout;
-typedef enum { NORTHWEST, NORTH, NORTHEAST, EAST, SOUTHEAST, SOUTH, SOUTHWEST, WEST, CENTER } BackgroundImageAnchor;
+typedef enum { TOP_LEFT, TOP, TOP_RIGHT, LEFT, CENTER, RIGHT, BOTTOM_LEFT, BOTTOM, BOTTOM_RIGHT } BackgroundImageAnchor;
 
 #define MAX_CHILDREN 512
 #define BLANK_CHAR 0

--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -65,6 +65,7 @@ typedef enum MouseTrackingProtocols { NORMAL_PROTOCOL, UTF8_PROTOCOL, SGR_PROTOC
 typedef enum MouseShapes { BEAM, HAND, ARROW } MouseShape;
 typedef enum { NONE, MENUBAR, WINDOW, ALL } WindowTitleIn;
 typedef enum { TILING, SCALED, MIRRORED } BackgroundImageLayout;
+typedef enum { NORTHWEST, NORTH, NORTHEAST, EAST, SOUTHEAST, SOUTH, SOUTHWEST, WEST, CENTER } BackgroundImageAnchor;
 
 #define MAX_CHILDREN 512
 #define BLANK_CHAR 0

--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -64,7 +64,7 @@ typedef enum MouseTrackingModes { NO_TRACKING, BUTTON_MODE, MOTION_MODE, ANY_MOD
 typedef enum MouseTrackingProtocols { NORMAL_PROTOCOL, UTF8_PROTOCOL, SGR_PROTOCOL, URXVT_PROTOCOL, SGR_PIXEL_PROTOCOL} MouseTrackingProtocol;
 typedef enum MouseShapes { BEAM, HAND, ARROW } MouseShape;
 typedef enum { NONE, MENUBAR, WINDOW, ALL } WindowTitleIn;
-typedef enum { TILING, SCALED, MIRRORED } BackgroundImageLayout;
+typedef enum { TILING, SCALED, MIRRORED, CLAMPED } BackgroundImageLayout;
 typedef enum { NORTHWEST, NORTH, NORTHEAST, EAST, SOUTHEAST, SOUTH, SOUTHWEST, WEST, CENTER } BackgroundImageAnchor;
 
 #define MAX_CHILDREN 512

--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -598,7 +598,8 @@ def set_background_image(
     path: Optional[str],
     os_window_ids: Tuple[int, ...],
     configured: bool = True,
-    layout_name: Optional[str] = None
+    layout_name: Optional[str] = None,
+    anchor_name: Optional[str] = None
 ) -> None:
     pass
 

--- a/kitty/graphics.h
+++ b/kitty/graphics.h
@@ -66,6 +66,7 @@ typedef struct {
     unsigned int height, width;
     uint8_t* bitmap;
     uint32_t refcnt;
+    BackgroundImageAnchor anchor;
 } BackgroundImage;
 
 typedef struct {

--- a/kitty/graphics.h
+++ b/kitty/graphics.h
@@ -66,7 +66,6 @@ typedef struct {
     unsigned int height, width;
     uint8_t* bitmap;
     uint32_t refcnt;
-    BackgroundImageAnchor anchor;
 } BackgroundImage;
 
 typedef struct {

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -1110,8 +1110,8 @@ opt('background_image_layout', 'tiled',
     long_text='Whether to tile, scale or clamp the background image.'
     )
 
-opt('background_image_anchor', 'northwest',
-    choices=('northwest', 'north', 'northeast', 'east', 'southeast', 'south', 'southwest', 'west', 'center'), ctype='bganchor',
+opt('background_image_anchor', 'top-left',
+    choices=('top-left', 'top', 'top-right', 'left', 'center', 'right', 'bottom-left', 'bottom', 'bottom-right'), ctype='bganchor',
     long_text='Where to position the background image in the window.'
     )
 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -1106,8 +1106,8 @@ opt('background_image', 'none',
     )
 
 opt('background_image_layout', 'tiled',
-    choices=('mirror-tiled', 'scaled', 'tiled'), ctype='bglayout',
-    long_text='Whether to tile or scale the background image.'
+    choices=('mirror-tiled', 'scaled', 'tiled', 'clamped'), ctype='bglayout',
+    long_text='Whether to tile, scale or clamp the background image.'
     )
 
 opt('background_image_anchor', 'northwest',

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -1110,6 +1110,11 @@ opt('background_image_layout', 'tiled',
     long_text='Whether to tile or scale the background image.'
     )
 
+opt('background_image_anchor', 'northwest',
+    choices=('northwest', 'north', 'northeast', 'east', 'southeast', 'south', 'southwest', 'west', 'center'), ctype='bganchor',
+    long_text='Where to position the background image in the window.'
+    )
+
 opt('background_image_linear', 'no',
     option_type='to_bool', ctype='bool',
     long_text='When background image is scaled, whether linear interpolation should be used.'

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -71,7 +71,7 @@ class Parser:
             raise ValueError(f"The value {val} is not a valid choice for background_image_layout")
         ans["background_image_layout"] = val
 
-    choices_for_background_image_layout = frozenset(('mirror-tiled', 'scaled', 'tiled'))
+    choices_for_background_image_layout = frozenset(('mirror-tiled', 'scaled', 'tiled', 'clamped'))
 
     def background_image_linear(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['background_image_linear'] = to_bool(val)

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -63,7 +63,7 @@ class Parser:
             raise ValueError(f"The value {val} is not a valid choice for background_image_anchor")
         ans["background_image_anchor"] = val
 
-    choices_for_background_image_anchor = frozenset(('northwest', 'north', 'northeast', 'east', 'southeast', 'south', 'southwest', 'west', 'center'))
+    choices_for_background_image_anchor = frozenset(('top-left', 'top', 'top-right', 'left', 'center', 'right', 'bottom-left', 'bottom', 'bottom-right'))
 
     def background_image_layout(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         val = val.lower()

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -57,6 +57,14 @@ class Parser:
     def background_image(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['background_image'] = config_or_absolute_path(val)
 
+    def background_image_anchor(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        val = val.lower()
+        if val not in self.choices_for_background_image_anchor:
+            raise ValueError(f"The value {val} is not a valid choice for background_image_anchor")
+        ans["background_image_anchor"] = val
+
+    choices_for_background_image_anchor = frozenset(('northwest', 'north', 'northeast', 'east', 'southeast', 'south', 'southwest', 'west', 'center'))
+
     def background_image_layout(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         val = val.lower()
         if val not in self.choices_for_background_image_layout:

--- a/kitty/options/to-c-generated.h
+++ b/kitty/options/to-c-generated.h
@@ -695,6 +695,19 @@ convert_from_opts_background_image_layout(PyObject *py_opts, Options *opts) {
 }
 
 static void
+convert_from_python_background_image_anchor(PyObject *val, Options *opts) {
+    opts->background_image_anchor = bganchor(val);
+}
+
+static void
+convert_from_opts_background_image_anchor(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "background_image_anchor");
+    if (ret == NULL) return;
+    convert_from_python_background_image_anchor(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
 convert_from_python_background_image_linear(PyObject *val, Options *opts) {
     opts->background_image_linear = PyObject_IsTrue(val);
 }
@@ -1048,6 +1061,8 @@ convert_opts_from_python_opts(PyObject *py_opts, Options *opts) {
     convert_from_opts_background_image(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_background_image_layout(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_background_image_anchor(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_background_image_linear(py_opts, opts);
     if (PyErr_Occurred()) return false;

--- a/kitty/options/to-c.h
+++ b/kitty/options/to-c.h
@@ -81,24 +81,18 @@ bglayout(PyObject *layout_name) {
 static BackgroundImageAnchor
 bganchor(PyObject *anchor_name) {
     const char *name = PyUnicode_AsUTF8(anchor_name);
-    if (strcmp(name, "top") == 0) {
-        return TOP;
-    } else if (strcmp(name, "top-right") == 0) {
-        return TOP_RIGHT;
-    } else if (strcmp(name, "left") == 0) {
-        return LEFT;
-    } else if (strcmp(name, "center") == 0) {
-        return CENTER;
-    } else if (strcmp(name, "right") == 0) {
-        return RIGHT;
-    } else if (strcmp(name, "bottom-left") == 0) {
-        return BOTTOM_LEFT;
-    } else if (strcmp(name, "bottom") == 0) {
-        return BOTTOM;
-    } else if (strcmp(name, "bottom-right") == 0) {
-        return BOTTOM_RIGHT;
+    BackgroundImageAnchor anchor = { .x = 0.5f, .y = 0.5f };
+    if (strstr(name, "top") != NULL) {
+        anchor.y = 0.0f;
+    } else if (strstr(name, "bottom") != NULL) {
+        anchor.y = 1.0f;
     }
-    return TOP_LEFT;
+    if (strstr(name, "left") != NULL) {
+        anchor.x = 0.0f;
+    } else if (strstr(name, "right") != NULL) {
+        anchor.x = 1.0f;
+    }
+    return anchor;
 }
 
 #define STR_SETTER(name) { \

--- a/kitty/options/to-c.h
+++ b/kitty/options/to-c.h
@@ -77,6 +77,36 @@ bglayout(PyObject *layout_name) {
     return TILING;
 }
 
+static BackgroundImageAnchor
+bganchor(PyObject *anchor_name) {
+    const char *name = PyUnicode_AsUTF8(anchor_name);
+    if (strcmp(name, "north") == 0) {
+        return NORTH;
+    }
+    else if (strcmp(name, "northeast") == 0) {
+        return NORTHEAST;
+    }
+    else if (strcmp(name, "east") == 0) {
+        return EAST;
+    }
+    else if (strcmp(name, "southeast") == 0) {
+        return SOUTHEAST;
+    }
+    else if (strcmp(name, "south") == 0) {
+        return SOUTH;
+    }
+    else if (strcmp(name, "southwest") == 0) {
+        return SOUTHWEST;
+    }
+    else if (strcmp(name, "west") == 0) {
+        return WEST;
+    }
+    else if (strcmp(name, "center") == 0) {
+        return CENTER;
+    }
+    return NORTHWEST;
+}
+
 #define STR_SETTER(name) { \
     free(opts->name); opts->name = NULL; \
     if (src == Py_None || !PyUnicode_Check(src)) return; \

--- a/kitty/options/to-c.h
+++ b/kitty/options/to-c.h
@@ -72,6 +72,7 @@ bglayout(PyObject *layout_name) {
         case 't': return TILING;
         case 'm': return MIRRORED;
         case 's': return SCALED;
+        case 'c': return CLAMPED;
         default: break;
     }
     return TILING;

--- a/kitty/options/to-c.h
+++ b/kitty/options/to-c.h
@@ -81,31 +81,24 @@ bglayout(PyObject *layout_name) {
 static BackgroundImageAnchor
 bganchor(PyObject *anchor_name) {
     const char *name = PyUnicode_AsUTF8(anchor_name);
-    if (strcmp(name, "north") == 0) {
-        return NORTH;
-    }
-    else if (strcmp(name, "northeast") == 0) {
-        return NORTHEAST;
-    }
-    else if (strcmp(name, "east") == 0) {
-        return EAST;
-    }
-    else if (strcmp(name, "southeast") == 0) {
-        return SOUTHEAST;
-    }
-    else if (strcmp(name, "south") == 0) {
-        return SOUTH;
-    }
-    else if (strcmp(name, "southwest") == 0) {
-        return SOUTHWEST;
-    }
-    else if (strcmp(name, "west") == 0) {
-        return WEST;
-    }
-    else if (strcmp(name, "center") == 0) {
+    if (strcmp(name, "top") == 0) {
+        return TOP;
+    } else if (strcmp(name, "top-right") == 0) {
+        return TOP_RIGHT;
+    } else if (strcmp(name, "left") == 0) {
+        return LEFT;
+    } else if (strcmp(name, "center") == 0) {
         return CENTER;
+    } else if (strcmp(name, "right") == 0) {
+        return RIGHT;
+    } else if (strcmp(name, "bottom-left") == 0) {
+        return BOTTOM_LEFT;
+    } else if (strcmp(name, "bottom") == 0) {
+        return BOTTOM;
+    } else if (strcmp(name, "bottom-right") == 0) {
+        return BOTTOM_RIGHT;
     }
-    return NORTHWEST;
+    return TOP_LEFT;
 }
 
 #define STR_SETTER(name) { \

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -14,6 +14,7 @@ from kitty.types import FloatEdges, SingleKey
 import kitty.types
 
 if typing.TYPE_CHECKING:
+    choices_for_background_image_anchor = typing.Literal['northwest', 'north', 'northeast', 'east', 'southeast', 'south', 'southwest', 'west', 'center']
     choices_for_background_image_layout = typing.Literal['mirror-tiled', 'scaled', 'tiled']
     choices_for_default_pointer_shape = typing.Literal['arrow', 'beam', 'hand']
     choices_for_linux_display_server = typing.Literal['auto', 'wayland', 'x11']
@@ -27,6 +28,7 @@ if typing.TYPE_CHECKING:
     choices_for_tab_powerline_style = typing.Literal['angled', 'round', 'slanted']
     choices_for_tab_switch_strategy = typing.Literal['last', 'left', 'previous', 'right']
 else:
+    choices_for_background_image_anchor = str
     choices_for_background_image_layout = str
     choices_for_default_pointer_shape = str
     choices_for_linux_display_server = str
@@ -53,6 +55,7 @@ option_names = (  # {{{
  'allow_remote_control',
  'background',
  'background_image',
+ 'background_image_anchor',
  'background_image_layout',
  'background_image_linear',
  'background_opacity',
@@ -453,6 +456,7 @@ class Options:
     allow_remote_control: str = 'n'
     background: Color = Color(0, 0, 0)
     background_image: typing.Optional[str] = None
+    background_image_anchor: choices_for_background_image_anchor = 'northwest'
     background_image_layout: choices_for_background_image_layout = 'tiled'
     background_image_linear: bool = False
     background_opacity: float = 1.0

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -14,7 +14,7 @@ from kitty.types import FloatEdges, SingleKey
 import kitty.types
 
 if typing.TYPE_CHECKING:
-    choices_for_background_image_anchor = typing.Literal['northwest', 'north', 'northeast', 'east', 'southeast', 'south', 'southwest', 'west', 'center']
+    choices_for_background_image_anchor = typing.Literal['top-left', 'top', 'top-right', 'left', 'center', 'right', 'bottom-left', 'bottom', 'bottom-right']
     choices_for_background_image_layout = typing.Literal['mirror-tiled', 'scaled', 'tiled', 'clamped']
     choices_for_default_pointer_shape = typing.Literal['arrow', 'beam', 'hand']
     choices_for_linux_display_server = typing.Literal['auto', 'wayland', 'x11']
@@ -456,7 +456,7 @@ class Options:
     allow_remote_control: str = 'n'
     background: Color = Color(0, 0, 0)
     background_image: typing.Optional[str] = None
-    background_image_anchor: choices_for_background_image_anchor = 'northwest'
+    background_image_anchor: choices_for_background_image_anchor = 'top-left'
     background_image_layout: choices_for_background_image_layout = 'tiled'
     background_image_linear: bool = False
     background_opacity: float = 1.0

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -15,7 +15,7 @@ import kitty.types
 
 if typing.TYPE_CHECKING:
     choices_for_background_image_anchor = typing.Literal['northwest', 'north', 'northeast', 'east', 'southeast', 'south', 'southwest', 'west', 'center']
-    choices_for_background_image_layout = typing.Literal['mirror-tiled', 'scaled', 'tiled']
+    choices_for_background_image_layout = typing.Literal['mirror-tiled', 'scaled', 'tiled', 'clamped']
     choices_for_default_pointer_shape = typing.Literal['arrow', 'beam', 'hand']
     choices_for_linux_display_server = typing.Literal['auto', 'wayland', 'x11']
     choices_for_macos_show_window_title_in = typing.Literal['all', 'menubar', 'none', 'window']

--- a/kitty/rc/set_background_image.py
+++ b/kitty/rc/set_background_image.py
@@ -24,6 +24,7 @@ class SetBackgroundImage(RemoteCommand):
     img_id+: Unique uuid (as string) used for chunking
     match: Window to change opacity in
     layout: The image layout
+    anchor: The image anchor
     all: Boolean indicating operate on all windows
     configured: Boolean indicating if the configured value should be changed
     '''
@@ -52,6 +53,12 @@ choices=tiled,scaled,mirror-tiled,configured
 How the image should be displayed. The value of configured will use the configured value.
 
 
+--anchor
+type=choices
+choices=northwest,north,northeast,east,southeast,south,southwest,west,northwest,north,center,configured
+Where the image should be positioned. The value of configured will use the configured value.
+
+
 --no-response
 type=bool-set
 default=false
@@ -74,6 +81,7 @@ failed, the command will exit with a success code.
             'match': opts.match,
             'configured': opts.configured,
             'layout': opts.layout,
+            'anchor': opts.anchor,
             'all': opts.all,
             'img_id': str(uuid4())
         }
@@ -110,6 +118,7 @@ failed, the command will exit with a success code.
         windows = self.windows_for_payload(boss, window, payload_get)
         os_windows = tuple({w.os_window_id for w in windows})
         layout = payload_get('layout')
+        anchor = payload_get('anchor')
         if data == '-':
             path = None
         else:
@@ -120,7 +129,7 @@ failed, the command will exit with a success code.
             f.flush()
 
         try:
-            boss.set_background_image(path, os_windows, payload_get('configured'), layout)
+            boss.set_background_image(path, os_windows, payload_get('configured'), layout, anchor)
         except ValueError as err:
             err.hide_traceback = True  # type: ignore
             raise

--- a/kitty/rc/set_background_image.py
+++ b/kitty/rc/set_background_image.py
@@ -49,7 +49,7 @@ Change the configured background image which is used for new OS windows.
 
 --layout
 type=choices
-choices=tiled,scaled,mirror-tiled,configured
+choices=tiled,scaled,mirror-tiled,clamped,configured
 How the image should be displayed. The value of configured will use the configured value.
 
 

--- a/kitty/rc/set_background_image.py
+++ b/kitty/rc/set_background_image.py
@@ -55,7 +55,7 @@ How the image should be displayed. The value of configured will use the configur
 
 --anchor
 type=choices
-choices=northwest,north,northeast,east,southeast,south,southwest,west,northwest,north,center,configured
+choices=top-left,top,top-right,left,center,right,bottom-left,bottom,bottom-right,configured
 Where the image should be positioned. The value of configured will use the configured value.
 
 

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -166,7 +166,7 @@ typedef struct {
 static CellProgramLayout cell_program_layouts[NUM_PROGRAMS];
 static ssize_t blit_vertex_array;
 typedef struct {
-    GLint image_location, unscaled_location, translate_location, sizes_location, opacity_location, premult_location;
+    GLint image_location, rescaled_location, transform_location, sizes_location, opacity_location, premult_location;
 } BGImageProgramLayout;
 static BGImageProgramLayout bgimage_program_layout = {0};
 typedef struct {
@@ -198,8 +198,8 @@ init_cell_program(void) {
     bgimage_program_layout.image_location = get_uniform_location(BGIMAGE_PROGRAM, "image");
     bgimage_program_layout.opacity_location = get_uniform_location(BGIMAGE_PROGRAM, "opacity");
     bgimage_program_layout.sizes_location = get_uniform_location(BGIMAGE_PROGRAM, "sizes");
-    bgimage_program_layout.unscaled_location = get_uniform_location(BGIMAGE_PROGRAM, "unscaled");
-    bgimage_program_layout.translate_location = get_uniform_location(BGIMAGE_PROGRAM, "translate");
+    bgimage_program_layout.rescaled_location = get_uniform_location(BGIMAGE_PROGRAM, "rescaled");
+    bgimage_program_layout.transform_location = get_uniform_location(BGIMAGE_PROGRAM, "transform");
     bgimage_program_layout.premult_location = get_uniform_location(BGIMAGE_PROGRAM, "premult");
     tint_program_layout.tint_color_location = get_uniform_location(TINT_PROGRAM, "tint_color");
     tint_program_layout.edges_location = get_uniform_location(TINT_PROGRAM, "edges");
@@ -408,28 +408,28 @@ draw_bg(OSWindow *w) {
     bind_program(BGIMAGE_PROGRAM);
     bind_vertex_array(blit_vertex_array);
 
-    const bool unscaled = OPT(background_image_layout) == TILING || OPT(background_image_layout) == MIRRORED || OPT(background_image_layout) == CLAMPED;
+    const bool rescaled = OPT(background_image_layout) == TILING || OPT(background_image_layout) == MIRRORED || OPT(background_image_layout) == CLAMPED;
     static bool bgimage_constants_set = false;
     if (!bgimage_constants_set) {
         glUniform1i(bgimage_program_layout.image_location, BGIMAGE_UNIT);
         glUniform1f(bgimage_program_layout.opacity_location, OPT(background_opacity));
-        glUniform1f(bgimage_program_layout.unscaled_location, (GLfloat)unscaled);
+        glUniform1f(bgimage_program_layout.rescaled_location, (GLfloat)rescaled);
         bgimage_constants_set = true;
     }
-    float translate_left = 0.0f, translate_top = 0.0f;
-    if (unscaled) {
+    float pos_left_relative = 0.0f, pos_top_relative = 0.0f;
+    if (rescaled) {
         if (OPT(background_image_anchor) == TOP || OPT(background_image_anchor) == CENTER || OPT(background_image_anchor) == BOTTOM) {
-            translate_left = ((float)w->window_width / 2.0f - (float)w->bgimage->width / 2.0f) / (float)w->bgimage->width;
+            pos_left_relative = 0.5f;
         } else if (OPT(background_image_anchor) == TOP_RIGHT || OPT(background_image_anchor) == RIGHT || OPT(background_image_anchor) == BOTTOM_RIGHT) {
-            translate_left = ((float)w->window_width - (float)w->bgimage->width) / (float)w->bgimage->width;
+            pos_left_relative = 1.0f;
         }
         if (OPT(background_image_anchor) == LEFT || OPT(background_image_anchor) == CENTER || OPT(background_image_anchor) == RIGHT) {
-            translate_top = ((float)w->window_height / 2.0f - (float)w->bgimage->height / 2.0f) / (float)w->bgimage->height;
+            pos_top_relative = 0.5f;
         } else if (OPT(background_image_anchor) == BOTTOM_LEFT || OPT(background_image_anchor) == BOTTOM || OPT(background_image_anchor) == BOTTOM_RIGHT) {
-            translate_top = ((float)w->window_height - (float)w->bgimage->height) / (float)w->bgimage->height;
+            pos_top_relative = 1.0f;
         }
     }
-    glUniform2f(bgimage_program_layout.translate_location, (GLfloat)translate_left, (GLfloat)translate_top);
+    glUniform2f(bgimage_program_layout.transform_location, (GLfloat)pos_left_relative, (GLfloat)pos_top_relative);
     glUniform4f(bgimage_program_layout.sizes_location,
         (GLfloat)w->window_width, (GLfloat)w->window_height, (GLfloat)w->bgimage->width, (GLfloat)w->bgimage->height);
     glUniform1f(bgimage_program_layout.premult_location, w->is_semi_transparent ? 1.f : 0.f);

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -417,15 +417,15 @@ draw_bg(OSWindow *w) {
         bgimage_constants_set = true;
     }
     float translate_left = 0.0f, translate_top = 0.0f;
-    if (OPT(background_image_layout) != SCALED) {
-        if (w->bgimage->anchor == NORTH || w->bgimage->anchor == CENTER || w->bgimage->anchor == SOUTH) {
+    if (OPT(background_image_layout) == TILING || OPT(background_image_layout) == MIRRORED) {
+        if (OPT(background_image_anchor) == NORTH || OPT(background_image_anchor) == CENTER || OPT(background_image_anchor) == SOUTH) {
             translate_left = ((float)w->window_width / 2.0f - (float)w->bgimage->width / 2.0f) / (float)w->bgimage->width;
-        } else if (w->bgimage->anchor == NORTHEAST || w->bgimage->anchor == EAST || w->bgimage->anchor == SOUTHEAST) {
+        } else if (OPT(background_image_anchor) == NORTHEAST || OPT(background_image_anchor) == EAST || OPT(background_image_anchor) == SOUTHEAST) {
             translate_left = ((float)w->window_width - (float)w->bgimage->width) / (float)w->bgimage->width;
         }
-        if (w->bgimage->anchor == WEST || w->bgimage->anchor == CENTER || w->bgimage->anchor == EAST) {
+        if (OPT(background_image_anchor) == WEST || OPT(background_image_anchor) == CENTER || OPT(background_image_anchor) == EAST) {
             translate_top = ((float)w->window_height / 2.0f - (float)w->bgimage->height / 2.0f) / (float)w->bgimage->height;
-        } else if (w->bgimage->anchor == SOUTHWEST || w->bgimage->anchor == SOUTH || w->bgimage->anchor == SOUTHEAST) {
+        } else if (OPT(background_image_anchor) == SOUTHWEST || OPT(background_image_anchor) == SOUTH || OPT(background_image_anchor) == SOUTHEAST) {
             translate_top = ((float)w->window_height - (float)w->bgimage->height) / (float)w->bgimage->height;
         }
     }

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -418,14 +418,14 @@ draw_bg(OSWindow *w) {
     }
     float translate_left = 0.0f, translate_top = 0.0f;
     if (unscaled) {
-        if (OPT(background_image_anchor) == NORTH || OPT(background_image_anchor) == CENTER || OPT(background_image_anchor) == SOUTH) {
+        if (OPT(background_image_anchor) == TOP || OPT(background_image_anchor) == CENTER || OPT(background_image_anchor) == BOTTOM) {
             translate_left = ((float)w->window_width / 2.0f - (float)w->bgimage->width / 2.0f) / (float)w->bgimage->width;
-        } else if (OPT(background_image_anchor) == NORTHEAST || OPT(background_image_anchor) == EAST || OPT(background_image_anchor) == SOUTHEAST) {
+        } else if (OPT(background_image_anchor) == TOP_RIGHT || OPT(background_image_anchor) == RIGHT || OPT(background_image_anchor) == BOTTOM_RIGHT) {
             translate_left = ((float)w->window_width - (float)w->bgimage->width) / (float)w->bgimage->width;
         }
-        if (OPT(background_image_anchor) == WEST || OPT(background_image_anchor) == CENTER || OPT(background_image_anchor) == EAST) {
+        if (OPT(background_image_anchor) == LEFT || OPT(background_image_anchor) == CENTER || OPT(background_image_anchor) == RIGHT) {
             translate_top = ((float)w->window_height / 2.0f - (float)w->bgimage->height / 2.0f) / (float)w->bgimage->height;
-        } else if (OPT(background_image_anchor) == SOUTHWEST || OPT(background_image_anchor) == SOUTH || OPT(background_image_anchor) == SOUTHEAST) {
+        } else if (OPT(background_image_anchor) == BOTTOM_LEFT || OPT(background_image_anchor) == BOTTOM || OPT(background_image_anchor) == BOTTOM_RIGHT) {
             translate_top = ((float)w->window_height - (float)w->bgimage->height) / (float)w->bgimage->height;
         }
     }

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -180,7 +180,6 @@ add_os_window() {
             global_state.bgimage = calloc(1, sizeof(BackgroundImage));
             if (!global_state.bgimage) fatal("Out of memory allocating the global bg image object");
             global_state.bgimage->refcnt++;
-            global_state.bgimage->anchor = OPT(background_image_anchor);
             size_t size;
             if (png_path_to_bitmap(OPT(background_image), &global_state.bgimage->bitmap, &global_state.bgimage->width, &global_state.bgimage->height, &size)) {
                 send_bgimage_to_gpu(OPT(background_image_layout), global_state.bgimage);
@@ -994,7 +993,6 @@ pyset_background_image(PyObject *self UNUSED, PyObject *args) {
             make_os_window_context_current(os_window);
             free_bgimage(&os_window->bgimage, true);
             os_window->bgimage = bgimage;
-            os_window->bgimage->anchor = anchor;
             os_window->render_calls = 0;
             if (bgimage) bgimage->refcnt++;
         END_WITH_OS_WINDOW

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -137,6 +137,7 @@ send_bgimage_to_gpu(BackgroundImageLayout layout, BackgroundImage *bgimage) {
     RepeatStrategy r;
     switch (layout) {
         case SCALED:
+        case CLAMPED:
             r = REPEAT_CLAMP; break;
         case MIRRORED:
             r = REPEAT_MIRROR; break;

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -47,6 +47,7 @@ typedef struct {
 
     char* background_image;
     BackgroundImageLayout background_image_layout;
+    BackgroundImageAnchor background_image_anchor;
     bool background_image_linear;
     float background_tint;
 


### PR DESCRIPTION
This PR adds two new options: `background_image_anchor` and `background_image_layout clamped`.

![chicken_clamp_bottom_right](https://user-images.githubusercontent.com/72330683/139504549-30245dfa-c46f-49b5-83ce-536062611174.png)

## The story

We already have a nice option called `background_image_layout`. But there are situations where `tiled` and `scaled` are not enough. Let's take an example:

I want to show a cute kitty on the bottom edge of the screen, so I created a background image that matches the size of my window. Looks like the problem has been solved.

![kitty_scaled](https://user-images.githubusercontent.com/72330683/139506993-9f3579ba-6913-44d7-a576-b23dfe58ef1b.png)

But once I change the size of the window, everything is messed up.

![the_problem_with_scaled](https://user-images.githubusercontent.com/72330683/139507159-043ffd87-c0b7-420b-827c-51d80ebe52df.png)

This occurred because the size of the image is synchronized with the size of the window. 

Since I don't want to squash my kitty, I changed `background_image_layout` to `tiled`, and created a new background image with a large padding to align it with size of the window.

However, this still did not solve the problem. When I enlarged the window, not only did my kitty move from the center, but their entire body appeared from the bottom of the window.

![the_problem_with_tiled](https://user-images.githubusercontent.com/72330683/139507891-2d9ed32b-ade0-4083-965a-02c70d7a1118.png)

Here we can take advantage of the options that are added in this PR.

I cropped the background image to the size of the area I wanted to show, and set `background_image_anchor` to `bottom`, `background_image_layout` to `clamped`.

Now, the problem is solved, and my kitty stays at the bottom of the window, no matter how small or large I make it.

![problem_solved](https://user-images.githubusercontent.com/72330683/139509198-a2d1dfeb-67a5-4953-977d-5feff2f486d9.png)

I hope you like this.

## Other examples

### More natural tiling

```sh
background_image_layout tiled
# background_image_anchor center
```

![bandana_current](https://user-images.githubusercontent.com/72330683/139509890-d9548654-fdb4-46e5-be02-c148ad2b7b19.png)

```sh
background_image_layout tiled
background_image_anchor center
```

![bandana_bgimage_options](https://user-images.githubusercontent.com/72330683/139509964-95e8dc93-c270-4630-82e9-0103483aa746.png)

### Current process' logo at the bottom-right corner

```sh
background_image_layout clamped
background_image_anchor bottom-right
```

```fish
function on_preexec --on-event fish_preexec
  switch (string split -m1 ' ' "$argv")
    case nvim
      kitty @set-background-image --no-response &>/dev/null ~/.config/kitty/logo/nvim.png
    case podman
      kitty @set-background-image --no-response &>/dev/null ~/.config/kitty/logo/podman.png
    case '*'
      kitty @set-background-image --no-response &>/dev/null ~/.config/kitty/logo/unknown.png
  end
end

function on_prompt --on-event fish_prompt
  kitty @set-background-image --no-response &>/dev/null ~/.config/kitty/logo/fish.png &
    disown
end
```

https://user-images.githubusercontent.com/72330683/139510057-71674992-bd1c-4aa8-accc-431d872f2cb3.mp4
