### PR TITLE
Add default choice option for ask kitten

### DIFF
--- a/kittens/ask/main.py
+++ b/kittens/ask/main.py
@@ -300,8 +300,8 @@ def main(args: List[str]) -> Response:
         prompt = '> '
         with suppress(KeyboardInterrupt, EOFError):
             if cli_opts.default:
-                def prefill_text():
-                    readline.insert_text(cli_opts.default)
+                def prefill_text() -> None:
+                    readline.insert_text(cli_opts.default or '')
                     readline.redisplay()
                 readline.set_pre_input_hook(prefill_text)
                 response = input(prompt)

--- a/kittens/ask/main.py
+++ b/kittens/ask/main.py
@@ -298,7 +298,15 @@ def main(args: List[str]) -> Response:
 
         prompt = '> '
         with suppress(KeyboardInterrupt, EOFError):
-            response = input(prompt)
+            if cli_opts.default:
+                def prefill_text():
+                    readline.insert_text(cli_opts.default)
+                    readline.redisplay()
+                readline.set_pre_input_hook(prefill_text)
+                response = input(prompt)
+                readline.set_pre_input_hook()
+            else:
+                response = input(prompt)
     return {'items': items, 'response': response}
 
 

--- a/kittens/ask/main.py
+++ b/kittens/ask/main.py
@@ -241,13 +241,14 @@ class Choose(Handler):
         if text in self.allowed:
             self.response = text
             self.quit_loop(0)
+        elif self.cli_opts.type == 'yesno' and text == 'q':
+            self.on_interrupt()
 
     def on_key(self, key_event: KeyEventType) -> None:
-        if self.cli_opts.type == 'yesno':
-            if key_event.matches('esc'):
-                self.on_text('n')
-            elif key_event.matches('enter'):
-                self.on_text('y')
+        if key_event.matches('esc'):
+            self.on_interrupt()
+        elif key_event.matches('enter'):
+            self.quit_loop(0)
 
     def on_click(self, ev: MouseEvent) -> None:
         for letter, r in self.clickable_ranges.items():

--- a/kittens/ask/main.py
+++ b/kittens/ask/main.py
@@ -222,7 +222,7 @@ class Choose(Handler):
         extra = (self.screen_size.cols - w) // 2
         x = extra
         nx = x + wcswidth(yes) + len(sep)
-        self.clickable_ranges = {'y': Range(x, x + wcswidth(yes) - 1, y), 'n': Range(nx, nx + 1, y)}
+        self.clickable_ranges = {'y': Range(x, x + wcswidth(yes) - 1, y), 'n': Range(nx, nx + 2, y)}
         self.print(' ' * extra + text, end='')
 
     def on_text(self, text: str, in_bracketed_paste: bool = False) -> None:

--- a/kittens/ask/main.py
+++ b/kittens/ask/main.py
@@ -262,6 +262,7 @@ class Choose(Handler):
         self.draw_screen()
 
     def on_interrupt(self) -> None:
+        self.response = ''
         self.quit_loop(1)
     on_eot = on_interrupt
 

--- a/kittens/ask/main.py
+++ b/kittens/ask/main.py
@@ -95,6 +95,12 @@ letter is the accelerator key and text is the corresponding text.  There can be
 an optional color specification after the letter to indicate what color it should
 be.
 For example: y:Yes and n;red:No
+
+
+--default -d
+A default choice or text. If unspecified, it is no for yesno and empty for the
+others. If the input type is choices and the specified value is not one of the
+available choices, it is empty.
 '''
 
 
@@ -132,7 +138,6 @@ class Choose(Handler):
 
     def __init__(self, cli_opts: AskCLIOptions) -> None:
         self.cli_opts = cli_opts
-        self.response = 'n' if cli_opts.type == 'yesno' else ''
         self.allowed = frozenset('yn')
         self.choices: Dict[str, Choice] = {}
         self.clickable_ranges: Dict[str, Range] = {}
@@ -148,6 +153,12 @@ class Choose(Handler):
                 allowed.append(letter)
                 self.choices[letter] = Choice(text, idx, color)
             self.allowed = frozenset(allowed)
+        if not cli_opts.default:
+            self.response = 'n' if cli_opts.type == 'yesno' else ''
+        elif cli_opts.type == 'choices' and cli_opts.default not in self.allowed:
+            self.response = ''
+        else:
+            self.response = cli_opts.default
 
     def initialize(self) -> None:
         self.cmd.set_cursor_visible(False)

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1425,7 +1425,7 @@ class Boss:
 
     def do_set_tab_title(self, title: str, tab_id: int) -> None:
         tm = self.active_tab_manager
-        if tm is not None and title:
+        if tm is not None:
             tab_id = int(tab_id)
             for tab in tm.tabs:
                 if tab.id == tab_id:

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -654,7 +654,7 @@ class Boss:
             if window.has_running_program:
                 msg += ' ' + _('It is running a program.')
             self._run_kitten(
-                'ask', ['--type=yesno', '--message', msg],
+                'ask', ['--type=yesno', '--default=y', '--message', msg],
                 window=window,
                 custom_callback=partial(self.handle_close_window_confirmation, window.id)
             )
@@ -676,7 +676,7 @@ class Boss:
                 window: Optional[Window] = None, confirm_on_cancel: bool = False) -> None:
         def callback_(res: Dict[str, Any], x: int, boss: Boss) -> None:
             callback(res.get('response') == 'y', *args)
-        self._run_kitten('ask', ['--type=yesno', '--message', msg],
+        self._run_kitten('ask', ['--type=yesno', '--default=y', '--message', msg],
                          window=window, custom_callback=callback_, default_data={'response': 'y' if confirm_on_cancel else 'n'})
 
     def confirm_tab_close(self, tab: Tab) -> None:

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1418,7 +1418,9 @@ class Boss:
     def set_tab_title(self) -> None:
         tab = self.active_tab
         if tab:
-            args = ['--name=tab-title', '--message', _('Enter the new title for this tab below.'), 'do_set_tab_title', str(tab.id)]
+            args = [
+                '--name=tab-title', '--message', _('Enter the new title for this tab below.'),
+                '--default', tab.name or tab.title, 'do_set_tab_title', str(tab.id)]
             self._run_kitten('ask', args)
 
     def do_set_tab_title(self, title: str, tab_id: int) -> None:

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -653,6 +653,7 @@ class Window:
                     'What would you like to do with this URL:\n') +
                     styled(unquote(url), fg='yellow'),
                     '--choice=o:Open', '--choice=c:Copy to clipboard', '--choice=n;red:Nothing'
+                    '--default=o'
                     ],
                     window=self,
                     custom_callback=partial(self.hyperlink_open_confirmed, url, cwd),

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -652,7 +652,7 @@ class Window:
                 get_boss()._run_kitten('ask', ['--type=choices', '--message', _(
                     'What would you like to do with this URL:\n') +
                     styled(unquote(url), fg='yellow'),
-                    '--choice=o:Open', '--choice=c:Copy to clipboard', '--choice=n;red:Nothing'
+                    '--choice=o:Open', '--choice=c:Copy to clipboard', '--choice=n;red:Nothing',
                     '--default=o'
                     ],
                     window=self,


### PR DESCRIPTION
Add default choice option for ask kitten.
Press Enter to select the default, Esc to select nothing (Ctrl+C).
Make the `No` click range the same as `Yes` for easy clicking.
Makes the default take effect for text input, applied in set_tab_title action.
The tab title can be cleared, and the window title will be used again.
Set reasonable default choice for some features that use ask kitten.

However, my personal preference for quit confirmation is still `No` as the default.

Please review if there are any problems, thank you.