### PR TITLE
Docs: scrolling to the last jumped position

### DIFF
--- a/docs/shell-integration.rst
+++ b/docs/shell-integration.rst
@@ -91,6 +91,13 @@ following mapping in :file:`kitty.conf`:
 Now, pressing :kbd:`F1` will cause the output of the last jumped to command to
 be opened in a pager for easy browsing.
 
+You can also add shortcut to scroll to the last jumped position. For example,
+define the following in :file:`kitty.conf`:
+
+.. code:: conf
+
+   map f1 scroll_to_prompt 0
+
 
 How it works
 -----------------


### PR DESCRIPTION
Also add additional shortcut binding instructions for jumping back to the last jump position.

Regarding the `this` documented in the documentation. Do you think the mappable action needs to be renamed? The current name is `mouse_select_cmd_output`.

Also I found that when mouse_map is bound to an invalid action, it does not output an error message in stderr when loading and verifying the configuration file.