### PR TITLE
Fix unwanted hyperlink opening when hyperlink_id is 0

### DIFF
--- a/kitty/window.py
+++ b/kitty/window.py
@@ -644,7 +644,7 @@ class Window:
 
     def open_url(self, url: str, hyperlink_id: int, cwd: Optional[str] = None) -> None:
         opts = get_options()
-        if hyperlink_id:
+        if isinstance(hyperlink_id, int):
             if not opts.allow_hyperlinks:
                 return
             from urllib.parse import unquote, urlparse, urlunparse


### PR DESCRIPTION
The result of
```python
if 0
```
is false, when the hyperlink_id is 0. The interpreter goes to the line
```python
get_boss().open_url(url, cwd=cwd)
```
This leads to unwanted result.