### PR TITLE
Use show_error kitten to display launch URL error messages

### DIFF
--- a/kittens/show_error/main.py
+++ b/kittens/show_error/main.py
@@ -23,11 +23,12 @@ def real_main(args: List[str]) -> None:
     cli_opts, items = parse_args(args[1:], OPTIONS, '', msg, 'hints', result_class=ErrorCLIOptions)
     error_message = sys.stdin.buffer.read().decode('utf-8')
     sys.stdin = open(os.ctermid())
-    print(styled(cli_opts.title, fg_intense=True, fg='red', bold=True))
-    print()
+    if cli_opts.title:
+        print(styled(cli_opts.title, fg_intense=True, fg='red', bold=True))
+        print()
     print(error_message)
     print()
-    input('Press Enter to close.')
+    input('\x1b[1;32mPress Enter to close\x1b[m')
 
 
 def main(args: List[str]) -> None:

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -2278,10 +2278,14 @@ class Boss:
                 tab.remove_window(w)
 
         if failures:
-            with force_window_launch(needs_window_replaced):
-                from kittens.tui.operations import styled
-                spec = '\n  '.join(styled(u, fg='red') for u in failures)
-                self.launch('--hold', '--type=os-window', kitty_exe(), '+runpy', fr'print("Unknown URL type, cannot open:\n\n ", {spec!r});')
+            from kittens.tui.operations import styled
+            spec = '\n  '.join(styled(u, fg='red') for u in failures)
+            bdata = f"Unknown URL type, cannot open:\n\n  {spec}".encode('utf-8')
+            special_window = SpecialWindow([kitty_exe(), '+kitten', 'show_error', '--title', 'Open URL Error'], bdata, 'Open URL Error')
+            if needs_window_replaced and tab is not None:
+                tab.new_special_window(special_window)
+            else:
+                self._new_os_window(special_window)
             clear_initial_window()
             needs_window_replaced = False
         if actions:


### PR DESCRIPTION
Use the show_error kitten.
This will allow to close with ctrl+d.

Please review, thank you.