### PR TITLE
macOS menu and docs minor tweaks

### DIFF
--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -380,7 +380,16 @@ cocoa_create_global_menu(void) {
                 keyEquivalent:@""];
     [appMenu addItem:[NSMenuItem separatorItem]];
     MENU_ITEM(appMenu, @"Preferences…", edit_config_file);
-    MENU_ITEM(appMenu, @"Reload preferences", reload_config);
+    MENU_ITEM(appMenu, @"Reload Preferences", reload_config);
+    [appMenu addItem:[NSMenuItem separatorItem]];
+
+    NSMenu* servicesMenu = [[NSMenu alloc] init];
+    [NSApp setServicesMenu:servicesMenu];
+    [[appMenu addItemWithTitle:@"Services"
+                        action:NULL
+                 keyEquivalent:@""] setSubmenu:servicesMenu];
+    [servicesMenu release];
+    [appMenu addItem:[NSMenuItem separatorItem]];
 
     [appMenu addItemWithTitle:[NSString stringWithFormat:@"Hide %@", app_name]
                        action:@selector(hide:)
@@ -392,15 +401,6 @@ cocoa_create_global_menu(void) {
     [appMenu addItemWithTitle:@"Show All"
                        action:@selector(unhideAllApplications:)
                 keyEquivalent:@""];
-    [appMenu addItem:[NSMenuItem separatorItem]];
-
-    NSMenu* servicesMenu = [[NSMenu alloc] init];
-    [NSApp setServicesMenu:servicesMenu];
-    [[appMenu addItemWithTitle:@"Services"
-                        action:NULL
-                 keyEquivalent:@""] setSubmenu:servicesMenu];
-    [servicesMenu release];
-
     [appMenu addItem:[NSMenuItem separatorItem]];
 
     [[appMenu addItemWithTitle:@"Secure Keyboard Entry"
@@ -470,7 +470,7 @@ cocoa_create_global_menu(void) {
                 keyEquivalent:@""];
     NSMenu* helpMenu = [[NSMenu alloc] initWithTitle:@"Help"];
     [helpMenuItem setSubmenu:helpMenu];
-    [[helpMenu addItemWithTitle:[NSString stringWithFormat:@"Visit %@ website", app_name]
+    [[helpMenu addItemWithTitle:[NSString stringWithFormat:@"Visit %@ Website", app_name]
                          action:@selector(open_kitty_website_url:)
                   keyEquivalent:@"?"]
                       setTarget:global_menu_target];

--- a/kitty/fonts/core_text.py
+++ b/kitty/fonts/core_text.py
@@ -65,7 +65,7 @@ def find_best_match(family: str, bold: bool = False, italic: bool = False, ignor
         ] == italic else 0
         monospace_match = 1 if candidate['monospace'] else 0
         is_regular_width = not candidate['expanded'] and not candidate['condensed']
-        # prefer demi-bold to bold to heavy, less bold means less chance of
+        # prefer semi-bold to bold to heavy, less bold means less chance of
         # overflow
         weight_distance_from_medium = abs(candidate['weight'])
         return style_match, monospace_match, 1 if is_regular_width else 0, 1 - weight_distance_from_medium

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -33,9 +33,11 @@ opt('font_family', 'monospace',
     long_text='''
 You can specify different fonts for the bold/italic/bold-italic variants.
 To get a full list of supported fonts use the `kitty list-fonts` command.
-By default they are derived automatically, by the OSes font system. Setting
-them manually is useful for font families that have many weight variants like
-Book, Medium, Thick, etc. For example::
+By default they are derived automatically, by the OSes font system. When
+bold_font or bold_italic_font is set to :code:`auto`, the priority of bold
+fonts is semi-bold, bold, heavy. Setting them manually is useful for font
+families that have many weight variants like Book, Medium, Thick, etc.
+For example::
 
     font_family      Operator Mono Book
     bold_font        Operator Mono Medium


### PR DESCRIPTION
Capitalize the menu item and slightly adjusted the position of the Service menu item according to the convention.

Make them consistent with other menu items.

Add a note on the priority of bold fonts in the document.

Also I found that in the generated kitty.conf, the valid values in the comments are not easily distinguishable from the normal text. Would you be willing to leave backquotes to specifically indicate the values that can be set?

I also found that ``` :link:`title <url>` ``` is forcing line breaks in kitty.conf if the URL is too long, making the URL not recognized by mouseover and certainly not by kitten hints. I don't have a good idea for now and it doesn't matter, so I'll leave it like that.