### PR TITLE
Fix macOS fallback configuration folder location and menu minor tweaks

### DIFF
--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -46,7 +46,7 @@ priority) than any user config files. It can be used to specify system-wide
 defaults for all users.
 '''.replace(
     '{macos_confpath}',
-    (':file:`~/Library/Preferences/{appname}/{conf_name}.conf`,' if is_macos else ''), 1
+    (':file:`~/Library/Application Support/{appname}/{conf_name}.conf`,' if is_macos else ''), 1
 )
 
 

--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -380,7 +380,16 @@ cocoa_create_global_menu(void) {
                 keyEquivalent:@""];
     [appMenu addItem:[NSMenuItem separatorItem]];
     MENU_ITEM(appMenu, @"Preferences…", edit_config_file);
-    MENU_ITEM(appMenu, @"Reload preferences", reload_config);
+    MENU_ITEM(appMenu, @"Reload Preferences", reload_config);
+    [appMenu addItem:[NSMenuItem separatorItem]];
+
+    NSMenu* servicesMenu = [[NSMenu alloc] init];
+    [NSApp setServicesMenu:servicesMenu];
+    [[appMenu addItemWithTitle:@"Services"
+                        action:NULL
+                 keyEquivalent:@""] setSubmenu:servicesMenu];
+    [servicesMenu release];
+    [appMenu addItem:[NSMenuItem separatorItem]];
 
     [appMenu addItemWithTitle:[NSString stringWithFormat:@"Hide %@", app_name]
                        action:@selector(hide:)
@@ -392,15 +401,6 @@ cocoa_create_global_menu(void) {
     [appMenu addItemWithTitle:@"Show All"
                        action:@selector(unhideAllApplications:)
                 keyEquivalent:@""];
-    [appMenu addItem:[NSMenuItem separatorItem]];
-
-    NSMenu* servicesMenu = [[NSMenu alloc] init];
-    [NSApp setServicesMenu:servicesMenu];
-    [[appMenu addItemWithTitle:@"Services"
-                        action:NULL
-                 keyEquivalent:@""] setSubmenu:servicesMenu];
-    [servicesMenu release];
-
     [appMenu addItem:[NSMenuItem separatorItem]];
 
     [[appMenu addItemWithTitle:@"Secure Keyboard Entry"
@@ -470,7 +470,7 @@ cocoa_create_global_menu(void) {
                 keyEquivalent:@""];
     NSMenu* helpMenu = [[NSMenu alloc] initWithTitle:@"Help"];
     [helpMenuItem setSubmenu:helpMenu];
-    [[helpMenu addItemWithTitle:[NSString stringWithFormat:@"Visit %@ website", app_name]
+    [[helpMenu addItemWithTitle:[NSString stringWithFormat:@"Visit %@ Website", app_name]
                          action:@selector(open_kitty_website_url:)
                   keyEquivalent:@"?"]
                       setTarget:global_menu_target];

--- a/kitty/constants.py
+++ b/kitty/constants.py
@@ -63,7 +63,7 @@ def _get_config_dir() -> str:
         locations.append(os.path.abspath(os.path.expanduser(os.environ['XDG_CONFIG_HOME'])))
     locations.append(os.path.expanduser('~/.config'))
     if is_macos:
-        locations.append(os.path.expanduser('~/Library/Preferences'))
+        locations.append(os.path.expanduser('~/Library/Application Support'))
     for loc in filter(None, os.environ.get('XDG_CONFIG_DIRS', '').split(os.pathsep)):
         locations.append(os.path.abspath(os.path.expanduser(loc)))
     for loc in locations:


### PR DESCRIPTION
Under macOS, `~/Library/Preferences` only holds property list files, all application custom configurations and data are generally located in `~/Library/Application Support`.

In addition, I capitalized the menu item and slightly adjusted the position of the Service menu item according to the convention.

Make them consistent with other menu items.