### PR TITLE
Update IME status when window lost focus

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -864,6 +864,12 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     showCursor(window);
 
     _glfwInputWindowFocus(window, false);
+    // IME is cancelled when losing the focus
+    if ([window->ns.view hasMarkedText]) {
+        [window->ns.view unmarkText];
+        GLFWkeyevent dummy = {.action = GLFW_RELEASE, .ime_state = GLFW_IME_PREEDIT_CHANGED};
+        _glfwInputKeyboard(window, &dummy);
+    }
 }
 
 - (void)windowDidChangeScreen:(NSNotification *)notification


### PR DESCRIPTION
As mentioned in the previous issue, if you switch window focus during input method input state, the pre-edit text is not cleared.

https://github.com/kovidgoyal/kitty/issues/4219

This PR solves the issue.