### PR TITLE
Remove a space that was accidentally introduced earlier

### DIFF
--- a/kitty/debug_config.py
+++ b/kitty/debug_config.py
@@ -91,7 +91,7 @@ def compare_opts(opts: KittyOpts, print: Print) -> None:
     for f in changed_opts:
         val = getattr(opts, f)
         if isinstance(val, dict):
-            print(f'{title(f)}:')
+            print(title(f'{f}:'))
             if f == 'symbol_map':
                 for k in sorted(val):
                     print(f'\tU+{k[0]:04x} - U+{k[1]:04x} → {val[k]}')

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -895,7 +895,7 @@ def resolve_aliases_and_parse_actions(
             parts = rest.split(maxsplit=1)
             if parts[0] != alias.name:
                 continue
-            new_defn = f'{possible_alias} {alias.value} {f" {parts[1]}" if len(parts) > 1 else ""}'
+            new_defn = f'{possible_alias} {alias.value}{f" {parts[1]}" if len(parts) > 1 else ""}'
             new_aliases = aliases.copy()
             new_aliases[possible_alias] = [a for a in aliases[possible_alias] if a is not alias]
             yield from resolve_aliases_and_parse_actions(new_defn, new_aliases, map_type)


### PR DESCRIPTION
Remove a space that was introduced by mistake.

Also add colors to the colon after the title of the dict type in debug_config to be consistent with the rest.