### PR TITLE
Docs: no-cwd will not disable fish's built-in CWD reporting

### DIFF
--- a/docs/shell-integration.rst
+++ b/docs/shell-integration.rst
@@ -72,6 +72,8 @@ no-cwd
     :ac:`new_window_with_cwd` and similar to open windows logged
     into remote machines using the :doc:`ssh kitten <kittens/ssh>`
     automatically with the same working directory as the current window.
+    Note that for the ``fish`` shell this will not disable its built-in current
+    working directory reporting.
 
 no-prompt-mark
     Turn off marking of prompts. This disables jumping to prompt, browsing

--- a/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
+++ b/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
@@ -97,7 +97,7 @@ function __ksi_schedule --on-event fish_prompt -d "Setup kitty integration after
 
     # Enable CWD reporting
     if not contains "no-cwd" $_ksi
-        # This function name is from fish and will override the builtin one if fish enabled this feature by default.
+        # This function name is from fish and will override the builtin one, which is enabled by default for kitty in fish 3.5.0+.
         # We provide this to ensure that fish 3.2.0 and above will work.
         # https://github.com/fish-shell/fish-shell/blob/3.2.0/share/functions/__fish_config_interactive.fish#L275
         function __update_cwd_osc --on-variable PWD -d "Report PWD changes to kitty"


### PR DESCRIPTION
The PR I submitted has been merged in fish and will enable CWD reporting by default for kitty in the next fish release.
The format is `file://` escaped URL.