### PR TITLE
macOS: Allow the New kitty Here services to open multiple folders

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -53,6 +53,8 @@ Detailed list of changes
 
 - Fix continued lines not having their continued status reset on line feed (:iss:`4837`)
 
+- macOS: Allow the New kitty Tab/Window Here services to open multiple selected folders.  (:pull:`4848`)
+
 
 0.24.4 [2022-03-03]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -463,9 +463,12 @@ class Boss:
         w = self.active_window_for_cwd
         self._new_os_window(args, CwdRequest(w))
 
-    def new_os_window_with_wd(self, wd: str) -> None:
-        special_window = SpecialWindow(None, cwd=wd)
-        self._new_os_window(special_window)
+    def new_os_window_with_wd(self, wd: Union[str, List[str]]) -> None:
+        if isinstance(wd, str):
+            wd = [wd]
+        for path in wd:
+            special_window = SpecialWindow(None, cwd=path)
+            self._new_os_window(special_window)
 
     def add_child(self, window: Window) -> None:
         assert window.child.pid is not None and window.child.child_fd is not None
@@ -1848,11 +1851,14 @@ class Boss:
     def new_tab_with_cwd(self, *args: str) -> None:
         self._create_tab(list(args), cwd_from=CwdRequest(self.active_window_for_cwd))
 
-    def new_tab_with_wd(self, wd: str) -> None:
+    def new_tab_with_wd(self, wd: Union[str, List[str]]) -> None:
         if not self.os_window_map:
             self.add_os_window()
-        special_window = SpecialWindow(None, cwd=wd)
-        self._new_tab(special_window)
+        if isinstance(wd, str):
+            wd = [wd]
+        for path in wd:
+            special_window = SpecialWindow(None, cwd=path)
+            self._new_tab(special_window)
 
     def _new_window(self, args: List[str], cwd_from: Optional[CwdRequest] = None) -> Optional[Window]:
         tab = self.active_tab

--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -1041,8 +1041,17 @@ process_cocoa_pending_actions(void) {
     if (cocoa_pending_actions[TOGGLE_MACOS_SECURE_KEYBOARD_ENTRY]) { call_boss(toggle_macos_secure_keyboard_entry, NULL); }
     if (cocoa_pending_actions[TOGGLE_FULLSCREEN]) { call_boss(toggle_fullscreen, NULL); }
     if (cocoa_pending_actions_data.wd) {
-        if (cocoa_pending_actions[NEW_OS_WINDOW_WITH_WD]) { call_boss(new_os_window_with_wd, "s", cocoa_pending_actions_data.wd); }
-        if (cocoa_pending_actions[NEW_TAB_WITH_WD]) { call_boss(new_tab_with_wd, "s", cocoa_pending_actions_data.wd); }
+#define C(a, f) \
+        if (cocoa_pending_actions[a]) { \
+            PyObject *wds = PyUnicode_FromString(cocoa_pending_actions_data.wd); \
+            PyObject *sep = PyUnicode_FromString(":"); \
+            PyObject *paths = PyUnicode_Split(wds, sep, -1); \
+            call_boss(f, "O", paths); \
+            Py_DECREF(paths); Py_DECREF(sep); Py_DECREF(wds); \
+        }
+        C(NEW_OS_WINDOW_WITH_WD, new_os_window_with_wd);
+        C(NEW_TAB_WITH_WD, new_tab_with_wd);
+#undef C
         free(cocoa_pending_actions_data.wd);
         cocoa_pending_actions_data.wd = NULL;
     }


### PR DESCRIPTION
Select multiple folders in Finder, right click, and `New kitty Tab/Window Here` in Services will open them all.

Before this PR only the last one will be opened.

https://github.com/kovidgoyal/kitty/pull/4618#issuecomment-1030595767