### PR TITLE
diff kitten: Fix wrong number of scrolling lines after context switch

### DIFF
--- a/kittens/diff/main.py
+++ b/kittens/diff/main.py
@@ -293,10 +293,11 @@ class DiffHandler(Handler):
 
     def scroll_lines(self, amt: int = 1) -> None:
         new_pos = max(0, min(self.scroll_pos + amt, self.max_scroll_pos))
+        amt = new_pos - self.scroll_pos
         if new_pos == self.scroll_pos:
             self.cmd.bell()
             return
-        if abs(new_pos - self.scroll_pos) >= self.num_lines - 1:
+        if abs(amt) >= self.num_lines - 1:
             self.scroll_pos = new_pos
             self.draw_screen()
             return


### PR DESCRIPTION
After switching contexts in diff kitten, scrolling may result in a miscalculation of the number of lines, resulting in a blank drawing.

```text
# scroll_pos: 95, amt: 147, num_lines: 31, max_scroll_pos: 116, new_pos: 116
screen_scroll 147
CSI code H is not allowed to have negative parameter (-115)
```

https://github.com/kovidgoyal/kitty/issues/4831