### PR TITLE
Also move overlay line for CSI ECH,DCH

### DIFF
--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -1722,6 +1722,7 @@ screen_repeat_character(Screen *self, unsigned int count) {
 
 void
 screen_delete_characters(Screen *self, unsigned int count) {
+    MOVE_OVERLAY_LINE_WITH_CURSOR;
     // Delete characters, later characters are moved left
     const unsigned int top = 0, bottom = self->lines ? self->lines - 1 : 0;
     if (count == 0) count = 1;
@@ -1739,6 +1740,7 @@ screen_delete_characters(Screen *self, unsigned int count) {
 
 void
 screen_erase_characters(Screen *self, unsigned int count) {
+    MOVE_OVERLAY_LINE_WITH_CURSOR;
     // Delete characters replacing them by spaces
     if (count == 0) count = 1;
     unsigned int x = self->cursor->x;


### PR DESCRIPTION
Without this, the VIM banner might not be properly cleared when overlay text is active.

Repro:
1. Switch to Korean IM (to trigger screen updates while overlay text is active)
2. Run `nvim`(https://neovim.io/) (note that nvim clears banner after first text input while original vim clears banner when user switches to insert mode, so only nvim triggers  the bug)
3. Check that the VIM banner is shown.
4. Press r, k, s, and then k. Pressing k commits a text(가) with overlay text(나) still active, and triggers the bug. The VIM banner needs to be cleared, but some characters are not cleared.

When nvim move cursor & issues CSI ECH to clear the banner lines, kitty only clears the overlay text and not the actual text backed up in `Screen.overlay_line`. When kitty later deactivates the overlay line(to move it), the text backed up in `Screen.overlay_line` reappears because it hasn't been cleared by the CSI sequence from nvim.

