### PR TITLE
Add wheel_scroll_min_lines to set the minimum scrolling lines

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -135,6 +135,8 @@ Detailed list of changes
 
 - Wayland: Fix touchpads and high resolution wheels not scrolling at the same speed on monitors with different scales (:iss:`4703`)
 
+- Add an option :opt:`wheel_scroll_min_lines` to set the minimum number of lines for mouse wheel scrolling (:pull:`4710`)
+
 
 0.24.2 [2022-02-03]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -888,9 +888,13 @@ scroll_event(double UNUSED xoffset, double yoffset, int flags, int modifiers) {
     } else {
         SCALE_SCROLL(wheel_scroll_multiplier);
         s = (int) round(yoffset);
+        int min_lines = OPT(wheel_scroll_min_lines);
+        if (min_lines > 0 && abs(s) < min_lines) s = yoffset > 0 ? min_lines : -min_lines;
+        // Add the minimum number of lines when it is negative and the scrolling acceleration takes effect
+        else if (min_lines < 0) s = yoffset > 0 ? s - min_lines : s + min_lines;
         // apparently on cocoa some mice generate really small yoffset values
         // when scrolling slowly https://github.com/kovidgoyal/kitty/issues/1238
-        if (s == 0 && yoffset != 0) s = yoffset > 0 ? 1 : -1;
+        if (s == 0) s = yoffset > 0 ? 1 : -1;
         screen->pending_scroll_pixels = 0;
     }
 #undef SCALE_SCROLL

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -347,6 +347,16 @@ as macOS and Wayland. Use negative numbers to change scroll direction.
 '''
     )
 
+opt('wheel_scroll_min_lines', '1',
+    option_type='int', ctype='int',
+    long_text='''
+The minimum number of lines scrolled by the mouse wheel. The scrolling
+acceleration only takes effect after it reaches the number. Note that this is
+only used for low precision scrolling devices. With a negative number, the
+minimum number of lines will always be added.
+'''
+    )
+
 opt('touch_scroll_multiplier', '1.0',
     option_type='float', ctype='double',
     long_text='''

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -1272,6 +1272,9 @@ class Parser:
     def wayland_titlebar_color(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['wayland_titlebar_color'] = titlebar_color(val)
 
+    def wheel_scroll_min_lines(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        ans['wheel_scroll_min_lines'] = int(val)
+
     def wheel_scroll_multiplier(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['wheel_scroll_multiplier'] = float(val)
 

--- a/kitty/options/to-c-generated.h
+++ b/kitty/options/to-c-generated.h
@@ -188,6 +188,19 @@ convert_from_opts_wheel_scroll_multiplier(PyObject *py_opts, Options *opts) {
 }
 
 static void
+convert_from_python_wheel_scroll_min_lines(PyObject *val, Options *opts) {
+    opts->wheel_scroll_min_lines = PyLong_AsLong(val);
+}
+
+static void
+convert_from_opts_wheel_scroll_min_lines(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "wheel_scroll_min_lines");
+    if (ret == NULL) return;
+    convert_from_python_wheel_scroll_min_lines(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
 convert_from_python_touch_scroll_multiplier(PyObject *val, Options *opts) {
     opts->touch_scroll_multiplier = PyFloat_AsDouble(val);
 }
@@ -1022,6 +1035,8 @@ convert_opts_from_python_opts(PyObject *py_opts, Options *opts) {
     convert_from_opts_scrollback_fill_enlarged_window(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_wheel_scroll_multiplier(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_wheel_scroll_min_lines(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_touch_scroll_multiplier(py_opts, opts);
     if (PyErr_Occurred()) return false;

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -437,6 +437,7 @@ option_names = (  # {{{
  'visual_window_select_characters',
  'watcher',
  'wayland_titlebar_color',
+ 'wheel_scroll_min_lines',
  'wheel_scroll_multiplier',
  'window_alert_on_bell',
  'window_border_width',
@@ -580,6 +581,7 @@ class Options:
     visual_bell_duration: float = 0
     visual_window_select_characters: str = '1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ'
     wayland_titlebar_color: int = 0
+    wheel_scroll_min_lines: int = 1
     wheel_scroll_multiplier: float = 5.0
     window_alert_on_bell: bool = True
     window_border_width: typing.Tuple[float, str] = (0.5, 'pt')

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -24,6 +24,7 @@ typedef struct {
 typedef struct {
     monotonic_t visual_bell_duration, cursor_blink_interval, cursor_stop_blinking_after, mouse_hide_wait, click_interval;
     double wheel_scroll_multiplier, touch_scroll_multiplier;
+    int wheel_scroll_min_lines;
     bool enable_audio_bell;
     CursorShape cursor_shape;
     float cursor_beam_thickness;


### PR DESCRIPTION
Under macOS, some mice have a scroll wheel that starts at yoffset 0.100...1 (with default multiplier it's 0.500..5), resulting in one line per click with a slow scroll.
If a larger multiplier is set, the acceleration is too fast.

Add a new option `wheel_scroll_min_lines` to set the minimum number of scrolling lines.

If the number is positive, the minimum number of lines will be taken. (Obviously acceleration does not take effect when the minimum number is not reached.)
If it is negative, the number of lines is always added and the acceleration remains the same and takes effect immediately.

For me personally, I use the default `wheel_scroll_multiplier 5.0`, and `wheel_scroll_min_lines -2`.

Please review, thank you.