### PR TITLE
Shell integration: Check fish version and exit on outdated versions

### DIFF
--- a/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
+++ b/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
@@ -19,6 +19,8 @@ end
 
 status is-interactive || exit 0
 not functions -q __ksi_schedule || exit 0
+# Check fish version 3.3.0+ efficiently and exit on outdated versions
+set -q fish_killring || exit 0
 
 function __ksi_schedule --on-event fish_prompt -d "Setup kitty integration after other scripts have run, we hope"
     functions --erase __ksi_schedule

--- a/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
+++ b/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
@@ -20,7 +20,9 @@ end
 status is-interactive || exit 0
 not functions -q __ksi_schedule || exit 0
 # Check fish version 3.3.0+ efficiently and exit on outdated versions
-set -q fish_killring || exit 0
+# "Warning: Update fish to version 3.3.0+ to enable kitty shell integration.\n"
+set -q fish_killring
+or echo -en "\eP@kitty-print|V2FybmluZzogVXBkYXRlIGZpc2ggdG8gdmVyc2lvbiAzLjMuMCsgdG8gZW5hYmxlIGtpdHR5IHNoZWxsIGludGVncmF0aW9uLgo=\e\\" && exit 0
 
 function __ksi_schedule --on-event fish_prompt -d "Setup kitty integration after other scripts have run, we hope"
     functions --erase __ksi_schedule


### PR DESCRIPTION
Efficiently check the version via the new variable added in fish 3.3.0 and exit when not satisfied to avoid breaking outdated fish.

```text
set --show fish_killring 
$fish_killring: set in global scope, unexported, with 0 elements
Variable is read-only
```

I have benchmarked that using glob or regex to check the version string will have performance loss. (The fish that comes with some Linux distributions is broken and has no version number.)

Consistent with the behavior when using lower version of the shell and not outputting warning text.
This is equivalent to not enabling integration.

I have not introduced `\eP@kitty-print|...` or `base64` to minimize the impact.

Please review, thank you.