### PR TITLE
Fix not being able to quit after closing the quit confirmation window

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1249,12 +1249,15 @@ class Boss:
         self._run_kitten('ask', ['--type=yesno', '--message', _(
             'Are you sure you want to quit kitty, it has {} windows running?').format(num)],
             window=tm.active_window,
-            custom_callback=self.handle_quit_confirmation
+            custom_callback=self.handle_quit_confirmation,
+            action_on_removal=partial(self.handle_quit_confirmation, {})
         )
         set_application_quit_request(CLOSE_BEING_CONFIRMED)
 
     def handle_quit_confirmation(self, data: Dict[str, Any], *a: Any) -> None:
-        set_application_quit_request(IMPERATIVE_CLOSE_REQUESTED if data['response'] == 'y' else NO_CLOSE_REQUESTED)
+        if current_application_quit_request() == IMPERATIVE_CLOSE_REQUESTED:
+            return
+        set_application_quit_request(IMPERATIVE_CLOSE_REQUESTED if data.get('response') == 'y' else NO_CLOSE_REQUESTED)
 
     def notify_on_os_window_death(self, address: str) -> None:
         import socket


### PR DESCRIPTION
After using ctrl+shift+w to close the quit confirmation window, kitty cannot quit anymore. This PR fixes the issue.

Please check if this needs to be handled in `ask_to_read_clipboard()`, `file_transmission` as well, especially if the program expects to get cancellation response, or the state needs to be reset.