### PR TITLE
Improve the select_tab switcher with context and [New tab] option

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -2116,15 +2116,14 @@ class Boss:
                     if tab.id == ans:
                         self.set_active_tab(tab)
 
-        ct = self.active_tab
-        entries = ()
+        entries: Tuple[Tuple[int, str], ...] = ()
         entries = entries + ((0, '[New tab]'),)
         for t in self.all_tabs:
             title = t.title
             count = len(t.windows)
             if count > 1:
                 title = title + ' [{count} windows]'.format(count=count)
-            if t.id == ct.id:
+            if t.id == getattr(self.active_tab, 'id'):
                 title = title + ' [current tab]'
             entries = entries + ((t.id, title),)
 

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -2109,13 +2109,26 @@ class Boss:
     def select_tab(self) -> None:
 
         def chosen(ans: Union[None, str, int]) -> None:
+            if ans == 0:
+                self.new_tab()
             if isinstance(ans, int):
                 for tab in self.all_tabs:
                     if tab.id == ans:
                         self.set_active_tab(tab)
 
         ct = self.active_tab
-        self.choose_entry('Choose a tab to switch to', ((t.id, t.title) for t in self.all_tabs if t is not ct), chosen)
+        entries = ()
+        entries = entries + ((0, '[New tab]'),)
+        for t in self.all_tabs:
+            title = t.title
+            count = len(t.windows)
+            if count > 1:
+                title = title + ' [{count} windows]'.format(count=count)
+            if t.id == ct.id:
+                title = title + ' [current tab]'
+            entries = entries + ((t.id, title),)
+
+        self.choose_entry('Choose a tab to switch to', entries, chosen)
 
     @ac('win', '''
         Detach a window, moving it to another tab or OS Window


### PR DESCRIPTION
The PR improves the usability of the `select_tab` switcher to provide additional context and functionality. This makes it more useful as a kind of "on-demand" tab bar.

Lately I've been using `tab_bar_style hidden` for the simplicity and focus that it provides. In this mode, the `select_tab` command becomes very useful as a way to navigate tabs. Specifically, I use it to:

1. Switch to an existing tab that I recently used.
2. Get a quick awareness of what tabs I have open and decide whether to reuse a tab or open a new one.

The current `select_tab` implementation works well for the first use case but not the second. Personally, I want the ability to go to the `select_tab` screen and decide what to do next. This PR:

- Adds a "[New tab]" option, which is helpful in situations where an existing tab cannot be reused.
- Includes the current tab and marks it with "[current tab]".
- Marks tabs with multiple windows with the window count ("[3 windows]").

I find this gives me a much better jumping off point:

<img width="260" alt="Screen Shot 2022-01-15 at 8 28 24 PM" src="https://user-images.githubusercontent.com/739304/149644787-73da0850-e453-41aa-a78d-437858f89758.png">

This is definitely a personal viewpoint, so I don't expect this to be merged as-is. I opened a PR because it seemed more illustrative than an issue. I'm happy to help iterate on this if there are ideas about how to improve it.

It's also worth noting that none of this strictly requires a change to kitty and is easily implementable as a kitten. I've done so here:

https://github.com/chriszarate/dotfiles/blob/daf4c3036e91f76e88c0f63f64b7c285e7029e68/kitty/kittens/select_tab.py