### PR TITLE
Check the symbol strings and prepend them to template

### DIFF
--- a/kitty/tab_bar.py
+++ b/kitty/tab_bar.py
@@ -187,9 +187,9 @@ def draw_title(draw_data: DrawData, screen: Screen, tab: TabBarData, index: int)
     template = draw_data.title_template
     if tab.is_active and draw_data.active_title_template is not None:
         template = draw_data.active_title_template
-    if '{activity_symbol' not in template:
+    if eval_locals['activity_symbol'] and 'activity_symbol' not in template:
         template = '{fmt.fg.red}{activity_symbol}{fmt.fg.default}' + template
-    if '{bell_symbol' not in template:
+    if eval_locals['bell_symbol'] and 'bell_symbol' not in template:
         template = '{fmt.fg.red}{bell_symbol}{fmt.fg.default}' + template
     try:
         title = eval(compile_template(template), {'__builtins__': {}}, eval_locals)


### PR DESCRIPTION
Check the symbol string, if it is empty then it does not need to be prepended to the template.

Check `activity_symbol` and `bell_symbol` without `{` to allow scenarios that are not directly used.
It is unlikely that there is a case where these strings are used in the template, and I think checking the names is enough.

The following usage scenarios are now possible:
```shell
kitty --config=NONE -o 'tab_activity_symbol !' -o 'tab_title_template {activity_symbol or bell_symbol}{title}'

kitty --config=NONE -o 'bell_on_tab *' -o 'tab_activity_symbol ~' -o 'tab_title_template { "!" if bell_symbol and activity_symbol else bell_symbol or activity_symbol}{title}'
```

Tested with
```shell
sleep 3 && printf '\a' && sleep 3
```

Please review if it is appropriate, thank you.