### PR TITLE
Add terminfo src file when packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1259,6 +1259,7 @@ def package(args: Options, bundle_type: str) -> None:
         odir = os.path.join(x, 'terminfo')
         safe_makedirs(odir)
         build_terminfo['compile_terminfo'](odir)
+    shutil.copy2('terminfo/kitty.terminfo', os.path.join(libdir, 'terminfo'))
     shutil.copy2('__main__.py', libdir)
     shutil.copy2('logo/kitty-128.png', os.path.join(libdir, 'logo'))
     shutil.copy2('logo/kitty.png', os.path.join(libdir, 'logo'))


### PR DESCRIPTION
ssh kitten needs to send `terminfo/kitty.terminfo`.