### PR TITLE
Avoid defining variable names that already exist and remove redundant variable assignments

### DIFF
--- a/glfw/linux_notify.c
+++ b/glfw/linux_notify.c
@@ -35,10 +35,10 @@ notification_created(DBusMessage *msg, const char* errmsg, void *data) {
         if (data) free(data);
         return;
     }
-    uint32_t notification_id;
-    if (!glfw_dbus_get_args(msg, "Failed to get Notification uid", DBUS_TYPE_UINT32, &notification_id, DBUS_TYPE_INVALID)) return;
+    uint32_t id;
+    if (!glfw_dbus_get_args(msg, "Failed to get Notification uid", DBUS_TYPE_UINT32, &id, DBUS_TYPE_INVALID)) return;
     NotificationCreatedData *ncd = (NotificationCreatedData*)data;
-    if (ncd->callback) ncd->callback(ncd->next_id, notification_id, ncd->data);
+    if (ncd->callback) ncd->callback(ncd->next_id, id, ncd->data);
     if (data) free(data);
 }
 
@@ -46,12 +46,12 @@ static DBusHandlerResult
 message_handler(DBusConnection *conn UNUSED, DBusMessage *msg, void *user_data UNUSED) {
     /* printf("session_bus message_handler invoked interface: %s member: %s\n", dbus_message_get_interface(msg), dbus_message_get_member(msg)); */
     if (dbus_message_is_signal(msg, NOTIFICATIONS_IFACE, "ActionInvoked")) {
-        uint32_t notification_id;
+        uint32_t id;
         const char *action;
         if (glfw_dbus_get_args(msg, "Failed to get args from ActionInvoked notification signal",
-                    DBUS_TYPE_UINT32, &notification_id, DBUS_TYPE_STRING, &action, DBUS_TYPE_INVALID)) {
+                    DBUS_TYPE_UINT32, &id, DBUS_TYPE_STRING, &action, DBUS_TYPE_INVALID)) {
             if (activated_handler) {
-                activated_handler(notification_id, action);
+                activated_handler(id, action);
                 return DBUS_HANDLER_RESULT_HANDLED;
             }
         }

--- a/glfw/wl_text_input.c
+++ b/glfw/wl_text_input.c
@@ -25,20 +25,20 @@ static void commit(void) {
 }
 
 static void
-text_input_enter(void *data UNUSED, struct zwp_text_input_v3 *text_input UNUSED, struct wl_surface *surface UNUSED) {
+text_input_enter(void *data UNUSED, struct zwp_text_input_v3 *txt_input UNUSED, struct wl_surface *surface UNUSED) {
     debug("text-input: enter event\n");
-    if (text_input) {
-        zwp_text_input_v3_enable(text_input);
-        zwp_text_input_v3_set_content_type(text_input, ZWP_TEXT_INPUT_V3_CONTENT_HINT_NONE, ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_TERMINAL);
+    if (txt_input) {
+        zwp_text_input_v3_enable(txt_input);
+        zwp_text_input_v3_set_content_type(txt_input, ZWP_TEXT_INPUT_V3_CONTENT_HINT_NONE, ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_TERMINAL);
         commit();
     }
 }
 
 static void
-text_input_leave(void *data UNUSED, struct zwp_text_input_v3 *text_input UNUSED, struct wl_surface *surface UNUSED) {
+text_input_leave(void *data UNUSED, struct zwp_text_input_v3 *txt_input UNUSED, struct wl_surface *surface UNUSED) {
     debug("text-input: leave event\n");
-    if (text_input) {
-        zwp_text_input_v3_disable(text_input);
+    if (txt_input) {
+        zwp_text_input_v3_disable(txt_input);
         commit();
     }
 }
@@ -57,7 +57,7 @@ send_text(const char *text, GLFWIMEState ime_state) {
 static void
 text_input_preedit_string(
         void                     *data UNUSED,
-        struct zwp_text_input_v3 *text_input UNUSED,
+        struct zwp_text_input_v3 *txt_input UNUSED,
         const char               *text,
         int32_t                  cursor_begin,
         int32_t                  cursor_end
@@ -68,7 +68,7 @@ text_input_preedit_string(
 }
 
 static void
-text_input_commit_string(void *data UNUSED, struct zwp_text_input_v3 *text_input UNUSED, const char *text) {
+text_input_commit_string(void *data UNUSED, struct zwp_text_input_v3 *txt_input UNUSED, const char *text) {
     debug("text-input: commit_string event: text: %s\n", text);
     free(pending_commit);
     pending_commit = text ? _glfw_strdup(text) : NULL;
@@ -77,14 +77,14 @@ text_input_commit_string(void *data UNUSED, struct zwp_text_input_v3 *text_input
 static void
 text_input_delete_surrounding_text(
         void *data UNUSED,
-        struct zwp_text_input_v3 *zwp_text_input_v3 UNUSED,
+        struct zwp_text_input_v3 *txt_input UNUSED,
         uint32_t before_length,
         uint32_t after_length) {
     debug("text-input: delete_surrounding_text event: before_length: %u after_length: %u\n", before_length, after_length);
 }
 
 static void
-text_input_done(void *data UNUSED, struct zwp_text_input_v3 *zwp_text_input_v3 UNUSED, uint32_t serial UNUSED) {
+text_input_done(void *data UNUSED, struct zwp_text_input_v3 *txt_input UNUSED, uint32_t serial UNUSED) {
     debug("text-input: done event: serial: %u current_commit_serial: %u\n", serial, commit_serial);
     if (serial != commit_serial) {
         _glfwInputError(GLFW_PLATFORM_ERROR, "Wayland: text_input_done serial mismatch, expected=%u got=%u\n", commit_serial, serial);

--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -896,9 +896,9 @@ void _glfwPlatformSetWindowSize(_GLFWwindow* window, int width, int height)
     if (width != window->wl.width || height != window->wl.height) {
         window->wl.user_requested_content_size.width = width;
         window->wl.user_requested_content_size.height = height;
-        int32_t width = 0, height = 0;
-        set_csd_window_geometry(window, &width, &height);
-        window->wl.width = width; window->wl.height = height;
+        int32_t w = 0, h = 0;
+        set_csd_window_geometry(window, &w, &h);
+        window->wl.width = w; window->wl.height = h;
         resizeFramebuffer(window);
         ensure_csd_resources(window);
         wl_surface_commit(window->wl.surface);
@@ -1667,9 +1667,9 @@ static void drag_enter(void *data UNUSED, struct wl_data_device *wl_data_device 
             while (window)
             {
                 if (window->wl.surface == surface) {
-                    for (size_t x = 0; x < d->mimes_count; x++) {
-                        int prio = _glfwInputDrop(window, d->mimes[x], NULL, 0);
-                        if (prio > format_priority) d->mime_for_drop = d->mimes[x];
+                    for (size_t j = 0; j < d->mimes_count; j++) {
+                        int prio = _glfwInputDrop(window, d->mimes[j], NULL, 0);
+                        if (prio > format_priority) d->mime_for_drop = d->mimes[j];
                     }
                     break;
                 }
@@ -1695,8 +1695,8 @@ static void drop(void *data UNUSED, struct wl_data_device *wl_data_device UNUSED
     for (size_t i = 0; i < arraysz(_glfw.wl.dataOffers); i++) {
         if (_glfw.wl.dataOffers[i].offer_type == DRAG_AND_DROP && _glfw.wl.dataOffers[i].mime_for_drop) {
             size_t sz = 0;
-            char *data = read_data_offer(_glfw.wl.dataOffers[i].id, _glfw.wl.dataOffers[i].mime_for_drop, &sz);
-            if (data) {
+            char *d = read_data_offer(_glfw.wl.dataOffers[i].id, _glfw.wl.dataOffers[i].mime_for_drop, &sz);
+            if (d) {
                 // We dont do finish as this requires version 3 for wl_data_device_manager
                 // which then requires more work with calling set_actions for drag and drop to function
                 // wl_data_offer_finish(_glfw.wl.dataOffers[i].id);
@@ -1705,13 +1705,13 @@ static void drop(void *data UNUSED, struct wl_data_device *wl_data_device UNUSED
                 while (window)
                 {
                     if (window->wl.surface == _glfw.wl.dataOffers[i].surface) {
-                        _glfwInputDrop(window, _glfw.wl.dataOffers[i].mime_for_drop, data, sz);
+                        _glfwInputDrop(window, _glfw.wl.dataOffers[i].mime_for_drop, d, sz);
                         break;
                     }
                     window = window->next;
                 }
 
-                free(data);
+                free(d);
             }
             destroy_data_offer(&_glfw.wl.dataOffers[i]);
             break;

--- a/kittens/choose/main.c
+++ b/kittens/choose/main.c
@@ -55,7 +55,7 @@ create_job(size_t i, size_t blocksz, GlobalData *global) {
     if (ans->start >= global->haystack_count) ans->count = 0;
     else ans->count = global->haystack_count - ans->start;
     ans->max_haystack_len = 0;
-    for (size_t i = ans->start; i < ans->start + ans->count; i++) ans->max_haystack_len = MAX(ans->max_haystack_len, global->haystack[i].haystack_len);
+    for (size_t j = ans->start; j < ans->start + ans->count; j++) ans->max_haystack_len = MAX(ans->max_haystack_len, global->haystack[j].haystack_len);
     if (ans->count > 0) {
         ans->workspace = alloc_workspace(ans->max_haystack_len, global);
         if (!ans->workspace) { free(ans); return NULL; }

--- a/kittens/ssh/main.py
+++ b/kittens/ssh/main.py
@@ -219,16 +219,16 @@ def parse_ssh_args(args: List[str]) -> Tuple[List[str], List[str], bool]:
     expecting_option_val = False
     passthrough = False
     stop_option_processing = False
-    for arg in args:
+    for argument in args:
         if len(server_args) > 1 or stop_option_processing:
-            server_args.append(arg)
+            server_args.append(argument)
             continue
-        if arg.startswith('-') and not expecting_option_val:
-            if arg == '--':
+        if argument.startswith('-') and not expecting_option_val:
+            if argument == '--':
                 stop_option_processing = True
                 continue
             # could be a multi-character option
-            all_args = arg[1:]
+            all_args = argument[1:]
             for i, arg in enumerate(all_args):
                 arg = '-' + arg
                 if arg in passthrough_args:
@@ -247,10 +247,10 @@ def parse_ssh_args(args: List[str]) -> Tuple[List[str], List[str], bool]:
                 raise InvalidSSHArgs(f'unknown option -- {arg[1:]}')
             continue
         if expecting_option_val:
-            ssh_args.append(arg)
+            ssh_args.append(argument)
             expecting_option_val = False
             continue
-        server_args.append(arg)
+        server_args.append(argument)
     if not server_args:
         raise InvalidSSHArgs()
     return ssh_args, server_args, passthrough

--- a/kittens/themes/main.py
+++ b/kittens/themes/main.py
@@ -309,10 +309,6 @@ class ThemesHandler(Handler):
                 next_line()
             next_line()
 
-        def write_line(text: str) -> None:
-            self.write(text)
-            next_line()
-
         self.cmd.set_cursor_position()
         next_line()
         self.cmd.styled(theme.name.center(sz), bold=True, fg='green')

--- a/kitty/conf/generate.py
+++ b/kitty/conf/generate.py
@@ -289,8 +289,8 @@ def generate_class(defn: Definition, loc: str) -> Tuple[str, str]:
             for cond, items in only.items():
                 cond = 'is_macos' if cond == 'macos' else 'not is_macos'
                 a(f'if {cond}:')
-                for (text, func) in items:
-                    for val in func(text):
+                for (text, parser_func) in items:
+                    for val in parser_func(text):
                         a(f'    defaults.{aname}.append({val!r})  # noqa')
 
     t('')

--- a/kitty/fonts/box_drawing.py
+++ b/kitty/fonts/box_drawing.py
@@ -624,7 +624,6 @@ def shade(buf: BufType, width: int, height: int, light: bool = False, invert: bo
     dest = bytearray(width * height) if invert else buf
 
     for r in range(number_of_rows):
-        y = r * square_sz
         is_odd = r % 2 != 0
         if is_odd:
             continue

--- a/kitty/freetype.c
+++ b/kitty/freetype.c
@@ -92,7 +92,7 @@ get_load_flags(int hinting, int hintstyle, int base) {
     int flags = base;
     if (hinting) {
         if (hintstyle >= 3) flags |= FT_LOAD_TARGET_NORMAL;
-        else if (0 < hintstyle  && hintstyle < 3) flags |= FT_LOAD_TARGET_LIGHT;
+        else if (0 < hintstyle) flags |= FT_LOAD_TARGET_LIGHT;
     } else flags |= FT_LOAD_NO_HINTING;
     return flags;
 }

--- a/kitty/freetype_render_ui_text.c
+++ b/kitty/freetype_render_ui_text.c
@@ -93,7 +93,7 @@ get_load_flags(int hinting, int hintstyle, int base) {
     int flags = base;
     if (hinting) {
         if (hintstyle >= 3) flags |= FT_LOAD_TARGET_NORMAL;
-        else if (0 < hintstyle  && hintstyle < 3) flags |= FT_LOAD_TARGET_LIGHT;
+        else if (0 < hintstyle) flags |= FT_LOAD_TARGET_LIGHT;
     } else flags |= FT_LOAD_NO_HINTING;
     return flags;
 }

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -155,10 +155,10 @@ show_mouse_cursor(GLFWwindow *w) {
 }
 
 void
-blank_os_window(OSWindow *w) {
+blank_os_window(OSWindow *osw) {
     color_type color = OPT(background);
-    if (w->num_tabs > 0) {
-        Tab *t = w->tabs + w->active_tab;
+    if (osw->num_tabs > 0) {
+        Tab *t = osw->tabs + osw->active_tab;
         if (t->num_windows == 1) {
             Window *w = t->windows + t->active_window;
             Screen *s = w->render_data.screen;
@@ -167,7 +167,7 @@ blank_os_window(OSWindow *w) {
             }
         }
     }
-    blank_canvas(w->is_semi_transparent ? w->background_opacity : 1.0f, color);
+    blank_canvas(osw->is_semi_transparent ? osw->background_opacity : 1.0f, color);
 }
 
 static void

--- a/kitty/layout/grid.py
+++ b/kitty/layout/grid.py
@@ -64,7 +64,6 @@ class Grid(Layout):
         return layout_func(num_windows, bias=variable_bias(num_windows, biased_map) if num_windows > 1 else None)
 
     def apply_bias(self, idx: int, increment: float, all_windows: WindowList, is_horizontal: bool = True) -> bool:
-        b = self.biased_cols if is_horizontal else self.biased_rows
         num_windows = all_windows.num_groups
         ncols, nrows, special_rows, special_col = calc_grid_size(num_windows)
 

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -1705,9 +1705,9 @@ screen_delete_lines(Screen *self, unsigned int count) {
 
 void
 screen_insert_characters(Screen *self, unsigned int count) {
-    const unsigned int top = 0, bottom = self->lines ? self->lines - 1 : 0;
+    const unsigned int bottom = self->lines ? self->lines - 1 : 0;
     if (count == 0) count = 1;
-    if (top <= self->cursor->y && self->cursor->y <= bottom) {
+    if (self->cursor->y <= bottom) {
         unsigned int x = self->cursor->x;
         unsigned int num = MIN(self->columns - x, count);
         linebuf_init_line(self->linebuf, self->cursor->y);
@@ -1732,9 +1732,9 @@ void
 screen_delete_characters(Screen *self, unsigned int count) {
     MOVE_OVERLAY_LINE_WITH_CURSOR;
     // Delete characters, later characters are moved left
-    const unsigned int top = 0, bottom = self->lines ? self->lines - 1 : 0;
+    const unsigned int bottom = self->lines ? self->lines - 1 : 0;
     if (count == 0) count = 1;
-    if (top <= self->cursor->y && self->cursor->y <= bottom) {
+    if (self->cursor->y <= bottom) {
         unsigned int x = self->cursor->x;
         unsigned int num = MIN(self->columns - x, count);
         linebuf_init_line(self->linebuf, self->cursor->y);

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -1531,8 +1531,8 @@ screen_cursor_at_a_shell_prompt(const Screen *self) {
 }
 
 bool
-screen_fake_move_cursor_to_position(Screen *self, index_type x, index_type y) {
-    SelectionBoundary a = {.x=x, .y=y}, b = {.x=self->cursor->x, .y=self->cursor->y};
+screen_fake_move_cursor_to_position(Screen *self, index_type start_x, index_type start_y) {
+    SelectionBoundary a = {.x=start_x, .y=start_y}, b = {.x=self->cursor->x, .y=self->cursor->y};
     SelectionBoundary *start, *end; int key;
     if (a.y < b.y || (a.y == b.y && a.x < b.x)) { start = &a; end = &b; key = GLFW_FKEY_LEFT; }
     else { start = &b; end = &a; key = GLFW_FKEY_RIGHT; }

--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -360,7 +360,6 @@ class Tab:  # {{{
                 else:
                     cmd = resolved_shell(get_options())
                     check_for_suitability = False
-                cmd = self.args.args or resolved_shell(get_options())
         if check_for_suitability:
             old_exe = cmd[0]
             if not os.path.isabs(old_exe):

--- a/kitty/utils.py
+++ b/kitty/utils.py
@@ -720,13 +720,12 @@ def read_shell_environment(opts: Optional[Options] = None) -> Dict[str, str]:
             return ans
         with os.fdopen(master, 'rb') as stdout, os.fdopen(slave, 'wb'):
             raw = b''
-            from subprocess import TimeoutExpired
             from time import monotonic
             start_time = monotonic()
             while monotonic() - start_time < 1.5:
                 try:
                     ret: Optional[int] = p.wait(0.01)
-                except TimeoutExpired:
+                except subprocess.TimeoutExpired:
                     ret = None
                 with suppress(Exception):
                     raw += stdout.read()


### PR DESCRIPTION
Refactor the code related to variable name and variable assignment.

https://lgtm.com/projects/g/kovidgoyal/kitty?mode=list

(There are many warnings that I think can be ignored.)

I'm not sure about the following one, so I left it unchanged and it looks like the variables w, h are not used.

```diff
diff --git a/kittens/icat/main.py b/kittens/icat/main.py
index 2507a28b..b60e0142 100755
--- a/kittens/icat/main.py
+++ b/kittens/icat/main.py
@@ -168,7 +168,6 @@ def set_cursor(cmd: GraphicsCommand, width: int, height: int, align: str) -> Non
     cw = int(ss.width / ss.cols)
     num_of_cells_needed = int(ceil(width / cw))
     if num_of_cells_needed > ss.cols:
-        w, h = fit_image(width, height, ss.width, height)
         ch = int(ss.height / ss.rows)
         num_of_rows_needed = int(ceil(height / ch))
         cmd.c, cmd.r = ss.cols, num_of_rows_needed
```

kittens/diff/speedup.c

There is a global variable `b`, however, the local variable `b` is defined and used in several places, and I have left it unchanged.

```c
static LineBuffer b;
```

There is also the global variable `fds` in the `kitty/child-monitor.c` and the heavily used local variable `fds`.

There are also warnings such as `Call to next() in a generator` that I have not handled.

Please check if these changes are appropriate, thank you.