### PR TITLE
Disable aliases when patching functions in zsh integration

### DIFF
--- a/shell-integration/zsh/kitty-integration
+++ b/shell-integration/zsh/kitty-integration
@@ -54,7 +54,7 @@ builtin typeset -ag precmd_functions
 precmd_functions+=(_ksi_deferred_init)
 
 _ksi_deferred_init() {
-    builtin emulate -L zsh -o no_warn_create_global
+    builtin emulate -L zsh -o no_warn_create_global -o no_aliases
 
     # Recognized options: no-cursor, no-title, no-prompt-mark, no-complete.
     builtin local -a opt


### PR DESCRIPTION
Fixes #4446.

Note: untested.