### PR TITLE
macOS: Add archive file type and standalone open with kitty service

### DIFF
--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -520,6 +520,19 @@ cocoa_send_notification(PyObject *self UNUSED, PyObject *args) {
     return YES;
 }
 
+- (BOOL)openFileURLs:(NSPasteboard*)pasteboard
+        userData:(NSString *) UNUSED userData  error:(NSError **) UNUSED error {
+    NSDictionary *options = @{ NSPasteboardURLReadingFileURLsOnlyKey: @YES };
+    NSArray *urlArray = [pasteboard readObjectsForClasses:[NSArray arrayWithObject:[NSURL class]] options:options];
+    for (NSURL *url in urlArray) {
+        NSString *path = [url path];
+        if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
+            set_cocoa_pending_action(LAUNCH_URL, [[[NSURL fileURLWithPath:path] absoluteString] UTF8String]);
+        }
+    }
+    return YES;
+}
+
 @end
 
 // global menu {{{

--- a/setup.py
+++ b/setup.py
@@ -1090,6 +1090,12 @@ def macos_info_plist() -> bytes:
             'NSRequiredContext': {'NSTextContent': 'FilePath'},
             'NSSendTypes': ['NSFilenamesPboardType', 'public.plain-text'],
         },
+        {
+            'NSMenuItem': {'default': f'Open with {appname}'},
+            'NSMessage': 'openFileURLs',
+            'NSRequiredContext': {'NSTextContent': 'FilePath'},
+            'NSSendTypes': ['NSFilenamesPboardType', 'public.plain-text'],
+        },
     ]
 
     pl = dict(

--- a/setup.py
+++ b/setup.py
@@ -1006,21 +1006,19 @@ def macos_info_plist() -> bytes:
         {
             'CFBundleTypeName': 'Text files',
             'LSItemContentTypes': ['public.text'],
-            'LSTypeIsPackage': False,
             'CFBundleTypeRole': 'Editor',
             'LSHandlerRank': 'Alternate',
         },
         {
             'CFBundleTypeName': 'Image files',
             'LSItemContentTypes': ['public.image'],
-            'LSTypeIsPackage': False,
             'CFBundleTypeRole': 'Viewer',
             'LSHandlerRank': 'Alternate',
         },
         # Allows dragging arbitrary files to kitty Dock icon, and list kitty in the Open With context menu.
         {
             'CFBundleTypeName': 'All files',
-            'LSItemContentTypes': ['public.content', 'public.data'],
+            'LSItemContentTypes': ['public.archive', 'public.content', 'public.data'],
             'CFBundleTypeRole': 'Editor',
             'LSHandlerRank': 'Alternate',
         },


### PR DESCRIPTION
Add archive file type.

There are still file types that are not recognized (e.g. conf, rst), so add a standalone service to open them.
Users can right click on the file and select `Open with kitty` in the service submenu.

At this point, the compressed file can be extracted. Although it is not possible to compress the files.
If one really want to solve it, it looks like a kitten is needed to select the multi-file actions.
It is indeed very complicated.

Please review, thank you.

---
One issue remains:

Opening kitty via service, an initial window appears, and then the new tab or new OS window is shown.
This also affects `New kitty tab Here`, `New kitty Window Here`.

I first checked the launch_urls, `def clear_initial_window()` not called.
```text
needs_window_replaced = 
(not no_replace_window) # -> True
and (
  (not self.cocoa_application_launched) # -> False
  or 
  (not self.os_window_map) # -> False
) # -> False 
and w is not None and w.id == 1 # -> True
```

It looks like there are already `os_window_map`.