### PR TITLE
Append long_text only if at least one documented option exists

### DIFF
--- a/kitty/conf/types.py
+++ b/kitty/conf/types.py
@@ -255,13 +255,15 @@ class MultiOption:
     def as_conf(self, commented: bool = False, level: int = 0) -> List[str]:
         ans: List[str] = []
         a = ans.append
+        documented = False
         for k in self.items:
             if k.documented:
+                documented = True
                 a(f'{self.name} {k.defval_as_str if k.add_to_default else ""}'.rstrip())
                 if not k.add_to_default and k.defval_as_str:
                     a('')
                     a(f'#: E.g. {self.name} {k.defval_as_str}'.rstrip())
-        if self.long_text:
+        if self.long_text and documented:
             a('')
             a(render_block(self.long_text))
             a('')


### PR DESCRIPTION
For MultiOption, if `documented=False` is set and long_text is also present, then the commented configuration file will be generated with only the long_text, without any name above.

The recent `kitten_alias` changes is affected by this.