### PR TITLE
Fix unicode-input docs redirect

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -111,7 +111,10 @@ def add_old_redirects(loc: str) -> None:
                     link_name = os.path.join(base, f'{bname}.html') if base else f'{bname}.html'
                     generate_redirect_html(link_name, bname)
 
-    generate_redirect_html(os.path.join(loc, 'kittens', 'unicode-input.html'), 'unicode_input')
+    old_unicode_input_path = os.path.join(loc, 'kittens', 'unicode-input')
+    os.makedirs(old_unicode_input_path, exist_ok=True)
+    generate_redirect_html(os.path.join(old_unicode_input_path, 'index.html'), '../unicode_input')
+    generate_redirect_html(f'{old_unicode_input_path}.html', 'unicode_input')
 
 
 def run_docs(args: Any) -> None:


### PR DESCRIPTION
Sorry, I missed some files in the last PR.
I hope that all the required html files are generated this time.

```text
docs/_build/dirhtml/kittens/unicode-input.html
docs/_build/dirhtml/kittens/unicode-input/
docs/_build/dirhtml/kittens/unicode-input/index.html

docs/_build/dirhtml/kittens/unicode_input.html
docs/_build/dirhtml/kittens/unicode_input/
docs/_build/dirhtml/kittens/unicode_input/index.html
```