### PR TITLE
Fix test on ZFS

### DIFF
--- a/kitty/fast-file-copy.c
+++ b/kitty/fast-file-copy.c
@@ -60,9 +60,9 @@ copy_with_sendfile(int infd, int outfd, off_t in_pos, size_t len, FastFileCopyBu
         off_t r = in_pos;
         ssize_t n = sendfile(outfd, infd, &r, len);
         if (n < 0) {
-            if (errno != EAGAIN) return false;
+            if (errno == EAGAIN) continue;
             if (errno == ENOSYS || errno == EPERM) return copy_with_buffer(infd, outfd, in_pos, len, fcb);
-            continue;
+            return false;
         }
         if (n == 0) {
             // happens if input file is truncated
@@ -83,9 +83,9 @@ copy_with_file_range(int infd, int outfd, off_t in_pos, size_t len, FastFileCopy
         off64_t r = in_pos;
         ssize_t n = copy_file_range(infd, &r, outfd, NULL, len, 0);
         if (n < 0) {
-            if (errno != EAGAIN) return false;
+            if (errno == EAGAIN) continue;
             if (errno == ENOSYS || errno == EPERM) return copy_with_sendfile(infd, outfd, in_pos, len, fcb);
-            continue;
+            return false;
         }
         if (n == 0) {
             // happens if input file is truncated


### PR DESCRIPTION
While testing the latest master version on Linux, I discovered that the test test_disk_cache (kitty_tests.graphics.TestGraphics) fails when the cache directory is on ZFS. This also happens with the latest version 0.24.1. On a tmpfs, everything works fine.
The error message is "Failed to copy data to new disk cache file during defrag: Invalid argument". I tracked the error to the call `ssize_t n = copy_file_range(infd, &r, outfd, NULL, len, 0);`, which returns -1 and sets `errno` to 22. One instance of the arguments to the function I observed was `infd`: 7, `r`: 72, `outfd`: 8, `len`: 36.
Perhaps this is caused by me running ZFS 2.1.2 on Linux 5.16.0, which is not a supported combination. This ZFS version is only "compatible with 3.10 - 5.15 kernels" according to the release notes. Or maybe it's just not implemented. Whatever the case may be, kitty should fall back to a different implementation, as it already does, if `copy_file_range()` does not exist at all. There is even some code that attempts to do exactly that but there is a logic error that prevents it from working properly. If `errno` is `EAGAIN`, the second if statement is never true and if `errno` is not `EAGAIN`, the function returns immediately, not checking the second if statement:
```c
if (n < 0) {
    if (errno != EAGAIN) return false;
    if (errno == ENOSYS || errno == EPERM) return copy_with_sendfile(infd, outfd, in_pos, len, fcb);
    continue;
}
```
A logically equivalent change to the one in the first commit would have been to simply swap the two if statements but I find my version to be more readable.
This logic error can also be found in `copy_with_sendfile()`.

While we are at it, add all the error codes from https://go.dev/src/internal/poll/copy_file_range_linux.go for different filesystems and older kernel versions to the list of error codes from `copy_file_range()`.

To reproduce the problem, execute `KITTY_CACHE_DIRECTORY=/path/to/zfs python3 test.py` with `KITTY_CACHE_DIRECTORY` pointing to a directory on ZFS.

I found this while trying to build kitty using Nix since Nix creates a sandbox in /tmp, which is stored on ZFS on my machine.

I spent too many hours debugging and fixing this 😅.