### PR TITLE
Ensure resize when toggling between maximized window and fullscreen

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -2476,6 +2476,9 @@ bool _glfwPlatformToggleFullscreen(_GLFWwindow* w, unsigned int flags) {
             }
             [window setStyleMask: sm];
         }
+        // macOS forgets to trigger windowDidResize when switching from maximized window to fullscreen, so we need to do it manually.
+        // The window size is actually the same, but the dis-/appearance of the title bar causes the height of the usable area to change.
+        [[NSNotificationCenter defaultCenter] postNotificationName:NSWindowDidResizeNotification object:window];
     } else {
         bool in_fullscreen = sm & NSWindowStyleMaskFullScreen;
         if (in_fullscreen) made_fullscreen = false;


### PR DESCRIPTION
When toggling between maximized window and traditional fullscreen, we
need to manually trigger windowDidResize to ensure that the fullscreen
window is resized correctly.

macOS probably ignores the change because the window size actually
stays the same. However, the disappearance of the title bar causes the
usable height to change, leading to the text being stretched when
switching to fullscreen, and this results in ugly artifacts.