### PR TITLE
Shell integration: Restore XDG_DATA_DIRS right after fish integration script is loaded

### DIFF
--- a/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
+++ b/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
@@ -1,16 +1,10 @@
 #!/bin/fish
 
-status is-interactive || exit 0
-not functions -q __ksi_schedule || exit 0
-
-function __ksi_schedule --on-event fish_prompt -d "Setup kitty integration after other scripts have run, we hope"
-    functions --erase __ksi_schedule
-    test -n "$KITTY_SHELL_INTEGRATION" || return 0
-
-    # To use fish's autoloading feature, kitty prepends the vendored integration script directory to XDG_DATA_DIRS.
-    # The original paths needs to be restored here to not affect other programs.
-    # In particular, if the original XDG_DATA_DIRS does not exist, it needs to be removed.
-    if set -q XDG_DATA_DIRS KITTY_FISH_XDG_DATA_DIR
+# To use fish's autoloading feature, kitty prepends the vendored integration script directory to XDG_DATA_DIRS.
+# The original paths needs to be restored here to not affect other programs.
+# In particular, if the original XDG_DATA_DIRS does not exist, it needs to be removed.
+if set -q KITTY_FISH_XDG_DATA_DIR
+    if set -q XDG_DATA_DIRS
         set --global --export --path XDG_DATA_DIRS "$XDG_DATA_DIRS"
         if set -l index (contains -i "$KITTY_FISH_XDG_DATA_DIR" $XDG_DATA_DIRS)
             set --erase --global XDG_DATA_DIRS[$index]
@@ -20,22 +14,31 @@ function __ksi_schedule --on-event fish_prompt -d "Setup kitty integration after
             set --global --export --unpath XDG_DATA_DIRS "$XDG_DATA_DIRS"
         end
     end
+    set --erase KITTY_FISH_XDG_DATA_DIR
+end
+
+status is-interactive || exit 0
+not functions -q __ksi_schedule || exit 0
+
+function __ksi_schedule --on-event fish_prompt -d "Setup kitty integration after other scripts have run, we hope"
+    functions --erase __ksi_schedule
+    test -n "$KITTY_SHELL_INTEGRATION" || return 0
     set --local _ksi (string split " " -- "$KITTY_SHELL_INTEGRATION")
-    set --erase KITTY_SHELL_INTEGRATION KITTY_FISH_XDG_DATA_DIR
+    set --erase KITTY_SHELL_INTEGRATION
 
     # Enable cursor shape changes for default mode and vi mode
     if not contains "no-cursor" $_ksi
         and not functions -q __ksi_set_cursor
 
         function __ksi_block_cursor --on-event fish_preexec -d "Set cursor shape to blinking default shape before executing command"
-            printf "\e[0 q"
+            echo -en "\e[0 q"
         end
 
         function __ksi_set_cursor --on-variable fish_key_bindings -d "Set the cursor shape for different modes when switching key bindings"
             if test "$fish_key_bindings" = fish_default_key_bindings
                 not functions -q __ksi_bar_cursor || return
                 function __ksi_bar_cursor --on-event fish_prompt -d "Set cursor shape to blinking bar on prompt"
-                    printf "\e[5 q"
+                    echo -en "\e[5 q"
                 end
             else
                 functions --erase __ksi_bar_cursor
@@ -56,7 +59,7 @@ function __ksi_schedule --on-event fish_prompt -d "Setup kitty integration after
             end
 
             # Change the cursor shape for current mode
-            test "$fish_bind_mode" = "insert" && printf "\e[5 q" || printf "\e[1 q"
+            test "$fish_bind_mode" = "insert" && echo -en "\e[5 q" || echo -en "\e[1 q"
         end
 
         __ksi_set_cursor
@@ -69,22 +72,14 @@ function __ksi_schedule --on-event fish_prompt -d "Setup kitty integration after
         and not set -q __ksi_prompt_state
         set --global __ksi_prompt_state first-run
 
-        function __ksi_function_is_not_empty -d "Check if the specified function exists and is not empty"
-            functions --no-details $argv[1] | string match -qnvr '^ *(#|function |end$|$)'
-        end
-
-        function __ksi_mark -d "Tell kitty to mark the current cursor position using OSC 133"
-            printf "\e]133;%s\a" "$argv[1]"
-        end
-
         function __ksi_prompt_start
             # Preserve the command exit code from $status
             set --local cmd_status $status
             if contains "$__ksi_prompt_state" post-exec first-run
-                __ksi_mark D
+                echo -en "\e]133;D\a"
             end
             set --global __ksi_prompt_state prompt-start
-            __ksi_mark A
+            echo -en "\e]133;A\a"
             return $cmd_status
         end
 
@@ -98,15 +93,17 @@ function __ksi_schedule --on-event fish_prompt -d "Setup kitty integration after
             end
             printf '%s' $op[-1] # print the last component without a newline
             set --global __ksi_prompt_state prompt-end
-            __ksi_mark B
+            echo -en "\e]133;B\a"
             return $cmd_status
         end
 
         functions -c fish_prompt __ksi_original_fish_prompt
 
-        if __ksi_function_is_not_empty fish_mode_prompt
+        # Check whether the mode prompt function exists and is not empty
+        if functions --no-details fish_mode_prompt | string match -qnvr '^ *(#|function |end$|$)'
+            # When vi mode changes, fish redraws fish_prompt when fish_mode_prompt is empty.
+            # Some prompt rely on this side effect to draw vi mode indicator.
             # See https://github.com/starship/starship/issues/1283
-            # for why we have to test for a non-empty fish_mode_prompt
             functions -c fish_mode_prompt __ksi_original_fish_mode_prompt
             function fish_mode_prompt
                 __ksi_prompt_start
@@ -124,17 +121,16 @@ function __ksi_schedule --on-event fish_prompt -d "Setup kitty integration after
 
         function __ksi_mark_output_start --on-event fish_preexec
             set --global __ksi_prompt_state pre-exec
-            __ksi_mark C
+            echo -en "\e]133;C\a"
         end
 
         function __ksi_mark_output_end --on-event fish_postexec
             set --global __ksi_prompt_state post-exec
-            __ksi_mark "D;$status"
+            echo -en "\e]133;D;$status\a"
         end
-        # With prompt marking kitty clears the current prompt on resize so we need
-        # fish to redraw it
-        set --global fish_handle_reflow 1
 
-        functions --erase __ksi_function_is_not_empty
+        # With prompt marking, kitty clears the current prompt on resize,
+        # so we need fish to redraw it.
+        set --global fish_handle_reflow 1
     end
 end


### PR DESCRIPTION
Need to restore XDG_DATA_DIRS after the script is loaded and before exiting. Otherwise it will affect other programs.
In fish master branch, loading from env will take precedence and hopefully will not affect other programs.

Reduce function calls again, since no more functions will be added to reuse them in the near future.

Use the simpler echo instead of printf to improve marking performance (Well, in ns, almost negligible).

Please review, thank you.