### PR TITLE
Do not report cursor position when the cursor is scrolled off the screen

### DIFF
--- a/kitty/window.py
+++ b/kitty/window.py
@@ -1070,7 +1070,8 @@ class Window:
     def show_scrollback(self) -> None:
         text = self.as_text(as_ansi=True, add_history=True, add_wrap_markers=True)
         data = self.pipe_data(text, has_wrap_markers=True)
-        get_boss().display_scrollback(self, data['text'], data['input_line_number'])
+        cursor_on_screen = self.screen.scrolled_by < self.screen.lines - self.screen.cursor.y
+        get_boss().display_scrollback(self, data['text'], data['input_line_number'], report_cursor=cursor_on_screen)
 
     @ac('cp', '''
         Show output from the last shell command in a pager like less


### PR DESCRIPTION
When the cursor is not on the screen, the cursor position should not be reported to the scrollback pager.

https://github.com/kovidgoyal/kitty/issues/3948#issuecomment-954886836