### PR TITLE
Add new dotted and dashed underline values

### DIFF
--- a/kittens/tui/operations.py
+++ b/kittens/tui/operations.py
@@ -166,11 +166,8 @@ def scroll_screen(amt: int = 1) -> str:
     return '\033[' + str(abs(amt)) + ('T' if amt < 0 else 'S')
 
 
-STANDARD_COLORS = {name: i for i, name in enumerate(
-    'black red green yellow blue magenta cyan gray'.split())}
-STANDARD_COLORS['white'] = STANDARD_COLORS['gray']
-UNDERLINE_STYLES = {name: i + 1 for i, name in enumerate(
-    'straight double curly dotted dashed'.split())}
+STANDARD_COLORS = {'black': 0, 'red': 1, 'green': 2, 'yellow': 3, 'blue': 4, 'magenta': 5, 'cyan': 6, 'gray': 7, 'white': 7}
+UNDERLINE_STYLES = {'straight': 1, 'double': 2, 'curly': 3, 'dotted': 4, 'dashed': 5}
 
 
 ColorSpec = Union[int, str, Color]

--- a/kittens/tui/operations.py
+++ b/kittens/tui/operations.py
@@ -170,7 +170,7 @@ STANDARD_COLORS = {name: i for i, name in enumerate(
     'black red green yellow blue magenta cyan gray'.split())}
 STANDARD_COLORS['white'] = STANDARD_COLORS['gray']
 UNDERLINE_STYLES = {name: i + 1 for i, name in enumerate(
-    'straight double curly'.split())}
+    'straight double curly dotted dashed'.split())}
 
 
 ColorSpec = Union[int, str, Color]

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -360,7 +360,7 @@ opt('url_color', '#0087bd',
     option_type='to_color', ctype='color_as_int',
     long_text='''
 The color and style for highlighting URLs on mouse-over. :code:`url_style` can
-be one of: none, single, double, curly
+be one of: none, straight, double, curly, dotted, dashed
 '''
     )
 

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -500,16 +500,12 @@ def scrollback_pager_history_size(x: str) -> int:
     return min(ans, 4096 * 1024 * 1024 - 1)
 
 
+# "single" for backwards compat
+url_style_map = {'none': 0, 'single': 1, 'straight': 1, 'double': 2, 'curly': 3, 'dotted': 4, 'dashed': 5}
+
+
 def url_style(x: str) -> int:
-    # for backwards compat
-    if x == 'single':
-        x = 'straight'
     return url_style_map.get(x, url_style_map['curly'])
-
-
-url_style_map = {
-    v: i for i, v in enumerate('none straight double curly dotted dashed'.split())
-}
 
 
 def url_prefixes(x: str) -> Tuple[str, ...]:

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -501,11 +501,14 @@ def scrollback_pager_history_size(x: str) -> int:
 
 
 def url_style(x: str) -> int:
+    # for backwards compat
+    if x == 'single':
+        x = 'straight'
     return url_style_map.get(x, url_style_map['curly'])
 
 
 url_style_map = {
-    v: i for i, v in enumerate('none single double curly'.split())
+    v: i for i, v in enumerate('none straight double curly dotted dashed'.split())
 }
 
 


### PR DESCRIPTION
Add new dotted and dashed underline values.
Add new style options for url underline style.
Also use "straight" for single underline, consistent with the protocol extension document.

Use fixed values for dict, which is unlikely to change in the near future, instead of string splitting and for loops.