### PR TITLE
Fix macOS shortcut for debug_config and info plist minor tweaks

### DIFF
--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -133,7 +133,7 @@ Input unicode character             :sc:`input_unicode_character` (also :kbd:`�
 Open URL in web browser             :sc:`open_url`
 Reset the terminal                  :sc:`reset_terminal` (also :kbd:`⌥+⌘+r` on macOS)
 Reload :file:`kitty.conf`           :sc:`reload_config_file` (also :kbd:`⌃+⌘+,` on macOS)
-Debug :file:`kitty.conf`            :sc:`debug_config` (also :kbd:`⌘+⌥+f6` on macOS)
+Debug :file:`kitty.conf`            :sc:`debug_config` (also :kbd:`⌥+⌘+,` on macOS)
 Pass current selection to program   :sc:`pass_selection_to_program`
 Edit |kitty| config file            :sc:`edit_config_file` (also :kbd:`⌘+,` on macOS)
 Open a |kitty| shell                :sc:`kitty_shell`

--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -10,8 +10,8 @@ possibilities.
 You can open the config file within kitty by pressing :sc:`edit_config_file` (:kbd:`⌘+,` on macOS).
 You can reload the config file within kitty by pressing
 :sc:`reload_config_file` (:kbd:`⌃+⌘+,` on macOS) or sending kitty the ``SIGUSR1`` signal.
-You can also display the current configuration by pressing the :sc:`debug_config`
-(:kbd:`⌘+⌥+,` on macOS) key.
+You can also display the current configuration by pressing :sc:`debug_config`
+(:kbd:`⌥+⌘+,` on macOS).
 
 .. _confloc:
 

--- a/setup.py
+++ b/setup.py
@@ -1035,7 +1035,7 @@ def macos_info_plist() -> bytes:
         # Bundle Version Info
         CFBundleVersion=VERSION,
         CFBundleShortVersionString=VERSION,
-        CFBundleInfoDictionaryVersion=VERSION,
+        CFBundleInfoDictionaryVersion='6.0',
         NSHumanReadableCopyright=time.strftime('Copyright %Y, Kovid Goyal'),
         CFBundleGetInfoString='kitty - The fast, feature-rich, GPU based terminal emulator. https://sw.kovidgoyal.net/kitty/',
         # Operating System Version

--- a/setup.py
+++ b/setup.py
@@ -1048,8 +1048,8 @@ def macos_info_plist() -> bytes:
         # App Execution
         CFBundleExecutable=appname,
         LSEnvironment={'KITTY_LAUNCHED_BY_LAUNCH_SERVICES': '1'},
-        # Launch Conditions
         LSRequiresNativeExecution=True,
+        NSSupportsSuddenTermination=False,
         # Localization
         # see https://github.com/kovidgoyal/kitty/issues/1233
         CFBundleDevelopmentRegion='English',


### PR DESCRIPTION
Fix macOS shortcut for debug_config.

Set the InfoDictionary version explicitly, hopefully the behavior will be unchanged when the default version is upgraded.

Since we have the quit confirmation feature, so we explicitly specify that sudden termination is not supported.
