### PR TITLE
Fix remove window logo by remote control

### DIFF
--- a/kitty/window.py
+++ b/kitty/window.py
@@ -1074,8 +1074,9 @@ class Window:
         }
 
     def set_logo(self, path: str, position: str = '', alpha: float = -1) -> None:
-        from .options.utils import config_or_absolute_path
-        path = config_or_absolute_path(path, get_options().env) or path
+        if path:
+            from .options.utils import config_or_absolute_path
+            path = config_or_absolute_path(path, get_options().env) or ''
         set_window_logo(self.os_window_id, self.tab_id, self.id, path, position or '', alpha)
 
     # actions {{{


### PR DESCRIPTION
After executing `kitty @ set-window-logo none`, path is set to empty string and `config_or_absolute_path()` gets the config_dir folder path, causing graphics.c `png_path_to_bitmap()` to report an error.

```text
Failed while reading from file: $HOME/.config/kitty/ with error: Is a directory
```