### PR TITLE
Add standalone action for scrolling prompt to the top and fix scrolling

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -59,7 +59,11 @@ Detailed list of changes
 
 - Wayland: Fix a regression that broke IME when changing windows/tabs (:iss:`4853`)
 
+- macOS: Fix Unicode paths not decoded correctly when dropping files (:pull:`4879`)
+
 - Avoid flicker when starting kittens such as the hints kitten (:iss:`4674`)
+
+- A new action :ac:`scroll_prompt_to_top` to move the current prompt to the top (:pull:`4891`)
 
 
 0.24.4 [2022-03-03]

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -797,15 +797,15 @@ class Boss:
         See :sc:`reset_terminal <reset_terminal>` for details. For example::
 
             # Reset the terminal
-            map kitty_mod+f9 clear_terminal reset active
+            map f1 clear_terminal reset active
             # Clear the terminal screen by erasing all contents
-            map kitty_mod+f10 clear_terminal clear active
+            map f1 clear_terminal clear active
             # Clear the terminal scrollback by erasing it
-            map kitty_mod+f11 clear_terminal scrollback active
+            map f1 clear_terminal scrollback active
             # Scroll the contents of the screen into the scrollback
-            map kitty_mod+f12 clear_terminal scroll active
+            map f1 clear_terminal scroll active
             # Clear everything up to the line with the cursor
-            map kitty_mod+f9 clear_terminal to_cursor active
+            map f1 clear_terminal to_cursor active
         ''')
     def clear_terminal(self, action: str, only_active: bool) -> None:
         if only_active:

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -815,19 +815,21 @@ class Boss:
                 windows.append(w)
         else:
             windows = list(self.all_windows)
-        reset = action == 'reset'
-        how = 3 if action == 'scrollback' else 2
-        for w in windows:
-            if action in ('to_cursor', 'scroll'):
-                w.screen.scroll_until_cursor_prompt()
-                if action == 'to_cursor':
-                    w.screen.clear_scrollback()
-                continue
-            w.screen.cursor.x = w.screen.cursor.y = 0
-            if reset:
-                w.screen.reset()
-            else:
-                w.screen.erase_in_display(how, False)
+        if action == 'reset':
+            for w in windows:
+                w.clear_screen(reset=True, scrollback=True)
+        elif action == 'scrollback':
+            for w in windows:
+                w.clear_screen(scrollback=True)
+        elif action == 'clear':
+            for w in windows:
+                w.clear_screen()
+        elif action == 'scroll':
+            for w in windows:
+                w.scroll_prompt_to_top()
+        elif action == 'to_cursor':
+            for w in windows:
+                w.scroll_prompt_to_top(clear_scrollback=True)
 
     def increase_font_size(self) -> None:  # legacy
         cfs = global_font_size()

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -3650,13 +3650,15 @@ map('Reset the terminal',
 You can create shortcuts to clear/reset the terminal. For example::
 
     # Reset the terminal
-    map kitty_mod+f9 clear_terminal reset active
+    map f1 clear_terminal reset active
     # Clear the terminal screen by erasing all contents
-    map kitty_mod+f10 clear_terminal clear active
+    map f1 clear_terminal clear active
     # Clear the terminal scrollback by erasing it
-    map kitty_mod+f11 clear_terminal scrollback active
+    map f1 clear_terminal scrollback active
     # Scroll the contents of the screen into the scrollback
-    map kitty_mod+f12 clear_terminal scroll active
+    map f1 clear_terminal scroll active
+    # Clear everything up to the line with the cursor
+    map f1 clear_terminal to_cursor active
 
 If you want to operate on all windows instead of just the current one, use
 :italic:`all` instead of :italic:`active`.

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -1308,6 +1308,13 @@ class Window:
                 text = text.replace(b'\r\n', b'\n').replace(b'\n', b'\r')
             self.screen.paste(text)
 
+    def clear_screen(self, reset: bool = False, scrollback: bool = False) -> None:
+        self.screen.cursor.x = self.screen.cursor.y = 0
+        if reset:
+            self.screen.reset()
+        else:
+            self.screen.erase_in_display(3 if scrollback else 2, False)
+
     # actions {{{
 
     @ac('cp', 'Show scrollback in a pager like less')
@@ -1445,7 +1452,16 @@ class Window:
         if self.screen.is_main_linebuf():
             self.screen.scroll_to_prompt(num_of_prompts)
 
-    @ac('sc', 'Scroll prompt to the bottom of the screen, filling in extra lines form the scrollback buffer')
+    @ac('sc', 'Scroll prompt to the top of the screen, filling screen with empty lines')
+    def scroll_prompt_to_top(self, clear_scrollback: bool = False) -> None:
+        if self.screen.is_main_linebuf():
+            self.screen.scroll_until_cursor_prompt()
+            if clear_scrollback:
+                self.screen.clear_scrollback()
+            elif self.screen.scrolled_by > 0:
+                self.screen.scroll(SCROLL_FULL, False)
+
+    @ac('sc', 'Scroll prompt to the bottom of the screen, filling in extra lines from the scrollback buffer')
     def scroll_prompt_to_bottom(self) -> None:
         self.screen.scroll_prompt_to_bottom()
 


### PR DESCRIPTION
Refactor clear_terminal to move the functions to Window.
Add a standalone action for scrolling prompt to the top. (corresponds to `scroll_prompt_to_bottom`)
Fix the action not scrolling to the bottom when the screen is scrolled.
Avoid using already defined shortcuts in examples.

Please review, thank you.