### PR TITLE
Fix issue with launch when running scripts without exec permission

### DIFF
--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -389,7 +389,7 @@ class Tab:  # {{{
                                     line = f.read(4096).splitlines()[0]
                                     cmd += shlex.split(line) + [old_exe]
                                 else:
-                                    cmd += [resolved_shell(get_options())[0], cmd[0]]
+                                    cmd += [resolved_shell(get_options())[0], old_exe]
                                 if cmd_rest:
                                     cmd += cmd_rest
         fenv: Dict[str, str] = {}

--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -383,12 +383,15 @@ class Tab:  # {{{
                         import shlex
                         with suppress(OSError):
                             with open(old_exe) as f:
+                                cmd_rest = cmd[1:] if len(cmd) > 1 else []
                                 cmd = [kitty_exe(), '+hold']
                                 if f.read(2) == '#!':
                                     line = f.read(4096).splitlines()[0]
                                     cmd += shlex.split(line) + [old_exe]
                                 else:
                                     cmd += [resolved_shell(get_options())[0], cmd[0]]
+                                if cmd_rest:
+                                    cmd += cmd_rest
         fenv: Dict[str, str] = {}
         if env:
             fenv.update(env)


### PR DESCRIPTION
When executing a script without execute permission via launch, the arguments are missing.
I didn't think of any reason why the arguments need to be removed, so please let me know if I'm wrong.

Also fix `cmd[0]` that was replaced with `kitty` being executed incorrectly when there was no shebang.

I have a question, why do we use `kitty +hold` here?
If opts.hold is configured, is this a double hold?
