### PR TITLE
Add light and dark to the macOS title bar option

### DIFF
--- a/gen-config.py
+++ b/gen-config.py
@@ -31,7 +31,7 @@ def main() -> None:
             if opt.parser_func.__name__ in ('to_color_or_none', 'cursor_text_color'):
                 nullable_colors.append(opt.name)
                 all_colors.append(opt.name)
-            elif opt.parser_func.__name__ in ('to_color', 'macos_titlebar_color'):
+            elif opt.parser_func.__name__ in ('to_color', 'titlebar_color', 'macos_titlebar_color'):
                 all_colors.append(opt.name)
     patch_color_list('kitty/rc/set_colors.py', nullable_colors, 'NULLABLE')
     patch_color_list('kittens/themes/collection.py', all_colors, 'ALL', ' ' * 8)

--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -620,6 +620,16 @@ cocoa_set_activation_policy(bool hide_from_tasks) {
 }
 
 void
+cocoa_set_titlebar_appearance(void *w, unsigned int theme)
+{
+    if (!theme) return;
+    @autoreleasepool {
+        NSWindow *window = (NSWindow*)w;
+        [window setAppearance:[NSAppearance appearanceNamed:((theme == 2) ? NSAppearanceNameVibrantDark : NSAppearanceNameVibrantLight)]];
+    } // autoreleasepool
+}
+
+void
 cocoa_set_titlebar_color(void *w, color_type titlebar_color)
 {
     @autoreleasepool {

--- a/kitty/config.py
+++ b/kitty/config.py
@@ -181,7 +181,7 @@ def load_config(*paths: str, overrides: Optional[Iterable[str]] = None, accumula
     opts.action_alias = {}
     opts.mouse_map = []
     opts.map = []
-    if opts.background_opacity < 1.0 and opts.macos_titlebar_color:
+    if opts.background_opacity < 1.0 and opts.macos_titlebar_color > 0:
         log_error('Cannot use both macos_titlebar_color and background_opacity')
         opts.macos_titlebar_color = 0
     opts.config_paths = paths

--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -452,7 +452,7 @@ def init_cell_program() -> None:
     pass
 
 
-def set_titlebar_color(os_window_id: int, color: int, use_system_color: bool = False) -> bool:
+def set_titlebar_color(os_window_id: int, color: int, use_system_color: bool = False, system_color: int = 0) -> bool:
     pass
 
 

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -21,6 +21,7 @@ extern void cocoa_create_global_menu(void);
 extern void cocoa_hide_window_title(void *w);
 extern void cocoa_system_beep(const char*);
 extern void cocoa_set_activation_policy(bool);
+extern void cocoa_set_titlebar_appearance(void *w, unsigned int theme);
 extern void cocoa_set_titlebar_color(void *w, color_type color);
 extern bool cocoa_alt_option_key_pressed(unsigned long);
 extern size_t cocoa_get_workspace_ids(void *w, size_t *workspace_ids, size_t array_sz);
@@ -677,11 +678,12 @@ intercept_cocoa_fullscreen(GLFWwindow *w) {
 #endif
 
 void
-set_titlebar_color(OSWindow *w, color_type color, bool use_system_color) {
+set_titlebar_color(OSWindow *w, color_type color, bool use_system_color, unsigned int system_color UNUSED) {
     if (w->handle && (!w->last_titlebar_color || (w->last_titlebar_color & 0xffffff) != (color & 0xffffff))) {
         w->last_titlebar_color = (1 << 24) | (color & 0xffffff);
 #ifdef __APPLE__
         if (!use_system_color) cocoa_set_titlebar_color(glfwGetCocoaWindow(w->handle), color);
+        else cocoa_set_titlebar_appearance(glfwGetCocoaWindow(w->handle), system_color);
 #else
         if (global_state.is_wayland && glfwWaylandSetTitlebarColor) glfwWaylandSetTitlebarColor(w->handle, color, use_system_color);
 #endif

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -2735,7 +2735,7 @@ egr()  # }}}
 agr('os', 'OS specific tweaks')
 
 opt('wayland_titlebar_color', 'system',
-    option_type='macos_titlebar_color',
+    option_type='titlebar_color',
     long_text='''
 Change the color of the kitty window's titlebar on Wayland systems with client
 side window decorations such as GNOME. A value of :code:`system` means to use
@@ -2749,7 +2749,8 @@ opt('macos_titlebar_color', 'system',
     option_type='macos_titlebar_color',
     long_text='''
 Change the color of the kitty window's titlebar on macOS. A value of
-:code:`system` means to use the default system color, a value of
+:code:`system` means to use the default system color, :code:`light` or
+:code:`dark` can also be used to set it explicitly. A value of
 :code:`background` means to use the background color of the currently active
 window and finally you can use an arbitrary color, such as :code:`#12af59` or
 :code:`red`. WARNING: This option works by using a hack, as there is no proper

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -14,8 +14,8 @@ from kitty.options.utils import (
     macos_option_as_alt, macos_titlebar_color, optional_edge_width, parse_map, parse_mouse_map,
     resize_draw_strategy, scrollback_lines, scrollback_pager_history_size, shell_integration,
     store_multiple, symbol_map, tab_activity_symbol, tab_bar_edge, tab_bar_margin_height,
-    tab_bar_min_tabs, tab_fade, tab_font_style, tab_separator, tab_title_template, to_cursor_shape,
-    to_font_size, to_layout_names, to_modifiers, url_prefixes, url_style,
+    tab_bar_min_tabs, tab_fade, tab_font_style, tab_separator, tab_title_template, titlebar_color,
+    to_cursor_shape, to_font_size, to_layout_names, to_modifiers, url_prefixes, url_style,
     visual_window_select_characters, window_border_width, window_size
 )
 
@@ -1263,7 +1263,7 @@ class Parser:
             ans["watcher"][k] = v
 
     def wayland_titlebar_color(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
-        ans['wayland_titlebar_color'] = macos_titlebar_color(val)
+        ans['wayland_titlebar_color'] = titlebar_color(val)
 
     def wheel_scroll_multiplier(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['wheel_scroll_multiplier'] = float(val)

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -680,13 +680,22 @@ def allow_hyperlinks(x: str) -> int:
     return 1 if to_bool(x) else 0
 
 
-def macos_titlebar_color(x: str) -> int:
+def titlebar_color(x: str) -> int:
     x = x.strip('"')
     if x == 'system':
         return 0
     if x == 'background':
         return 1
     return (color_as_int(to_color(x)) << 8) | 2
+
+
+def macos_titlebar_color(x: str) -> int:
+    x = x.strip('"')
+    if x == 'light':
+        return -1
+    if x == 'dark':
+        return -2
+    return titlebar_color(x)
 
 
 def macos_option_as_alt(x: str) -> int:

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -825,9 +825,10 @@ PYWRAP1(set_titlebar_color) {
     id_type os_window_id;
     unsigned int color;
     int use_system_color = 0;
-    PA("KI|p", &os_window_id, &color, &use_system_color);
+    unsigned int system_color = 0;
+    PA("KI|pI", &os_window_id, &color, &use_system_color, &system_color);
     WITH_OS_WINDOW(os_window_id)
-        set_titlebar_color(os_window, color, use_system_color);
+        set_titlebar_color(os_window, color, use_system_color, system_color);
         Py_RETURN_TRUE;
     END_WITH_OS_WINDOW
     Py_RETURN_FALSE;

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -281,7 +281,7 @@ void send_image_to_gpu(uint32_t*, const void*, int32_t, int32_t, bool, bool, boo
 void send_sprite_to_gpu(FONTS_DATA_HANDLE fg, unsigned int, unsigned int, unsigned int, pixel*);
 void blank_canvas(float, color_type);
 void blank_os_window(OSWindow *);
-void set_titlebar_color(OSWindow *w, color_type color, bool use_system_color);
+void set_titlebar_color(OSWindow *w, color_type color, bool use_system_color, unsigned int system_color);
 FONTS_DATA_HANDLE load_fonts_data(double, double, double);
 void send_prerendered_sprites_for_window(OSWindow *w);
 #ifdef __APPLE__

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -741,14 +741,14 @@ class Window:
     def change_titlebar_color(self) -> None:
         opts = get_options()
         val = opts.macos_titlebar_color if is_macos else opts.wayland_titlebar_color
-        if val:
+        if val > 0:
             if (val & 0xff) == 1:
                 val = self.screen.color_profile.default_bg
             else:
                 val = val >> 8
             set_titlebar_color(self.os_window_id, val)
         else:
-            set_titlebar_color(self.os_window_id, 0, True)
+            set_titlebar_color(self.os_window_id, 0, True, -val)
 
     def change_colors(self, changes: Dict[DynamicColor, Optional[str]]) -> None:
         dirtied = default_bg_changed = False


### PR DESCRIPTION
Support for explicitly setting the window title bar style for macOS.

When the system appearance of macOS is set to Auto, you can set the appearance of kitty to a fixed Light or Dark.