### PR TITLE
Shell integration: Improvements for fish integration

### DIFF
--- a/docs/shell-integration.rst
+++ b/docs/shell-integration.rst
@@ -68,6 +68,8 @@ no-prompt-mark
 
 no-complete
     Turn off completion for the kitty command.
+    Note that for the ``fish`` shell this does not take effect, since fish
+    already comes with a kitty completion script.
 
 
 More ways to browse command output

--- a/shell-integration/fish/vendor_completions.d/kitty.fish
+++ b/shell-integration/fish/vendor_completions.d/kitty.fish
@@ -1,5 +1,7 @@
-if functions -q _ksi_completions
-    complete -f -c kitty -a "(_ksi_completions)"
-else
-    complete -f -c kitty -a "(commandline -cop | kitty +complete fish)"
+function __ksi_completions
+    set --local ct (commandline --current-token)
+    set --local tokens (commandline --tokenize --cut-at-cursor --current-process)
+    printf "%s\n" $tokens $ct | command kitty +complete fish2
 end
+
+complete -f -c kitty -a "(__ksi_completions)"


### PR DESCRIPTION
* Move the completion function to the autocomplete script.

It was written this way because the autocomplete script is located in the user configuration folder and overrides the script that comes with fish. So it was necessary to detect and use the old one. However, now it only loads when integration is enabled, so you can just use the new version.

And `no-complete` doesn't make sense either, because it's not appropriate to use `complete --erase kitty`.

* Fix some issues with cursor shape setting, respect user configuration.

The vi mode cursor setup takes effect when the user has not done any cursor configuration. Enables as a whole, otherwise it would be weird.

In previous version, the cursor functions is cleared when `set -g fish_key_bindings fish_default_key_bindings` is executed twice, this fixes that issue as well.

* Functions and vars start with two underscores, following the convention.

```text
functions:
__ksi_mark (Tell kitty to mark the current cursor position using OSC 133)
__ksi_mark_output_end
__ksi_mark_output_start
__ksi_original_fish_mode_prompt
__ksi_original_fish_prompt
__ksi_osc
__ksi_prompt_end
__ksi_prompt_start
__ksi_set_cursor (Set cursor shape for fish default mode)

variables:
$__ksi_prompt_state (Variable)
```

---

The last possible improvement that can be made is the loading part.

I did a test and in the fish master branch, the configuration loading order is:
- kitty-shell-integration.fish from XDG_DATA_DIRS
- ~/.config/fish/conf.d
- ~/.config/fish/config.fish
- fish -C argument

(In fish 3.3.1, the configuration from environment variables is not the first to be loaded. There is still an issue discussing the correct order in which conf should be loaded.)

`-C` is always loaded at the end.

Event functions are executed in insertion order, so only the `__ksi_schedule --on-event fish_prompt` registered with `fish -C` will be the last to be executed. Otherwise it is the first to be executed, before the other plugins's `--on-event fish_prompt`.

It looks like this parameter just needs to be inserted when it's not `launch --type=background`.

But it may be affected by the parameter length limit?