### PR TITLE
Fix document link scrolling issue

### DIFF
--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -22,7 +22,7 @@ function scroll_sidebar_node_into_view(a) {
         a = a.offsetParent;
         if (!a || a == ss) break;
     }
-    ss.scrollTop = pos;
+    ss.scrollTo({top: pos, behavior: 'instant'});
 }
 
 function mark_current_link(sidebar_tree, a, onload) {


### PR DESCRIPTION
Fix an issue where opening a document link with hashtag in Chrome would not scroll to the anchor.

When the body of the document and the sidebar are in smooth scrolling at the same time, the scrolling of the body is stopped, resulting in not positioning to the anchor.

Any links that open in Chrome are at the top of the page.

https://stackoverflow.com/questions/49318497/google-chrome-simultaneously-smooth-scrollintoview-with-more-elements-doesn