### PR TITLE
Docs: Remove whitespace underline decoration in conf code highlighting

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -28,3 +28,7 @@ details > summary {
     text-decoration-color: var(--color-link-underline);
     text-decoration-line: underline;
 }
+
+.highlight-conf .w {
+    text-decoration: none;
+}


### PR DESCRIPTION
All pages that use `conf` syntax highlighting have a noticeable underline style for the whitespace characters in the dark theme, making it difficult to distinguish them from the actual underline `_` character.

```rst
.. highlight:: conf
.. code:: conf
```

Open the following page and click the button in the upper right corner to switch to the document dark theme.

https://sw.kovidgoyal.net/kitty/conf/
https://sw.kovidgoyal.net/kitty/actions/
https://sw.kovidgoyal.net/kitty/shell-integration/
https://sw.kovidgoyal.net/kitty/open_actions/
https://sw.kovidgoyal.net/kitty/kittens/hyperlinked_grep/

This PR removes the underline text decoration.