### PR TITLE
When the color is set to none get-colors should not return a color value

### DIFF
--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -682,7 +682,7 @@ class ColorProfile:
 
     default_bg: int
 
-    def as_dict(self) -> Dict[str, int]:
+    def as_dict(self) -> Dict[str, Optional[int]]:
         pass
 
     def as_color(self, val: int) -> Optional[Color]:

--- a/kitty/rc/get_colors.py
+++ b/kitty/rc/get_colors.py
@@ -45,7 +45,11 @@ configured colors.
         ans = {k: getattr(opts, k) for k in opts if isinstance(getattr(opts, k), Color)}
         if not payload_get('configured'):
             windows = self.windows_for_match_payload(boss, window, payload_get)
-            ans.update({k: color_from_int(v) for k, v in windows[0].current_colors.items()})
+            for k, v in windows[0].current_colors.items():
+                if v is None:
+                    ans.pop(k, None)
+                else:
+                    ans[k] = color_from_int(v)
         all_keys = natsort_ints(ans)
         maxlen = max(map(len, all_keys))
         return '\n'.join(('{:%ds} {}' % maxlen).format(key, color_as_sharp(ans[key])) for key in all_keys)

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -494,7 +494,7 @@ class Window:
         }
 
     @property
-    def current_colors(self) -> Dict[str, int]:
+    def current_colors(self) -> Dict[str, Optional[int]]:
         return self.screen.color_profile.as_dict()
 
     @property


### PR DESCRIPTION
Some colors can be set to none.
Everything works fine when using `set-colors --configured` and `get-colors --configured`.

However, after setting the current window color to none, get-colors still returns the color, with a value of `#000000` .

```shell
$ kitty @ set-colors selection_background=none
$ kitty @ get-colors
...
selection_background    #000000
...
```

This PR adds None type to current_colors.
Returns none correctly when the color is explicitly set to none.
The value will be updated or removed when get-colors is called.