### PR TITLE
hints kitten: Match and strip Unicode single and double quotes

### DIFF
--- a/kittens/hints/main.py
+++ b/kittens/hints/main.py
@@ -230,7 +230,7 @@ def regex_finditer(pat: 'Pattern[str]', minimum_match_length: int, text: str) ->
             yield s, e, m.groupdict()
 
 
-closing_bracket_map = {'(': ')', '[': ']', '{': '}', '<': '>', '*': '*', '"': '"', "'": "'"}
+closing_bracket_map = {'(': ')', '[': ']', '{': '}', '<': '>', '*': '*', '"': '"', "'": "'", "“": "”", "‘": "’"}
 opening_brackets = ''.join(closing_bracket_map)
 PostprocessorFunc = Callable[[str, int, int], Tuple[int, int]]
 postprocessor_map: Dict[str, PostprocessorFunc] = {}
@@ -288,11 +288,12 @@ def quotes(text: str, s: int, e: int) -> Tuple[int, int]:
     # Remove matching quotes
     if s < e <= len(text):
         before = text[s]
-        if before in '\'"':
-            if text[e-1] == before:
+        if before in '\'"“‘':
+            q = closing_bracket_map[before]
+            if text[e-1] == q:
                 s += 1
                 e -= 1
-            elif text[e:e+1] == before:
+            elif text[e:e+1] == q:
                 s += 1
     return s, e
 


### PR DESCRIPTION
Match and strip unicode single and double quotes.
U+2018, U+2019
U+201C, U+201D

When using `wget`, the downloaded filename is surrounded by Unicode quotes.

Since the quotes are matched on the left and right ends (after the file extension), it is unlikely to produce many false positives.