### PR TITLE
Fix remote control scroll-window argument parsing

### DIFF
--- a/kitty/rc/scroll_window.py
+++ b/kitty/rc/scroll_window.py
@@ -40,9 +40,8 @@ class ScrollWindow(RemoteCommand):
         if amt not in ('start', 'end'):
             pages = 'p' in amt
             unscroll = 'u' in amt
-            amt = amt.replace('p', '')
             mult = -1 if amt.endswith('-') and not unscroll else 1
-            q = int(amt.replace('-', ''))
+            q = int(amt.rstrip('+-pu'))
             amount = q * mult, 'p' if pages else ('u' if unscroll else 'l')
 
         return {'match': opts.match, 'amount': amount}


### PR DESCRIPTION
When executing the remote control `scroll-window 1u` (or end with `+`), an exception is thrown.

```text
ValueError: invalid literal for int() with base 10: '1u'
```

I also found that when "unscroll" is executed with escape code or this remote control command. The cursor position does not seem to be updated. For example, after generating some empty lines under the current prompt cursor, execute unscroll. `printf "\e[3+T"`
Although the scrollback content is moved down. But the cursor did not move down together.

Would you mind taking a look? Thanks.

Perhaps the cursor position needs to be updated even when scrollback is scrolled, to keep it at the shell prompt. (when not unscrolling past the cursor position)

---

Also, for "unscroll", the common meaning of this word seems to be:
"To open or unfold progressively, as a scroll does."

I felt some confusion when I learned the name of this feature.
I don't have any ideas, just letting you know.