### PR TITLE
macOS: Fix global shortcuts with shift modifier key not working

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,10 +22,7 @@ from pygments.token import (  # type: ignore
     Comment, Keyword, Literal, Name, Number, String, Whitespace
 )
 from sphinx import addnodes, version_info
-from sphinx.builders.html.transforms import KeyboardTransform
 from sphinx.util.logging import getLogger
-
-KeyboardTransform.builders = ('html', 'dirhtml')  # type: ignore
 
 kitty_src = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if kitty_src not in sys.path:


### PR DESCRIPTION
NSEvent `charactersIgnoringModifiers` does not convert keystrokes to characters without the shift modifier, instead, the shift modifier is applied.

However, in the system preferences, it is always the unmodified keys that are recorded.

This PR tries to solve the issue. Do a conversion of the shift modifier key character and check it first. And adds the shiftable shortcut with "shift" to the global shortcut.

You can't use `event.characters`, since there are also the option key modified chars.

Please review if there is any problem, thank you.

---

https://developer.apple.com/documentation/appkit/nsevent/1524605-charactersignoringmodifiers?language=objc

> charactersIgnoringModifiers
> The characters generated by a key event as if no modifier key (except for Shift) applies.

keyDown:
Shift+Cmd+7
event.characters -> "7"
event.charactersIgnoringModifiers -> "&"
Cmd+7
event.characters -> "7"
event.charactersIgnoringModifiers -> "7"

com.apple.symbolichotkeys:
Shift+Cmd+7 -> "c:120000:55" (7)
Cmd+7 -> "c:100000:55" (7)
