### PR TITLE
Slightly tweaked macOS modifier key documentation

### DIFF
--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -34,8 +34,8 @@ Action                      Shortcut
 ========================    =======================
 New tab                     :sc:`new_tab` (also :kbd:`⌘+t` on macOS)
 Close tab                   :sc:`close_tab` (also :kbd:`⌘+w` on macOS)
-Next tab                    :sc:`next_tab` (also :kbd:`^+⇥` and :kbd:`⇧+⌘+]` on macOS)
-Previous tab                :sc:`previous_tab` (also :kbd:`⇧+^+⇥` and :kbd:`⇧+⌘+[` on macOS)
+Next tab                    :sc:`next_tab` (also :kbd:`⌃+⇥` and :kbd:`⇧+⌘+]` on macOS)
+Previous tab                :sc:`previous_tab` (also :kbd:`⇧+⌃+⇥` and :kbd:`⇧+⌘+[` on macOS)
 Next layout                 :sc:`next_layout`
 Move tab forward            :sc:`move_tab_forward`
 Move tab backward           :sc:`move_tab_backward`
@@ -124,13 +124,13 @@ Paste from selection                :sc:`paste_from_selection`
 Increase font size                  :sc:`increase_font_size` (also :kbd:`⌘++` on macOS)
 Decrease font size                  :sc:`decrease_font_size` (also :kbd:`⌘+-` on macOS)
 Restore font size                   :sc:`reset_font_size` (also :kbd:`⌘+0` on macOS)
-Toggle fullscreen                   :sc:`toggle_fullscreen` (also :kbd:`^+⌘+f` on macOS)
+Toggle fullscreen                   :sc:`toggle_fullscreen` (also :kbd:`⌃+⌘+f` on macOS)
 Toggle maximized                    :sc:`toggle_maximized`
-Input unicode character             :sc:`input_unicode_character` (also :kbd:`^+⌘+space` on macOS)
+Input unicode character             :sc:`input_unicode_character` (also :kbd:`⌃+⌘+space` on macOS)
 Click URL using the keyboard        :sc:`open_url`
 Reset the terminal                  :sc:`reset_terminal`
-Reload :file:`kitty.conf`           :sc:`reload_config_file` (also :kbd:`^+⌘+,` on macOS)
-Debug :file:`kitty.conf`            :sc:`debug_config` (also :kbd:`⌘+option+f6` on macOS)
+Reload :file:`kitty.conf`           :sc:`reload_config_file` (also :kbd:`⌃+⌘+,` on macOS)
+Debug :file:`kitty.conf`            :sc:`debug_config` (also :kbd:`⌘+⌥+f6` on macOS)
 Pass current selection to program   :sc:`pass_selection_to_program`
 Edit |kitty| config file            :sc:`edit_config_file`
 Open a |kitty| shell                :sc:`kitty_shell`

--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -9,9 +9,9 @@ possibilities.
 
 You can open the config file within kitty by pressing :sc:`edit_config_file`.
 You can reload the config file within kitty by pressing
-:sc:`reload_config_file` (:kbd:`^+⌘+,` on macOS) or sending kitty the ``SIGUSR1`` signal.
+:sc:`reload_config_file` (:kbd:`⌃+⌘+,` on macOS) or sending kitty the ``SIGUSR1`` signal.
 You can also display the current configuration by pressing the :sc:`debug_config`
-(:kbd:`⌘+option+f6` on macOS) key.
+(:kbd:`⌘+⌥+f6` on macOS) key.
 
 .. _confloc:
 

--- a/docs/keyboard-protocol.rst
+++ b/docs/keyboard-protocol.rst
@@ -144,7 +144,8 @@ Modifiers
 
 This protocol supports six modifier keys, :kbd:`shift, alt, ctrl, super, hyper
 and meta` as well as :kbd:`num_lock and caps_lock`. Here :kbd:`super` is either
-the *Windows/Linux* key or the *Cmd* key on mac keyboards. :kbd:`hyper` and
+the *Windows/Linux* key or the :kbd:`command` key on mac keyboards. The
+:kbd:`alt` key is also the :kbd:`option` key on mac keyboards. :kbd:`hyper` and
 :kbd:`meta` are typically present only on X11/Wayland based systems with
 special XKB rules. Modifiers are encoded as a bit field with::
 

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -36,8 +36,8 @@ SubSequenceMap = Dict[KeySequence, Tuple[KeyAction, ...]]
 SequenceMap = Dict[SingleKey, SubSequenceMap]
 MINIMUM_FONT_SIZE = 4
 default_tab_separator = ' ┇'
-mod_map = {'CTRL': 'CONTROL', 'CMD': 'SUPER', '⌘': 'SUPER',
-           '⌥': 'ALT', 'OPTION': 'ALT', 'OPT': 'ALT', 'KITTY_MOD': 'KITTY'}
+mod_map = {'⌃': 'CONTROL', 'CTRL': 'CONTROL', '⇧': 'SHIFT', '⌥': 'ALT', 'OPTION': 'ALT', 'OPT': 'ALT',
+           '⌘': 'SUPER', 'COMMAND': 'SUPER', 'CMD': 'SUPER', 'KITTY_MOD': 'KITTY'}
 character_key_name_aliases_with_ascii_lowercase: Dict[str, str] = character_key_name_aliases.copy()
 for x in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ':
     character_key_name_aliases_with_ascii_lowercase[x] = x.lower()


### PR DESCRIPTION
Added command key full name.
Added modifier key Unicode character.
Replaced ASCII `^` with the control modifier key Unicode character representation.

I'm not sure about using :ref: `Modifier key definitions <modifiers>` in the documentation.
https://sw.kovidgoyal.net/kitty/conf/#keyboard-shortcuts
` For a list of modifier names, see: :link: GLFW mods ... `

```python
ref_map = { ..., 'modifiers': f'{website_url("keyboard-protocol")}#modifiers', ... }
```

I also found some :kbd: conversion issues in the generated HTML documents.

Execute make html in the master branch.

Comma in the key name. Space-separated words are parsed as standalone keys, e.g. `and`.

```html
the <kbd>Enter,</kbd> <kbd>Tab</kbd> <kbd>and</kbd> <kbd>Backspace</kbd> keys
```

In previous versions, such as the online version :kbd: was rendered as a whole < kbd >.

https://sw.kovidgoyal.net/kitty/keyboard-protocol/