### PR TITLE
Make scroll to prompt action perform better positioning

### DIFF
--- a/docs/shell-integration.rst
+++ b/docs/shell-integration.rst
@@ -154,6 +154,11 @@ Just before starting to draw the PS1 prompt send the escape code::
 
     <OSC>133;A<ST>
 
+Binary marks can be used to distinguish the prompt from each other::
+
+    <OSC>133;A;b=0<ST>
+    <OSC>133;A;b=1<ST>
+
 Just before starting to draw the PS2 prompt send the escape code::
 
     <OSC>133;A;k=s<ST>

--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -169,11 +169,13 @@ typedef struct {
 } CPUCell;
 
 typedef enum { UNKNOWN_PROMPT_KIND = 0, PROMPT_START = 1, SECONDARY_PROMPT = 2, OUTPUT_START = 3 } PromptKind;
+typedef enum { PROMPT_BIT_EVEN = 0, PROMPT_BIT_ODD = 1 } PromptBit;
 typedef union LineAttrs {
     struct {
         uint8_t continued : 1;
         uint8_t has_dirty_text : 1;
         PromptKind prompt_kind : 2;
+        PromptBit prompt_bit : 1;
     };
     uint8_t val;
 } LineAttrs ;

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -1977,7 +1977,7 @@ screen_history_scroll_to_prompt(Screen *self, int num_of_prompts_to_jump) {
     num_of_prompts_to_jump = num_of_prompts_to_jump < 0 ? -num_of_prompts_to_jump : num_of_prompts_to_jump;
     int y = -self->scrolled_by;
     Line *line;
-    PromptBit pb;
+    PromptBit pb = PROMPT_BIT_EVEN;
 #define ensure_y_ok if (y >= (int)self->lines || -y > (int)self->historybuf->count) return false;
 #define set_prompt_bit if (line->attrs.prompt_kind == PROMPT_START) pb = line->attrs.prompt_bit;
 #define move_y_to_start_of_prompt set_prompt_bit; while (-y + 1 <= (int)self->historybuf->count) { line = range_line_(self, y - 1); if (line->attrs.prompt_kind != PROMPT_START || line->attrs.prompt_bit != pb) break; y--; }

--- a/kitty/shell.py
+++ b/kitty/shell.py
@@ -179,10 +179,12 @@ def real_main(global_opts: RCOptions) -> None:
         print(f'The ID of the previously active window is: {awid}')
 
     pre_prompt = set_window_title('The kitty shell') + set_cursor_shape('bar')
-    pre_prompt += f'\x1b]133;A;redraw={0 if is_libedit else 1}\x1b\\'
+    pre_prompt += f'\x1b]133;A;b=__BINARY_MARK__;redraw={0 if is_libedit else 1}\x1b\\'
+    prompt_binary_mark = True
     while True:
         try:
-            print(end=pre_prompt)
+            prompt_binary_mark ^= True
+            print(end=pre_prompt.replace('__BINARY_MARK__', '0' if prompt_binary_mark else '1'))
             try:
                 scmdline = input(f'{kitty_face} ')
             except UnicodeEncodeError:

--- a/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
+++ b/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
@@ -39,6 +39,7 @@ function _ksi_main
 
     if not contains "no-prompt-mark" $_ksi
         set --global _ksi_prompt_state "first-run"
+        set --global _ksi_prompt_bit 0
 
         function _ksi_function_is_not_empty -d "Check if the specified function exists and is not empty"
             functions $argv[1] | string match -qnvr '^ *(#|function |end$|$)'
@@ -54,7 +55,13 @@ function _ksi_main
                 _ksi_mark "D"
             end
             set --global _ksi_prompt_state "prompt_start"
-            _ksi_mark "A"
+            # prompt start binary mark
+            if test $_ksi_prompt_bit -eq 0
+                set --global _ksi_prompt_bit 1
+            else
+                set --global _ksi_prompt_bit 0
+            end
+            _ksi_mark "A;b=$_ksi_prompt_bit"
             return "$cmd_status" # preserve the value of $status
         end
 

--- a/shell-integration/kitty.bash
+++ b/shell-integration/kitty.bash
@@ -23,12 +23,12 @@ _ksi_main() {
         # "
     }
 
-    if [[ "${_ksi_prompt[cursor]}" == "y" ]]; then 
+    if [[ "${_ksi_prompt[cursor]}" == "y" ]]; then
         PS1="\[\e[5 q\]$PS1"  # blinking bar cursor
         PS0="\[\e[1 q\]$PS0"  # blinking block cursor
     fi
 
-    if [[ "${_ksi_prompt[title]}" == "y" ]]; then 
+    if [[ "${_ksi_prompt[title]}" == "y" ]]; then
         # see https://www.gnu.org/software/bash/manual/html_node/Controlling-the-Prompt.html#Controlling-the-Prompt
         PS1="\[\e]2;\w\a\]$PS1"
         if [[ "$HISTCONTROL" == *"ignoreboth"* ]] || [[ "$HISTCONTROL" == *"ignorespace"* ]]; then
@@ -39,17 +39,19 @@ _ksi_main() {
         PS0+="$orig_ps0"
     fi
 
-    if [[ "${_ksi_prompt[mark]}" == "y" ]]; then 
+    if [[ "${_ksi_prompt[mark]}" == "y" ]]; then
+        # prompt start binary mark
+        _ksi_pb=0
         # bash does not redraw the leading lines in a multiline prompt so
         # mark them as secondary prompts
         local secondary_prompt="\n\[\e]133;A;k=s\a\]"
         PS1=${PS1//"\n"/"$secondary_prompt"}
-        PS1="\[\e]133;A\a\]$PS1"
+        PS1="\[\e]133;A;b=\$((_ksi_pb^=1))\a\]$PS1"
         PS2="\[\e]133;A;k=s\a\]$PS2"
         PS0="\[\e]133;C\a\]$PS0"
     fi
 
-    if [[ "${_ksi_prompt[complete]}" == "y" ]]; then 
+    if [[ "${_ksi_prompt[complete]}" == "y" ]]; then
         _ksi_completions() {
             local src
             local limit


### PR DESCRIPTION
Mark different prompts with a binary mark.

This allows kitty to distinguish between different prompts when performing scroll to prompt, and to scroll to the exact position.

Please review if it is appropriate, thank you.

The kitty shell, fish and bash integration script has been updated and works well.
However, I don't know how to implement it in zsh and need help.

This issue was previously mentioned in #4166