### PR TITLE
Docs: Fix remote control launch description and other minor tweaks

### DIFF
--- a/bypy/sources.json
+++ b/bypy/sources.json
@@ -75,7 +75,7 @@
         "unix": {
             "filename": "libxkbcommon-1.0.3.tar.xz",
             "hash": "sha256:a2202f851e072b84e64a395212cbd976ee18a8ee602008b0bad02a13247dbc52",
-            "urls": ["http://xkbcommon.org/download/{filename}"]
+            "urls": ["https://xkbcommon.org/download/{filename}"]
         }
     },
 
@@ -115,7 +115,7 @@
         "unix": {
             "filename": "readline-8.1.tar.gz",
             "hash": "sha256:f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02",
-            "urls": ["http://ftp.gnu.org/gnu/readline/{filename}"]
+            "urls": ["https://ftp.gnu.org/gnu/readline/{filename}"]
         }
     },
 
@@ -180,7 +180,7 @@
         "unix": {
             "filename": "libpng-1.6.37.tar.xz",
             "hash": "sha256:505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca",
-            "urls": ["http://downloads.sourceforge.net/sourceforge/libpng/{filename}"]
+            "urls": ["https://downloads.sourceforge.net/sourceforge/libpng/{filename}"]
         }
     },
 
@@ -199,7 +199,7 @@
         "unix": {
             "filename": "graphite2-1.3.14.tgz",
             "hash": "sha256:f99d1c13aa5fa296898a181dff9b82fb25f6cc0933dbaa7a475d8109bd54209d",
-            "urls": ["http://downloads.sourceforge.net/silgraphite/{filename}"]
+            "urls": ["https://downloads.sourceforge.net/silgraphite/{filename}"]
         }
     },
 
@@ -259,7 +259,7 @@
         "unix": {
             "filename": "fontconfig-2.13.1.tar.bz2",
             "hash": "sha256:f655dd2a986d7aa97e052261b36aa67b0a64989496361eca8d604e6414006741",
-            "urls": ["http://www.fontconfig.org/release/{filename}"]
+            "urls": ["https://www.fontconfig.org/release/{filename}"]
         }
     },
 

--- a/docs/kittens/hyperlinked_grep.rst
+++ b/docs/kittens/hyperlinked_grep.rst
@@ -3,7 +3,7 @@ Hyperlinked grep
 
 
 This kitten allows you to search your files using `ripgrep
-<https://www.google.com/search?q=ripgrep>`_ and open the results
+<https://github.com/BurntSushi/ripgrep>`_ and open the results
 directly in your favorite editor in the terminal, at the line containing
 the search result, simply by clicking on the result you want.
 

--- a/glfw/cocoa_init.m
+++ b/glfw/cocoa_init.m
@@ -574,7 +574,7 @@ int _glfwPlatformInit(void)
     {
         NSEventModifierFlags modifierFlags = [event modifierFlags] & (NSEventModifierFlagShift | NSEventModifierFlagOption | NSEventModifierFlagCommand | NSEventModifierFlagControl);
         if (modifierFlags & NSEventModifierFlagCommand) {
-            // From http://cocoadev.com/index.pl?GameKeyboardHandlingAlmost
+            // From https://cocoadev.github.io/GameKeyboardHandlingAlmost/
             // This works around an AppKit bug, where key up events while holding
             // down the command key don't get sent to the key window.
             [[NSApp keyWindow] sendEvent:event];

--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -413,7 +413,7 @@ def seq_as_rst(
             if defval is not None:
                 a(textwrap.indent(f'Default: :code:`{defval}`', ' ' * 4))
             if opt.get('choices'):
-                a(textwrap.indent('Choices: :code:`{}`'.format(', '.join(sorted(opt['choices']))), ' ' * 4))
+                a(textwrap.indent('Choices: {}'.format(', '.join(f':code:`{c}`' for c in sorted(opt['choices']))), ' ' * 4))
             a('')
 
     text = '\n'.join(blocks)

--- a/kitty/colors.h
+++ b/kitty/colors.h
@@ -64,7 +64,7 @@ extern PyTypeObject Color_Type;
 
 static inline double
 rgb_luminance(ARGB32 c) {
-    // From ITU BT 601 http://www.itu.int/rec/R-REC-BT.601
+    // From ITU BT 601 https://www.itu.int/rec/R-REC-BT.601
     return 0.299 * c.red + 0.587 * c.green + 0.114 * c.blue;
 }
 

--- a/kitty/main.py
+++ b/kitty/main.py
@@ -114,7 +114,7 @@ def get_macos_shortcut_for(
     # for maximum robustness we should use opts.alias_map to resolve
     # aliases however this requires parsing everything on startup which could
     # be potentially slow. Lets just hope the user doesnt alias these
-    # fucntions.
+    # functions.
     ans = None
     candidates = []
     qkey = tuple(defn.split())

--- a/kitty/open_actions.py
+++ b/kitty/open_actions.py
@@ -133,7 +133,6 @@ def url_matches_criterion(purl: 'ParseResult', url: str, unquoted_path: str, mc:
 
     if mc.type == 'file':
         import fnmatch
-        import posixpath
         try:
             fname = posixpath.basename(unquoted_path)
         except Exception:

--- a/kitty/rc/launch.py
+++ b/kitty/rc/launch.py
@@ -45,7 +45,7 @@ class Launch(RemoteCommand):
 
     short_desc = 'Run an arbitrary process in a new window/tab'
     desc = (
-        ' Prints out the id of the newly opened window. Any command line arguments'
+        'Prints out the id of the newly opened window. Any command line arguments'
         ' are assumed to be the command line used to run in the new window, if none'
         ' are provided, the default shell is run. For example:'
         ' :code:`kitty @ launch --title Email mutt`.'

--- a/kitty/remote_control.py
+++ b/kitty/remote_control.py
@@ -29,7 +29,6 @@ active_async_requests: Dict[str, float] = {}
 
 
 def encode_response_for_peer(response: Any) -> bytes:
-    import json
     return b'\x1bP@kitty-cmd' + json.dumps(response).encode('utf-8') + b'\x1b\\'
 
 


### PR DESCRIPTION
The remote control launch command description uses code blocks enclosed in the generated docs HTML.
This PR fixes the issue.

Also use `:code:` to enclose choices.
Replace links with HTTPS.
Removed some duplicate imports.