### PR TITLE
Add comments and minor tweaks to fish integration

### DIFF
--- a/shell-integration/bash/kitty.bash
+++ b/shell-integration/bash/kitty.bash
@@ -61,7 +61,7 @@ _ksi_main() {
 
     if [[ "${_ksi_prompt[cursor]}" == "y" ]]; then 
         _ksi_prompt[ps1]+="\[\e[5 q\]"  # blinking bar cursor
-        _ksi_prompt[ps0]+="\[\e[5 q\]"  # blinking block cursor
+        _ksi_prompt[ps0]+="\[\e[1 q\]"  # blinking block cursor
     fi
 
     if [[ "${_ksi_prompt[title]}" == "y" ]]; then 

--- a/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
+++ b/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
@@ -27,8 +27,8 @@ function __ksi_schedule --on-event fish_prompt -d "Setup kitty integration after
     if not contains "no-cursor" $_ksi
         and not functions -q __ksi_set_cursor
 
-        function __ksi_block_cursor --on-event fish_preexec -d "Set cursor shape to steady block before executing command"
-            printf "\e[2 q"
+        function __ksi_block_cursor --on-event fish_preexec -d "Set cursor shape to blinking block before executing command"
+            printf "\e[1 q"
         end
 
         function __ksi_set_cursor --on-variable fish_key_bindings -d "Set the cursor shape for different modes when switching key bindings"


### PR DESCRIPTION
Set cursor shape to steady block before executing commands in vi mode. I left this out.
Configure the vi mode cursor shape on demand. If the user only uses normal mode, no vi mode global variables will be added.
Since it is unlikely that more features will be added in the future, remove one function call at each marking.
Add a brief comment to the XDG_DATA_DIRS section.