### PR TITLE
macOS: Fix keyboard input not working after toggling full screen

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -1644,6 +1644,9 @@ void _glfwPlatformUpdateIMEState(_GLFWwindow *w, const GLFWIMEUpdateEvent *ev) {
     [self setResizeIncrements:NSMakeSize(1.0, 1.0)];
     [super toggleFullScreen:sender];
     [self setResizeIncrements:original];
+    // When the window decoration is hidden, toggling fullscreen causes the style mask to be changed,
+    // and causes the first responder to be cleared.
+    if (glfw_window && !glfw_window->decorated && glfw_window->ns.view) [self makeFirstResponder:glfw_window->ns.view];
 }
 
 @end


### PR DESCRIPTION
```shell
kitty --config=NONE -o hide_window_decorations=yes
```

Issue:
https://github.com/kovidgoyal/kitty/issues/4349

I am not sure if this is the best way to handle this, please review, thanks.