### PR TITLE
Docs: Prefer namespaced launch points

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -208,7 +208,7 @@ bitmapped fonts.
 
         symbol_map U+23FB-U+23FE,U+2B58,U+E200-U+E2A9,U+E0A0-U+E0A3,U+E0B0-U+E0BF,U+E0C0-U+E0C8,U+E0CC-U+E0CF,U+E0D0-U+E0D2,U+E0D4,U+E700-U+E7C5,U+F000-U+F2E0,U+2665,U+26A1,U+F400-U+F4A8,U+F67C,U+E000-U+E00A,U+F300-U+F313,U+E5FA-U+E62B Symbols Nerd Font
 
-If your font is not listed in ``kitty list-fonts`` it means that it is not
+If your font is not listed in ``kitty +list-fonts`` it means that it is not
 monospace or is a bitmapped font. On Linux you can list all monospace fonts with::
 
     fc-list : family spacing outline scalable | grep -e spacing=100 -e spacing=90 | grep -e outline=True | grep -e scalable=True
@@ -236,7 +236,7 @@ command to rebuild your fontconfig cache::
 
     fc-cache -r
 
-Then, the font will be available in ``kitty list-fonts``.
+Then, the font will be available in ``kitty +list-fonts``.
 
 
 How can I assign a single global shortcut to bring up the kitty terminal?

--- a/kittens/icat/main.py
+++ b/kittens/icat/main.py
@@ -102,7 +102,7 @@ detecting image display support.
 --print-window-size
 type=bool-set
 Print out the window size as :italic:`widthxheight` (in pixels) and quit. This is a
-convenience method to query the window size if using kitty icat from a
+convenience method to query the window size if using :code:`kitty +kitten icat` from a
 scripting language that cannot make termios calls.
 
 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -33,7 +33,7 @@ and even specify special fonts for particular characters.
 opt('font_family', 'monospace',
     long_text='''
 You can specify different fonts for the bold/italic/bold-italic variants.
-To get a full list of supported fonts use the `kitty list-fonts` command.
+To get a full list of supported fonts use the `kitty +list-fonts` command.
 By default they are derived automatically, by the OSes font system. When
 bold_font or bold_italic_font is set to :code:`auto` on macOS, the priority of
 bold fonts is semi-bold, bold, heavy. Setting them manually is useful for font
@@ -166,11 +166,11 @@ disable a feature in the italic font but not in the regular font.
 On Linux, these are read from the FontConfig database first and then this,
 setting is applied, so they can be configured in a single, central place.
 
-To get the PostScript name for a font, use :code:`kitty + list-fonts --psnames`:
+To get the PostScript name for a font, use :code:`kitty +list-fonts --psnames`:
 
 .. code-block:: sh
 
-    $ kitty + list-fonts --psnames | grep Fira
+    $ kitty +list-fonts --psnames | grep Fira
     Fira Code
     Fira Code Bold (FiraCode-Bold)
     Fira Code Light (FiraCode-Light)


### PR DESCRIPTION
Replace `kitty list-fonts` with `kitty +list-fonts`.

According to the following commit, it is recommended to use namespaced launch points.

https://github.com/kovidgoyal/kitty/commit/b9f21f285ce800dfd020fd99d5b2fa622438d334