### PR TITLE
Docs: Enable kbd transform when building dirhtml with sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,10 @@ from pygments.token import (  # type: ignore
     Comment, Keyword, Literal, Name, Number, String, Whitespace
 )
 from sphinx import addnodes, version_info  # type: ignore
+from sphinx.builders.html.transforms import KeyboardTransform  # type: ignore
 from sphinx.util.logging import getLogger  # type: ignore
+
+KeyboardTransform.builders = ('html', 'dirhtml')  # type: ignore
 
 kitty_src = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if kitty_src not in sys.path:


### PR DESCRIPTION
I found that when building the docs, make html and make dirhtml end up with different kbd styles.

This PR enables sphinx KeyboardTransform builtin extension. The final result will be the same.

related:

https://github.com/sphinx-doc/sphinx/issues/7530

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd#representing_keystrokes_within_an_input
