### PR TITLE
Allow launch with cwd to work with ssh kitten when the shell is configured

### DIFF
--- a/kitty/window.py
+++ b/kitty/window.py
@@ -20,7 +20,7 @@ from typing import (
 from .child import ProcessDesc
 from .cli_stub import CLIOptions
 from .config import build_ansi_color_table
-from .constants import appname, is_macos, shell_path, wakeup
+from .constants import appname, is_macos, wakeup
 from .fast_data_types import (
     BGIMAGE_PROGRAM, BLIT_PROGRAM, CELL_BG_PROGRAM, CELL_FG_PROGRAM,
     CELL_PROGRAM, CELL_SPECIAL_PROGRAM, CURSOR_BEAM, CURSOR_BLOCK,
@@ -47,7 +47,7 @@ from .typing import BossType, ChildType, EdgeLiteral, TabType, TypedDict
 from .utils import (
     get_primary_selection, kitty_ansi_sanitizer_pat, load_shaders, log_error,
     open_cmd, open_url, parse_color_set, path_from_osc7_url,
-    resolve_custom_file, sanitize_title, set_primary_selection
+    resolve_custom_file, resolved_shell, sanitize_title, set_primary_selection
 )
 
 MatchPatternType = Union[Pattern[str], Tuple[Pattern[str], Optional[Pattern[str]]]]
@@ -1172,7 +1172,7 @@ class Window:
         return self.child.foreground_cwd or self.child.current_cwd
 
     def modify_argv_for_launch_with_cwd(self, argv: List[str]) -> str:
-        if argv[0] != shell_path or not self.screen.last_reported_cwd:
+        if argv[0] != resolved_shell(get_options())[0] or not self.screen.last_reported_cwd:
             return self.cwd_of_child or ''
         from kittens.ssh.main import is_kitten_cmdline, set_cwd_in_cmdline
         ssh_kitten_cmdline: List[str] = []


### PR DESCRIPTION
The launch with cwd actions (e.g. `new_window_with_cwd`) uses the configured shell by default.
So when checking it is also compared against the configured shell.
Otherwise, if the action is executed on a window using ssh kitten, the configured shell will be used to open the remote cwd path locally.

https://github.com/kovidgoyal/kitty/pull/4836#issuecomment-1069070364