### PR TITLE
Fix action dump_lines_with_attrs

### DIFF
--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -3716,7 +3716,7 @@ dump_lines_with_attrs(Screen *self, PyObject *accum) {
         Line *line = range_line_(self, y);
         t = PyUnicode_FromFormat("\x1b[31m%d: \x1b[39m", y++);
         if (t) {
-            PyObject_CallFunctionObjArgs(accum, t);
+            PyObject_CallFunctionObjArgs(accum, t, NULL);
             Py_DECREF(t);
         }
         switch (line->attrs.prompt_kind) {


### PR DESCRIPTION
An exception occurs when executing `dump_lines_with_attrs`.

```text
TypeError: list.append() takes exactly one argument (4 given)
...
    self.screen.dump_lines_with_attrs(strings.append)
SystemError: <method 'dump_lines_with_attrs' of 'fast_data_types.Screen' objects> returned a result with an error set
```