### PR TITLE
Add a new mappable action nth_os_window to focus OS window

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -148,6 +148,9 @@ To update |kitty|, :doc:`follow the instructions <binary>`.
 - macOS: Fix keyboard input not working after toggling traditional fullscreen
   till the window is clicked in
 
+- A new mappable action ``nth_os_window`` to to focus the specified nth OS
+  window. (:pull:`4316`)
+
 
 0.23.1 [2021-08-17]
 ----------------------

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1183,6 +1183,13 @@ class Boss:
                     text = '\n'.join(parse_uri_list(text))
                 w.paste(text)
 
+    @ac('win', 'Focus the nth OS window')
+    def nth_os_window(self, num: int = 1) -> None:
+        if self.os_window_map and num > 0:
+            ids = list(self.os_window_map.keys())
+            os_window_id = ids[min(num, len(ids)) - 1]
+            focus_os_window(os_window_id, True)
+
     @ac('win', 'Close the currently active OS Window')
     def close_os_window(self) -> None:
         tm = self.active_tab_manager

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -250,7 +250,7 @@ def remote_control(func: str, rest: str) -> FuncArgsType:
     return func, args
 
 
-@func_with_args('nth_window', 'scroll_to_prompt', 'visual_window_select_action_trigger')
+@func_with_args('nth_os_window', 'nth_window', 'scroll_to_prompt', 'visual_window_select_action_trigger')
 def single_integer_arg(func: str, rest: str) -> FuncArgsType:
     try:
         num = int(rest)


### PR DESCRIPTION
When the user has multiple OS windows, this action can be used to quickly switch to the desired window.

Some other terminal emulators also have this feature by default, but their shortcuts are not fully customizable.