### PR TITLE
New get-text extent: last_non_empty_output

### DIFF
--- a/kitty/rc/get_text.py
+++ b/kitty/rc/get_text.py
@@ -30,14 +30,14 @@ class GetText(RemoteCommand):
     options_spec = MATCH_WINDOW_OPTION + '''\n
 --extent
 default=screen
-choices=screen, all, selection, first_cmd_output_on_screen, last_cmd_output, last_complete_output, last_visited_cmd_output
+choices=screen, all, selection, first_cmd_output_on_screen, last_cmd_output, last_non_empty_output, last_visited_cmd_output
 What text to get. The default of :code:`screen` means all text currently on the screen.
 :code:`all` means all the screen+scrollback and :code:`selection` means the
 currently selected text. :code:`first_cmd_output_on_screen` means the output of the first
-command that was run in the window on screen. :code:`last_cmd_output` means
-the output of the last command that was run in the window. :code:`last_complete_output` means
-the output of the last command which is followed by a prompt (useful when
-executing get-text in the same window). :code:`last_visited_cmd_output` means
+command that was run in the window on screen. :code:`last_cmd_output` and
+:code:`last_non_empty_output` means the output of the last command that was run
+in the window (with the latter skipping commands without any output).
+:code:`last_visited_cmd_output` means
 the first command output below the last scrolled position via scroll_to_prompt. The last four
 requires :ref:`shell_integration` to be enabled.
 
@@ -97,9 +97,9 @@ Clear the selection in the matched window, if any
                 as_ansi=bool(payload_get('ansi')),
                 add_wrap_markers=bool(payload_get('wrap_markers')),
             )
-        elif payload_get('extent') == 'last_complete_output':
+        elif payload_get('extent') == 'last_non_empty_output':
             ans = window.cmd_output(
-                CommandOutput.last_complete_run,
+                CommandOutput.last_non_empty_run,
                 as_ansi=bool(payload_get('ansi')),
                 add_wrap_markers=bool(payload_get('wrap_markers')),
             )

--- a/kitty/rc/get_text.py
+++ b/kitty/rc/get_text.py
@@ -30,13 +30,15 @@ class GetText(RemoteCommand):
     options_spec = MATCH_WINDOW_OPTION + '''\n
 --extent
 default=screen
-choices=screen, all, selection, first_cmd_output_on_screen, last_cmd_output, last_visited_cmd_output
+choices=screen, all, selection, first_cmd_output_on_screen, last_cmd_output, last_complete_output, last_visited_cmd_output
 What text to get. The default of :code:`screen` means all text currently on the screen.
 :code:`all` means all the screen+scrollback and :code:`selection` means the
 currently selected text. :code:`first_cmd_output_on_screen` means the output of the first
 command that was run in the window on screen. :code:`last_cmd_output` means
-the output of the last command that was run in the window. :code:`last_visited_cmd_output` means
-the first command output below the last scrolled position via scroll_to_prompt. The last three
+the output of the last command that was run in the window. :code:`last_complete_output` means
+the output of the last command which is followed by a prompt (useful when
+executing get-text in the same window). :code:`last_visited_cmd_output` means
+the first command output below the last scrolled position via scroll_to_prompt. The last four
 requires :ref:`shell_integration` to be enabled.
 
 
@@ -92,6 +94,12 @@ Clear the selection in the matched window, if any
         elif payload_get('extent') == 'last_cmd_output':
             ans = window.cmd_output(
                 CommandOutput.last_run,
+                as_ansi=bool(payload_get('ansi')),
+                add_wrap_markers=bool(payload_get('wrap_markers')),
+            )
+        elif payload_get('extent') == 'last_complete_output':
+            ans = window.cmd_output(
+                CommandOutput.last_complete_run,
                 as_ansi=bool(payload_get('ansi')),
                 add_wrap_markers=bool(payload_get('wrap_markers')),
             )

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -2767,7 +2767,7 @@ typedef enum CommandOutputs
 } CommandOutput;
 
 static bool
-find_cmd_output(Screen *self, OutputOffset *oo, index_type start_screen_y, unsigned int scrolled_by, int direction, bool on_screen_only) {
+find_cmd_output(Screen *self, OutputOffset *oo, index_type start_screen_y, unsigned int scrolled_by, CommandOutput direction, bool on_screen_only) {
     bool found_prompt = false, found_output = false, found_next_prompt = false;
     int start = 0, end = 0;
     int init_y = start_screen_y - scrolled_by, y1 = init_y, y2 = init_y;
@@ -2855,7 +2855,7 @@ find_cmd_output(Screen *self, OutputOffset *oo, index_type start_screen_y, unsig
 
 static PyObject*
 cmd_output(Screen *self, PyObject *args) {
-    unsigned int which = 0;
+    CommandOutput which = LAST_RUN_CMD;
     DECREF_AFTER_FUNCTION PyObject *which_args = PyTuple_GetSlice(args, 0, 1);
     DECREF_AFTER_FUNCTION PyObject *as_text_args = PyTuple_GetSlice(args, 1, PyTuple_GET_SIZE(args));
     if (!which_args || !as_text_args) return NULL;

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -2795,9 +2795,12 @@ find_cmd_output(Screen *self, OutputOffset *oo, index_type start_screen_y, unsig
                 }
                 found_next_prompt = true; end = y1;
             } else if (line && line->attrs.prompt_kind == OUTPUT_START && !line->attrs.continued) {
-                if (direction == -2 && !found_next_prompt) {
-                    // The command output is incomplete, because it is not
-                    // followed by a prompt.
+                if (direction == -2 && y1 == init_y) {
+                    // Commands without output don't have an OUTPUT_START
+                    // marker with the exception of the currently running
+                    // command. It gets an OUTPUT_START even before the
+                    // first output is written, so we must skip the
+                    // output market if it is on the last line.
                 } else {
                     start = y1;
                     break;
@@ -2864,7 +2867,7 @@ cmd_output(Screen *self, PyObject *args) {
             if (self->last_visited_prompt.scrolled_by <= self->historybuf->count && self->last_visited_prompt.is_set) {
                 found = find_cmd_output(self, &oo, self->last_visited_prompt.y, self->last_visited_prompt.scrolled_by, 0, false);
             } break;
-        case 3: // last complete cmd
+        case 3: // last non-empty cmd output
             // When scrolled, the starting point of the search for the last command output
             // is actually out of the screen, so add the number of scrolled lines
             found = find_cmd_output(self, &oo, self->cursor->y + self->scrolled_by, self->scrolled_by, -2, false);

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -2756,13 +2756,15 @@ get_line_from_offset(void *x, int y) {
     return range_line_(r->screen, r->start + y);
 }
 
-typedef enum FindCmdOutputDirections
+
+/* Matches kitty.window.CommandOutput */
+typedef enum CommandOutputs
 {
     LAST_RUN_CMD = 0,
-    LAST_NON_EMPTY_CMD = 1,
-    FIRST_ON_SCREEN = 2,
-    LAST_VISISTED_CMD = 3,
-} FindCmdOutputDirection;
+    FIRST_ON_SCREEN = 1,
+    LAST_VISISTED_CMD = 2,
+    LAST_NON_EMPTY_CMD = 3,
+} CommandOutput;
 
 static bool
 find_cmd_output(Screen *self, OutputOffset *oo, index_type start_screen_y, unsigned int scrolled_by, int direction, bool on_screen_only) {
@@ -2863,19 +2865,19 @@ cmd_output(Screen *self, PyObject *args) {
     bool found = false;
 
     switch (which) {
-        case 0: // last run cmd
+        case LAST_RUN_CMD: // last run cmd
             // When scrolled, the starting point of the search for the last command output
             // is actually out of the screen, so add the number of scrolled lines
             found = find_cmd_output(self, &oo, self->cursor->y + self->scrolled_by, self->scrolled_by, LAST_RUN_CMD, false);
             break;
-        case 1: // first on screen
+        case FIRST_ON_SCREEN: // first on screen
             found = find_cmd_output(self, &oo, 0, self->scrolled_by, FIRST_ON_SCREEN, true);
             break;
-        case 2: // last visited cmd
+        case LAST_VISISTED_CMD: // last visited cmd
             if (self->last_visited_prompt.scrolled_by <= self->historybuf->count && self->last_visited_prompt.is_set) {
                 found = find_cmd_output(self, &oo, self->last_visited_prompt.y, self->last_visited_prompt.scrolled_by, LAST_VISISTED_CMD, false);
             } break;
-        case 3: // last non-empty cmd output
+        case LAST_NON_EMPTY_CMD: // last non-empty cmd output
             // When scrolled, the starting point of the search for the last command output
             // is actually out of the screen, so add the number of scrolled lines
             found = find_cmd_output(self, &oo, self->cursor->y + self->scrolled_by, self->scrolled_by, LAST_NON_EMPTY_CMD, false);

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -162,6 +162,7 @@ class DynamicColor(IntEnum):
     default_fg, default_bg, cursor_color, highlight_fg, highlight_bg = range(1, 6)
 
 
+# Matches kitty/screen.c/CommandOutput
 class CommandOutput(IntEnum):
     last_run, first_on_screen, last_visited, last_non_empty_run = 0, 1, 2, 3
 

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -163,7 +163,7 @@ class DynamicColor(IntEnum):
 
 
 class CommandOutput(IntEnum):
-    last_run, first_on_screen, last_visited, last_complete_run = 0, 1, 2, 3
+    last_run, first_on_screen, last_visited, last_non_empty_run = 0, 1, 2, 3
 
 
 DYNAMIC_COLOR_CODES = {

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -163,7 +163,7 @@ class DynamicColor(IntEnum):
 
 
 class CommandOutput(IntEnum):
-    last_run, first_on_screen, last_visited = 0, 1, 2
+    last_run, first_on_screen, last_visited, last_complete_run = 0, 1, 2, 3
 
 
 DYNAMIC_COLOR_CODES = {

--- a/kitty_tests/screen.py
+++ b/kitty_tests/screen.py
@@ -1027,6 +1027,11 @@ class TestScreen(BaseTest):
             s.cmd_output(2, a.append)
             return ''.join(a)
 
+        def lcco():
+            a = []
+            s.cmd_output(3, a.append)
+            return ''.join(a)
+
         s = self.create_screen()
         s.draw('abcd'), s.index(), s.carriage_return()
         s.draw('12'), s.index(), s.carriage_return()
@@ -1098,3 +1103,8 @@ class TestScreen(BaseTest):
         draw_prompt('p1')
         draw_output(30)
         self.ae(tuple(map(int, lco().split())), tuple(range(0, 30)))
+
+        draw_prompt('a'), draw_output(2, 'a')
+        draw_prompt('b'), draw_output(2, 'b')
+        self.ae(lcco(), '0a\n1a')
+        self.ae(lco(), '0b\n1b')

--- a/kitty_tests/screen.py
+++ b/kitty_tests/screen.py
@@ -1027,7 +1027,7 @@ class TestScreen(BaseTest):
             s.cmd_output(2, a.append)
             return ''.join(a)
 
-        def lcco():
+        def lnco():
             a = []
             s.cmd_output(3, a.append)
             return ''.join(a)
@@ -1104,7 +1104,10 @@ class TestScreen(BaseTest):
         draw_output(30)
         self.ae(tuple(map(int, lco().split())), tuple(range(0, 30)))
 
+        # last non-empty command output
         draw_prompt('a'), draw_output(2, 'a')
-        draw_prompt('b'), draw_output(2, 'b')
-        self.ae(lcco(), '0a\n1a')
-        self.ae(lco(), '0b\n1b')
+        draw_prompt('b'), mark_output()
+        self.ae(lco(), '')
+        self.ae(lnco(), '0a\n1a')
+        s.draw('running'), s.index(),  s.carriage_return()
+        self.ae(lnco(), 'running')


### PR DESCRIPTION
This allows running `kitty @ get-text --extent last_complete_output` to
get the previous command's output in the same window.

See https://github.com/kovidgoyal/kitty/discussions/4962 .

I'll try this out over the next days but wanted to push it as a draft right away to get CI feedback and maybe even some early feedback on my code. A hint on how to best fix the test would be very welcome!