### PR TITLE
Shell integration: Mark fish prompt on cancel or syntax error

### DIFF
--- a/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
+++ b/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
@@ -72,7 +72,7 @@ function __ksi_schedule --on-event fish_prompt -d "Setup kitty integration after
     # Enable prompt marking with OSC 133
     if not contains "no-prompt-mark" $_ksi
         and not set -q __ksi_prompt_state
-        function __ksi_mark_prompt_start --on-event fish_prompt
+        function __ksi_mark_prompt_start --on-event fish_prompt --on-event fish_cancel --on-event fish_posterror
             test "$__ksi_prompt_state" != prompt-start
             and echo -en "\e]133;D\a"
             set --global __ksi_prompt_state prompt-start


### PR DESCRIPTION
When using Ctrl+C to cancel an unexecuted command, or when entering a command containing a syntax error,
the `fish_prompt` event will not be fired, even if a new prompt has been drawn.
These two events `fish_cancel`, `fish_posterror` will be triggered before the prompt is redrawn (at the beginning of the new line).

Also `fish_prompt` will not be triggered if the buffered prompt is repainted on a new line. For example, bind shortcuts to execute `echo debug; commandline -f repaint`.
However, I think the current way is good enough.

If you want to make sure the prompt carries OSC 133 and handles pipestatus correctly, please let me know. However this will result in more fish code to maintain.