### PR TITLE
ssh kitten: Improve login shell exec and add uid suffix to macOS tmp rdir symlink

### DIFF
--- a/kittens/ssh/main.py
+++ b/kittens/ssh/main.py
@@ -25,7 +25,7 @@ from typing import (
 )
 
 from kitty.constants import (
-    cache_dir, runtime_dir, shell_integration_dir, ssh_control_master_template,
+    runtime_dir, shell_integration_dir, ssh_control_master_template,
     terminfo_dir
 )
 from kitty.fast_data_types import get_options

--- a/kittens/ssh/main.py
+++ b/kittens/ssh/main.py
@@ -451,7 +451,7 @@ def connection_sharing_args(opts: SSHOptions, kitty_pid: int) -> List[str]:
     # ~104 chars. macOS has no system runtime dir so we use a cache dir in
     # /Users/WHY_DOES_ANYONE_USE_MACOS/Library/Caches/APPLE_ARE_IDIOTIC
     if len(rd) > 35 and os.path.isdir('/tmp'):
-        idiotic_design = '/tmp/kssh-rdir'
+        idiotic_design = f'/tmp/kssh-rdir-{os.getuid()}'
         try:
             os.symlink(rd, idiotic_design)
         except FileExistsError:

--- a/kittens/ssh/main.py
+++ b/kittens/ssh/main.py
@@ -227,8 +227,6 @@ def bootstrap_script(
     with open(os.path.join(shell_integration_dir, 'ssh', f'bootstrap.{script_type}')) as f:
         ans = f.read()
     pw = secrets.token_hex()
-    ddir = os.path.join(cache_dir(), 'ssh')
-    os.makedirs(ddir, exist_ok=True)
     data = {'pw': pw, 'env': dict(os.environ), 'opts': ssh_opts_dict, 'cli_hostname': cli_hostname, 'cli_uname': cli_uname}
     db = json.dumps(data)
     with SharedMemory(size=len(db) + SharedMemory.num_bytes_for_size, mode=stat.S_IREAD, prefix=f'kssh-{os.getpid()}-') as shm:

--- a/shell-integration/ssh/bootstrap.py
+++ b/shell-integration/ssh/bootstrap.py
@@ -124,7 +124,7 @@ def compile_terminfo(base):
     q = os.path.join(base, tname, '78', 'xterm-kitty')
     if not os.path.exists(q):
         os.makedirs(os.path.dirname(q), exist_ok=True)
-        os.symlink("../x/xterm-kitty", q)
+        os.symlink('../x/xterm-kitty', q)
 
 
 def get_data():

--- a/shell-integration/ssh/bootstrap.sh
+++ b/shell-integration/ssh/bootstrap.sh
@@ -275,10 +275,7 @@ if [ "$tty_ok" = "y" ]; then
 fi
 
 login_shell_is_ok() {
-    if [ -z "$login_shell" -o ! -x "$login_shell" ]; then return 1; fi
-    case "$login_shell" in
-        *sh) return 0;
-    esac
+    if [ -n "$login_shell" -a -x "$login_shell" ]; then return 0; fi
     return 1
 }
 

--- a/shell-integration/ssh/bootstrap.sh
+++ b/shell-integration/ssh/bootstrap.sh
@@ -149,9 +149,9 @@ while n > 0:
         }
     elif detect_perl; then
         read_n_bytes_from_tty() {
-            command "$perl" -MList::Util=min -e \
-'open(my $fh,"</dev/tty"); binmode($fh); my ($n,$buf)=(@ARGV[0],"");'\
-'while($n){my $rv=sysread($fh,$buf,min(65536,$n)); die($!) if !defined($rv); die() if !$rv; $n-=$rv; print $buf;}' "$1" 2> /dev/null
+            command "$perl" -MList::Util=min -e '
+open(my $fh,"<","/dev/tty");binmode($fh);binmode(STDOUT);my ($n,$buf)=(@ARGV[0],"");
+while($n>0){my $rv=sysread($fh,$buf,min(65536,$n));unless($rv){exit(1);};$n-=$rv;print STDOUT $buf;}' "$1" 2> /dev/null
         }
     else
         read_n_bytes_from_tty() {

--- a/shell-integration/ssh/bootstrap.sh
+++ b/shell-integration/ssh/bootstrap.sh
@@ -475,3 +475,6 @@ execute_with_python
 execute_with_perl
 execute_sh_with_posix_env
 exec "$login_shell" "-l"
+
+printf "%s\n" "Could not execute the shell as a login shell" > /dev/stderr
+exec "$login_shell"

--- a/shell-integration/ssh/bootstrap.sh
+++ b/shell-integration/ssh/bootstrap.sh
@@ -171,6 +171,7 @@ hostname="$HOSTNAME"
 # ensure $HOME is set
 [ -z "$HOME" ] && HOME=~
 # ensure $USER is set
+[ -z "$USER" ] && USER="$LOGNAME"
 [ -z "$USER" ] && USER="$(command whoami 2> /dev/null)"
 
 leading_data=""

--- a/shell-integration/ssh/bootstrap.sh
+++ b/shell-integration/ssh/bootstrap.sh
@@ -17,8 +17,8 @@ die() { printf "\033[31m%s\033[m\n\r" "$*" > /dev/stderr; cleanup_on_bootstrap_e
 python_detected="0"
 detect_python() {
     if [ python_detected = "1" ]; then
-        [ -n "$python" ] && return 0;
-        return 1;
+        [ -n "$python" ] && return 0
+        return 1
     fi
     python_detected="1"
     python=$(command -v python3)
@@ -31,8 +31,8 @@ detect_python() {
 perl_detected="0"
 detect_perl() {
     if [ perl_detected = "1" ]; then
-        [ -n "$perl" ] && return 0;
-        return 1;
+        [ -n "$perl" ] && return 0
+        return 1
     fi
     perl_detected="1"
     perl=$(command -v perl)
@@ -155,7 +155,7 @@ while n > 0:
         }
     else
         read_n_bytes_from_tty() {
-            command dd bs=1 count="$1" < /dev/tty 2> /dev/null
+            command dd bs=1 count="$1" 2> /dev/null < /dev/tty
         }
     fi
 fi
@@ -205,7 +205,7 @@ compile_terminfo() {
     # compile terminfo for this system
     if [ -x "$(command -v tic)" ]; then
         tic_out=$(command tic -x -o "$1/$tname" "$1/.terminfo/kitty.terminfo" 2>&1)
-        [ $? = 0 ] || die "Failed to compile terminfo with err: $tic_out";
+        [ $? = 0 ] || die "Failed to compile terminfo with err: $tic_out"
     fi
 
     # Ensure the 78 dir is present
@@ -288,7 +288,7 @@ parse_passwd_record() {
 using_getent() {
     cmd=$(command -v getent)
     if [ -n "$cmd" ]; then
-        output=$(command $cmd passwd $USER 2>/dev/null)
+        output=$(command "$cmd" passwd "$USER" 2>/dev/null)
         if [ $? = 0 ]; then
             login_shell=$(echo $output | parse_passwd_record)
             if login_shell_is_ok; then return 0; fi
@@ -300,7 +300,7 @@ using_getent() {
 using_id() {
     cmd=$(command -v id)
     if [ -n "$cmd" ]; then
-        output=$(command $cmd -P $USER 2>/dev/null)
+        output=$(command "$cmd" -P "$USER" 2>/dev/null)
         if [ $? = 0 ]; then
             login_shell=$(echo $output | parse_passwd_record)
             if login_shell_is_ok; then return 0; fi
@@ -313,7 +313,7 @@ using_python() {
     if detect_python; then
         output=$(command "$python" -c "import pwd, os; print(pwd.getpwuid(os.geteuid()).pw_shell)")
         if [ $? = 0 ]; then
-            login_shell=$output
+            login_shell="$output"
             if login_shell_is_ok; then return 0; fi
         fi
     fi
@@ -324,7 +324,7 @@ using_perl() {
     if detect_perl; then
         output=$(command "$perl" -e 'my $shell = (getpwuid($<))[8]; print $shell')
         if [ $? = 0 ]; then
-            login_shell=$output
+            login_shell="$output"
             if login_shell_is_ok; then return 0; fi
         fi
     fi
@@ -431,19 +431,20 @@ execute_sh_with_posix_env() {
     command "$login_shell" -l -c ":" > /dev/null 2> /dev/null && return  # sh supports -l so use that
     [ -z "$shell_integration_dir" ] && die "Could not read data over tty ssh kitten cannot function"
     sh_dir="$shell_integration_dir/sh"
-    command mkdir -p "$sh_dir" || die "Creating $sh_dir failed";
+    command mkdir -p "$sh_dir" || die "Creating $sh_dir failed"
     sh_script="$sh_dir/login_shell_env.sh"
     # Source /etc/profile, ~/.profile, and then check and source ENV
     printf "%s" '
 if [ -n "$KITTY_SH_INJECT" ]; then
     unset ENV; unset KITTY_SH_INJECT
-    _ksi_safe_source() { if [ -f "$1" -a -r "$1" ]; then . "$1"; return 0; fi; return 1; }
-    if [ -n "$KITTY_SH_POSIX_ENV" ]; then export ENV="$KITTY_SH_POSIX_ENV"; fi
+    _ksi_safe_source() { [ -f "$1" -a -r "$1" ] || return 1; . "$1"; return 0; }
+    [ -n "$KITTY_SH_POSIX_ENV" ] && export ENV="$KITTY_SH_POSIX_ENV"
     unset KITTY_SH_POSIX_ENV
     _ksi_safe_source "/etc/profile"; _ksi_safe_source "${HOME-}/.profile"
-    if [ -n "$ENV" ]; then _ksi_safe_source "$ENV"; fi
+    [ -n "$ENV" ] && _ksi_safe_source "$ENV"
+    unset -f _ksi_safe_source
 fi' > "$sh_script"
-    export KITTY_SH_INJECT=1
+    export KITTY_SH_INJECT="1"
     [ -n "$ENV" ] && export KITTY_SH_POSIX_ENV="$ENV"
     export ENV="$sh_script"
     exec "$login_shell"
@@ -468,8 +469,8 @@ esac
 # We need to pass the first argument to the executed program with a leading -
 # to make sure the shell executes as a login shell. Note that not all shells
 # support exec -a so we use the below to try to detect such shells
-[ "$(exec -a echo echo OK 2> /dev/null)" = "OK" ] && exec -a "-$shell_name" $login_shell
+[ "$(exec -a echo echo OK 2> /dev/null)" = "OK" ] && exec -a "-$shell_name" "$login_shell"
 execute_with_python
 execute_with_perl
 execute_sh_with_posix_env
-exec $login_shell "-l"
+exec "$login_shell" "-l"


### PR DESCRIPTION
- Remove the left out _ksi_safe_source in the sh startup script.
- Use POSIX LOGNAME when USER is empty.
- Allow shells that do not support `-l` option and shells whose names do not end with `sh` to run.
- Add uid suffix to macOS tmp rdir symlink.
- Other minor tweaks.

I tested dropbear SSH server, which is commonly used for embedded devices as well as network devices.
However, the parameter exceeds the upper limit (9000 bytes).
I tried trimming the bootstrap script and it works fine.
Maybe the comments and indents need to be removed in `prepare_script()`, or just send it via STDIN (--kitten or ssh.conf configuration).

Due to the recent changes, symlink loop error occurs. I solved it by removing the .terminfo folder.
```text
mv: can't stat '/root/./.terminfo/x/xterm-kitty': Symbolic link loop
```