### PR TITLE
Check macOS less version

### DIFF
--- a/kittens/ssh/main.py
+++ b/kittens/ssh/main.py
@@ -602,8 +602,10 @@ def run_ssh(ssh_args: List[str], server_args: List[str], found_extra_args: Tuple
     need_to_request_data = True
     if use_kitty_askpass:
         sentinel = os.path.join(cache_dir(), 'openssh-is-new-enough-for-askpass')
-        if os.path.exists(sentinel) or ssh_version() >= (8, 4):
-            open(sentinel, 'w').close()
+        sentinel_exists = os.path.exists(sentinel)
+        if sentinel_exists or ssh_version() >= (8, 4):
+            if not sentinel_exists:
+                open(sentinel, 'w').close()
             # SSH_ASKPASS_REQUIRE was introduced in 8.4 release on 2020-09-27
             need_to_request_data = False
             os.environ['SSH_ASKPASS_REQUIRE'] = 'force'

--- a/kitty/utils.py
+++ b/kitty/utils.py
@@ -945,3 +945,19 @@ def path_from_osc7_url(url: str) -> str:
         from urllib.parse import urlparse, unquote
         return unquote(urlparse(url).path)
     return ''
+
+
+@run_once
+def macos_version() -> Tuple[int, ...]:
+    import platform
+    return tuple(map(int, platform.mac_ver()[0].split('.')))
+
+
+@run_once
+def less_version(less_exe: str = 'less') -> int:
+    import subprocess
+    o = subprocess.check_output([less_exe, '-V'], stderr=subprocess.STDOUT).decode()
+    m = re.match(r'less (\d+)', o)
+    if m is None:
+        raise ValueError(f'Invalid version string for less: {o}')
+    return int(m.group(1))


### PR DESCRIPTION
In macOS 12.3, less has been upgraded to 581.x, which is new enough.
Also check `/usr/bin/less` for lower versions of macOS, which will work when users replace it themselves.

When the sentinel file for SSH version exists, it will no longer be touched, reducing IO.