### PR TITLE
README: Add link for packaging status

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -11,4 +11,4 @@ https://www.reddit.com/r/KittyTerminal[Reddit community]
 
 Packaging status in various repositories:
 
-image:https://repology.org/badge/vertical-allrepos/kitty.svg[https://repology.org/project/kitty/versions]
+image:https://repology.org/badge/vertical-allrepos/kitty.svg["Packaging status", link="https://repology.org/project/kitty/versions"]


### PR DESCRIPTION
The current README packaging status image is linked to the cached image on the github camo service when shown on GitHub.
Change the link to Repology versions page.