### PR TITLE
Fix Clang warning

### DIFF
--- a/glfw/cocoa_init.m
+++ b/glfw/cocoa_init.m
@@ -455,7 +455,7 @@ void* _glfwLoadLocalVulkanLoaderNS(void)
 
 static bool
 is_modified_tab(NSEvent *event, NSEventModifierFlags modifierFlags) {
-    switch (modifierFlags) {
+    switch ((NSUInteger)modifierFlags) {
         // No need to handle shift+tab, [shift]+option+tab
         case NSEventModifierFlagShift:
         case NSEventModifierFlagOption:


### PR DESCRIPTION
Without this, kitty fails to compile:
```
glfw/cocoa_init.m:462:14: error: case value not in enumerated type
      'NSEventModifierFlags' (aka 'enum NSEventModifierFlags')
      [-Werror,-Wswitch]
        case (NSEventModifierFlagShift | NSEventModifierFlagOption):
             ^
glfw/cocoa_init.m:465:14: error: case value not in enumerated type
      'NSEventModifierFlags' (aka 'enum NSEventModifierFlags')
      [-Werror,-Wswitch]
        case (NSEventModifierFlagShift | NSEventModifierFlagCommand):
             ^
```
I thought about changing the type of the `modifierFlags` function parameter from `NSEventModifierFlags` to `NSUInteger` since `NSEventModifierFlags` is defined as an enum according to https://developer.apple.com/documentation/appkit/nseventmodifierflags?language=objc and is technically not the proper type for a bit field. But since Apple themselves define `modifierFlags` as `NSEventModifierFlags` according to https://developer.apple.com/documentation/appkit/nsevent/1534405-modifierflags?language=objc, I think the fix in this commit is better.
This warning was introduced with commit f9944e614088c4977ad9c9f1d1b44d97643e8d5b.