### PR TITLE
ssh kitten minor tweaks and docs

### DIFF
--- a/docs/kittens/ssh.rst
+++ b/docs/kittens/ssh.rst
@@ -50,6 +50,10 @@ quick example:
    copy --dest=foo/bar some-file
    copy --glob some/files.*
 
+   # Include secondary config files
+   include other-hosts.conf
+   globinclude ssh/**/*.conf
+
 
 See below for full details on the syntax and options of :file:`ssh.conf`.
 

--- a/kittens/ssh/main.py
+++ b/kittens/ssh/main.py
@@ -104,8 +104,14 @@ def make_tarfile(ssh_opts: SSHOptions, base_env: Dict[str, str]) -> bytes:
             tf.add(ci.local_path, arcname=ci.arcname, filter=filter_from_globs(*ci.exclude_patterns))
         add_data_as_file(tf, 'data.sh', env_script)
         if ksi:
-            arcname = 'home/' + rd + '/shell-integration'
-            tf.add(shell_integration_dir, arcname=arcname, filter=filter_from_globs(f'{arcname}/ssh/bootstrap.*'))
+            arcname = f'home/{rd}/shell-integration'
+            exclude_patterns = (
+                '*/.DS_Store',
+                f'{arcname}/ssh/bootstrap.*',
+                # zsh integration script for backward compatibility
+                f'{arcname}/zsh/kitty.zsh',
+            )
+            tf.add(shell_integration_dir, arcname=arcname, filter=filter_from_globs(*exclude_patterns))
         tf.add(terminfo_dir, arcname='home/.terminfo', filter=normalize_tarinfo)
     return buf.getvalue()
 

--- a/kittens/ssh/options/definition.py
+++ b/kittens/ssh/options/definition.py
@@ -86,7 +86,7 @@ that resolve to a location outside the HOME are not allowed.
 ''')
 
 opt('shell_integration', 'inherit', long_text='''
-Control the shell integration on the remote host. See ref:`shell_integration`
+Control the shell integration on the remote host. See :ref:`shell_integration`
 for details on how this setting works. The special value :code:`inherit` means
 use the setting from kitty.conf. This setting is useful for overriding
 integration on a per-host basis.''')

--- a/shell-integration/ssh/bootstrap.sh
+++ b/shell-integration/ssh/bootstrap.sh
@@ -71,9 +71,9 @@ fi
 data_started="n"
 data_complete="n"
 if [ -z "$HOSTNAME" ]; then
-    hostname=$(hostname 2> /dev/null)
+    hostname=$(command hostname 2> /dev/null)
     if [ -z "$hostname" ]; then 
-        hostname=$(hostnamectl hostname 2> /dev/null)
+        hostname=$(command hostnamectl hostname 2> /dev/null)
         if [ -z "$hostname" ]; then
             hostname="_"; 
         fi
@@ -84,7 +84,7 @@ fi
 # ensure $HOME is set
 if [ -z "$HOME" ]; then HOME=~; fi
 # ensure $USER is set
-if [ -z "$USER" ]; then USER=$(whoami 2> /dev/null); fi
+if [ -z "$USER" ]; then USER=$(command whoami 2> /dev/null); fi
 
 # ask for the SSH data
 data_password="DATA_PASSWORD"
@@ -108,7 +108,7 @@ untar_and_read_env() {
     # extract the tar file atomically, in the sense that any file from the 
     # tarfile is only put into place after it has been fully written to disk
 
-    tdir=$(mktemp -d "$HOME/.kitty-ssh-kitten-untar-XXXXXXXXXXXX");
+    tdir=$(command mktemp -d "$HOME/.kitty-ssh-kitten-untar-XXXXXXXXXXXX");
     [ $? = 0 ] || die "Creating temp directory failed";
     read_n_bytes_from_tty "$1" | command base64 -d | command tar xjf - --no-same-owner -C "$tdir";
     data_file="$tdir/data.sh";
@@ -189,7 +189,7 @@ detect_python() {
 }
 
 parse_passwd_record() {
-    printf "%s" "$(grep -o '[^:]*$')"
+    printf "%s" "$(command grep -o '[^:]*$')"
 }
 
 using_getent() {
@@ -218,7 +218,7 @@ using_id() {
 
 using_passwd() {
     if [ -f "/etc/passwd" -a -r "/etc/passwd" ]; then 
-        output=$(grep "^$USER:" /etc/passwd 2>/dev/null)
+        output=$(command grep "^$USER:" /etc/passwd 2>/dev/null)
         if [ $? = 0 ]; then 
             login_shell=$(echo $output | parse_passwd_record);
             if login_shell_is_ok; then return 0; fi
@@ -321,8 +321,8 @@ case "$KITTY_SHELL_INTEGRATION" in
         ;;
     (*) 
         # not blank
-        q=$(printf "%s" "$KITTY_SHELL_INTEGRATION" | grep '\bno-rc\b')
-        if [ -z "$q"  ]; then
+        q=$(printf "%s" "$KITTY_SHELL_INTEGRATION" | command grep '\bno-rc\b')
+        if [ -z "$q" ]; then
             exec_with_shell_integration
             # exec failed, unset 
             unset KITTY_SHELL_INTEGRATION


### PR DESCRIPTION
- Explicitly use command
- Remove trailing spaces and semicolons
- Exclude shell integration files: .DS_Store and kitty.zsh (from kitty.zsh: `... users are discouraged from sourcing kitty.zsh ...`)
- Add include and globinclude config examples and fix rst `ref shell_integration`

I tested busybox + zsh and it works fine. It seems to be compatible with the commands in coreutils.

---

Is it possible to name certain ssh.conf configuration blocks and then use them when connecting?
For example for ephemeral containers, the hostname is a random string.
These environments are not `pets` and do not have names, but would like other tools to be able to specify named configuration when calling `kitty +kitten ssh`.
E.g. `kitty +kitten ssh --kitty-ssh-config=named_config,maybe-with-glob-*`

How do I enable integration for `ssh -t host fish`?
Because fish is not POSIX compatible, there are times when it is not appropriate to set it to `SHELL` (login shell).
Is it possible to set in the config file and automatically enabled when the command name matches?