### PR TITLE
kittens/hyperlinked_grep: document how to tell fish to autocomplete with rg

### DIFF
--- a/docs/kittens/hyperlinked_grep.rst
+++ b/docs/kittens/hyperlinked_grep.rst
@@ -57,6 +57,11 @@ Then, for example, for ZSH, add the following to :file:`.zshrc`::
 
     compdef _rg hg
 
+Note to fish users: you can combine both the aliasing/wrapping and pointing fish
+to rg's autocompletion with a fish "wrapper" function in your :file:`config.fish`::
+
+    function hg --wraps rg; kitty +kitten hyperlinked_grep $argv; end
+
 To learn more about kitty's powerful framework for customizing URL click
 actions, :doc:`see here </open_actions>`.
 


### PR DESCRIPTION
It was documented for zsh (2 lines above) but not fish.

While looking for how to do the same in fish, I couldn't find how to do
*exactly the same*, but turns out there's a neat way to do both the
aliasing and autocompletion mapping at the same time.

See https://fishshell.com/docs/current/cmds/function.html :

> `-w WRAPPED_COMMAND` or `--wraps=WRAPPED_COMMAND` causes the function
> to inherit completions from the given wrapped command. See the
> documentation for [complete](https://fishshell.com/docs/current/cmds/complete.html#cmd-complete)
> for more information.

## Screenshot showing both aliasing & completions work
![screenshot_kitty_2022-01-08-14:46:04](https://user-images.githubusercontent.com/522085/148657681-bf150c47-fe39-4849-b479-138eb66e35e1.png)

