### PR TITLE
Bash integration: Use builtin to call the commands

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -78,7 +78,7 @@ Detailed list of changes
 0.24.3 [future]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- BASH integration: No longer modify :file:`~/.bashrc` to load :ref:`shell integration <shell_integration>`.
+- Bash integration: No longer modify :file:`~/.bashrc` to load :ref:`shell integration <shell_integration>`.
   It is recommended to remove the lines used to load the shell integration from :file:`~/.bashrc` as they are no-ops.
 
 - macOS: Allow kitty to handle various URL types. Can be configured via

--- a/shell-integration/bash/kitty.bash
+++ b/shell-integration/bash/kitty.bash
@@ -20,7 +20,7 @@ _ksi_main() {
 
     _ksi_debug_print() {
         # print a line to STDOUT of parent kitty process
-        builtin local b=$(command base64 <<< "${@}" | tr -d \\n)
+        builtin local b=$(builtin command base64 <<< "${@}" | tr -d \\n)
         builtin printf "\eP@kitty-print|%s\e\\" "$b"
         # "
     }
@@ -40,7 +40,7 @@ _ksi_main() {
         if [[ "$KITTY_BASH_INJECT" == *"posix"* ]]; then
             _ksi_safe_source "$KITTY_BASH_POSIX_ENV" && builtin export ENV="$KITTY_BASH_POSIX_ENV";
         else
-            set +o posix;
+            builtin set +o posix;
             # See run_startup_files() in shell.c in the BASH source code
             if builtin shopt -q login_shell; then
                 if [[ "$KITTY_BASH_INJECT" != *"no-profile"* ]]; then
@@ -99,7 +99,7 @@ _ksi_main() {
         fi
         if [[ -n "${_ksi_prompt[ps1]}" ]]; then
             if [[ "${_ksi_prompt[mark]}" == "y" && ( "${PS1}" == *"\n"* || "${PS1}" == *$'\n'* ) ]]; then
-                local oldval=$(builtin shopt -p extglob)
+                builtin local oldval=$(builtin shopt -p extglob)
                 builtin shopt -s extglob
                 # bash does not redraw the leading lines in a multiline prompt so
                 # mark the last line as a secondary prompt. Otherwise on resize the
@@ -108,7 +108,7 @@ _ksi_main() {
                 # the second part appends a newline with the secondary marking
                 # the third part appends everything after the last newline
                 PS1=${PS1%@('\n'|$'\n')*}${_ksi_prompt[secondary_prompt]}${PS1##*@('\n'|$'\n')};
-                eval "$oldval"
+                builtin eval "$oldval"
             fi
             PS1="${_ksi_prompt[ps1]}$PS1"
         fi
@@ -134,7 +134,7 @@ _ksi_main() {
             _ksi_debug_print "ignoreboth or ignorespace present in bash HISTCONTROL setting, showing running command in window title will not be robust"
         fi
         _ksi_get_current_command() {
-            local last_cmd=$(HISTTIMEFORMAT= builtin history 1)
+            builtin local last_cmd=$(HISTTIMEFORMAT= builtin history 1)
             last_cmd="${last_cmd#*[[:digit:]]*[[:space:]]}"  # remove leading history number
             last_cmd="${last_cmd#"${last_cmd%%[![:space:]]*}"}"  # remove remaining leading whitespace
             builtin printf "\e]2;%s\a" "${last_cmd}"
@@ -154,7 +154,7 @@ _ksi_main() {
             builtin local limit
             # Send all words up to the word the cursor is currently on
             builtin let limit=1+$COMP_CWORD
-            src=$(builtin printf "%s\n" "${COMP_WORDS[@]:0:$limit}" | command kitty +complete bash)
+            src=$(builtin printf "%s\n" "${COMP_WORDS[@]:0:$limit}" | builtin command kitty +complete bash)
             if [[ $? == 0 ]]; then
                 builtin eval ${src}
             fi

--- a/shell-integration/bash/kitty.bash
+++ b/shell-integration/bash/kitty.bash
@@ -20,8 +20,8 @@ _ksi_main() {
 
     _ksi_debug_print() {
         # print a line to STDOUT of parent kitty process
-        builtin local b=$(builtin command base64 <<< "${@}" | tr -d \\n)
-        builtin printf "\eP@kitty-print|%s\e\\" "$b"
+        builtin local b=$(builtin command base64 <<< "${@}")
+        builtin printf "\eP@kitty-print|%s\e\\" "${b//\\n}"
         # "
     }
 

--- a/shell-integration/bash/kitty.bash
+++ b/shell-integration/bash/kitty.bash
@@ -41,7 +41,7 @@ _ksi_main() {
             _ksi_safe_source "$KITTY_BASH_POSIX_ENV" && builtin export ENV="$KITTY_BASH_POSIX_ENV";
         else
             builtin set +o posix;
-            # See run_startup_files() in shell.c in the BASH source code
+            # See run_startup_files() in shell.c in the Bash source code
             if builtin shopt -q login_shell; then
                 if [[ "$KITTY_BASH_INJECT" != *"no-profile"* ]]; then
                     _ksi_safe_source "$KITTY_BASH_ETC_LOCATION/profile";

--- a/shell-integration/bash/kitty.bash
+++ b/shell-integration/bash/kitty.bash
@@ -22,7 +22,6 @@ _ksi_main() {
         # print a line to STDOUT of parent kitty process
         builtin local b=$(builtin command base64 <<< "${@}")
         builtin printf "\eP@kitty-print|%s\e\\" "${b//\\n}"
-        # "
     }
 
     _ksi_safe_source() {

--- a/shell-integration/bash/kitty.bash
+++ b/shell-integration/bash/kitty.bash
@@ -21,14 +21,14 @@ _ksi_main() {
     _ksi_debug_print() {
         # print a line to STDOUT of parent kitty process
         builtin local b=$(command base64 <<< "${@}" | tr -d \\n)
-        builtin printf "\eP@kitty-print|%s\e\\" "$b" 
+        builtin printf "\eP@kitty-print|%s\e\\" "$b"
         # "
     }
 
     _ksi_safe_source() {
-        if [[ -f "$1" && -r "$1" ]]; then 
-            builtin source "$1"; 
-            builtin return 0; 
+        if [[ -f "$1" && -r "$1" ]]; then
+            builtin source "$1";
+            builtin return 0;
         fi
         builtin return 1;
     }
@@ -37,15 +37,15 @@ _ksi_main() {
         builtin unset ENV;
         if [[ -z "$HOME" ]]; then HOME=~; fi
         if [[ -z "$KITTY_BASH_ETC_LOCATION" ]]; then KITTY_BASH_ETC_LOCATION="/etc"; fi
-        if [[ "$KITTY_BASH_INJECT" == *"posix"* ]]; then 
+        if [[ "$KITTY_BASH_INJECT" == *"posix"* ]]; then
             _ksi_safe_source "$KITTY_BASH_POSIX_ENV" && builtin export ENV="$KITTY_BASH_POSIX_ENV";
         else
-            set +o posix; 
+            set +o posix;
             # See run_startup_files() in shell.c in the BASH source code
             if builtin shopt -q login_shell; then
                 if [[ "$KITTY_BASH_INJECT" != *"no-profile"* ]]; then
                     _ksi_safe_source "$KITTY_BASH_ETC_LOCATION/profile";
-                    _ksi_safe_source "$HOME/.bash_profile" || _ksi_safe_source "$HOME/.bash_login" || _ksi_safe_source "$HOME/.profile"; 
+                    _ksi_safe_source "$HOME/.bash_profile" || _ksi_safe_source "$HOME/.bash_login" || _ksi_safe_source "$HOME/.profile";
                 fi
             else
                 if [[ "$KITTY_BASH_INJECT" != *"no-rc"* ]]; then
@@ -65,8 +65,8 @@ _ksi_main() {
     fi
     builtin unset -f _ksi_safe_source
 
-    _ksi_set_mark() { 
-        _ksi_prompt["${1}_mark"]="\[\e]133;k;${1}_kitty\a\]" 
+    _ksi_set_mark() {
+        _ksi_prompt["${1}_mark"]="\[\e]133;k;${1}_kitty\a\]"
     }
 
     _ksi_set_mark start
@@ -105,7 +105,7 @@ _ksi_main() {
                 # mark the last line as a secondary prompt. Otherwise on resize the
                 # lines before the last line will be erased by kitty.
                 # the first part removes everything from the last \n onwards
-                # the second part appends a newline with the secondary marking 
+                # the second part appends a newline with the secondary marking
                 # the third part appends everything after the last newline
                 PS1=${PS1%@('\n'|$'\n')*}${_ksi_prompt[secondary_prompt]}${PS1##*@('\n'|$'\n')};
                 eval "$oldval"
@@ -121,12 +121,12 @@ _ksi_main() {
         fi
     }
 
-    if [[ "${_ksi_prompt[cursor]}" == "y" ]]; then 
+    if [[ "${_ksi_prompt[cursor]}" == "y" ]]; then
         _ksi_prompt[ps1_suffix]+="\[\e[5 q\]"  # blinking bar cursor
         _ksi_prompt[ps0_suffix]+="\[\e[0 q\]"  # blinking default cursor
     fi
 
-    if [[ "${_ksi_prompt[title]}" == "y" ]]; then 
+    if [[ "${_ksi_prompt[title]}" == "y" ]]; then
         # see https://www.gnu.org/software/bash/manual/html_node/Controlling-the-Prompt.html#Controlling-the-Prompt
         # we use suffix here because some distros add title setting to their bashrc files by default
         _ksi_prompt[ps1_suffix]+="\[\e]2;\w\a\]"
@@ -142,13 +142,13 @@ _ksi_main() {
         _ksi_prompt[ps0_suffix]+='$(_ksi_get_current_command)'
     fi
 
-    if [[ "${_ksi_prompt[mark]}" == "y" ]]; then 
+    if [[ "${_ksi_prompt[mark]}" == "y" ]]; then
         _ksi_prompt[ps1]+="\[\e]133;A\a\]"
         _ksi_prompt[ps2]+="\[\e]133;A;k=s\a\]"
         _ksi_prompt[ps0]+="\[\e]133;C\a\]"
     fi
 
-    if [[ "${_ksi_prompt[complete]}" == "y" ]]; then 
+    if [[ "${_ksi_prompt[complete]}" == "y" ]]; then
         _ksi_completions() {
             builtin local src
             builtin local limit
@@ -164,19 +164,19 @@ _ksi_main() {
 
     # wrap our prompt additions in markers we can use to remove them using
     # bash's anemic pattern substitution
-    if [[ -n "${_ksi_prompt[ps0]}" ]]; then 
+    if [[ -n "${_ksi_prompt[ps0]}" ]]; then
         _ksi_prompt[ps0]="${_ksi_prompt[start_mark]}${_ksi_prompt[ps0]}${_ksi_prompt[end_mark]}"
     fi
-    if [[ -n "${_ksi_prompt[ps0_suffix]}" ]]; then 
+    if [[ -n "${_ksi_prompt[ps0_suffix]}" ]]; then
         _ksi_prompt[ps0_suffix]="${_ksi_prompt[start_suffix_mark]}${_ksi_prompt[ps0_suffix]}${_ksi_prompt[end_suffix_mark]}"
     fi
-    if [[ -n "${_ksi_prompt[ps1]}" ]]; then 
+    if [[ -n "${_ksi_prompt[ps1]}" ]]; then
         _ksi_prompt[ps1]="${_ksi_prompt[start_mark]}${_ksi_prompt[ps1]}${_ksi_prompt[end_mark]}"
     fi
-    if [[ -n "${_ksi_prompt[ps1_suffix]}" ]]; then 
+    if [[ -n "${_ksi_prompt[ps1_suffix]}" ]]; then
         _ksi_prompt[ps1_suffix]="${_ksi_prompt[start_suffix_mark]}${_ksi_prompt[ps1_suffix]}${_ksi_prompt[end_suffix_mark]}"
     fi
-    if [[ -n "${_ksi_prompt[ps2]}" ]]; then 
+    if [[ -n "${_ksi_prompt[ps2]}" ]]; then
         _ksi_prompt[ps2]="${_ksi_prompt[start_mark]}${_ksi_prompt[ps2]}${_ksi_prompt[end_mark]}"
     fi
     builtin unset _ksi_prompt[start_mark]


### PR DESCRIPTION
Explicitly use `builtin` to call the commands.
Use Bash's string manipulation facility to remove new lines.
Use the official project name of Bash.

GNU Bash
https://www.gnu.org/software/bash/

---

Also, the fish installed in CI is an outdated version. This version is broken and not worth supporting. I believe it will not work.

https://github.com/kovidgoyal/kitty/commit/081d6a3f166d013e49193838474415e0ded5ebd5

`sudo apt-get install -y ... fish`

```text
https://github.com/kovidgoyal/kitty/pull/4558#issuecomment-1020261408

faho commented on Jan 25

> ... Ubuntu's packages in 20.04 (the current LTS) are still at 3.1.0 (not even 3.1.2, the bugfix release) with some Debian patches.
> That's rather out of date (about 80% of commits in 3.3.1) and makes tests with it essentially meaningless.

https://github.com/kovidgoyal/kitty/issues/4619

>> If you would like to support old versions, please let me know and I will revert them.
>
> It's fine, if fish's maintainer feels that 3.1.2 is not supported, I am
> OK with not supporting it in kitty.
```