### PR TITLE
Add option to configure shell integration enabled by environment var

### DIFF
--- a/docs/shell-integration.rst
+++ b/docs/shell-integration.rst
@@ -47,25 +47,34 @@ default, all shell integration is enabled. Individual features can be turned
 off or it can be disabled entirely as well. The :opt:`shell_integration` option
 takes a space separated list of keywords:
 
+enabled
+    Enable shell integration. This is the default.
+
 disabled
-    turn off all shell integration
+    Turn off all shell integration.
 
 no-rc
-    dont modify the shell's launch environment to enable integration. Useful if you prefer
-    to :ref:`manually enable integration <manual_shell_integration>`.
+    Don't modify the shell's rc files to enable integration. Useful if you prefer
+    to :ref:`manually enable integration <manual_shell_integration>`. Turn off bash
+    automatic integration.
+
+no-env
+    Don't modify the shell's launch environment to enable integration. Useful if you prefer
+    to :ref:`manually enable integration <manual_shell_integration>`. Turn off zsh and fish
+    automatic integration.
 
 no-cursor
-    turn off changing of the text cursor to a bar when editing text
+    Turn off changing of the text cursor to a bar when editing text.
 
 no-title
-    turn off setting the kitty window/tab title based on shell state
+    Turn off setting the kitty window/tab title based on shell state.
 
 no-prompt-mark
-    turn off marking of prompts. This disables jumping to prompt, browsing
+    Turn off marking of prompts. This disables jumping to prompt, browsing
     output of last command and click to move cursor functionality.
 
 no-complete
-    turn off completion for the kitty command.
+    Turn off completion for the kitty command.
 
 
 More ways to browse command output

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -2657,11 +2657,13 @@ with the mouse or the :doc:`hints kitten </kittens/hints>`. The special value of
     )
 
 opt('shell_integration', 'enabled',
+    option_type='shell_integration',
     long_text='''
 Enable shell integration on supported shells. This enables features such as
 jumping to previous prompts, browsing the output of the previous command in a
 pager, etc. on supported shells.  Set to ``disabled`` to turn off shell
-integration, completely. See :ref:`shell_integration` for details.
+integration, completely. Features can also be turned off individually. See
+:ref:`shell_integration` for details.
 ''')
 
 opt('term', 'xterm-kitty',

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -12,8 +12,8 @@ from kitty.options.utils import (
     deprecated_hide_window_decorations_aliases, deprecated_macos_show_window_title_in_menubar_alias,
     deprecated_send_text, disable_ligatures, edge_width, env, font_features, hide_window_decorations,
     macos_option_as_alt, macos_titlebar_color, optional_edge_width, parse_map, parse_mouse_map,
-    resize_draw_strategy, scrollback_lines, scrollback_pager_history_size, symbol_map,
-    tab_activity_symbol, tab_bar_edge, tab_bar_margin_height, tab_bar_min_tabs, tab_fade,
+    resize_draw_strategy, scrollback_lines, scrollback_pager_history_size, shell_integration,
+    symbol_map, tab_activity_symbol, tab_bar_edge, tab_bar_margin_height, tab_bar_min_tabs, tab_fade,
     tab_font_style, tab_separator, tab_title_template, to_cursor_shape, to_font_size, to_layout_names,
     to_modifiers, url_prefixes, url_style, visual_window_select_characters, watcher,
     window_border_width, window_size
@@ -1147,7 +1147,7 @@ class Parser:
         ans['shell'] = str(val)
 
     def shell_integration(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
-        ans['shell_integration'] = str(val)
+        ans['shell_integration'] = shell_integration(val)
 
     def single_window_margin_width(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['single_window_margin_width'] = optional_edge_width(val)

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -674,6 +674,15 @@ def allow_hyperlinks(x: str) -> int:
     return 1 if to_bool(x) else 0
 
 
+def shell_integration(x: str) -> str:
+    s = {'enabled', 'disabled', 'no-rc', 'no-env', 'no-cursor', 'no-title', 'no-prompt-mark', 'no-complete'}
+    q = set(x.split())
+    if not q.issubset(s):
+        log_error(f'Invalid shell integration options: {q - s}, ignoring')
+        return ' '.join(q & s)
+    return x
+
+
 def macos_titlebar_color(x: str) -> int:
     x = x.strip('"')
     if x == 'system':


### PR DESCRIPTION
After the recent changes, only bash actually needs to modify the rc file to enable shell integration.
A new option `no-env` has been added, along with `no-rc` to control both cases independently.

Also added definition type check to the shell_integration option to filter out invalid values.