### PR TITLE
Add a new mappable action close_other_tabs_in_os_window

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -77,6 +77,8 @@ Detailed list of changes
 - Fix resizing window that is extra tall/wide because of left-over cells not
   working reliably (:iss:`4913`)
 
+- A new action :ac:`close_other_tabs_in_os_window` to close other tabs in the active OS window (:pull:`4944`)
+
 
 0.24.4 [2022-03-03]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -92,7 +92,7 @@ For macOS, you may also need to put that file under :file:`~/.terminfo/78/`::
 
     mkdir -p ~/.terminfo/{78,x}
     ln -snf ../x/xterm-kitty ~/.terminfo/78/xterm-kitty
-    tic -x -o ~/.terminfo $KITTY_INSTALLATION_DIR/terminfo/kitty.terminfo
+    tic -x -o ~/.terminfo "$KITTY_INSTALLATION_DIR/terminfo/kitty.terminfo"
 
 Note that ``sudo`` might remove TERMINFO.  Then setting it at the shell prompt can
 be too late, because command line editing may not be reinitialized.  In that case

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -673,6 +673,15 @@ class Boss:
         if tab:
             self.confirm_tab_close(tab)
 
+    @ac('tab', 'Close all the tabs in the current OS window other than the currently active tab')
+    def close_other_tabs_in_os_window(self) -> None:
+        tm = self.active_tab_manager
+        if tm is not None and len(tm.tabs) > 1:
+            active_tab = self.active_tab
+            for tab in tm:
+                if tab is not active_tab:
+                    self.close_tab(tab)
+
     def confirm(
         self, msg: str,  # can contain newlines and ANSI formatting
         callback: Callable[..., None],  # called with True or False and *args


### PR DESCRIPTION
Since we can already close other windows in tabs with `close_other_windows_in_tab`, add another action to close other tabs.

Please review, thanks.