### PR TITLE
clone-in-kitty: Skip some user-related environment variables

### DIFF
--- a/kitty/launch.py
+++ b/kitty/launch.py
@@ -568,6 +568,7 @@ class CloneCmd:
             elif k == 'env':
                 self.env = parse_bash_env(v) if self.envfmt == 'bash' else parse_null_env(v)
                 for filtered in (
+                    'HOME', 'LOGNAME', 'USER',
                     # some people export these. We want the shell rc files to
                     # recreate them
                     'PS0', 'PS1', 'PS2', 'PS3', 'PS4', 'RPS1', 'PROMPT_COMMAND', 'SHLVL',


### PR DESCRIPTION
There are also environment variables such as `XDG_*` (and `PATH`) that start with the `$HOME` path when the user is different. These are left to the users to work out.