### PR TITLE
show_error kitten: Exit at EOF

### DIFF
--- a/kittens/show_error/main.py
+++ b/kittens/show_error/main.py
@@ -32,7 +32,7 @@ def real_main(args: List[str]) -> None:
 
 def main(args: List[str]) -> None:
     try:
-        with suppress(KeyboardInterrupt):
+        with suppress(KeyboardInterrupt, EOFError):
             real_main(args)
     except Exception:
         import traceback


### PR DESCRIPTION
When an error message is displayed, pressing ctrl+d will exit.

I've been annoyed with this one for a while now.