### PR TITLE
Allow macOS notification to play sound

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -2439,7 +2439,7 @@ void _glfwPlatformSetCursor(_GLFWwindow* window, _GLFWcursor* cursor UNUSED)
 bool _glfwPlatformIsFullscreen(_GLFWwindow* w, unsigned int flags) {
     NSWindow *window = w->ns.object;
     bool traditional = !(flags & 1);
-    if (traditional) { if(@available(macOS 10.16, *)) return w->ns.in_traditional_fullscreen; }
+    if (traditional) { if(@available(macOS 11.0, *)) return w->ns.in_traditional_fullscreen; }
     NSWindowStyleMask sm = [window styleMask];
     return sm & NSWindowStyleMaskFullScreen;
 }
@@ -2450,7 +2450,7 @@ bool _glfwPlatformToggleFullscreen(_GLFWwindow* w, unsigned int flags) {
     bool traditional = !(flags & 1);
     NSWindowStyleMask sm = [window styleMask];
     if (traditional) {
-        if (@available(macOS 10.16, *)) {
+        if (@available(macOS 11.0, *)) {
             // As of Big Turd NSWindowStyleMaskFullScreen is no longer useable
             if (!w->ns.in_traditional_fullscreen) {
                 w->ns.pre_full_screen_style_mask = sm;


### PR DESCRIPTION
Allow macOS notification to play system alert sound.

Also solved an issue with macOS notifications not showing up. Now macOS notifications from the cli program will be properly alerted when kitty is in the foreground.