### PR TITLE
ssh kitten: Reduce bootstrap args to support dropbear, fix NetBSD terminfo, and more

### DIFF
--- a/kittens/ssh/main.py
+++ b/kittens/ssh/main.py
@@ -233,7 +233,7 @@ def prepare_script(ans: str, replacements: Dict[str, str], script_type: str) -> 
     if script_type == 'sh':
         # Remove comments and indents. The dropbear SSH server has 9000 bytes limit on ssh arguments length.
         # Needs to be trimmed before replacing EXEC_CMD to avoid affecting the indentation of user commands.
-        ans = re.sub(r'^\s*#.*\n|^\s*', '', ans, flags=re.MULTILINE)
+        ans = re.sub(r'^[ \t]*#.*$|^[ \t]*', '', ans, flags=re.MULTILINE)
     return re.sub('|'.join(fr'\b{k}\b' for k in replacements), sub, ans)
 
 

--- a/kittens/ssh/main.py
+++ b/kittens/ssh/main.py
@@ -223,13 +223,17 @@ def safe_remove(x: str) -> None:
         os.remove(x)
 
 
-def prepare_script(ans: str, replacements: Dict[str, str]) -> str:
+def prepare_script(ans: str, replacements: Dict[str, str], script_type: str) -> str:
     for k in ('EXEC_CMD',):
         replacements[k] = replacements.get(k, '')
 
     def sub(m: 're.Match[str]') -> str:
         return replacements[m.group()]
 
+    if script_type == 'sh':
+        # Remove comments and indents. The dropbear SSH server has 9000 bytes limit on ssh arguments length.
+        # Needs to be trimmed before replacing EXEC_CMD to avoid affecting the indentation of user commands.
+        ans = re.sub(r'^\s*#.*\n|^\s*', '', ans, flags=re.MULTILINE)
     return re.sub('|'.join(fr'\b{k}\b' for k in replacements), sub, ans)
 
 
@@ -269,7 +273,7 @@ def bootstrap_script(
     if request_data:
         sd.update(sensitive_data)
     replacements.update(sensitive_data)
-    return prepare_script(ans, sd), replacements, shm
+    return prepare_script(ans, sd, script_type), replacements, shm
 
 
 def get_ssh_cli() -> Tuple[Set[str], Set[str]]:

--- a/kitty_tests/shell_integration.py
+++ b/kitty_tests/shell_integration.py
@@ -171,6 +171,8 @@ function _set_status_prompt; function fish_prompt; echo -n "$pipestatus $status 
             pty.send_cmd_to_child('set -q XDG_DATA_DIRS; or echo ok')
             pty.wait_till(lambda: pty.screen_contents().count(right_prompt) == 2)
             self.ae(str(pty.screen.line(1)), 'ok')
+
+            # CWD reporting
             self.assertTrue(pty.screen.last_reported_cwd.endswith(self.home_dir))
             q = os.path.join(self.home_dir, 'testing-cwd-notification-🐱')
             os.mkdir(q)

--- a/kitty_tests/ssh.py
+++ b/kitty_tests/ssh.py
@@ -10,7 +10,8 @@ from functools import lru_cache
 
 from kittens.ssh.config import load_config
 from kittens.ssh.main import (
-    bootstrap_script, get_connection_data, wrap_bootstrap_script
+    bootstrap_script, get_connection_data, get_remote_command,
+    wrap_bootstrap_script
 )
 from kittens.ssh.options.types import Options as SSHOptions
 from kittens.ssh.options.utils import DELETE_ENV_VAR
@@ -77,6 +78,11 @@ print(' '.join(map(str, buf)))'''), lines=13, cols=77)
         self.ae(parse(conf).env, {'a': 'b'})
         self.ae(parse(conf, '1').env, {'a': 'c', 'b': 'b'})
         self.ae(parse(conf, '2').env, {'a': 'c', 'b': 'b'})
+
+    def test_ssh_bootstrap_sh_cmd_limit(self):
+        rcmd, _, _ = get_remote_command([], SSHOptions({'interpreter': 'sh'}))
+        # dropbear has a 9000 bytes maximum command length limit
+        self.assertLessEqual(sum(len(x) for x in rcmd), 9000)
 
     @property
     @lru_cache()

--- a/kitty_tests/ssh.py
+++ b/kitty_tests/ssh.py
@@ -10,8 +10,7 @@ from functools import lru_cache
 
 from kittens.ssh.config import load_config
 from kittens.ssh.main import (
-    bootstrap_script, get_connection_data, get_remote_command,
-    wrap_bootstrap_script
+    bootstrap_script, get_connection_data, wrap_bootstrap_script
 )
 from kittens.ssh.options.types import Options as SSHOptions
 from kittens.ssh.options.utils import DELETE_ENV_VAR
@@ -80,7 +79,8 @@ print(' '.join(map(str, buf)))'''), lines=13, cols=77)
         self.ae(parse(conf, '2').env, {'a': 'c', 'b': 'b'})
 
     def test_ssh_bootstrap_sh_cmd_limit(self):
-        rcmd, _, _ = get_remote_command([], SSHOptions({'interpreter': 'sh'}))
+        sh_script, _, _ = bootstrap_script(SSHOptions({'interpreter': 'sh'}), script_type='sh', remote_args=[], request_id='123-123')
+        rcmd = wrap_bootstrap_script(sh_script, 'sh')
         # dropbear has a 9000 bytes maximum command length limit
         self.assertLessEqual(sum(len(x) for x in rcmd), 9000)
 

--- a/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
+++ b/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
@@ -73,7 +73,7 @@ function __ksi_schedule --on-event fish_prompt -d "Setup kitty integration after
     if not contains "no-prompt-mark" $_ksi
         and not set -q __ksi_prompt_state
         function __ksi_mark_prompt_start --on-event fish_prompt
-            contains "$__ksi_prompt_state" post-exec pre-exec ""
+            test "$__ksi_prompt_state" != prompt-start
             and echo -en "\e]133;D\a"
             set --global __ksi_prompt_state prompt-start
             echo -en "\e]133;A\a"

--- a/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
+++ b/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
@@ -97,12 +97,13 @@ function __ksi_schedule --on-event fish_prompt -d "Setup kitty integration after
 
     # Enable CWD reporting
     if not contains "no-cwd" $_ksi
-        # This is actually builtin to fish but stupidly gated on TERM
-        # https://github.com/fish-shell/fish-shell/blob/master/share/functions/__fish_config_interactive.fish#L257
-        function __ksi_report_cwd --on-variable PWD --description "Report PWD changes to the terminal"
-            status --is-command-substitution; and return
-            echo -en "\e]7;kitty-shell-cwd://$hostname$PWD\a"
+        # This function name is from fish and will override the builtin one if fish enabled this feature by default.
+        # We provide this to ensure that fish 3.2.0 and above will work.
+        # https://github.com/fish-shell/fish-shell/blob/3.2.0/share/functions/__fish_config_interactive.fish#L275
+        function __update_cwd_osc --on-variable PWD -d "Report PWD changes to kitty"
+            status is-command-substitution
+            or echo -en "\e]7;kitty-shell-cwd://$hostname$PWD\a"
         end
-        __ksi_report_cwd
+        __update_cwd_osc
     end
 end

--- a/shell-integration/ssh/bootstrap.py
+++ b/shell-integration/ssh/bootstrap.py
@@ -21,7 +21,7 @@ data_dir = shell_integration_dir = ''
 request_data = int('REQUEST_DATA')
 leading_data = b''
 HOME = os.path.expanduser('~')
-login_shell = pwd.getpwuid(os.geteuid()).pw_shell or 'sh'
+login_shell = pwd.getpwuid(os.geteuid()).pw_shell or os.environ.get('SHELL') or 'sh'
 
 
 def set_echo(fd, on=False):

--- a/shell-integration/ssh/bootstrap.py
+++ b/shell-integration/ssh/bootstrap.py
@@ -137,7 +137,13 @@ def compile_terminfo(base):
     if not tic:
         return
     tname = '.terminfo'
+    q = os.path.join(base, tname, '78', 'xterm-kitty')
+    if not os.path.exists(q):
+        os.makedirs(os.path.dirname(q), exist_ok=True)
+        os.symlink('../x/xterm-kitty', q)
     if os.path.exists('/usr/share/misc/terminfo.cdb'):
+        # NetBSD requires this
+        os.symlink('../../.terminfo.cdb', os.path.join(base, tname, 'x', 'xterm-kitty'))
         tname += '.cdb'
     os.environ['TERMINFO'] = os.path.join(HOME, tname)
     p = subprocess.Popen(
@@ -148,10 +154,6 @@ def compile_terminfo(base):
     if rc != 0:
         getattr(sys.stderr, 'buffer', sys.stderr).write(p.stdout)
         raise SystemExit('Failed to compile the terminfo database')
-    q = os.path.join(base, tname, '78', 'xterm-kitty')
-    if not os.path.exists(q):
-        os.makedirs(os.path.dirname(q), exist_ok=True)
-        os.symlink('../x/xterm-kitty', q)
 
 
 def iter_base64_data(f):

--- a/shell-integration/ssh/bootstrap.sh
+++ b/shell-integration/ssh/bootstrap.sh
@@ -88,24 +88,26 @@ mv_files_and_dirs() {
 }
 
 compile_terminfo() {
-    # export TERMINFO
     tname=".terminfo"
+    # Ensure the 78 dir is present
+    if [ ! -f "$1/$tname/78/xterm-kitty" ]; then
+        command mkdir -p "$1/$tname/78"
+        command ln -sf "../x/xterm-kitty" "$1/$tname/78/xterm-kitty"
+    fi
+
     if [ -e "/usr/share/misc/terminfo.cdb" ]; then
-        # NetBSD requires this see https://github.com/kovidgoyal/kitty/issues/4622
+        # NetBSD requires this file, see https://github.com/kovidgoyal/kitty/issues/4622
+        command ln -sf "../../.terminfo.cdb" "$1/$tname/x/xterm-kitty"
         tname=".terminfo.cdb"
     fi
+
+    # export TERMINFO
     export TERMINFO="$HOME/$tname"
 
     # compile terminfo for this system
     if [ -x "$(command -v tic)" ]; then
         tic_out=$(command tic -x -o "$1/$tname" "$1/.terminfo/kitty.terminfo" 2>&1)
         [ $? = 0 ] || die "Failed to compile terminfo with err: $tic_out"
-    fi
-
-    # Ensure the 78 dir is present
-    if [ ! -f "$1/$tname/78/xterm-kitty" ]; then
-        command mkdir -p "$1/$tname/78"
-        command ln -sf "../x/xterm-kitty" "$1/$tname/78/xterm-kitty"
     fi
 }
 

--- a/shell-integration/ssh/bootstrap.sh
+++ b/shell-integration/ssh/bootstrap.sh
@@ -274,7 +274,8 @@ exec_zsh_with_integration() {
         export ZDOTDIR="$shell_integration_dir/zsh"
         exec "$login_shell" "-l"
     fi
-    unset KITTY_ORIG_ZDOTDIR  # ensure this is not propagated
+    # ensure this is not propagated
+    unset KITTY_ORIG_ZDOTDIR
 }
 
 exec_fish_with_integration() {
@@ -313,8 +314,10 @@ exec_with_shell_integration() {
 }
 
 execute_sh_with_posix_env() {
-    [ "$shell_name" = "sh" ] || return  # only for sh as that is likely to be POSIX compliant
-    command "$login_shell" -l -c ":" > /dev/null 2> /dev/null && return  # sh supports -l so use that
+    # only for sh as that is likely to be POSIX compliant
+    [ "$shell_name" = "sh" ] || return
+    # sh supports -l so use that
+    command "$login_shell" -l -c ":" > /dev/null 2> /dev/null && return
     [ -z "$shell_integration_dir" ] && die "Could not read data over tty ssh kitten cannot function"
     sh_dir="$shell_integration_dir/sh"
     command mkdir -p "$sh_dir" || die "Creating $sh_dir failed"

--- a/shell-integration/ssh/bootstrap.sh
+++ b/shell-integration/ssh/bootstrap.sh
@@ -232,6 +232,10 @@ using_passwd() {
     return 1
 }
 
+using_shell_env() {
+    [ -n "$SHELL" ] && login_shell="$SHELL" && login_shell_is_ok
+}
+
 execute_with_python() {
     if detect_python; then
         exec "$python" "-c" "import os; os.execlp('$login_shell', '-' '$shell_name')"
@@ -250,7 +254,7 @@ if [ -n "$KITTY_LOGIN_SHELL" ]; then
     login_shell="$KITTY_LOGIN_SHELL"
     unset KITTY_LOGIN_SHELL
 else
-    using_getent || using_id || using_python || using_perl || using_passwd || die "Could not detect login shell"
+    using_getent || using_id || using_python || using_perl || using_passwd || using_shell_env || login_shell="sh"
 fi
 shell_name=$(command basename $login_shell)
 [ -n "$login_cwd" ] && cd "$login_cwd"


### PR DESCRIPTION
I don't use NetBSD, but I decided to install it for testing. I found an error reported in the terminfo preparation part. .terminfo.cdb is a file and cannot be accessed as a folder. I adjusted the order to make sure that both .terminfo (the folder) and .terminfo.cdb are generated.

dropbear has a 9000 bytes ssh args limit. Remove bootstrap script comments and indents to support connecting to OpenWRT or embedded devices.

Use built-in cwd reporting function name from fish. When the feature enabled by default in future fish versions, this will override the built-in one.
I also just added this (hours ago) and am about to suggest fish to enable this.
Do you think it would be acceptable to turn this on for all versions of kitty? (Obviously there would be at most some error logs, no more harm.)

Add `force` option for `askpass` to skip ssh version check.

POSIX SHELL is not suitable to be preferred as login shell, but can fall back to that environment variable.