### PR TITLE
Fix automatic bash integration configuration options not taking effect

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -39,6 +39,8 @@ Detailed list of changes
 
 - Shell integration: Add a command to :ref:`clone_shell`
 
+- Shell integration: Fix a regression that bash integration code causing :opt:`shell_integration` configuration not taking effect (:iss:`4955`)
+
 - Remote control: Allow using :ref:`Boolean operators <search_syntax>` when constructing queries to match windows or tabs
 
 - Sessions: Fix :code:`os_window_size` and :code:`os_window_class` not applying to the first OS Window (:iss:`4957`)

--- a/shell-integration/bash/kitty.bash
+++ b/shell-integration/bash/kitty.bash
@@ -2,6 +2,8 @@
 
 if [[ "$-" != *i* ]] ; then builtin return; fi  # check in interactive mode
 if [[ -z "$KITTY_SHELL_INTEGRATION" ]]; then builtin return; fi
+if [[ "$_ksi_sourced" == "y" || "${_ksi_prompt[sourced]}" == "y" ]]; then builtin return; fi  # we have already sourced
+_ksi_sourced="y"
 
 _ksi_inject() {
     # Load the normal bash startup files
@@ -63,14 +65,8 @@ if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
     builtin return
 fi
 
-if [[ "${_ksi_prompt[sourced]}" == "y" ]]; then
-    # we have already run
-    builtin unset KITTY_SHELL_INTEGRATION
-    builtin return
-fi
-
 # this is defined outside _ksi_main to make it global without using declare -g
-# which is not available on older bash
+# which is not available on bash 4.1 and below
 builtin declare -A _ksi_prompt
 _ksi_prompt=(
     [cursor]='y' [title]='y' [mark]='y' [complete]='y' [cwd]='y' [ps0]='' [ps0_suffix]='' [ps1]='' [ps1_suffix]='' [ps2]=''
@@ -93,6 +89,7 @@ _ksi_main() {
     IFS="$ifs"
 
     builtin unset KITTY_SHELL_INTEGRATION
+    builtin unset _ksi_sourced
 
     _ksi_debug_print() {
         # print a line to STDERR of parent kitty process


### PR DESCRIPTION
When bash integration script is sourced in bashrc,
such as when old automatic shell integration code exists,
or when integration is configured manually,
`builtin declare -A _ksi_prompt` is defined in `_ksi_inject`,
causing `if [[ "${_ksi_prompt[sourced]}" == "y" ]]` not to take effect.

```bash
# with or without
export KITTY_SHELL_INTEGRATION=no-cursor

source /path/to/kitty.bash
```

```shell
kitty -o shell_integration=no-cursor
```

The above bashrc used with the command cannot make the `shell_integration` option take effect.

https://github.com/kovidgoyal/kitty/issues/4955

https://github.com/kovidgoyal/kitty/issues/4438#issuecomment-1096939501

Please review, thanks.