### PR TITLE
Fix hints kitten overlay ready reporting not enabled and eliminate flickering when exits

### DIFF
--- a/kittens/hints/main.py
+++ b/kittens/hints/main.py
@@ -118,6 +118,7 @@ def render(text: str, current_input: str, all_marks: Sequence[Mark], ignore_mark
 
 class Hints(Handler):
 
+    use_alternate_screen = False
     overlay_ready_report_needed = True
 
     def __init__(self, text: str, all_marks: Sequence[Mark], index_map: Dict[int, Mark], args: HintsCLIOptions):

--- a/kittens/hints/main.py
+++ b/kittens/hints/main.py
@@ -27,7 +27,7 @@ from kitty.utils import (
 from ..tui.handler import Handler, result_handler
 from ..tui.loop import Loop
 from ..tui.operations import faint, styled
-from ..tui.utils import report_unhandled_error
+from ..tui.utils import report_error, report_unhandled_error
 
 
 @lru_cache()
@@ -503,7 +503,7 @@ def run(args: HintsCLIOptions, text: str, extra_cli_args: Sequence[str] = ()) ->
             all_marks = tuple(mark(pattern, post_processors, text, args))
         if not all_marks:
             none_of = {'url': 'URLs', 'hyperlink': 'hyperlinks'}.get(args.type, 'matches')
-            input(_('No {} found, press Enter to quit.').format(none_of))
+            report_error(_('No {} found.').format(none_of))
             return None
 
         largest_index = all_marks[-1].index

--- a/kittens/show_error/main.py
+++ b/kittens/show_error/main.py
@@ -38,7 +38,7 @@ def main(args: List[str]) -> None:
     except Exception:
         import traceback
         traceback.print_exc()
-        input('Press Enter to close.')
+        input('Press Enter to close')
 
 
 if __name__ == '__main__':

--- a/kittens/tui/loop.py
+++ b/kittens/tui/loop.py
@@ -182,7 +182,7 @@ class UnhandledException(Handler):
         self.cmd.set_default_colors()
         self.write(self.tb.replace('\n', '\r\n'))
         self.write('\r\n')
-        self.write('Press the Enter key to quit')
+        self.write('Press Enter to quit')
 
     def on_key(self, key_event: KeyEventType) -> None:
         if key_event.key == 'ENTER':

--- a/kittens/tui/utils.py
+++ b/kittens/tui/utils.py
@@ -50,15 +50,22 @@ def human_size(
     return format_number(size / 1024**exponent, max_num_of_decimals) + sep + unit_list[exponent]
 
 
-def report_unhandled_error(msg: str = '') -> None:
-    ' Report an unhandled exception also sending the overlay ready message to ensure kitten is visible '
+def report_error(msg: str = '', return_code: int = 1, print_exc: bool = False) -> None:
+    ' Report an error also sending the overlay ready message to ensure kitten is visible '
     from .operations import overlay_ready
     print(end=overlay_ready())
     if msg:
         print(msg, file=sys.stderr)
-    cls, e, tb = sys.exc_info()
-    if e and not isinstance(e, (SystemExit, KeyboardInterrupt)):
-        import traceback
-        traceback.print_exc()
-    input('Press Enter to quit.')
-    raise SystemExit(1)
+    if print_exc:
+        cls, e, tb = sys.exc_info()
+        if e and not isinstance(e, (SystemExit, KeyboardInterrupt)):
+            import traceback
+            traceback.print_exc()
+    with suppress(KeyboardInterrupt, EOFError):
+        input('Press Enter to quit')
+    raise SystemExit(return_code)
+
+
+def report_unhandled_error(msg: str = '') -> None:
+    ' Report an unhandled exception with the overlay ready message '
+    return report_error(msg, print_exc=True)


### PR DESCRIPTION
Fix hints kitten overlay ready reporting not enabled.
Report overlay ready in case of no match.
Eliminate flickering when kitten exits in overlay.

Please review, thank you.
There may be cases where robustness needs to be improved.