### PR TITLE
Allows focus to the last window

### DIFF
--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -3222,7 +3222,15 @@ last two active windows, use the value -1.
 '''
     )
 
-map('Visually select focus window', 'focus_visible_window kitty_mod+f7 focus_visible_window')
+map('Visually select and focus window',
+    'focus_visible_window kitty_mod+f7 focus_visible_window',
+    long_text='''
+Display overlay numbers and alphabets on the window, and switch the focus to
+the window when you press the key. When there are only two windows the focus
+will be switched directly. You can change the overlay characters and their order
+with option :opt:`visual_window_select_characters`.
+'''
+    )
 map('Visually swap window with another', 'swap_with_window kitty_mod+f8 swap_with_window')
 egr()  # }}}
 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -3211,6 +3211,17 @@ map('Tenth window',
     'tenth_window kitty_mod+0 tenth_window',
     )
 
+map('Focus a specific window',
+    'nth_window ctrl+alt+p nth_window -1',
+    add_to_default=False,
+    long_text='''
+Focus to the window of the specified number. When the specified number is larger
+than the last window, focus to the last one. When the number is negative, switch
+to the nth previously active window. For example, to switch focus between the
+last two active windows, use the value -1.
+'''
+    )
+
 map('Visually select focus window', 'focus_visible_window kitty_mod+f7 focus_visible_window')
 map('Visually swap window with another', 'swap_with_window kitty_mod+f8 swap_with_window')
 egr()  # }}}

--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -499,7 +499,7 @@ class Tab:  # {{{
     @ac('win', '''
         Focus the nth window if positive or the previously active windows if negative
 
-        For example, to ficus the previously active window::
+        For example, to focus the previously active window::
 
             map ctrl+p nth_window -1
         ''')
@@ -508,6 +508,8 @@ class Tab:  # {{{
             if num < 0:
                 self.windows.make_previous_group_active(-num)
             else:
+                if num >= len(self.windows):
+                    num = max(0, len(self.windows) - 1)
                 self.current_layout.activate_nth_window(self.windows, num)
             self.relayout_borders()
 


### PR DESCRIPTION
Focuses to the last window when the nth_window parameter exceeds the number of windows.
The description of the visual window selection has also been added.

I found that nth_window jumps to not nth, but nth+1. (window index starts from 0)
Would you mind fixing this? It will brings minimal breaking changes and the user just needs to update their configuration.