### PR TITLE
clone-in-kitty: Fix activating the conda environment

### DIFF
--- a/kitty/launch.py
+++ b/kitty/launch.py
@@ -617,4 +617,4 @@ def clone_and_launch(msg: str, window: Window) -> None:
             cmdline[0] = window.child.final_exe
         if cmdline and cmdline == [window.child.final_exe] + window.child.argv[1:]:
             cmdline = window.child.unmodified_argv
-    launch(get_boss(), c.opts, cmdline, base_env=c.env, active=window, is_clone_launch=is_clone_launch)
+    launch(get_boss(), c.opts, cmdline, active=window, is_clone_launch=is_clone_launch)

--- a/kitty/launch.py
+++ b/kitty/launch.py
@@ -573,10 +573,13 @@ class CloneCmd:
                     # some people export these. We want the shell rc files to recreate them
                     'PS0', 'PS1', 'PS2', 'PS3', 'PS4', 'RPS1', 'PROMPT_COMMAND', 'SHLVL',
                     # conda state env vars
-                    'CONDA_SHLVL', 'CONDA_PREFIX', 'CONDA_EXE', 'CONDA_PROMPT_MODIFIER', 'CONDA_EXE', 'CONDA_PYTHON_EXE',
-                    # skip SSH environment variables
+                    'CONDA_SHLVL', 'CONDA_PREFIX', 'CONDA_PROMPT_MODIFIER', 'CONDA_EXE', 'CONDA_PYTHON_EXE', '_CE_CONDA', '_CE_M',
+                    # SSH environment variables
                     'SSH_CLIENT', 'SSH_CONNECTION', 'SSH_ORIGINAL_COMMAND', 'SSH_TTY', 'SSH2_TTY',
-                }}
+                } and not k.startswith((
+                    # conda state env vars for multi-level virtual environments
+                    'CONDA_PREFIX_',
+                ))}
             elif k == 'cwd':
                 self.cwd = v
 

--- a/kitty/launch.py
+++ b/kitty/launch.py
@@ -589,7 +589,7 @@ def clone_and_launch(msg: str, window: Window) -> None:
         c.opts.cwd = c.cwd
     c.opts.copy_colors = True
     c.opts.copy_env = False
-    if c.opts.type in ('clipboard', 'primary', 'background'):
+    if c.opts.type not in ('os-window', 'tab', 'window', 'overlay'):
         c.opts.type = 'window'
     is_clone_launch = serialize_env(c.shell, c.env or {})
     ssh_kitten_cmdline = window.ssh_kitten_cmdline()


### PR DESCRIPTION
- Use conda activate and avoid duplicate entries in the PATH.
- Avoid directly sets env vars when running clone-in-kitty locally. Fix the value is always the same when comparing conda env var.
- Explicitly specifies the allowed launch types.

Since conda activate still returns zero when activation fails, use environment variables to check for success.
When the activation fails, the PATH still contains the cloned virtual environment path, which cannot be avoided.

I tried zsh and after conda venv activation there are duplicate virtual environment paths in the PATH.
Do you encounter the same in your environment?

Also currently there are some errors after running clone-in-kitty.
```text
Failed to send resize signal to child with id: 2 (children count: 1) (add queue: 1)
Failed to send resize signal to child with id: 4 (children count: 1) (add queue: 1)
```

Thanks to the recent improvements, clone-in-kitty is now working properly in my environment again.