### PR TITLE
Fix cannot use colon in command strings with `combine`

### DIFF
--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -908,7 +908,7 @@ def resolve_aliases_and_parse_actions(
 
     if possible_alias == 'combine':
         sep, rest = rest.split(maxsplit=1)
-        parts = re.split(r'\s*' + re.escape(sep) + r'\s*', rest)
+        parts = re.split(re.escape(sep) + r'''(?=(?:[^'"]|'[^']*'|"[^"]*")*$)''', rest)
         for x in parts:
             if x:
                 yield from resolve_aliases_and_parse_actions(x, aliases, map_type)


### PR DESCRIPTION
I have this config and it fails due to the `:` in `:edit`:
```vim
map ctrl+shift+k>v>c combine : launch --cwd=current --type=tab vim -c ':edit $MYVIMRC': remote_control set-spacing padding=0
```
This would be an easy fix with a new regex to ignore `:` in string.