### PR TITLE
Docs: Fix GitHub discussion link in commented config

### DIFF
--- a/kitty/conf/types.py
+++ b/kitty/conf/types.py
@@ -53,6 +53,7 @@ def ref_map() -> Dict[str, str]:
         'sessions': f'{website_url("overview")}#startup-sessions',
         'functional': f'{website_url("keyboard-protocol")}#functional-key-definitions',
         'shell_integration': website_url("shell-integration"),
+        'github_discussions': 'https://github.com/kovidgoyal/kitty/discussions',
     }
     for actions in get_all_actions().values():
         for ac in actions:
@@ -69,6 +70,11 @@ def remove_markup(text: str) -> str:
         if m.group(1) == 'ac':
             q = m.group(2).split('<')[-1].rstrip('>')
             return ref_map()[f'action-{q}']
+        if m.group(1) == 'disc':
+            parts = m.group(2).split('<')
+            t = parts[0].strip()
+            q = parts[-1].rstrip('>')
+            return f'{t} {ref_map()["github_discussions"]}/{q}'
         return str(m.group(2))
 
     return re.sub(r':([a-zA-Z0-9]+):`(.+?)`', sub, text, flags=re.DOTALL)

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -1022,7 +1022,8 @@ The tab bar style, can be one of:
     :file:`tab_bar.py` in the kitty config directory. For examples of how to
     write such a function, see the functions named :code:`draw_tab_with_*` in
     kitty's source code: :file:`kitty/tab_bar.py`. See also
-    :disc:`this discussion <4447>` for examples from kitty users.
+    :disc:`this discussion <4447>`
+    for examples from kitty users.
 :code:`hidden`
     The tab bar is hidden. If you use this, you might want to create a
     mapping for the :ac:`select_tab`


### PR DESCRIPTION
Convert the following text role to link.
```text
:disc:`this discussion <4447>`
```

->

```text
#:     kitty's source code: kitty/tab_bar.py. See also
#:     this discussion https://github.com/kovidgoyal/kitty/discussions/4447
#:     for examples from kitty users.
```