### PR TITLE
Add mappable action reverse_scroll_to_cursor

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -93,6 +93,9 @@ Detailed list of changes
 
 - Fix a regression in the previous release that broke strikethrough (:disc:`4632`)
 
+- A new action :ac:`scroll_prompt_to_bottom` to moves the non-empty prompt lines
+  to the bottom. (:pull:`4634`)
+
 0.24.2 [2022-02-03]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -1105,6 +1105,9 @@ class Screen:
     def reverse_scroll(self, amt: int, fill_from_scrollback: bool = False) -> bool:
         pass
 
+    def scroll_prompt_to_bottom(self) -> None:
+        pass
+
     def clear_selection(self) -> None:
         pass
 

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -1241,6 +1241,10 @@ class Window:
         if self.screen.is_main_linebuf():
             self.screen.scroll_to_prompt(num_of_prompts)
 
+    @ac('sc', 'Scroll prompt to the bottom of the screen')
+    def scroll_prompt_to_bottom(self) -> None:
+        self.screen.scroll_prompt_to_bottom()
+
     @ac('mk', 'Toggle the current marker on/off')
     def toggle_marker(self, ftype: str, spec: Union[str, Tuple[Tuple[int, str], ...]], flags: int) -> None:
         from .marks import marker_from_spec


### PR DESCRIPTION
For some programs that don't work well, they won't clear the blank lines under the cursor line. This action can be used to reverse the scrolling.

Also adjusted the name of the menu item that clears to the cursor `Cmd+K`.
Used initial capitalization and simplified the text (as it also works for the cursor prompt).
Moved Reset to the bottom, as this cleans up the most.

Please review if it is appropriate, thank you.