### PR TITLE
Add missing click and double click names to debug config

### DIFF
--- a/kitty/debug_config.py
+++ b/kitty/debug_config.py
@@ -45,8 +45,9 @@ def mod_to_names(mods: int) -> Iterator[str]:
         GLFW_MOD_ALT, GLFW_MOD_CAPS_LOCK, GLFW_MOD_CONTROL, GLFW_MOD_HYPER,
         GLFW_MOD_META, GLFW_MOD_NUM_LOCK, GLFW_MOD_SHIFT, GLFW_MOD_SUPER
     )
-    modmap = {'shift': GLFW_MOD_SHIFT, 'alt': GLFW_MOD_ALT, 'ctrl': GLFW_MOD_CONTROL, ('cmd' if is_macos else 'super'): GLFW_MOD_SUPER,
-              'hyper': GLFW_MOD_HYPER, 'meta': GLFW_MOD_META, 'num_lock': GLFW_MOD_NUM_LOCK, 'caps_lock': GLFW_MOD_CAPS_LOCK}
+    modmap = {'ctrl': GLFW_MOD_CONTROL, 'shift': GLFW_MOD_SHIFT, ('opt' if is_macos else 'alt'): GLFW_MOD_ALT,
+              ('cmd' if is_macos else 'super'): GLFW_MOD_SUPER, 'hyper': GLFW_MOD_HYPER, 'meta': GLFW_MOD_META,
+              'caps_lock': GLFW_MOD_CAPS_LOCK, 'num_lock': GLFW_MOD_NUM_LOCK}
     for name, val in modmap.items():
         if mods & val:
             yield name

--- a/kitty/debug_config.py
+++ b/kitty/debug_config.py
@@ -102,7 +102,7 @@ def compare_mousemaps(final: MouseMap, initial: MouseMap, print: Callable[..., N
         names = list(mod_to_names(trigger.mods)) + [f'b{trigger.button+1}']
         when = {-1: 'repeat', 1: 'press', 2: 'doublepress', 3: 'triplepress'}.get(trigger.repeat_count, trigger.repeat_count)
         grabbed = 'grabbed' if trigger.grabbed else 'ungrabbed'
-        print('\t', '+'.join(names), when, grabbed, defn)
+        print('\t' + '+'.join(names), when, grabbed, defn)
 
     def print_changes(defns: MouseMap, changes: Set[MouseEvent], text: str) -> None:
         if changes:

--- a/kitty/debug_config.py
+++ b/kitty/debug_config.py
@@ -20,10 +20,9 @@ from .constants import (
 )
 from .fast_data_types import Color, num_users
 from .options.types import Options as KittyOpts, defaults
-from .options.utils import MouseMap
+from .options.utils import MouseMap, SequenceMap, mouse_button_map, mouse_trigger_count_map
 from .rgb import color_as_sharp
 from .types import MouseEvent, SingleKey
-from .typing import SequenceMap
 
 ShortcutMap = Dict[Tuple[SingleKey, ...], str]
 
@@ -51,6 +50,18 @@ def mod_to_names(mods: int) -> Iterator[str]:
     for name, val in modmap.items():
         if mods & val:
             yield name
+
+
+def mouse_button_num_to_name(num: int) -> str:
+    button_map = {v: k for k, v in mouse_button_map.items()}
+    name = f'b{num+1}'
+    return button_map.get(name, name)
+
+
+def mouse_trigger_count_to_name(count: int) -> str:
+    trigger_count_map = {str(v): k for k, v in mouse_trigger_count_map.items()}
+    k = str(count)
+    return trigger_count_map.get(k, k)
 
 
 def print_shortcut(key_sequence: Iterable[SingleKey], defn: str, print: Callable[..., None]) -> None:
@@ -99,8 +110,8 @@ def compare_mousemaps(final: MouseMap, initial: MouseMap, print: Callable[..., N
     changed = {k for k in set(final) & set(initial) if final[k] != initial[k]}
 
     def print_mouse_action(trigger: MouseEvent, defn: str) -> None:
-        names = list(mod_to_names(trigger.mods)) + [f'b{trigger.button+1}']
-        when = {-1: 'repeat', 1: 'press', 2: 'doublepress', 3: 'triplepress'}.get(trigger.repeat_count, trigger.repeat_count)
+        names = list(mod_to_names(trigger.mods)) + [mouse_button_num_to_name(trigger.button)]
+        when = mouse_trigger_count_to_name(trigger.repeat_count)
         grabbed = 'grabbed' if trigger.grabbed else 'ungrabbed'
         print('\t' + '+'.join(names), when, grabbed, defn)
 

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -42,6 +42,8 @@ character_key_name_aliases_with_ascii_lowercase: Dict[str, str] = character_key_
 for x in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ':
     character_key_name_aliases_with_ascii_lowercase[x] = x.lower()
 sequence_sep = '>'
+mouse_button_map = {'left': 'b1', 'middle': 'b3', 'right': 'b2'}
+mouse_trigger_count_map = {'doubleclick': -3, 'click': -2, 'release': -1, 'press': 1, 'doublepress': 2, 'triplepress': 3}
 FuncArgsType = Tuple[str, Sequence[Any]]
 func_with_args = KeyFuncWrapper[FuncArgsType]()
 DELETE_ENV_VAR = '_delete_this_env_var_'
@@ -1054,13 +1056,13 @@ def parse_mouse_map(val: str) -> Iterable[MouseMapping]:
         obutton = parts[0].lower()
         mods = 0
     try:
-        b = {'left': 'b1', 'middle': 'b3', 'right': 'b2'}.get(obutton, obutton)[1:]
+        b = mouse_button_map.get(obutton, obutton)[1:]
         button = getattr(defines, f'GLFW_MOUSE_BUTTON_{b}')
     except Exception:
         log_error(f'Mouse button: {xbutton} not recognized, ignoring')
         return
     try:
-        count = {'doubleclick': -3, 'click': -2, 'release': -1, 'press': 1, 'doublepress': 2, 'triplepress': 3}[event.lower()]
+        count = mouse_trigger_count_map[event.lower()]
     except KeyError:
         log_error(f'Mouse event type: {event} not recognized, ignoring')
         return


### PR DESCRIPTION
Adjust the order of modifier key names to match the config and docs.

The modifier key order was adjusted in the previous PR, but the debug config was left out and is now adjusted as well.
(ctrl, shift, alt/opt, super/cmd, ...)

https://github.com/kovidgoyal/kitty/pull/4238

Fix mouse maps are indented with one more space.

Add the missing mouse triggers click (-2) and double-click (-3).

Refactor the print functions to make it easier to use in custom kitten.

These functions, however, all seem to be repeating patterns, and I tried to "DRY" them, but got stuck with mypy.

BTW:
Why does kitty/boss.py have executable permission? In which scenario do it need to be executed directly?