### PR TITLE
Add option to set XDG sound theme on Linux

### DIFF
--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -386,7 +386,7 @@ void scroll_event(double, double, int, int);
 void on_key_input(GLFWkeyevent *ev);
 void request_window_attention(id_type, bool);
 #ifndef __APPLE__
-void play_canberra_sound(const char *which_sound, const char *event_id, bool is_path, const char *role);
+void play_canberra_sound(const char *which_sound, const char *event_id, bool is_path, const char *role, const char *theme_name);
 #endif
 SPRITE_MAP_HANDLE alloc_sprite_map(unsigned int, unsigned int);
 SPRITE_MAP_HANDLE free_sprite_map(SPRITE_MAP_HANDLE);

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -1387,8 +1387,8 @@ ring_audio_bell(void) {
 #ifdef __APPLE__
     cocoa_system_beep(OPT(bell_path));
 #else
-    if (OPT(bell_path)) play_canberra_sound(OPT(bell_path), "kitty bell", true, "event");
-    else play_canberra_sound("bell", "kitty bell", false, "event");
+    if (OPT(bell_path)) play_canberra_sound(OPT(bell_path), "kitty bell", true, "event", OPT(linux_bell_theme_name));
+    else play_canberra_sound("bell", "kitty bell", false, "event", OPT(linux_bell_theme_name));
 #endif
 }
 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -858,6 +858,12 @@ MP3 or WAV on macOS (NSSound)
 '''
     )
 
+opt('linux_bell_theme_name', '__custom',
+    long_text='If audio bell is enabled on Linux, sets the XDG Sound Theme kitty will use to play the bell sound.'
+    ' Defaults to the custom theme name used by GNOME and Budgie, falling back to the default freedesktop theme if it does not exist.'
+    ' This option may be removed if Linux ever provides desktop-agnostic support for setting system sound themes.'
+    )
+
 egr()  # }}}
 
 

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -1024,6 +1024,9 @@ class Parser:
     def kitty_mod(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['kitty_mod'] = to_modifiers(val)
 
+    def linux_bell_theme_name(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        ans['linux_bell_theme_name'] = str(val)
+
     def linux_display_server(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         val = val.lower()
         if val not in self.choices_for_linux_display_server:

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -376,6 +376,7 @@ option_names = (  # {{{
  'italic_font',
  'kitten_alias',
  'kitty_mod',
+ 'linux_bell_theme_name',
  'linux_display_server',
  'listen_on',
  'macos_colorspace',
@@ -534,6 +535,7 @@ class Options:
     input_delay: int = 3
     italic_font: str = 'auto'
     kitty_mod: int = 5
+    linux_bell_theme_name: str = '__custom'
     linux_display_server: choices_for_linux_display_server = 'auto'
     listen_on: str = 'none'
     macos_colorspace: choices_for_macos_colorspace = 'srgb'

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -29,6 +29,7 @@ typedef struct {
     double wheel_scroll_multiplier, touch_scroll_multiplier;
     int wheel_scroll_min_lines;
     bool enable_audio_bell;
+    const char *linux_bell_theme_name;
     CursorShape cursor_shape;
     float cursor_beam_thickness;
     float cursor_underline_thickness;


### PR DESCRIPTION
Based on #2125. The default sound theme is `__custom`, which is the custom theme created by GNOME and Budgie. If this theme doesn't exist, canberra instead uses the default theme to produce the sound, so it should work without a hitch on all desktop environments.

This is a draft because I was unable to figure out how to regenerate `to-c-generated.h` to get the changes to propagate, and it seems that the code to add a new option changed in the time between #2125 and now. Let me know how to get everything connected and I'll get it ready to merge.