### PR TITLE
Remove unused code

### DIFF
--- a/kitty_tests/graphics.py
+++ b/kitty_tests/graphics.py
@@ -12,7 +12,6 @@ from io import BytesIO
 from itertools import cycle
 from typing import NamedTuple
 
-from kitty.constants import cache_dir
 from kitty.fast_data_types import (
     load_png_data, parse_bytes, shm_unlink, shm_write, xor_data
 )
@@ -182,13 +181,6 @@ def make_send_command(screen):
 
 
 class TestGraphics(BaseTest):
-
-    def setUp(self):
-        cache_dir.set_override(tempfile.mkdtemp())
-
-    def tearDown(self):
-        os.rmdir(cache_dir())
-        cache_dir.clear_override()
 
     def test_xor_data(self):
 


### PR DESCRIPTION
Since 99d9cb0b0d6498d678de426a81e622dd3e3750d6 runs all tests with HOME set to a temporary directory, this code setting the cache directory to a temporary directory is no longer needed. `cache_dir()` will choose a directory in the home directory if neither KITTY_CACHE_DIRECTORY or XDG_CACHE_HOME are set.