### PR TITLE
Docs: Add missing macOS shortcuts and nth_os_window

### DIFF
--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -77,8 +77,11 @@ You can also define a shortcut to switch to the previously active window::
 
    map ctrl+p nth_window -1
 
-``nth_window`` will focus the nth window for positive numbers and the
-previously active windows for negative numbers.
+``nth_window`` will focus the nth window for positive numbers (starting from
+zero) and the previously active windows for negative numbers.
+
+To switch to the nth OS window, you can define ``nth_os_window``. Only positive
+numbers are accepted, starting from one.
 
 .. _detach_window:
 
@@ -127,12 +130,12 @@ Restore font size                   :sc:`reset_font_size` (also :kbd:`⌘+0` on 
 Toggle fullscreen                   :sc:`toggle_fullscreen` (also :kbd:`⌃+⌘+f` on macOS)
 Toggle maximized                    :sc:`toggle_maximized`
 Input unicode character             :sc:`input_unicode_character` (also :kbd:`⌃+⌘+space` on macOS)
-Click URL using the keyboard        :sc:`open_url`
-Reset the terminal                  :sc:`reset_terminal`
+Open URL in web browser             :sc:`open_url`
+Reset the terminal                  :sc:`reset_terminal` (also :kbd:`⌥+⌘+r` on macOS)
 Reload :file:`kitty.conf`           :sc:`reload_config_file` (also :kbd:`⌃+⌘+,` on macOS)
 Debug :file:`kitty.conf`            :sc:`debug_config` (also :kbd:`⌘+⌥+f6` on macOS)
 Pass current selection to program   :sc:`pass_selection_to_program`
-Edit |kitty| config file            :sc:`edit_config_file`
+Edit |kitty| config file            :sc:`edit_config_file` (also :kbd:`⌘+,` on macOS)
 Open a |kitty| shell                :sc:`kitty_shell`
 Increase background opacity         :sc:`increase_background_opacity`
 Decrease background opacity         :sc:`decrease_background_opacity`

--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -7,7 +7,7 @@ kitty.conf
 rendering frames-per-second. See below for an overview of all customization
 possibilities.
 
-You can open the config file within kitty by pressing :sc:`edit_config_file`.
+You can open the config file within kitty by pressing :sc:`edit_config_file` (:kbd:`⌘+,` on macOS).
 You can reload the config file within kitty by pressing
 :sc:`reload_config_file` (:kbd:`⌃+⌘+,` on macOS) or sending kitty the ``SIGUSR1`` signal.
 You can also display the current configuration by pressing the :sc:`debug_config`


### PR DESCRIPTION
Add missing macOS shortcuts.
Change the description of the open URL action.
Also add a brief description of how to quickly switch to the nth OS window.