### PR TITLE
Refactor: Avoid shadow the global variable name

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,6 +27,7 @@ jobs:
       uses: github/codeql-action/init@v1
       with:
         languages: python, c
+        setup-python-dependencies: false
 
     - name: Build kitty
       run: python3 .github/workflows/ci.py build

--- a/kitty/fonts.c
+++ b/kitty/fonts.c
@@ -1338,13 +1338,13 @@ typedef struct {
 DescriptorIndices descriptor_indices = {0};
 
 static bool
-set_symbol_maps(SymbolMap **symbol_maps, size_t *num, const PyObject *sm) {
+set_symbol_maps(SymbolMap **maps, size_t *num, const PyObject *sm) {
     *num = PyTuple_GET_SIZE(sm);
-    *symbol_maps = calloc(*num, sizeof(SymbolMap));
-    if (*symbol_maps == NULL) { PyErr_NoMemory(); return false; }
+    *maps = calloc(*num, sizeof(SymbolMap));
+    if (*maps == NULL) { PyErr_NoMemory(); return false; }
     for (size_t s = 0; s < *num; s++) {
         unsigned int left, right, font_idx;
-        SymbolMap *x = *symbol_maps + s;
+        SymbolMap *x = *maps + s;
         if (!PyArg_ParseTuple(PyTuple_GET_ITEM(sm, s), "III", &left, &right, &font_idx)) return NULL;
         x->left = left; x->right = right; x->font_idx = font_idx;
     }

--- a/kitty/fonts.c
+++ b/kitty/fonts.c
@@ -1338,11 +1338,11 @@ typedef struct {
 DescriptorIndices descriptor_indices = {0};
 
 static bool
-set_symbol_maps(SymbolMap **symbol_maps, size_t *num_symbol_maps, const PyObject *sm) {
-    *num_symbol_maps = PyTuple_GET_SIZE(sm);
-    *symbol_maps = calloc(*num_symbol_maps, sizeof(SymbolMap));
+set_symbol_maps(SymbolMap **symbol_maps, size_t *num, const PyObject *sm) {
+    *num = PyTuple_GET_SIZE(sm);
+    *symbol_maps = calloc(*num, sizeof(SymbolMap));
     if (*symbol_maps == NULL) { PyErr_NoMemory(); return false; }
-    for (size_t s = 0; s < *num_symbol_maps; s++) {
+    for (size_t s = 0; s < *num; s++) {
         unsigned int left, right, font_idx;
         SymbolMap *x = *symbol_maps + s;
         if (!PyArg_ParseTuple(PyTuple_GET_ITEM(sm, s), "III", &left, &right, &font_idx)) return NULL;


### PR DESCRIPTION
Avoid shadow the global variable name.

Disable automatic installation of Python dependencies on CI.

```text
CodeQL-Build
An error occurred while trying to automatically install Python dependencies:
Error: The process '.../auto_install_packages.py' failed with exit code 1

Please make sure any necessary dependencies are installed before calling the codeql-action/analyze step,
and add a 'setup-python-dependencies: false' argument to this step
to disable our automatic dependency installation and avoid this warning.
```