### PR TITLE
Seperate discrete (mouse wheel) and continuous (touchpad) scroll events on wayland

### DIFF
--- a/glfw/wl_init.c
+++ b/glfw/wl_init.c
@@ -317,10 +317,10 @@ static void pointerHandleButton(void* data UNUSED,
 #undef x
 #undef y
 
-// flags for ignoring axis events following axis_discrete events in the
+// counters for ignoring axis events following axis_discrete events in the
 // same frame along the same axis
-static bool ignoreNextX = false;
-static bool ignoreNextY = false;
+static unsigned int discreteXCount = 0;
+static unsigned int discreteYCount = 0;
 
 static void pointerHandleAxis(void* data UNUSED,
                               struct wl_pointer* pointer UNUSED,
@@ -337,15 +337,15 @@ static void pointerHandleAxis(void* data UNUSED,
            axis == WL_POINTER_AXIS_VERTICAL_SCROLL);
 
     if (axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL) {
-        if (ignoreNextX) {
-            ignoreNextX = false;
+        if (discreteXCount) {
+            --discreteXCount;
             return;
         }
         x = -wl_fixed_to_double(value);
     }
     else if (axis == WL_POINTER_AXIS_VERTICAL_SCROLL) {
-        if (ignoreNextY) {
-            ignoreNextY = false;
+        if (discreteYCount) {
+            --discreteYCount;
             return;
         }
         y = -wl_fixed_to_double(value);
@@ -357,8 +357,8 @@ static void pointerHandleAxis(void* data UNUSED,
 static void pointerHandleFrame(void* data UNUSED,
                                struct wl_pointer* pointer UNUSED)
 {
-    ignoreNextX = false;
-    ignoreNextY = false;
+    discreteXCount = 0;
+    discreteYCount = 0;
 }
 
 static void pointerHandleAxisSource(void* data UNUSED,
@@ -390,11 +390,11 @@ static void pointerHandleAxisDiscrete(void *data UNUSED,
 
     if (axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL) {
         x = -discrete;
-        ignoreNextX = true;
+        ++discreteXCount;
     }
     else if (axis == WL_POINTER_AXIS_VERTICAL_SCROLL) {
         y = -discrete;
-        ignoreNextY = true;
+        ++discreteYCount;
     }
 
     _glfwInputScroll(window, x, y, 0, _glfw.wl.xkb.states.modifiers);

--- a/glfw/wl_init.c
+++ b/glfw/wl_init.c
@@ -317,6 +317,11 @@ static void pointerHandleButton(void* data UNUSED,
 #undef x
 #undef y
 
+// flags for ignoring axis events following axis_discrete events in the
+// same frame along the same axis
+static bool ignoreNextX = false;
+static bool ignoreNextY = false;
+
 static void pointerHandleAxis(void* data UNUSED,
                               struct wl_pointer* pointer UNUSED,
                               uint32_t time UNUSED,
@@ -331,12 +336,68 @@ static void pointerHandleAxis(void* data UNUSED,
     assert(axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL ||
            axis == WL_POINTER_AXIS_VERTICAL_SCROLL);
 
-    if (axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL)
+    if (axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL) {
+        if (ignoreNextX) {
+            ignoreNextX = false;
+            return;
+        }
         x = -wl_fixed_to_double(value);
-    else if (axis == WL_POINTER_AXIS_VERTICAL_SCROLL)
+    }
+    else if (axis == WL_POINTER_AXIS_VERTICAL_SCROLL) {
+        if (ignoreNextY) {
+            ignoreNextY = false;
+            return;
+        }
         y = -wl_fixed_to_double(value);
+    }
 
     _glfwInputScroll(window, x, y, 1, _glfw.wl.xkb.states.modifiers);
+}
+
+static void pointerHandleFrame(void* data UNUSED,
+                               struct wl_pointer* pointer UNUSED)
+{
+    ignoreNextX = false;
+    ignoreNextY = false;
+}
+
+static void pointerHandleAxisSource(void* data UNUSED,
+                                    struct wl_pointer* pointer UNUSED,
+                                    uint32_t source UNUSED)
+{
+}
+
+static void pointerHandleAxisStop(void *data UNUSED,
+                  struct wl_pointer *wl_pointer UNUSED,
+                  uint32_t time UNUSED,
+                  uint32_t axis UNUSED)
+{
+}
+
+
+static void pointerHandleAxisDiscrete(void *data UNUSED,
+                  struct wl_pointer *wl_pointer UNUSED,
+                  uint32_t axis UNUSED,
+                  int32_t discrete UNUSED)
+{
+    _GLFWwindow* window = _glfw.wl.pointerFocus;
+    double x = 0.0, y = 0.0;
+    if (!window)
+        return;
+
+    assert(axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL ||
+           axis == WL_POINTER_AXIS_VERTICAL_SCROLL);
+
+    if (axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL) {
+        x = -discrete;
+        ignoreNextX = true;
+    }
+    else if (axis == WL_POINTER_AXIS_VERTICAL_SCROLL) {
+        y = -discrete;
+        ignoreNextY = true;
+    }
+
+    _glfwInputScroll(window, x, y, 0, _glfw.wl.xkb.states.modifiers);
 }
 
 static const struct wl_pointer_listener pointerListener = {
@@ -345,6 +406,10 @@ static const struct wl_pointer_listener pointerListener = {
     pointerHandleMotion,
     pointerHandleButton,
     pointerHandleAxis,
+    pointerHandleFrame,
+    pointerHandleAxisSource,
+    pointerHandleAxisStop,
+    pointerHandleAxisDiscrete,
 };
 
 static void keyboardHandleKeymap(void* data UNUSED,
@@ -571,7 +636,7 @@ static void registryHandleGlobal(void* data UNUSED,
     {
         if (!_glfw.wl.seat)
         {
-            _glfw.wl.seatVersion = min(4, version);
+            _glfw.wl.seatVersion = min(5, version);
             _glfw.wl.seat =
                 wl_registry_bind(registry, name, &wl_seat_interface,
                                  _glfw.wl.seatVersion);


### PR DESCRIPTION
This bumps seatVersion to 5. The code should still work if the user is using seatVersion 4.
Additionally this means that the code now requires libwayland 1.10 to compile. Even Ubuntu 16.04 had that version so we should be safe here.

Aside: doesn't glfw's license require marking the version as modified?