### PR TITLE
Fix missing `fmt.bg.normal` in tab title template

### DIFF
--- a/kitty/tab_bar.py
+++ b/kitty/tab_bar.py
@@ -179,6 +179,8 @@ def draw_title(draw_data: DrawData, screen: Screen, tab: TabBarData, index: int)
             'sup': SupSub(data),
             'sub': SupSub(data, True),
         }
+        normal_bg = draw_data.active_bg if tab.is_active else draw_data.inactive_bg
+        eval_locals['fmt'].bg.normal = f'\x1b[4{"8" + color_as_sgr(normal_bg)}m'
         title = eval(compile_template(template), {'__builtins__': {}}, eval_locals)
     except Exception as e:
         report_template_failure(template, str(e))


### PR DESCRIPTION
I'm currently using the stable version and realized that `{fmt.bg.normal}` was missing, which is one of [documentation example](https://sw.kovidgoyal.net/kitty/conf/#opt-kitty.tab_title_template). I think it's there to reset any background color changes to match the current tab background color. Just close the PR if you've already implemented this.

Here the result (the top windows is the fixed version):

![Demo](https://user-images.githubusercontent.com/60842560/146193789-3bedf404-0239-4ee0-8c79-29841510caa8.png)

I injected the `normal` field in the `draw_title` instead of passing some conditions to the lower code, which I think is too over engineering, but too many special cases like this in the future may pollute the code. Let me know if that's not your intention.