### PR TITLE
clone-in-kitty: Skip SSH_TTY and other SSH environment variables

### DIFF
--- a/kitty/launch.py
+++ b/kitty/launch.py
@@ -567,9 +567,13 @@ class CloneCmd:
                 self.args.append(v)
             elif k == 'env':
                 self.env = parse_bash_env(v) if self.envfmt == 'bash' else parse_null_env(v)
-                for filtered in ('PS0', 'PS1', 'PS2', 'PS3', 'PS4', 'RPS1', 'PROMPT_COMMAND'):
+                for filtered in (
                     # some people export these. We want the shell rc files to
                     # recreate them
+                    'PS0', 'PS1', 'PS2', 'PS3', 'PS4', 'RPS1', 'PROMPT_COMMAND', 'SHLVL',
+                    # skip SSH environment variables
+                    'SSH_CLIENT', 'SSH_CONNECTION', 'SSH_ORIGINAL_COMMAND', 'SSH_TTY', 'SSH2_TTY',
+                ):
                     self.env.pop(filtered, None)
             elif k == 'cwd':
                 self.cwd = v


### PR DESCRIPTION
Use new values for SSH environment variables, making sure SSH_TTY, etc. is correct.

Perhaps a configurable filter list (prefix `+` for whitelist item) would allow users to solve these problems on their own.

I'm wondering if we should check the `USER` environment variables matches current user in ssh kitten bootstrap script or when running it locally, and not use them (all env vars) if they (the user) are different. If SSH connects and switches users and then runs clone-in-kitty, the reported environment variables such as HOME, USER, etc. will most likely cause the environment to be abnormal.
