### PR TITLE
Allow ctrl+d to exit kitty hold

### DIFF
--- a/kitty/utils.py
+++ b/kitty/utils.py
@@ -907,5 +907,5 @@ def hold_till_enter() -> None:
         if not rd:
             break
         q = os.read(fd, 1)
-        if q in b'\n\r\x1b\x03':
+        if q in b'\n\r\x1b\x03\x04':
             break


### PR DESCRIPTION
Some features in kitty use `--hold` to display error messages.
Add support for exiting with ctrl+d EOF.

I also found a problem with the traceback message appearing on exit. (milliseconds before the window closes)

`kitty --hold not-exists`

```text
kitty/__main__.py

UnboundLocalError: local variable 'ret' referenced before assignment
```

Do we need to assign a default value first?