### PR TITLE
ssh kitten: Add support for FreeBSD tcsh sh default shells

### DIFF
--- a/docs/kittens/ssh.rst
+++ b/docs/kittens/ssh.rst
@@ -114,9 +114,9 @@ the TTY, any other requests are responded to by errors.
 .. note::
 
    When connecting to BSD servers, it is possible the bootstrap script will
-   fail or run slowly, because they are crippled in various ways. Your best bet
-   is to install python on the server, make sure the login shell is something
-   POSIX sh compliant, not csh, and use :code:`python` as the :opt:`interpreter
+   fail or run slowly, because the default shells are crippled in various ways.
+   Your best bet is to install python on the server, make sure the login shell
+   is something POSIX sh compliant, and use :code:`python` as the :opt:`interpreter
    <kitten-ssh.interpreter>` in :file:`ssh.conf`.
 
 .. include:: /generated/conf-kitten-ssh.rst

--- a/kittens/ssh/main.py
+++ b/kittens/ssh/main.py
@@ -407,10 +407,11 @@ def wrap_bootstrap_script(sh_script: str, interpreter: str) -> List[str]:
         unwrap_script = '''"import base64, sys; eval(compile(base64.standard_b64decode(sys.argv[-1]), 'bootstrap.py', 'exec'))"'''
     else:
         # We cant rely on base64 being available on the remote system, so instead
-        # we quote the bootstrap script by replacing ' and \ with \v and \f and
-        # surrounding with '
-        es = "'" + sh_script.replace("'", '\v').replace('\\', '\f') + "'"
-        unwrap_script = r"""'eval "$(echo "$0" | tr \\\v\\\f \\\047\\\134)"' """
+        # we quote the bootstrap script by replacing ' and \ with \v and \f
+        # also replacing \n and ! with \r and \b for tcsh
+        # finally surrounding with '
+        es = "'" + sh_script.replace("'", '\v').replace('\\', '\f').replace('\n', '\r').replace('!', '\b') + "'"
+        unwrap_script = r"""'eval "$(echo "$0" | tr \\\v\\\f\\\r\\\b \\\047\\\134\\\n\\\041)"' """
     return [interpreter, '-c', unwrap_script, es]
 
 


### PR DESCRIPTION
- Replacing `\n` and `!` with `\r` and `\241` (Inverted exclamation mark) for tcsh.
- Reimplement the login shell startup loading with POSIX ENV to support sh without the -l option.

FreeBSD 13.0 sh:
https://github.com/freebsd/freebsd-src/blob/release/13.0.0/bin/sh/main.c#L142-L151

Dash 0.5.11:
https://git.kernel.org/pub/scm/utils/dash/dash.git/tree/src/main.c?h=0.5.11#n149

All the default shells are now working fine under FreeBSD.

Please review, thank you.

---

> ... running FreeBSD, ... relies on termcap rather than terminfo ...
> ... convert the terminfo file ...  on local machine with kitty
>     infocmp -C xterm-kitty
> The output ... which should be appended to `/usr/share/misc/termcap` on the remote server ...

Does this need to be added to bootstrap script (sh and python)?

I see that if it fails in `untar_and_read_env` and exits, the temp folder is not cleared.
Is it possible to use trap and clear the temp folder?
