### PR TITLE
Add touch_scroll_pixel_per_line config option, implements #4694

### DIFF
--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -878,7 +878,12 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags, int modifiers) {
 // scale the scroll by the multiplier unless the mouse is grabbed. If the mouse is grabbed only change direction.
 #define SCALE_SCROLL(which) { double scale = OPT(which); if (screen->modes.mouse_tracking_mode) scale /= fabs(scale); yoffset *= scale; }
     if (is_high_resolution) {
-        SCALE_SCROLL(touch_scroll_multiplier);
+        if (OPT(touch_scroll_pixel_per_line) > 0) {
+            yoffset *= (global_state.callback_os_window->fonts_data->cell_height / OPT(touch_scroll_pixel_per_line));
+            SCALE_SCROLL(wheel_scroll_multiplier);
+        } else {
+            SCALE_SCROLL(touch_scroll_multiplier);
+        }
         double pixels = screen->pending_scroll_pixels + yoffset;
         if (fabs(pixels) < global_state.callback_os_window->fonts_data->cell_height) {
             screen->pending_scroll_pixels = pixels;

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -355,6 +355,17 @@ precision scrolling devices on platforms such as macOS and Wayland. Use negative
 numbers to change scroll direction.
 '''
     )
+
+opt('touch_scroll_pixel_per_line', '0.0',
+    option_type='float', ctype='double',
+    long_text='''
+Converts this many pixels scrolled by a high precision device to one mouse
+wheel scroll. When non-zero, overrides `touch_scroll_multiplier`, and uses
+`wheel_scroll_multiplier` to determine the number of lines scrolled instead.
+Useful when mouse is detected as high precision, or in mixed DPI environments
+to maintain a consistent scrolling speed across screens.
+'''
+    )
 egr()  # }}}
 
 # mouse {{{

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -1167,7 +1167,7 @@ class Parser:
     choices_for_strip_trailing_spaces = frozenset(('always', 'never', 'smart'))
 
     def symbol_map(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
-        for k, v in symbol_map(val):
+        for k, v in symbol_map(val, ans["symbol_map"]):
             ans["symbol_map"][k] = v
 
     def sync_to_monitor(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
@@ -1240,6 +1240,9 @@ class Parser:
 
     def touch_scroll_multiplier(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['touch_scroll_multiplier'] = float(val)
+
+    def touch_scroll_pixel_per_line(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        ans['touch_scroll_pixel_per_line'] = float(val)
 
     def update_check_interval(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['update_check_interval'] = float(val)

--- a/kitty/options/to-c-generated.h
+++ b/kitty/options/to-c-generated.h
@@ -201,6 +201,19 @@ convert_from_opts_touch_scroll_multiplier(PyObject *py_opts, Options *opts) {
 }
 
 static void
+convert_from_python_touch_scroll_pixel_per_line(PyObject *val, Options *opts) {
+    opts->touch_scroll_pixel_per_line = PyFloat_AsDouble(val);
+}
+
+static void
+convert_from_opts_touch_scroll_pixel_per_line(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "touch_scroll_pixel_per_line");
+    if (ret == NULL) return;
+    convert_from_python_touch_scroll_pixel_per_line(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
 convert_from_python_mouse_hide_wait(PyObject *val, Options *opts) {
     opts->mouse_hide_wait = parse_s_double_to_monotonic_t(val);
 }
@@ -1024,6 +1037,8 @@ convert_opts_from_python_opts(PyObject *py_opts, Options *opts) {
     convert_from_opts_wheel_scroll_multiplier(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_touch_scroll_multiplier(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_touch_scroll_pixel_per_line(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_mouse_hide_wait(py_opts, opts);
     if (PyErr_Occurred()) return false;

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -427,6 +427,7 @@ option_names = (  # {{{
  'tab_title_template',
  'term',
  'touch_scroll_multiplier',
+ 'touch_scroll_pixel_per_line',
  'update_check_interval',
  'url_color',
  'url_excluded_characters',
@@ -571,6 +572,7 @@ class Options:
     tab_title_template: str = '{fmt.fg.red}{bell_symbol}{activity_symbol}{fmt.fg.tab}{title}'
     term: str = 'xterm-kitty'
     touch_scroll_multiplier: float = 1.0
+    touch_scroll_pixel_per_line: float = 0.0
     update_check_interval: float = 24.0
     url_color: Color = Color(0, 135, 189)
     url_excluded_characters: str = ''

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -23,7 +23,7 @@ typedef struct {
 
 typedef struct {
     monotonic_t visual_bell_duration, cursor_blink_interval, cursor_stop_blinking_after, mouse_hide_wait, click_interval;
-    double wheel_scroll_multiplier, touch_scroll_multiplier;
+    double wheel_scroll_multiplier, touch_scroll_multiplier, touch_scroll_pixel_per_line;
     bool enable_audio_bell;
     CursorShape cursor_shape;
     float cursor_beam_thickness;


### PR DESCRIPTION
Implements #4694

Adds an option to map touch scrolling to lines instead of pixels for consistency on hidpi screens. Also provides a better fix for #4680.

Note that I defaulted to 0 to not break backwards compatibility. There is the challenge of finding out what to set this value to if your mouse scroll wheel is recognized as high precision and you want to map one scroll to one line. I found mine to be exactly 15 by printing out yoffset in the source code, but I'm not sure if this is different depending on system settings for scroll sensitivity.

Would it make sense to still use the `touch_scroll_multiplier` instead of `wheel_scroll_multiplier` for the number of lines to scroll outside of mouse tracking? I think it makes sense because it would allow reversing the touchpad without reversing the scrollwheel, but also I think it could be confusing.