### PR TITLE
wayland: always commit surface on configure

### DIFF
--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -519,10 +519,11 @@ static void xdgSurfaceHandleConfigure(void* data,
         debug("final window content size: %dx%d\n", window->wl.current.width, window->wl.current.height);
         _glfwInputWindowFocus(window, window->wl.current.toplevel_states & TOPLEVEL_STATE_ACTIVATED);
         ensure_csd_resources(window);
-        wl_surface_commit(window->wl.surface);
         inform_compositor_of_window_geometry(window, "configure");
         if (live_resize_done) _glfwInputLiveResize(window, false);
     }
+
+    wl_surface_commit(window->wl.surface);
 }
 
 static const struct xdg_surface_listener xdgSurfaceListener = {


### PR DESCRIPTION
A surface commit must happen after the acknowledgement of a configure, even if it is a same size configure.
Just move the surface commit outside of the if statement to make it always run on a xdg configure.