### PR TITLE
shell.nix: add dependency needed on Apple silicon

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -24,6 +24,8 @@ mkShell rec {
     libpng
     python3
     zlib
+  ] ++ lib.optionals (stdenv.isDarwin && (builtins.hasAttr "UserNotifications" darwin.apple_sdk.frameworks)) [
+    darwin.apple_sdk.frameworks.UserNotifications
   ] ++ optionals stdenv.isLinux [
     fontconfig libunistring libcanberra libX11
     libXrandr libXinerama libXcursor libxkbcommon libXi libXext


### PR DESCRIPTION
shell.nix is missing a depencency on the UserNotifications framework on macOS with Apple silicon. Unfortunately we can't just unconditionally include this dependency because Nixpkgs uses a different macOS SDK version for macOS on an Intel processor compared to macOS on Apple silicon. The older SDK version 10.12 on Intel does not have the UserNotifications framework, which would lead to an "attribute missing" error when trying to execute `nix-shell`. The condition can be dropped when the macOS SDK version for Intel processors is finally updated. See https://github.com/NixOS/nixpkgs/issues/101229 for progress on that.
See https://github.com/NixOS/nixpkgs/pull/137512 for more context.
Closes https://github.com/kovidgoyal/kitty/issues/4352.

@kovidgoyal Please don't merge this until someone with an M1 Mac has actually tested this.
@alexghr could you please test this and confirm that it fixes the problem? I don't have an M1 Mac to test with myself.