### PR TITLE
Add option action_alias

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -146,6 +146,10 @@ To update |kitty|, :doc:`follow the instructions <binary>`.
 - macOS: Fix keyboard input not working after toggling traditional fullscreen
   till the window is clicked in
 
+- A new option :opt:`action_alias` to create action alias with common options
+  for keyboard shortcuts and mouse actions. Can also be defined in
+  :file:`open-actions.conf`. (:pull:`4260`)
+
 
 0.23.1 [2021-08-17]
 ----------------------

--- a/docs/launch.rst
+++ b/docs/launch.rst
@@ -38,6 +38,14 @@ To pass the contents of the current screen and scrollback to the started process
 
 There are many more powerful options, refer to the complete list below.
 
+.. note::
+
+    To avoid duplicating launch actions with frequently used parameters, you can
+    use :opt:`action_alias` to define launch action aliases. For example::
+
+        action_alias launch_cwd launch --cwd=current
+
+
 The piping environment
 --------------------------
 

--- a/docs/open_actions.rst
+++ b/docs/open_actions.rst
@@ -29,16 +29,20 @@ action which can be used to run external programs. Entries are separated by
 blank lines.
 
 Actions are very powerful, anything that you can map to a key combination in
-`kitty.conf` can be used as an action. You can specify more than one action per
-entry if you like, for example:
+`kitty.conf` can be used as an action. You can use ``action_alias`` to define
+action aliases that can be reused in each entries. You can specify more than one
+action per entry if you like. For example:
 
 
 .. code:: conf
 
+    # Action aliases for open actions
+    action_alias launch_os_window launch --title ${FILE} --type=os-window
+
     # Tail a log file (*.log) in a new OS Window and reduce its font size
     protocol file
     ext log
-    action launch --title ${FILE} --type=os-window tail -f ${FILE_PATH}
+    action launch_os_window tail -f ${FILE_PATH}
     action change_font_size current -2
 
 

--- a/kitty/conf/types.py
+++ b/kitty/conf/types.py
@@ -185,11 +185,11 @@ class Option:
             return ans
         if option_group:
             sz = max(len(self.name), max(len(o.name) for o in option_group))
-            a(f'{self.name.ljust(sz)} {self.defval_as_string}')
+            a(f'{self.name.ljust(sz)} {self.defval_as_string}'.rstrip())
             for o in option_group:
-                a(f'{o.name.ljust(sz)} {o.defval_as_string}')
+                a(f'{o.name.ljust(sz)} {o.defval_as_string}'.rstrip())
         else:
-            a(f'{self.name} {self.defval_as_string}')
+            a(f'{self.name} {self.defval_as_string}'.rstrip())
         if self.long_text:
             a('')
             a(render_block(self.long_text))
@@ -248,8 +248,10 @@ class MultiOption:
         a = ans.append
         for k in self.items:
             if k.documented:
-                prefix = '' if k.add_to_default else '# '
-                a(f'{prefix}{self.name} {k.defval_as_str}')
+                a(f'{self.name} {k.defval_as_str if k.add_to_default else ""}'.rstrip())
+                if not k.add_to_default and k.defval_as_str:
+                    a('')
+                    a(f'#: E.g. {self.name} {k.defval_as_str}'.rstrip())
         if self.long_text:
             a('')
             a(render_block(self.long_text))
@@ -264,7 +266,7 @@ class MultiOption:
         a('')
         for k in self.items:
             if k.documented:
-                a(f'    {self.name:s} {k.defval_as_str}')
+                a(f'    {self.name:s} {k.defval_as_str}'.rstrip())
         a('')
         if self.long_text:
             a(expand_opt_references(conf_name, self.long_text))
@@ -297,8 +299,9 @@ class Mapping:
         if self.short_text:
             a(render_block(self.short_text.strip())), a('')
         for sc in [self] + action_group:
-            if sc.documented and sc.add_to_default:
-                a(sc.setting_name + ' ' + sc.parseable_text)
+            if sc.documented:
+                prefix = '' if sc.add_to_default else '#::  E.g. '
+                a(f'{prefix}{sc.setting_name} {sc.parseable_text}')
         if self.long_text:
             a(''), a(render_block(self.long_text.strip(), '#::  '))
         a('')

--- a/kitty/conf/utils.py
+++ b/kitty/conf/utils.py
@@ -118,7 +118,7 @@ def choices(*choices: str) -> Choice:
     return Choice(choices)
 
 
-def resolve_action_alias(key: str, val: str, aliases: Dict[str, Any]) -> Optional[str]:
+def resolve_action_alias(key: str, val: str, aliases: Dict[str, Any]) -> str:
     if key == 'map':
         # map: key <action> [args]
         idx = 1
@@ -129,7 +129,7 @@ def resolve_action_alias(key: str, val: str, aliases: Dict[str, Any]) -> Optiona
         # open_actions: <action> [args]
         idx = 0
     else:
-        return None
+        return val
     parts = val.split(maxsplit=idx+1)
     if len(parts) > idx and parts[idx] in aliases:
         action = aliases.get(parts[idx])
@@ -138,7 +138,7 @@ def resolve_action_alias(key: str, val: str, aliases: Dict[str, Any]) -> Optiona
             if len(action) > 1 and action[1]:
                 parts.insert(idx + 1, action[1])
             return ' '.join(parts)
-    return None
+    return val
 
 
 def parse_line(
@@ -176,9 +176,7 @@ def parse_line(
         return
     aliases = ans.get('action_alias')
     if key in ('map', 'mouse_map') and aliases:
-        resolved_val = resolve_action_alias(key, val, aliases)
-        if resolved_val is not None:
-            val = resolved_val
+        val = resolve_action_alias(key, val, aliases)
     if not parse_conf_item(key, val, ans):
         log_error(f'Ignoring unknown config key: {key}')
 

--- a/kitty/open_actions.py
+++ b/kitty/open_actions.py
@@ -50,9 +50,8 @@ def parse(lines: Iterable[str]) -> Generator[OpenAction, None, None]:
         key, rest = parts
         key = key.lower()
         if key == 'action':
-            alias_val = resolve_action_alias('open_actions', rest, action_aliases)
             with to_cmdline_implementation.filter_env_vars('URL', 'FILE_PATH', 'FILE', 'FRAGMENT'):
-                x = parse_key_action(alias_val if alias_val is not None else rest)
+                x = parse_key_action(resolve_action_alias('open_actions', rest, action_aliases))
             if x is not None:
                 actions.append(x)
         elif key == 'action_alias':

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -2870,6 +2870,17 @@ for instance, to remove the default shortcuts.
 '''
     )
 
+opt('+action_alias', 'launch_cwd launch --cwd=current',
+    option_type='action_alias',
+    add_to_default=False,
+    long_text='''
+You can create action aliases with common options. This can be used with
+keyboard shortcuts or mouse actions. Action aliases can override existing
+actions and only take effect for later bindings. Action aliases cannot be
+nested.
+'''
+    )
+
 opt('+kitten_alias', 'hints hints --hints-offset=0',
     option_type='kitten_alias',
     add_to_default=False,

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -6,7 +6,7 @@ from kitty.conf.utils import (
     unit_float
 )
 from kitty.options.utils import (
-    active_tab_title_template, adjust_baseline, adjust_line_height, allow_hyperlinks,
+    action_alias, active_tab_title_template, adjust_baseline, adjust_line_height, allow_hyperlinks,
     allow_remote_control, box_drawing_scale, clear_all_mouse_actions, clear_all_shortcuts,
     clipboard_control, config_or_absolute_path, copy_on_select, cursor_text_color,
     deprecated_hide_window_decorations_aliases, deprecated_macos_show_window_title_in_menubar_alias,
@@ -21,6 +21,10 @@ from kitty.options.utils import (
 
 
 class Parser:
+
+    def action_alias(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        for k, v in action_alias(val):
+            ans["action_alias"][k] = v
 
     def active_border_color(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['active_border_color'] = to_color_or_none(val)
@@ -1309,6 +1313,7 @@ class Parser:
 
 def create_result_dict() -> typing.Dict[str, typing.Any]:
     return {
+        'action_alias': {},
         'env': {},
         'font_features': {},
         'kitten_alias': {},

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -43,6 +43,7 @@ else:
     choices_for_tab_switch_strategy = str
 
 option_names = (  # {{{
+ 'action_alias',
  'active_border_color',
  'active_tab_background',
  'active_tab_font_style',
@@ -583,6 +584,7 @@ class Options:
     window_padding_width: FloatEdges = FloatEdges(left=0, top=0, right=0, bottom=0)
     window_resize_step_cells: int = 2
     window_resize_step_lines: int = 2
+    action_alias: typing.Dict[str, typing.List[str]] = {}
     env: typing.Dict[str, str] = {}
     font_features: typing.Dict[str, typing.Tuple[kitty.fonts.FontFeature, ...]] = {}
     kitten_alias: typing.Dict[str, typing.List[str]] = {}
@@ -698,6 +700,7 @@ class Options:
 
 
 defaults = Options()
+defaults.action_alias = {}
 defaults.env = {}
 defaults.font_features = {}
 defaults.kitten_alias = {}

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -772,6 +772,13 @@ def watcher(val: str, current_val: Container[str]) -> Iterable[Tuple[str, str]]:
         yield val, val
 
 
+def action_alias(val: str) -> Iterable[Tuple[str, List[str]]]:
+    parts = val.split(maxsplit=2)
+    if len(parts) >= 1:
+        name = parts.pop(0)
+        yield name, parts
+
+
 def kitten_alias(val: str) -> Iterable[Tuple[str, List[str]]]:
     parts = val.split(maxsplit=2)
     if len(parts) >= 2:

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -836,7 +836,7 @@ class BaseDefinition:
     action: KeyAction
 
     def resolve_kitten_aliases(self, aliases: Dict[str, List[str]]) -> KeyAction:
-        if not self.action.args or not aliases:
+        if self.action.func != 'kitten' or not self.action.args or not aliases:
             return self.action
         kitten = self.action.args[0]
         rest = str(self.action.args[1] if len(self.action.args) > 1 else '')

--- a/kitty_tests/options.py
+++ b/kitty_tests/options.py
@@ -53,6 +53,16 @@ class TestConfParsing(BaseTest):
         self.ae(opts.env, {'A': '1', 'B': 'x1', 'C': '', 'D': DELETE_ENV_VAR})
         ka = tuple(opts.keymap.values())[0]
         self.ae(ka.args, ('b', '--moo'))
+        opts = p('clear_all_shortcuts y', 'action_alias launch launch --default', 'action_alias a launch --foo --moo', 'action_alias b launch',
+                 'map f1 a --bar', 'map f2 launch', 'map f3 launch --foo', 'map f4 b', 'action_alias launch', 'map f5 launch')
+        self.ae(len(opts.keymap), 5)
+        ka = tuple(opts.keymap.values())
+        self.ae(ka[0].func, 'launch')
+        self.ae(ka[0].args, ('--foo', '--moo', '--bar'))
+        self.ae(ka[1].args, ('--default',))
+        self.ae(ka[2].args, ('--default', '--foo',))
+        self.ae(ka[3].args, ())
+        self.ae(ka[4].args, ())
         opts = p('kitty_mod alt')
         self.ae(opts.kitty_mod, to_modifiers('alt'))
         self.ae(next(keys_for_func(opts, 'next_layout')).mods, opts.kitty_mod)


### PR DESCRIPTION
New option action_alias is added to define common actions.
Also restrict kitten_alias to apply only to kitten actions.

---

I found a type mismatch issue. The `KeyAction` object is added to the args during the parsing of the combine action.


```python
class KeyAction(NamedTuple):
    func: str
    args: Tuple[Union[str, float, bool, int, None], ...] = ()

# options/utils.py
@func_with_args('combine')
def combine_parse(func: str, rest: str) -> FuncArgsType:
    # ...
    args = tuple(map(parse_key_action, filter(None, parts))) # parse_key_action() -> KeyAction
    return func, args

```

Should `KeyAction` be added to the Union type of KeyAction args?