### PR TITLE
Show tab name otherwise tab title for select_tab

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -2153,7 +2153,7 @@ class Boss:
 
         def format_tab_title(tab: Tab) -> str:
             w = 'windows' if tab.num_window_groups > 1 else 'window'
-            return f'{tab.title} [{tab.num_window_groups} {w}]'
+            return f'{tab.name or tab.title} [{tab.num_window_groups} {w}]'
 
         ct = self.active_tab
         st = ''


### PR DESCRIPTION
Currently `select_tab` only show the default tab title even after renaming it with `set_tab_title`.

I'm not sure if this was done on purpose. I think showing the renamed tab title in `select_tab` window would be useful.