### PR TITLE
Update cursor focus flag when preparing to render OS window

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -72,6 +72,8 @@ Detailed list of changes
 - Only check for updates in the official binary builds. Distro packages or source builds will no longer check for updates, regardless of the
   value of :opt:`update_check_interval`.
 
+- Fix :opt:`inactive_text_alpha` still being applied to the cursor hidden window after focus (:iss:`4928`)
+
 
 0.24.4 [2022-03-03]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -637,6 +637,7 @@ prepare_to_render_os_window(OSWindow *os_window, monotonic_t now, unsigned int *
             if (is_active_window) {
                 *active_window_id = w->id;
                 if (collect_cursor_info(&WD.screen->cursor_render_info, w, now, os_window)) needs_render = true;
+                WD.screen->cursor_render_info.is_focused = os_window->is_focused;
                 set_os_window_title_from_window(w, os_window);
                 *active_window_bg = window_bg;
             } else {


### PR DESCRIPTION
Fix inactive text alpha always being applied when starting a program with cursor hidden via session.

https://github.com/kovidgoyal/kitty/issues/4928

I'm not sure if there are other places affected, please review, thanks.