### PR TITLE
Make sure kitty is first in the PATH and not repeatedly added when it already exists

### DIFF
--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -769,8 +769,9 @@ SYSTEM_CONF = '/etc/xdg/kitty/kitty.conf'
 def create_opts(args: CLIOptions, accumulate_bad_lines: Optional[List[BadLineType]] = None) -> KittyOpts:
     from .config import load_config
     config = tuple(resolve_config(SYSTEM_CONF, defconf, args.config))
-    pat = re.compile(r'^([a-zA-Z0-9_ ]+)=')
-    overrides = (pat.sub(r'\1 ', a) for a in args.override or ())
+    # Does not cover the case where `name =` when `=` is the value.
+    pat = re.compile(r'^([a-zA-Z0-9_]+)[ \t]*=')
+    overrides = (pat.sub(r'\1 ', a.lstrip()) for a in args.override or ())
     opts = load_config(*config, overrides=overrides, accumulate_bad_lines=accumulate_bad_lines)
     return opts
 


### PR DESCRIPTION
Make sure kitty is first in the PATH and not repeatedly added when it already exists

After setting `env PATH=/path:$PATH`, the kitty path does not stay first, so the executed version of kitty may be incorrect. Also, the added path still exists when there is already a corresponding kitty in the new env PATH.

```shell
PATH=/usr/bin:/bin:/usr/sbin:/sbin kitty/launcher/kitty --config=NONE -o 'map f1 show_kitty_env_vars' sh -c 'printenv PATH;read'

# kitty env PATH (F1):
# /path/to/kitty/launcher/kitty.app/Contents/MacOS:/usr/bin:/bin:/usr/sbin:/sbin

# child env PATH:
# /path/to/kitty/launcher/kitty.app/Contents/MacOS:/usr/bin:/bin:/usr/sbin:/sbin
```

```shell
mkdir -p /tmp/kitty/bin
ln -s $PWD/kitty/launcher/kitty /tmp/kitty/bin/

PATH=/usr/bin:/bin:/usr/sbin:/sbin  kitty/launcher/kitty --config=NONE -o 'env=PATH=/tmp/kitty/bin:$PATH' -o 'map f1 show_kitty_env_vars' sh -c 'printenv PATH;read'

# kitty env PATH (F1):
# /path/to/kitty/launcher/kitty.app/Contents/MacOS:/usr/bin:/bin:/usr/sbin:/sbin

# child env PATH:
/tmp/kitty/bin:/path/to/kitty/launcher/kitty.app/Contents/MacOS:/usr/bin:/bin:/usr/sbin:/sbin
```

This PR fixes the issue.

```shell
# kitty env PATH (F1):
# /path/to/kitty/launcher/kitty.app/Contents/MacOS:/usr/bin:/bin:/usr/sbin:/sbin

# child env PATH:
# /tmp/kitty/bin:/usr/bin:/bin:/usr/sbin:/sbin
```

---

Make --override parameter compatible with 'env VAR=' syntax

The following works fine.

```shell
kitty --config=NONE -o 'env=VAR='
# overrides: env VAR=

kitty -o 'enabled_layouts tall:mirrored=true,fat'
kitty -o 'enabled_layouts=tall:mirrored=true,fat'
# overrides: enabled_layouts tall:mirrored=true,fat
```

However, there is a problem when overriding env with 'env VAR='.

```shell
kitty --config=NONE -o 'env VAR=a'
# overrides: env VAR a
# expect: env VAR=a

kitty --config=NONE -o 'env VAR='
# overrides: env VAR
# expect: env VAR=
```

The first commit fixes this issue.

Does not care about the following situations.

```shell
kitty --config=NONE -o 'url_excluded_characters ='
# overrides: url_excluded_characters
```