### PR TITLE
macOS: Fix the mouse cursor being set to arrow after switching desktops

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -144,6 +144,10 @@ Detailed list of changes
 
 - Add an option :opt:`wheel_scroll_min_lines` to set the minimum number of lines for mouse wheel scrolling when using a mouse with a wheel that generates very small offsets when slow scrolling (:pull:`4710`)
 
+- macOS: Allows to configure the toggle fullscreen shortcut in global menu. (:pull:`4714`)
+
+- macOS: Fix the mouse cursor being set to arrow after switching desktops or toggling fullscreen. (:pull:`4716`)
+
 
 0.24.2 [2022-02-03]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/glfw/cocoa_platform.h
+++ b/glfw/cocoa_platform.h
@@ -154,6 +154,8 @@ typedef struct _GLFWwindowNS
     // Whether a render frame has been requested for this window
     bool renderFrameRequested;
     GLFWcocoarenderframefun renderFrameCallback;
+    // update cursor after switching desktops with Mission Control
+    bool initialCursorUpdateRequested;
 } _GLFWwindowNS;
 
 typedef struct _GLFWDisplayLinkNS

--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -1028,6 +1028,8 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 
 - (void)updateTrackingAreas
 {
+    if (window && [window->ns.object areCursorRectsEnabled])
+        [window->ns.object disableCursorRects];
     if (trackingArea != nil)
     {
         [self removeTrackingArea:trackingArea];

--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -722,16 +722,29 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     }
 }
 
+
+- (void)windowWillEnterFullScreen:(NSNotification *)notification
+{
+    (void)notification;
+    if (window) window->ns.in_fullscreen_transition = true;
+}
+
 - (void)windowDidEnterFullScreen:(NSNotification *)notification
 {
     (void)notification;
-    window->ns.in_fullscreen_transition = false;
+    if (window) window->ns.in_fullscreen_transition = false;
+}
+
+- (void)windowWillExitFullScreen:(NSNotification *)notification
+{
+    (void)notification;
+    if (window) window->ns.in_fullscreen_transition = true;
 }
 
 - (void)windowDidExitFullScreen:(NSNotification *)notification
 {
     (void)notification;
-    window->ns.in_fullscreen_transition = false;
+    if (window) window->ns.in_fullscreen_transition = false;
 }
 
 @end // }}}
@@ -1566,10 +1579,11 @@ void _glfwPlatformUpdateIMEState(_GLFWwindow *w, const GLFWIMEUpdateEvent *ev) {
 
 - (void)toggleFullScreen:(nullable id)sender
 {
-    if (glfw_window->ns.in_fullscreen_transition) return;
-    if (glfw_window && glfw_window->ns.toggleFullscreenCallback && glfw_window->ns.toggleFullscreenCallback((GLFWwindow*)glfw_window) == 1)
-        return;
-    glfw_window->ns.in_fullscreen_transition = true;
+    if (glfw_window) {
+        if (glfw_window->ns.in_fullscreen_transition) return;
+        if (glfw_window->ns.toggleFullscreenCallback && glfw_window->ns.toggleFullscreenCallback((GLFWwindow*)glfw_window) == 1) return;
+        glfw_window->ns.in_fullscreen_transition = true;
+    }
     // When resizeIncrements is set, Cocoa cannot restore the original window size after returning from fullscreen.
     const NSSize original = [self resizeIncrements];
     [self setResizeIncrements:NSMakeSize(1.0, 1.0)];


### PR DESCRIPTION
macOS will set the cursor to arrow after milliseconds after the switch
desktop animation ends.
So the cursor that was updated immediately after the focus will be changed again.
This also affects toggling fullscreen.

Reduce unnecessary cursor updates since we don't use cursor rects.

Please review, thank you.