### PR TITLE
Add how the fish shell integration works and how to configure it manually

### DIFF
--- a/docs/shell-integration.rst
+++ b/docs/shell-integration.rst
@@ -138,7 +138,7 @@ Then in your shell's rc file, add the lines:
 
 For fish, add the lines:
 
-.. code-block:: sh
+.. code-block:: fish
 
     set --global KITTY_SHELL_INTEGRATION enabled
     source /path/to/integration/script


### PR DESCRIPTION
Add fish-related instructions to the shell integration documentation.

A brief description of how it works, and how the user should configure it manually.