### PR TITLE
Also fall back to check the last known working version of fish

### DIFF
--- a/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
+++ b/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
@@ -19,10 +19,10 @@ end
 
 status is-interactive || exit 0
 not functions -q __ksi_schedule || exit 0
-# Check fish version 3.3.0+ efficiently and exit on outdated versions
+# Check fish version 3.3.0+ efficiently and fallback to check the last working version 3.2.0, exit on outdated versions.
 # "Warning: Update fish to version 3.3.0+ to enable kitty shell integration.\n"
-set -q fish_killring
-or echo -en "\eP@kitty-print|V2FybmluZzogVXBkYXRlIGZpc2ggdG8gdmVyc2lvbiAzLjMuMCsgdG8gZW5hYmxlIGtpdHR5IHNoZWxsIGludGVncmF0aW9uLgo=\e\\" && exit 0
+set -q fish_killring || set -q status_generation || string match -qnv "3.1.*" "$version"
+or echo -en "\eP@kitty-print|V2FybmluZzogVXBkYXRlIGZpc2ggdG8gdmVyc2lvbiAzLjMuMCsgdG8gZW5hYmxlIGtpdHR5IHNoZWxsIGludGVncmF0aW9uLgo=\e\\" && exit 0 || exit 0
 
 function __ksi_schedule --on-event fish_prompt -d "Setup kitty integration after other scripts have run, we hope"
     functions --erase __ksi_schedule


### PR DESCRIPTION
The read-only variable fish_killring, added in fish 3.3.0, may become modifiable in the future.
So also fall back to check the last known working version: fish 3.2.0.

```text
https://fishshell.com/docs/3.2/relnotes.html#interactive-improvements

$status_generation: set in global scope, unexported, with 1 elements
Variable is read-only
$status_generation[1]: |0|
```

Finally check that the `$version` string does not match `3.1.*`.
All versions prior to 3.1.0 will not automatically load the integration script,
and if the user loads the script manually, errors will occur before reaching this check.

It will never reach `string match` unless fish breaks backward compatibility by removing the first two variables.
This is the last check to make sure the script will work properly.

Please review, thank you.