### PR TITLE
Fix not scrolling to the bottom when an interrupt is sent

### DIFF
--- a/kitty/window.py
+++ b/kitty/window.py
@@ -1217,6 +1217,7 @@ class Window:
         if text:
             set_clipboard_string(text)
         else:
+            self.scroll_end()
             self.write_to_child(self.encoded_key(KeyEvent(key=ord('c'), mods=GLFW_MOD_CONTROL)))
 
     @ac('cp', 'Copy the selected text from the active window to the clipboard and clear selection, if no selection, send SIGINT (aka :kbd:`ctrl+c`)')


### PR DESCRIPTION
Fix not scrolling to the bottom when an interrupt is sent.
Replicates the same side effects of keyboard key event.

```c
if (screen->scrolled_by && action == GLFW_PRESS && !is_modifier_key(key)) {
    screen_history_scroll(screen, SCROLL_FULL, false);  // scroll back to bottom
}
//...
schedule_write_to_child(w->id, 1, encoded_key, size);
```

https://github.com/kovidgoyal/kitty/discussions/4787