### PR TITLE
Add basic underline offset in px

### DIFF
--- a/kitty/core_text.m
+++ b/kitty/core_text.m
@@ -379,6 +379,7 @@ cell_metrics(PyObject *s, unsigned int* cell_width, unsigned int* cell_height, u
     int baseline_offset = 0;
     if (OPT(adjust_baseline_px) != 0) baseline_offset = OPT(adjust_baseline_px);
     else if (OPT(adjust_baseline_frac) != 0) baseline_offset = (int)(*cell_height * OPT(adjust_baseline_frac));
+    int underline_offset = OPT(underline_offset);
     *baseline = (unsigned int)floor(bounds_ascent + 0.5);
     // Not sure if we should add this to bounds ascent and then round it or add
     // it to already rounded baseline and round again.
@@ -397,6 +398,9 @@ cell_metrics(PyObject *s, unsigned int* cell_width, unsigned int* cell_height, u
         *baseline = adjust_ypos(*baseline, *cell_height, baseline_offset);
         *underline_position = adjust_ypos(*underline_position, *cell_height, baseline_offset);
         *strikethrough_position = adjust_ypos(*strikethrough_position, *cell_height, baseline_offset);
+    }
+    if (underline_offset){
+        *underline_position = adjust_ypos(*underline_position, *cell_height, underline_offset);
     }
 
     CFRelease(test_frame); CFRelease(path); CFRelease(framesetter);

--- a/kitty/freetype.c
+++ b/kitty/freetype.c
@@ -313,6 +313,7 @@ cell_metrics(PyObject *s, unsigned int* cell_width, unsigned int* cell_height, u
     int baseline_offset = 0;
     if (OPT(adjust_baseline_px) != 0) baseline_offset = OPT(adjust_baseline_px);
     else if (OPT(adjust_baseline_frac) != 0) baseline_offset = (int)(*cell_height * OPT(adjust_baseline_frac));
+    int underline_offset = OPT(underline_offset);
     *baseline = font_units_to_pixels_y(self, self->ascender);
     *underline_position = MIN(*cell_height - 1, (unsigned int)font_units_to_pixels_y(self, MAX(0, self->ascender - self->underline_position)));
     *underline_thickness = MAX(1, font_units_to_pixels_y(self, self->underline_thickness));
@@ -331,6 +332,9 @@ cell_metrics(PyObject *s, unsigned int* cell_width, unsigned int* cell_height, u
         *baseline = adjust_ypos(*baseline, *cell_height, baseline_offset);
         *underline_position = adjust_ypos(*underline_position, *cell_height, baseline_offset);
         *strikethrough_position = adjust_ypos(*strikethrough_position, *cell_height, baseline_offset);
+    }
+    if (underline_offset){
+        *underline_position = adjust_ypos(*underline_position, *cell_height, underline_offset);
     }
 }
 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -109,6 +109,11 @@ accordingly.
 '''
     )
 
+opt('underline_offset', '0',
+    option_type='int', ctype='int',
+    long_text='Defines the offset of the text underline (in px)'
+    )
+
 opt('+symbol_map', 'U+E0A0-U+E0A3,U+E0C0-U+E0C7 PowerlineSymbols',
     option_type='symbol_map',
     add_to_default=False,

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -1241,6 +1241,9 @@ class Parser:
     def touch_scroll_multiplier(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['touch_scroll_multiplier'] = float(val)
 
+    def underline_offset(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        ans['underline_offset'] = int(val)
+
     def update_check_interval(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['update_check_interval'] = float(val)
 

--- a/kitty/options/to-c-generated.h
+++ b/kitty/options/to-c-generated.h
@@ -71,6 +71,19 @@ convert_from_opts_adjust_baseline(PyObject *py_opts, Options *opts) {
 }
 
 static void
+convert_from_python_underline_offset(PyObject *val, Options *opts) {
+    opts->underline_offset = PyLong_AsLong(val);
+}
+
+static void
+convert_from_opts_underline_offset(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "underline_offset");
+    if (ret == NULL) return;
+    convert_from_python_underline_offset(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
 convert_from_python_disable_ligatures(PyObject *val, Options *opts) {
     opts->disable_ligatures = PyLong_AsLong(val);
 }
@@ -1017,6 +1030,8 @@ convert_opts_from_python_opts(PyObject *py_opts, Options *opts) {
     convert_from_opts_adjust_column_width(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_adjust_baseline(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_underline_offset(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_disable_ligatures(py_opts, opts);
     if (PyErr_Occurred()) return false;

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -427,6 +427,7 @@ option_names = (  # {{{
  'tab_title_template',
  'term',
  'touch_scroll_multiplier',
+ 'underline_offset',
  'update_check_interval',
  'url_color',
  'url_excluded_characters',
@@ -572,6 +573,7 @@ class Options:
     tab_title_template: str = '{fmt.fg.red}{bell_symbol}{activity_symbol}{fmt.fg.tab}{title}'
     term: str = 'xterm-kitty'
     touch_scroll_multiplier: float = 1.0
+    underline_offset: int = 0
     update_check_interval: float = 24.0
     url_color: Color = Color(0, 135, 189)
     url_excluded_characters: str = ''

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -43,6 +43,7 @@ typedef struct {
     float macos_thicken_font;
     WindowTitleIn macos_show_window_title_in;
     char *bell_path;
+    int underline_offset;
     int adjust_line_height_px, adjust_column_width_px, adjust_baseline_px;
     float adjust_line_height_frac, adjust_column_width_frac, adjust_baseline_frac;
     float background_opacity, dim_opacity;


### PR DESCRIPTION
Hi, so I recently started using macOS and noticed this issue described in #1945. I understand this is not a problem with kitty, but I still would like to have a config option to offset the underline position.

I've never worked with graphic libs before, and I'm just getting around kitty's codebase, so please let me know if there's something that I should do differently. Right now the `underline_offset`  config option is in pixels, but I think maybe it makes sense to use pts, however, I don't know how to convert pts to px within core_text.m.

Thank you.