### PR TITLE
macOS: Suppress the key combinations beep sound

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -753,6 +753,20 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 
 @end // }}}
 
+// Text input context class for the GLFW content view {{{
+
+@interface GLFWTextInputContext : NSTextInputContext
+@end
+
+@implementation GLFWTextInputContext
+- (void)doCommandBySelector:(SEL)selector
+{
+    // interpretKeyEvents: May call insertText: or doCommandBySelector:.
+    // With the default macOS keybindings, pressing certain key combinations 
+    // (e.g. Ctrl+/, Ctrl+Cmd+Down/Left/Right) will produce a beep sound.
+    debug_key("\n\tTextInputCtx: doCommandBySelector: (%s)\n", [NSStringFromSelector(selector) UTF8String]);
+}
+@end // }}}
 
 // Content view class for the GLFW window {{{
 
@@ -760,6 +774,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 {
     _GLFWwindow* window;
     NSTrackingArea* trackingArea;
+    GLFWTextInputContext* input_context;
     NSMutableAttributedString* markedText;
     NSRect markedRect;
     bool marked_text_cleared_by_insert;
@@ -780,6 +795,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     {
         window = initWindow;
         trackingArea = nil;
+        input_context = [[GLFWTextInputContext alloc] initWithClient:self];
         markedText = [[NSMutableAttributedString alloc] init];
         markedRect = NSMakeRect(0.0, 0.0, 0.0, 0.0);
         input_source_at_last_key_event = nil;
@@ -1033,6 +1049,11 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 
     [self addTrackingArea:trackingArea];
     [super updateTrackingAreas];
+}
+
+- (NSTextInputContext *)inputContext
+{
+    return input_context;
 }
 
 static UInt32


### PR DESCRIPTION
Implement our own NSTextInputContext and pass `doCommandBySelector` to the client for processing. There will no longer be a beep sound.

https://github.com/kovidgoyal/kitty/issues/4489

I have done a simple test, modifying the system key binding, the behavior remains the same as before, `doCommandBySelector` does not do anything.

```text
{
  "^/" = (insertText:, "Hello");
} 
```

When insert text is used in the system keybindgs (see above), the text can be inserted normally.

---

It should be noted that there has been a problem with key combinations such as ctrl + xxx for input methods, as I mentioned in a previous issue.
Although the keys are processed by IME, the characters are also output to the child program (e.g. Ctrl+.  -> insert: . (ASCII dot) && toggle IME function). This has nothing to do with this PR change, but maybe it can be handled here somewhere.