### PR TITLE
Cancel IME for active kitty or OS window only

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -713,6 +713,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
         [window->ns.view unmarkText];
         GLFWkeyevent dummy = {.action = GLFW_RELEASE, .ime_state = GLFW_IME_PREEDIT_CHANGED};
         _glfwInputKeyboard(window, &dummy);
+        _glfw.ns.text[0] = 0;
     }
 }
 

--- a/kitty/keys.c
+++ b/kitty/keys.c
@@ -81,6 +81,7 @@ active_window(void) {
 
 void
 update_ime_focus(OSWindow *osw, bool focused) {
+    if (!osw || !osw->handle) return;
     GLFWIMEUpdateEvent ev = { .focused = focused, .type = GLFW_IME_UPDATE_FOCUS };
     glfwUpdateIMEState(osw->handle, &ev);
 }


### PR DESCRIPTION
When the inactive window is closed, the input method will no longer be canceled.

I also found that when the window is redrawn (resized), the overlay text is cleared. Is there a good way to redraw it? 

Honestly, the edge case handling requires time investment and is not very useful. The good thing is that it reduces inconsistent state cases and hopefully (if no new bugs are introduced) makes the software more robust.