### PR TITLE
Add default shortcuts to the commented config, and unify the modifier key abbrs and ordering

### DIFF
--- a/kitty/conf/types.py
+++ b/kitty/conf/types.py
@@ -286,14 +286,14 @@ class Mapping:
     def key_text(self) -> str:
         return ''
 
-    def as_conf(self, commented: bool = False, level: int = 0) -> List[str]:
+    def as_conf(self, commented: bool = False, level: int = 0, action_group: List['Mapping'] = []) -> List[str]:
         ans: List[str] = []
-        if self.documented:
-            a = ans.append
-            if self.add_to_default:
-                a(self.setting_name + ' ' + self.parseable_text)
-            if self.long_text:
-                a(''), a(render_block(self.long_text.strip())), a('')
+        a = ans.append
+        for sc in [self] + action_group:
+            if sc.documented and sc.add_to_default:
+                a(sc.setting_name + ' ' + sc.parseable_text)
+        if self.documented and self.long_text:
+            a(''), a(render_block(self.long_text.strip())), a('')
         return ans
 
     def as_rst(
@@ -474,6 +474,8 @@ class Group:
         for item in self.iter_with_coalesced_options():
             if isinstance(item, Option):
                 lines = item.as_conf(option_group=self.coalesced_iterator_data.option_group_for_option(item))
+            elif isinstance(item, Mapping):
+                lines = item.as_conf(commented, level + 1, action_group=self.coalesced_iterator_data.action_group_for_action(item))
             else:
                 lines = item.as_conf(commented, level + 1)
             ans.extend(lines)

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -2941,7 +2941,7 @@ map('Scroll line up',
     'scroll_line_up kitty_mod+k scroll_line_up',
     )
 map('Scroll line up',
-    'scroll_line_up alt+cmd+page_up scroll_line_up',
+    'scroll_line_up opt+cmd+page_up scroll_line_up',
     only="macos",
     )
 map('Scroll line up',
@@ -2956,7 +2956,7 @@ map('Scroll line down',
     'scroll_line_down kitty_mod+j scroll_line_down',
     )
 map('Scroll line down',
-    'scroll_line_down alt+cmd+page_down scroll_line_down',
+    'scroll_line_down opt+cmd+page_down scroll_line_down',
     only="macos",
     )
 map('Scroll line down',
@@ -3520,7 +3520,7 @@ screen, for example, for ZSH add the following to :file:`~/.zshrc`:
     )
 
 map('Reset the terminal',
-    'reset_terminal cmd+option+r clear_terminal reset active',
+    'reset_terminal opt+cmd+r clear_terminal reset active',
     only="macos",
     )
 
@@ -3553,7 +3553,7 @@ its host environment. Useful for debugging issues.
     )
 
 map('Debug kitty configuration',
-    'debug_config cmd+option+, debug_config',
+    'debug_config opt+cmd+, debug_config',
     only='macos'
     )
 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -411,7 +411,7 @@ copy to a private kitty buffer instead. Map a shortcut with the
 :code:`paste_from_buffer` action to paste from this private buffer.
 For example::
 
-    map cmd+shift+v paste_from_buffer a1
+    map shift+cmd+v paste_from_buffer a1
 
 Note that copying to the clipboard is a security risk, as all programs,
 including websites open in your browser can read the contents of the
@@ -596,7 +596,7 @@ mma('Start selecting text even when grabbed',
     )
 
 mma('Start selecting text in a rectangle even when grabbed',
-    'start_rectangle_selection_grabbed shift+ctrl+alt+left press ungrabbed,grabbed mouse_selection rectangle',
+    'start_rectangle_selection_grabbed ctrl+shift+alt+left press ungrabbed,grabbed mouse_selection rectangle',
     )
 
 mma('Select a word even when grabbed',
@@ -609,7 +609,7 @@ mma('Select a line even when grabbed',
     )
 
 mma('Select line from point even when grabbed',
-    'select_line_from_point_grabbed shift+ctrl+alt+left triplepress ungrabbed,grabbed mouse_selection line_from_point',
+    'select_line_from_point_grabbed ctrl+shift+alt+left triplepress ungrabbed,grabbed mouse_selection line_from_point',
     long_text='Select from the clicked point to the end of the line'
     )
 
@@ -3224,7 +3224,7 @@ map('Previous tab',
     only="macos",
     )
 map('Previous tab',
-    'previous_tab shift+ctrl+tab previous_tab',
+    'previous_tab ctrl+shift+tab previous_tab',
     )
 
 map('New tab',
@@ -3329,7 +3329,7 @@ map('Increase font size',
     only="macos",
     )
 map('Increase font size',
-    'increase_font_size cmd+shift+equal change_font_size all +2.0',
+    'increase_font_size shift+cmd+equal change_font_size all +2.0',
     only="macos",
     )
 
@@ -3344,7 +3344,7 @@ map('Decrease font size',
     only="macos",
     )
 map('Decrease font size',
-    'decrease_font_size cmd+shift+minus change_font_size all -2.0',
+    'decrease_font_size shift+cmd+minus change_font_size all -2.0',
     only="macos",
     )
 
@@ -3450,7 +3450,7 @@ map('Unicode input',
     'input_unicode_character kitty_mod+u kitten unicode_input',
     )
 map('Unicode input',
-    'input_unicode_character cmd+ctrl+space kitten unicode_input',
+    'input_unicode_character ctrl+cmd+space kitten unicode_input',
     only="macos",
     )
 
@@ -3540,7 +3540,7 @@ the new conf settings *replace* the old ones.
     )
 
 map('Reload kitty.conf',
-    'reload_config_file cmd+control+, load_config_file',
+    'reload_config_file ctrl+cmd+, load_config_file',
     only='macos'
     )
 

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -34,7 +34,7 @@ SequenceMap = Dict[SingleKey, SubSequenceMap]
 MINIMUM_FONT_SIZE = 4
 default_tab_separator = ' ┇'
 mod_map = {'CTRL': 'CONTROL', 'CMD': 'SUPER', '⌘': 'SUPER',
-           '⌥': 'ALT', 'OPTION': 'ALT', 'KITTY_MOD': 'KITTY'}
+           '⌥': 'ALT', 'OPTION': 'ALT', 'OPT': 'ALT', 'KITTY_MOD': 'KITTY'}
 character_key_name_aliases_with_ascii_lowercase: Dict[str, str] = character_key_name_aliases.copy()
 for x in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ':
     character_key_name_aliases_with_ascii_lowercase[x] = x.lower()


### PR DESCRIPTION
I've noticed that many macOS shortcuts are missing from the commented config.

This PR adds all shortcuts to the commented config file.
Users can learn from the default config file and use the shortcuts, or change them as needed.

Also added abbreviated name for macOS Option keys `opt` and unified the use of abbreviated names, and the ordering of modifier keys `ctrl+shift+alt/opt+cmd`.

Please review if it is appropriate, thank you.