### PR TITLE
`dd ibs` and `ghead`

### DIFF
--- a/shell-integration/ssh/bootstrap.sh
+++ b/shell-integration/ssh/bootstrap.sh
@@ -119,6 +119,10 @@ else
         read_n_bytes_from_tty() {
             command head -c "$1" < /dev/tty
         }
+    elif [ "$(printf "%s" "test" | command ghead -c 3 2> /dev/null)" = "tes" ]; then
+        read_n_bytes_from_tty() {
+            command ghead -c "$1" < /dev/tty
+        }
     elif detect_python; then
         read_n_bytes_from_tty() {
             command "$python" "-c" "

--- a/shell-integration/ssh/bootstrap.sh
+++ b/shell-integration/ssh/bootstrap.sh
@@ -113,7 +113,7 @@ else
     }
 
     if [ "$(printf "%s" "test" | command head -c 3 2> /dev/null)" = "tes" ]; then
-        # using dd with bs=1 is very slow, so use head. On non GNU coreutils head
+        # Using dd with ibs=1 is very slow, so use head. On non GNU coreutils head
         # does not limit itself to reading -c bytes only from the pipe so we can potentially lose
         # some trailing data, for instance if the user starts typing. Cant be helped.
         read_n_bytes_from_tty() {
@@ -149,7 +149,7 @@ while n > 0:
         }
     else
         read_n_bytes_from_tty() {
-            command dd bs=1 count="$1" < /dev/tty 2> /dev/null
+            command dd ibs=1 count="$1" < /dev/tty 2> /dev/null
         }
     fi
 fi


### PR DESCRIPTION
`ibs` is ~48.41% faster (on my system) than `bs` for reading first _n_ bytes.  Also see [this](https://unix.stackexchange.com/a/278465).

As hack we could use `dd bs="$n" count=1` instead of `dd ibs=1 count="$n"` if file is small (because `dd bs="$n" count=1` uses more RAM, _~n_ bytes more).

On some OS (like OpenBSD) GNU head is `ghead`, not `head`.