### PR TITLE
Docs: Add zsh unfunction kitty-integration, recent changes and minor tweaks

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -148,8 +148,8 @@ To update |kitty|, :doc:`follow the instructions <binary>`.
 - When remembering OS window sizes for full screen windows use the size before
   the window became fullscreen (:iss:`4221`)
 
-- macOS: Fix keyboard input not working after toggling traditional fullscreen
-  till the window is clicked in
+- macOS: Fix keyboard input not working after toggling fullscreen till the
+  window is clicked in
 
 - A new mappable action ``nth_os_window`` to to focus the specified nth OS
   window. (:pull:`4316`)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -154,6 +154,12 @@ To update |kitty|, :doc:`follow the instructions <binary>`.
 - A new mappable action ``nth_os_window`` to to focus the specified nth OS
   window. (:pull:`4316`)
 
+- macOS: The kitty window can be scrolled by the mouse wheel when OS window not
+  in focus. (:pull:`4371`)
+
+- macOS: Light or dark system appearance can be specified in
+  :opt:`macos_titlebar_color` and used in kitty themes. (:pull:`4378`)
+
 
 0.23.1 [2021-08-17]
 ----------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -91,7 +91,7 @@ To update |kitty|, :doc:`follow the instructions <binary>`.
 - Linux: Fix IME with fcitx5 not working after fcitx5 is restarted
   (:pull:`4059`)
 
-- macOS: Various improvements to IME integration (:iss:`4219`)
+- Various improvements to IME integration (:iss:`4219`)
 
 - Remote file transfer: Fix transfer not working if custom ssh port or identity
   is specified on the command line (:iss:`4067`)

--- a/docs/shell-integration.rst
+++ b/docs/shell-integration.rst
@@ -213,7 +213,7 @@ Then in your shell's rc file, add the lines:
         if test -n "$KITTY_INSTALLATION_DIR"; then
             export KITTY_SHELL_INTEGRATION="enabled"
             autoload -Uz -- "$KITTY_INSTALLATION_DIR"/shell-integration/zsh/kitty-integration
-            kitty-integration
+            unfunction kitty-integration
         fi
 
 .. tab:: fish

--- a/docs/shell-integration.rst
+++ b/docs/shell-integration.rst
@@ -213,6 +213,7 @@ Then in your shell's rc file, add the lines:
         if test -n "$KITTY_INSTALLATION_DIR"; then
             export KITTY_SHELL_INTEGRATION="enabled"
             autoload -Uz -- "$KITTY_INSTALLATION_DIR"/shell-integration/zsh/kitty-integration
+            kitty-integration
             unfunction kitty-integration
         fi
 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -987,7 +987,7 @@ The tab bar style, can be one of:
     A user-supplied Python function called draw_tab is loaded from the file
     :file:`tab_bar.py` in the kitty config directory. For examples of how to
     write such a function, see the functions named :code:`draw_tab_with_*` in
-    kitty‘s source code: :file:`kitty/tab_bar.py`.
+    kitty's source code: :file:`kitty/tab_bar.py`.
 :code:`hidden`
     The tab bar is hidden. If you use this, you might want to create a
     mapping for the :ref:`action-select_tab`

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -35,8 +35,8 @@ opt('font_family', 'monospace',
 You can specify different fonts for the bold/italic/bold-italic variants.
 To get a full list of supported fonts use the `kitty list-fonts` command.
 By default they are derived automatically, by the OSes font system. When
-bold_font or bold_italic_font is set to :code:`auto`, the priority of bold
-fonts is semi-bold, bold, heavy. Setting them manually is useful for font
+bold_font or bold_italic_font is set to :code:`auto` on macOS, the priority of
+bold fonts is semi-bold, bold, heavy. Setting them manually is useful for font
 families that have many weight variants like Book, Medium, Thick, etc.
 For example::
 

--- a/shell-integration/zsh/.zshenv
+++ b/shell-integration/zsh/.zshenv
@@ -5,7 +5,7 @@
 # Don't use [[ -v ... ]] because it doesn't work in zsh < 5.4.
 if [[ -n "${KITTY_ORIG_ZDOTDIR+X}" ]]; then
     # Normally ZDOTDIR shouldn't be exported but it was in the environment
-    # of Kitty, so we export it.
+    # of kitty, so we export it.
     'builtin' 'export' ZDOTDIR="$KITTY_ORIG_ZDOTDIR"
     'builtin' 'unset' 'KITTY_ORIG_ZDOTDIR'
 else

--- a/shell-integration/zsh/kitty-integration
+++ b/shell-integration/zsh/kitty-integration
@@ -10,6 +10,7 @@
 # Kitty in all shells should add the following lines to their .zshrc:
 #
 #   if [[ -n $KITTY_INSTALLATION_DIR ]]; then
+#     export KITTY_SHELL_INTEGRATION="enabled"
 #     autoload -Uz -- "$KITTY_INSTALLATION_DIR"/shell-integration/zsh/kitty-integration
 #     kitty-integration
 #     unfunction kitty-integration

--- a/shell-integration/zsh/kitty-integration
+++ b/shell-integration/zsh/kitty-integration
@@ -1,13 +1,13 @@
 #!/bin/zsh
 #
-# Enables integration between zsh and Kitty based on KITTY_SHELL_INTEGRATION.
-# The latter is set by Kitty based on kitty.conf.
+# Enables integration between zsh and kitty based on KITTY_SHELL_INTEGRATION.
+# The latter is set by kitty based on kitty.conf.
 #
 # This is an autoloadable function. It's invoked automatically in shells
-# directly spawned by Kitty but not in any other shells. For example, running
+# directly spawned by kitty but not in any other shells. For example, running
 # `exec zsh`, `sudo -E zsh`, `tmux`, or plain `zsh` will create a shell where
 # kitty-integration won't automatically run. Zsh users who want integration with
-# Kitty in all shells should add the following lines to their .zshrc:
+# kitty in all shells should add the following lines to their .zshrc:
 #
 #   if [[ -n $KITTY_INSTALLATION_DIR ]]; then
 #     export KITTY_SHELL_INTEGRATION="enabled"
@@ -32,7 +32,7 @@ builtin emulate -L zsh -o no_warn_create_global
 # 2: none of the above.
 builtin typeset -gi _ksi_state
 
-# Asks Kitty to print $@ to its stdout. This is for debugging.
+# Asks kitty to print $@ to its stdout. This is for debugging.
 _ksi_debug_print() {
     builtin local data
     data=$(command base64 <<<"${(j: :}@}") || builtin return


### PR DESCRIPTION
- Add unfunction kitty-integration to the shell integration documentation.
- Unified use of lowercase names for `kitty`.
- Add some recent changes to the changelog.
- I previously introduced  Unicode left single quote in the docs and now replaced it with ASCII.
- Other minor changes.