### PR TITLE
Add launcher desktop file to open URLs on Linux and minor tweaks

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -79,7 +79,10 @@ Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - macOS: Allow kitty to handle various URL types. Can be configured via
-  :ref:`launch_actions`
+  :ref:`launch_actions` (:pull:`4618`)
+
+- macOS: Add a new service ``Open with kitty`` to open file types that are not
+  recognized by the system (:pull:`4641`)
 
 - Fix a regression in the previous release that broke :opt:`active_tab_foreground` (:iss:`4620`)
 

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -2256,7 +2256,7 @@ class Boss:
         else:
             w = None
         needs_window_replaced = False
-        if not no_replace_window:
+        if not no_replace_window and not get_options().startup_session:
             if w is not None and w.id == 1 and monotonic() - w.started_at < 2 and len(tuple(self.all_windows)) == 1:
                 # first window, soon after startup replace it
                 needs_window_replaced = True

--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -1008,14 +1008,14 @@ typedef struct {
 static CocoaPendingActionsData cocoa_pending_actions_data = {0};
 
 void
-set_cocoa_pending_action(CocoaPendingAction action, const char *wd) {
-    if (wd) {
-        if (action == LAUNCH_URL) {
+set_cocoa_pending_action(CocoaPendingAction action, const char *data) {
+    if (data) {
+        if (action == LAUNCH_URLS) {
             ensure_space_for(&cocoa_pending_actions_data, open_urls, char*, cocoa_pending_actions_data.open_urls_count + 8, open_urls_capacity, 8, true);
-            cocoa_pending_actions_data.open_urls[cocoa_pending_actions_data.open_urls_count++] = strdup(wd);
+            cocoa_pending_actions_data.open_urls[cocoa_pending_actions_data.open_urls_count++] = strdup(data);
         } else {
             if (cocoa_pending_actions_data.wd) free(cocoa_pending_actions_data.wd);
-            cocoa_pending_actions_data.wd = strdup(wd);
+            cocoa_pending_actions_data.wd = strdup(data);
         }
     }
     cocoa_pending_actions[action] = true;

--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -527,7 +527,7 @@ cocoa_send_notification(PyObject *self UNUSED, PyObject *args) {
     for (NSURL *url in urlArray) {
         NSString *path = [url path];
         if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
-            set_cocoa_pending_action(LAUNCH_URL, [[[NSURL fileURLWithPath:path] absoluteString] UTF8String]);
+            set_cocoa_pending_action(LAUNCH_URLS, [[[NSURL fileURLWithPath:path] absoluteString] UTF8String]);
         }
     }
     return YES;

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -456,7 +456,7 @@ static void get_window_dpi(GLFWwindow *w, double *x, double *y);
 #ifdef __APPLE__
 static bool
 apple_url_open_callback(const char* url) {
-    set_cocoa_pending_action(LAUNCH_URL, url);
+    set_cocoa_pending_action(LAUNCH_URLS, url);
     return true;
 }
 

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -298,7 +298,7 @@ typedef enum {
     NEXT_TAB,
     PREVIOUS_TAB,
     DETACH_TAB,
-    LAUNCH_URL,
+    LAUNCH_URLS,
     NEW_WINDOW,
     CLOSE_WINDOW,
     RESET_TERMINAL,

--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -383,15 +383,12 @@ class Tab:  # {{{
                         import shlex
                         with suppress(OSError):
                             with open(old_exe) as f:
-                                cmd_rest = cmd[1:]
-                                cmd = [kitty_exe(), '+hold']
                                 if f.read(2) == '#!':
                                     line = f.read(4096).splitlines()[0]
-                                    cmd += shlex.split(line) + [old_exe]
+                                    cmd[:0] = shlex.split(line)
                                 else:
-                                    cmd += [resolved_shell(get_options())[0], old_exe]
-                                if cmd_rest:
-                                    cmd += cmd_rest
+                                    cmd[:0] = [resolved_shell(get_options())[0]]
+                                cmd[:0] = [kitty_exe(), '+hold']
         fenv: Dict[str, str] = {}
         if env:
             fenv.update(env)

--- a/setup.py
+++ b/setup.py
@@ -969,6 +969,23 @@ Icon=kitty
 Categories=System;TerminalEmulator;
 '''
             )
+    with open(os.path.join(deskdir, 'kitty-launcher.desktop'), 'w') as f:
+        f.write(
+            '''\
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=kitty URL Launcher
+GenericName=Terminal emulator
+Comment=Open URLs with kitty
+TryExec=kitty
+Exec=kitty +open %U
+Icon=kitty
+Categories=System;TerminalEmulator;
+NoDisplay=true
+MimeType=x-scheme-handler/kitty;
+'''
+            )
 
     base = Path(ddir)
     in_src_launcher = base / (f'{libdir_name}/kitty/kitty/launcher/kitty')


### PR DESCRIPTION
Add `kitty-launcher.desktop` to handle URL scheme for Linux.
Add changelog entry for previous PR.
The initial window is not removed when using launch_urls if the startup session is configured.
Simplifies reassembling for the command when executing the scripts without exec permission.

Please review, thank you.