### PR TITLE
Docs: update the pygments URL and the markers doc URL

### DIFF
--- a/kittens/diff/options/definition.py
+++ b/kittens/diff/options/definition.py
@@ -54,7 +54,7 @@ agr('colors', 'Colors')
 opt('pygments_style', 'default',
     long_text='''
 The pygments color scheme to use for syntax highlighting. See :link:`pygments
-colors schemes <https://help.farbox.com/pygments.html>` for a list of schemes.
+builtin styles <https://pygments.org/styles/>` for a list of schemes.
 '''
     )
 

--- a/kitty/rc/create_marker.py
+++ b/kitty/rc/create_marker.py
@@ -3,7 +3,6 @@
 
 from typing import TYPE_CHECKING, Optional
 
-from kitty.constants import website_url
 from kitty.options.utils import parse_marker_spec
 
 from .base import (
@@ -25,9 +24,9 @@ class CreateMarker(RemoteCommand):
 
     short_desc = 'Create a marker that highlights specified text'
     desc = (
-        'Create a marker which can highlight text in the specified window. For example: '
-        'create_marker text 1 ERROR. For full details see: {}'
-    ).format(website_url('marks'))
+        'Create a marker which can highlight text in the specified window. For example:'
+        ' :code:`create_marker text 1 ERROR`. For full details see: :doc:`marks`'
+    )
     options_spec = MATCH_WINDOW_OPTION + '''\n
 --self
 type=bool-set

--- a/kitty/rc/get_colors.py
+++ b/kitty/rc/get_colors.py
@@ -25,8 +25,8 @@ class GetColors(RemoteCommand):
 
     short_desc = 'Get terminal colors'
     desc = (
-        'Get the terminal colors for the specified window (defaults to active window). '
-        'Colors will be output to stdout in the same syntax as used for kitty.conf'
+        'Get the terminal colors for the specified window (defaults to active window).'
+        ' Colors will be output to stdout in the same syntax as used for kitty.conf'
     )
     options_spec = '''\
 --configured -c


### PR DESCRIPTION
Use the pygments official website URL.

Use `:doc:` to generate relative URL with text in html document. Also show the link to the official website in the command line help.

Use `:code:` to wrap the command, which will be identified by cyan color in the command line help.

I can't replace `{hints_url}` in `kittens/hints/main.py` with a relative link to the document (which is the official URL in the locally generated document). So leave it as is.