### PR TITLE
Allows to open the command output in pager by mouse click

### DIFF
--- a/docs/shell-integration.rst
+++ b/docs/shell-integration.rst
@@ -74,29 +74,40 @@ on the output, define the following in :file:`kitty.conf`:
 
 .. code:: conf
 
-   mouse_map right press ungrabbed mouse_select_command_output
+    mouse_map right press ungrabbed mouse_select_command_output
 
 Now, when you right click on the output, the entire output is selected, ready
 to be copied.
 
 The feature to jump to previous prompts (
-:sc:`scroll_to_previous_prompt` and :sc:`scroll_to_next_prompt`) can be
-integrated with browsing command output as well. For example, define the
+:sc:`scroll_to_previous_prompt` and :sc:`scroll_to_next_prompt`) and mouse
+actions (``mouse_select_command_output`` and ``mouse_show_command_output``) can
+be integrated with browsing command output as well. For example, define the
 following mapping in :file:`kitty.conf`:
 
 .. code:: conf
 
-   map f1 show_last_visited_command_output
+    map f1 show_last_visited_command_output
 
-Now, pressing :kbd:`F1` will cause the output of the last jumped to command to
-be opened in a pager for easy browsing.
+Now, pressing :kbd:`F1` will cause the output of the last jumped to command or
+the last mouse clicked command output to be opened in a pager for easy browsing.
+
+In addition, You can define shortcut to get the first command output on screen.
+For example, define the following in :file:`kitty.conf`:
+
+.. code:: conf
+
+    map f1 show_first_command_output_on_screen
+
+Now, pressing :kbd:`F1` will cause the output of the first command output on
+screen to be opened in a pager.
 
 You can also add shortcut to scroll to the last jumped position. For example,
 define the following in :file:`kitty.conf`:
 
 .. code:: conf
 
-   map f1 scroll_to_prompt 0
+    map f1 scroll_to_prompt 0
 
 
 How it works
@@ -110,9 +121,9 @@ different shells.
 
 .. tab:: bash/zsh
 
-   For these shells, kitty adds a couple of lines to
-   the bottom of the shell's rc files (in an atomic manner) to load the shell
-   integration code.
+    For these shells, kitty adds a couple of lines to
+    the bottom of the shell's rc files (in an atomic manner) to load the shell
+    integration code.
 
 .. tab:: fish
 

--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -1272,7 +1272,7 @@ def set_window_padding(os_window_id: int, tab_id: int, window_id: int, left: int
 def click_mouse_url(os_window_id: int, tab_id: int, window_id: int) -> bool:
     pass
 
-def click_mouse_cmd_output(os_window_id: int, tab_id: int, window_id: int) -> bool:
+def click_mouse_cmd_output(os_window_id: int, tab_id: int, window_id: int, select_cmd_output: bool) -> bool:
     pass
 
 def move_cursor_to_mouse_if_in_prompt(os_window_id: int, tab_id: int, window_id: int) -> bool:

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -425,6 +425,12 @@ mouse_open_url(Window *w) {
 }
 
 bool
+mouse_set_last_visited_cmd_output(Window *w) {
+    Screen *screen = w->render_data.screen;
+    return screen_set_last_visited_prompt(screen, w->mouse_pos.cell_y);
+}
+
+bool
 mouse_select_cmd_output(Window *w) {
     Screen *screen = w->render_data.screen;
     return screen_select_cmd_output(screen, w->mouse_pos.cell_y);

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -616,6 +616,13 @@ mma('Select line from point even when grabbed',
 mma('Extend the current selection even when grabbed',
     'extend_selection_grabbed shift+right press ungrabbed,grabbed mouse_selection extend',
     )
+
+mma('Show clicked command output in pager',
+    'show_clicked_cmd_output_ungrabbed ctrl+shift+right press ungrabbed mouse_show_command_output',
+    long_text='''
+Requires :ref:`shell_integration` to work.
+'''
+    )
 egr()  # }}}
 egr()  # }}}
 
@@ -3006,11 +3013,14 @@ Requires :ref:`shell_integration` to work.
 map('Scroll to next shell prompt',
     'scroll_to_next_prompt kitty_mod+x scroll_to_prompt 1',
     long_text='''
+When the parameter is zero, scroll to the last jumped position, or the last clicked position by
+command output related mouse actions.
+
 Requires :ref:`shell_integration` to work.
 '''
     )
 
-map('Browse scrollback buffer in less',
+map('Browse scrollback buffer in pager',
     'show_scrollback kitty_mod+h show_scrollback',
     long_text='''
 You can pipe the contents of the current screen + history buffer as
@@ -3024,17 +3034,27 @@ see :doc:`launch`.
 '''
     )
 
-map('Browse output of the last shell command in less',
+map('Browse output of the last shell command in pager',
     'show_last_command_output kitty_mod+g show_last_command_output',
     long_text='''
-Requires :ref:`shell_integration` to work. You can pipe the output
-of the last command run in the shell using the :doc:`launch` function.
+You can also define additional shortcuts to get the command output.
+For example, to get the first command output on screen::
+
+    map f1 show_first_command_output_on_screen
+
+To get the command output that was last accessed by a keyboard action or mouse action::
+
+    map f1 show_last_visited_command_output
+
+You can pipe the output of the last command run in the shell using the :doc:`launch` function.
 For example, the following opens the output in less in an overlay window::
 
     map f1 launch --stdin-source=@last_cmd_output --stdin-add-formatting --type=overlay less +G -R
 
 To get the output of the first command on the screen, use :code:`@first_cmd_output_on_screen`.
 To get the output of the last jumped to command, use :code:`@last_visited_cmd_output`.
+
+Requires :ref:`shell_integration` to work.
 ''')
 egr()  # }}}
 

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -951,4 +951,6 @@ defaults.mouse_map = [
     MouseMapping(1, 1, 1, True, KeyAction('mouse_selection', (1,))),
     # extend_selection_grabbed
     MouseMapping(1, 1, 1, False, KeyAction('mouse_selection', (1,))),
+    # show_clicked_cmd_output_ungrabbed
+    MouseMapping(1, 5, 1, False, KeyAction('mouse_show_command_output')),
 ]

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -1269,7 +1269,10 @@ screen_cursor_to_column(Screen *self, unsigned int column) {
         linebuf_init_line(self->linebuf, bottom); \
         historybuf_add_line(self->historybuf, self->linebuf->line, &self->as_ansi_buf); \
         self->history_line_added_count++; \
-        if (self->last_visited_prompt.is_set && self->last_visited_prompt.scrolled_by <= self->historybuf->count) self->last_visited_prompt.scrolled_by++; \
+        if (self->last_visited_prompt.is_set) { \
+            if (self->last_visited_prompt.scrolled_by < self->historybuf->count) self->last_visited_prompt.scrolled_by++; \
+            else self->last_visited_prompt.is_set = false; \
+        } \
     } \
     linebuf_clear_line(self->linebuf, bottom, true); \
     self->is_dirty = true; \

--- a/kitty/screen.h
+++ b/kitty/screen.h
@@ -146,6 +146,7 @@ typedef struct {
     } last_rendered_window_char;
     struct {
         unsigned int scrolled_by;
+        index_type y;
         bool is_set;
     } last_visited_prompt;
 } Screen;
@@ -246,6 +247,7 @@ void set_active_hyperlink(Screen*, char*, char*);
 hyperlink_id_type screen_mark_hyperlink(Screen*, index_type, index_type);
 void screen_handle_graphics_command(Screen *self, const GraphicsCommand *cmd, const uint8_t *payload);
 bool screen_open_url(Screen*);
+bool screen_set_last_visited_prompt(Screen*, index_type);
 bool screen_select_cmd_output(Screen*, index_type);
 void screen_dirty_sprite_positions(Screen *self);
 void screen_rescale_images(Screen *self);

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -1091,12 +1091,13 @@ click_mouse_url(id_type os_window_id, id_type tab_id, id_type window_id) {
 }
 
 static bool
-click_mouse_cmd_output(id_type os_window_id, id_type tab_id, id_type window_id) {
-    bool selected = false;
+click_mouse_cmd_output(id_type os_window_id, id_type tab_id, id_type window_id, int select_cmd_output) {
+    bool handled = false;
     WITH_WINDOW(os_window_id, tab_id, window_id);
-    selected = mouse_select_cmd_output(window);
+    handled = mouse_set_last_visited_cmd_output(window);
+    if (select_cmd_output && handled) handled = mouse_select_cmd_output(window);
     END_WITH_WINDOW;
-    return selected;
+    return handled;
 }
 
 static bool
@@ -1127,8 +1128,8 @@ PYWRAP1(click_mouse_url) {
 }
 
 PYWRAP1(click_mouse_cmd_output) {
-    id_type a, b, c; PA("KKK", &a, &b, &c);
-    if (click_mouse_cmd_output(a, b, c)) { Py_RETURN_TRUE; }
+    id_type a, b, c; int d; PA("KKKp", &a, &b, &c, &d);
+    if (click_mouse_cmd_output(a, b, c, d)) { Py_RETURN_TRUE; }
     Py_RETURN_FALSE;
 }
 

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -311,6 +311,7 @@ void update_os_window_title(OSWindow *os_window);
 void fake_scroll(Window *w, int amount, bool upwards);
 Window* window_for_window_id(id_type kitty_window_id);
 bool mouse_open_url(Window *w);
+bool mouse_set_last_visited_cmd_output(Window *w);
 bool mouse_select_cmd_output(Window *w);
 bool move_cursor_to_mouse_if_at_shell_prompt(Window *w);
 void mouse_selection(Window *w, int code, int button);

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -1096,7 +1096,7 @@ class Window:
         cursor_on_screen = self.screen.scrolled_by < self.screen.lines - self.screen.cursor.y
         get_boss().display_scrollback(self, data['text'], data['input_line_number'], report_cursor=cursor_on_screen)
 
-    def show_cmd_output(self, which: CommandOutput, title: str = 'Command ouptut', as_ansi: bool = True, add_wrap_markers: bool = True) -> None:
+    def show_cmd_output(self, which: CommandOutput, title: str = 'Command output', as_ansi: bool = True, add_wrap_markers: bool = True) -> None:
         text = self.cmd_output(which, as_ansi=as_ansi, add_wrap_markers=add_wrap_markers)
         text = text.replace('\r\n', '\n').replace('\r', '\n')
         get_boss().display_scrollback(self, text, title=title, report_cursor=False)


### PR DESCRIPTION
Add `mouse_show_command_output`

Name the `command` consistently:
- For the user configuration part, use `command`.
- Use `cmd` in code, in parameters, to shorten the length.

Now mouse click will record the last jump position. So when using the relevant get last visited command output, it will also take effect for mouse actions.

Also there are too many shell integration URLs in the commented configuration files now, do you have any good ideas? Or just leave it as is?