### PR TITLE
Fix compilation on macOS 10.12

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -32,11 +32,6 @@
 #include <float.h>
 #include <string.h>
 
-#if (MAC_OS_X_VERSION_MAX_ALLOWED < 101300)
-#define NSControlStateValueOn NSOnState
-#define NSControlStateValueOff NSOffState
-#define NSControlStateValueMixed NSMixedState
-#endif
 
 static const char*
 polymorphic_string_as_utf8(id string) {

--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -20,6 +20,11 @@
 #include <crt_externs.h>
 #include <objc/runtime.h>
 
+#if (MAC_OS_X_VERSION_MAX_ALLOWED < 101300)
+#define NSControlStateValueOn NSOnState
+#define NSControlStateValueOff NSOffState
+#define NSControlStateValueMixed NSMixedState
+#endif
 #if (MAC_OS_X_VERSION_MAX_ALLOWED < 101200)
 #define NSWindowStyleMaskResizable NSResizableWindowMask
 #define NSEventModifierFlagOption NSAlternateKeyMask


### PR DESCRIPTION
Without this commit, kitty would fail to compile on macOS 10.12 with the error "use of undeclared identifier".
This problem was introduced in f7be4fab48d2e7cc7bbf9942d8a9fdbfba85b274, where some code was moved to a different file, without moving the corresponding `#define` statements.