### PR TITLE
Change size_t_min static function in kitty/ringbuf.c to static inline

### DIFF
--- a/kitty/ringbuf.c
+++ b/kitty/ringbuf.c
@@ -26,10 +26,6 @@
 #include <sys/param.h>
 #include <assert.h>
 
-static size_t
-size_t_min(size_t x, size_t y) {
-    return x > y ? y : x;
-}
 
 /*
  * The code is written for clarity, not cleverness or performance, and

--- a/kitty/ringbuf.h
+++ b/kitty/ringbuf.h
@@ -250,3 +250,8 @@ ringbuf_write(int fd, ringbuf_t rb, size_t count);
  */
 void *
 ringbuf_copy(ringbuf_t dst, ringbuf_t src, size_t count);
+
+static inline size_t
+size_t_min(size_t x, size_t y) {
+    return x > y ? y : x;
+}


### PR DESCRIPTION
Change static function  size_t_min in kitty/ringbuf.c to static inline function and move to kitty/ringbuf.h for simplifying .c file  