### PR TITLE
screen_linefeed: add missing MOVE_OVERLAY_LINE_WITH_CURSOR

### DIFF
--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -1344,6 +1344,7 @@ screen_carriage_return(Screen *self) {
 
 void
 screen_linefeed(Screen *self) {
+    MOVE_OVERLAY_LINE_WITH_CURSOR;
     bool in_margins = cursor_within_margins(self);
     screen_index(self);
     if (self->modes.mLNM) screen_carriage_return(self);


### PR DESCRIPTION
fixes ibus positioning problem when shell outputs text with pre-edit
overlay open as per suggestion in this comment:
https://github.com/kovidgoyal/kitty/issues/1000#issuecomment-972550266


Thanks for the suggestion!