### PR TITLE
Wayland: Fix IME is not enabled after switching the focus

### DIFF
--- a/glfw/wl_text_input.c
+++ b/glfw/wl_text_input.c
@@ -139,7 +139,12 @@ _glfwPlatformUpdateIMEState(_GLFWwindow *w, const GLFWIMEUpdateEvent *ev) {
     switch(ev->type) {
         case GLFW_IME_UPDATE_FOCUS:
             debug("\ntext-input: updating IME focus state, focused: %d\n", ev->focused);
-            if (ev->focused) zwp_text_input_v3_enable(text_input); else zwp_text_input_v3_disable(text_input);
+            if (ev->focused) {
+                zwp_text_input_v3_enable(text_input);
+                zwp_text_input_v3_set_content_type(text_input, ZWP_TEXT_INPUT_V3_CONTENT_HINT_NONE, ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_TERMINAL);
+            } else {
+                zwp_text_input_v3_disable(text_input);
+            }
             commit();
             break;
         case GLFW_IME_UPDATE_CURSOR_POSITION: {

--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -1361,7 +1361,7 @@ def set_os_window_title(os_window_id: int, title: str) -> None:
     pass
 
 
-def update_ime_position_for_window(window_id: int, force: bool = False, lost_focus: bool = False) -> bool:
+def update_ime_position_for_window(window_id: int, force: bool = False, update_focus: int = 0) -> bool:
     pass
 
 

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -764,7 +764,7 @@ restore_overlay_line(struct SaveOverlayLine *sol) {
         debug("Received input from child (%s) while overlay active. Overlay contents: %s\n", sol->func_name, PyUnicode_AsUTF8(sol->overlay_text));
         screen_draw_overlay_text(sol->screen, PyUnicode_AsUTF8(sol->overlay_text));
         Py_DECREF(sol->overlay_text);
-        update_ime_position_for_window(sol->screen->window_id, false, false);
+        update_ime_position_for_window(sol->screen->window_id, false, 0);
     }
 }
 

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -342,6 +342,6 @@ uint8_t* draw_single_ascii_char(const char ch, size_t *result_width, size_t *res
 bool is_os_window_fullscreen(OSWindow *);
 void update_ime_focus(OSWindow* osw, bool focused);
 void update_ime_position(Window* w, Screen *screen);
-bool update_ime_position_for_window(id_type window_id, bool force, bool lost_focus);
+bool update_ime_position_for_window(id_type window_id, bool force, int update_focus);
 void set_ignore_os_keyboard_processing(bool enabled);
 void update_menu_bar_title(PyObject *title UNUSED);

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -780,7 +780,7 @@ class Window:
         self.screen.focus_changed(focused)
         if focused:
             self.last_focused_at = monotonic()
-            update_ime_position_for_window(self.id)
+            update_ime_position_for_window(self.id, False, 1)
             changed = self.needs_attention
             self.needs_attention = False
             if changed:
@@ -789,7 +789,7 @@ class Window:
                     tab.relayout_borders()
         elif self.os_window_id == current_os_window():
             # Cancel IME composition after loses focus
-            update_ime_position_for_window(self.id, False, True)
+            update_ime_position_for_window(self.id, False, -1)
 
     def title_changed(self, new_title: Optional[str], is_base64: bool = False) -> None:
         self.child_title = process_title_from_child(new_title or self.default_title, is_base64)
@@ -1163,7 +1163,7 @@ class Window:
         if hasattr(self, 'screen'):
             if self.is_active and self.os_window_id == current_os_window():
                 # Cancel IME composition when window is destroyed
-                update_ime_position_for_window(self.id, False, True)
+                update_ime_position_for_window(self.id, False, -1)
             # Remove cycles so that screen is de-allocated immediately
             self.screen.reset_callbacks()
             del self.screen


### PR DESCRIPTION
Enable the IME under wayland after the window gets focus.
Also fixes the issue that pre-edit text cannot be cleared. After pressing backspace, the last character remains.

https://github.com/kovidgoyal/kitty/issues/4853

Please review, thank you.