### PR TITLE
Handle set colors exceptions

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1875,7 +1875,11 @@ class Boss:
         except (Exception, SystemExit) as err:
             self.show_error('Invalid set_colors mapping', str(err))
             return
-        payload = c.message_to_kitty(parse_rc_args([])[0], opts, items)
+        try:
+            payload = c.message_to_kitty(parse_rc_args([])[0], opts, items)
+        except (Exception, SystemExit) as err:
+            self.show_error('Failed to set colors', str(err))
+            return
         c.response_from_kitty(self, self.active_window, PayloadGetter(c, payload if isinstance(payload, dict) else {}))
 
     def _move_window_to(

--- a/kitty/rc/set_colors.py
+++ b/kitty/rc/set_colors.py
@@ -5,6 +5,7 @@
 import os
 from typing import TYPE_CHECKING, Dict, Iterable, Optional
 
+from kitty.cli import emph
 from kitty.config import parse_config
 from kitty.fast_data_types import patch_color_profiles, Color
 
@@ -95,6 +96,8 @@ this option, any color arguments are ignored and --configured and --all are impl
         if not opts.reset:
             try:
                 final_colors = parse_colors(args)
+            except FileNotFoundError as err:
+                raise ParsingOfArgsFailed(f'The colors configuration file {emph(err.filename)} was not found.') from err
             except Exception as err:
                 raise ParsingOfArgsFailed(str(err)) from err
         ans = {


### PR DESCRIPTION
When the file specified in the set colors parameter does not exist, using shortcuts to execute set_colors does not prompt an overlay error message and the keystroke is output to the program (e.g. shell).

The exception message is output to the kitty process stderr.

```shell
kitty -o 'map f1 set_colors invalid'
```

This PR provides friendly information for file non-existence exception and displays an overlay message prompt on errors. Users can also see better error messages when executing in the kitty shell.