### PR TITLE
Fix shell integration being disabled with one invalid option

### DIFF
--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -804,7 +804,7 @@ def shell_integration(x: str) -> FrozenSet[str]:
     q = frozenset(x.lower().split())
     if not q.issubset(s):
         log_error(f'Invalid shell integration options: {q - s}, ignoring')
-        return q & s
+        return q & s or frozenset({'invalid'})
     return q
 
 

--- a/kitty/shell_integration.py
+++ b/kitty/shell_integration.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 from typing import Dict, List, Optional
 
 from .constants import shell_integration_dir
-from .options.types import Options
+from .options.types import Options, defaults
 from .utils import log_error, which
 from .fast_data_types import get_options
 
@@ -170,6 +170,9 @@ def get_effective_ksi_env_var(opts: Optional[Options] = None) -> str:
     opts = opts or get_options()
     if 'disabled' in opts.shell_integration:
         return ''
+    # Use the default when shell_integration is empty due to misconfiguration
+    if 'invalid' in opts.shell_integration:
+        return ' '.join(defaults.shell_integration)
     return ' '.join(opts.shell_integration)
 
 


### PR DESCRIPTION
In the following case, the invalid option should be ignored and the default shell integration configuration should be used.
(Note that the default option value can be changed with setup.py)

```shell
kitty --config=NONE -o shell_integration=notitle -o shell=zsh
```