### PR TITLE
Cleanup previous PR

### DIFF
--- a/glfw/glfw.py
+++ b/glfw/glfw.py
@@ -111,7 +111,7 @@ def init_env(
 
     elif module == 'cocoa':
         ans.cppflags.append('-DGL_SILENCE_DEPRECATION')
-        for f_ in 'Cocoa Carbon IOKit CoreFoundation CoreVideo'.split():
+        for f_ in 'Cocoa IOKit CoreFoundation CoreVideo'.split():
             ans.ldpaths.extend(('-framework', f_))
 
     elif module == 'wayland':

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -685,7 +685,7 @@ PYWRAP0(get_options) {
 PYWRAP1(set_options) {
     PyObject *opts;
     int is_wayland = 0, debug_rendering = 0, debug_font_fallback = 0;
-    PA("O|pppp", &opts, &is_wayland, &debug_rendering, &debug_font_fallback);
+    PA("O|ppp", &opts, &is_wayland, &debug_rendering, &debug_font_fallback);
     if (opts == Py_None) {
         Py_CLEAR(options_object);
         Py_RETURN_NONE;


### PR DESCRIPTION
Revert the changes related to set_options debug_keyboard.
Remove the Carbon framework flag for glfw.

Sorry I didn't notice that debug_keyboard already exists.
Also the link dependency on Carbon has been moved and glfw no longer needs it.