### PR TITLE
clone-in-kitty: Remove duplicate PATH entries and minor refactoring

### DIFF
--- a/kitty/launch.py
+++ b/kitty/launch.py
@@ -574,7 +574,10 @@ class CloneCmd:
                     'CONDA_SHLVL', 'CONDA_PREFIX', 'CONDA_PROMPT_MODIFIER', 'CONDA_EXE', 'CONDA_PYTHON_EXE', '_CE_CONDA', '_CE_M',
                     # skip SSH environment variables
                     'SSH_CLIENT', 'SSH_CONNECTION', 'SSH_ORIGINAL_COMMAND', 'SSH_TTY', 'SSH2_TTY',
-                }}
+                } and not k.startswith((
+                    # conda state env vars for multi-level virtual environments
+                    'CONDA_PREFIX_',
+                ))}
             elif k == 'cwd':
                 self.cwd = v
 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -3768,18 +3768,21 @@ This will send "Special text" when you press the :kbd:`ctrl+alt+a` key
 combination.  The text to be sent is a python string literal so you can use
 escapes like :code:`\\x1b` to send control codes or :code:`\\u21fb` to send
 unicode characters (or you can just input the unicode characters directly as
-UTF-8 text). The first argument to :code:`send_text` is the keyboard modes in which to
-activate the shortcut. The possible values are :code:`normal` or :code:`application` or :code:`kitty`
-or a comma separated combination of them.  The special keyword :code:`all` means all
-modes. The modes :code:`normal` and :code:`application` refer to the DECCKM cursor key mode for
-terminals, and :code:`kitty` refers to the special kitty extended keyboard protocol.
+UTF-8 text). You can use the show_key kitten :code:`kitty +kitten show_key` to
+get the key escape codes you want to emulate. The first argument to
+:code:`send_text` is the keyboard modes in which to activate the shortcut. The
+possible values are :code:`normal` or :code:`application` or :code:`kitty` or a
+comma separated combination of them.  The special keyword :code:`all` means all
+modes. The modes :code:`normal` and :code:`application` refer to the DECCKM
+cursor key mode forterminals, and :code:`kitty` refers to the special kitty
+extended keyboard protocol.
 
 Some more examples::
 
-    # Output a word and move the cursor ro the start of the line (like typing and pressing Home)
+    # Output a word and move the cursor to the start of the line (like typing and pressing Home)
     map ctrl+alt+a send_text normal Word\\x1b[H
     map ctrl+alt+a send_text application Word\\x1bOH
-    # Run a command at a shell prompt (like typing the command and pressing enter)
+    # Run a command at a shell prompt (like typing the command and pressing Enter)
     map ctrl+alt+a send_text normal,application some command with arguments\r
 '''
     )

--- a/shell-integration/bash/kitty.bash
+++ b/shell-integration/bash/kitty.bash
@@ -215,7 +215,7 @@ _ksi_main() {
             builtin let limit=1+$COMP_CWORD
             src=$(builtin printf "%s\n" "${COMP_WORDS[@]:0:$limit}" | builtin command kitty +complete bash)
             if [[ $? == 0 ]]; then
-                builtin eval ${src}
+                builtin eval "${src}"
             fi
         }
         builtin complete -o nospace -F _ksi_completions kitty
@@ -273,13 +273,13 @@ _ksi_main() {
         if _ksi_s_is_ok "venv" && [ -n "${VIRTUAL_ENV}" -a -r "$venv" ]; then
             sourced="y"
             builtin unset VIRTUAL_ENV
-            . "$venv"
+            builtin source "$venv"
         fi; if _ksi_s_is_ok "conda" && [ -n "${CONDA_DEFAULT_ENV}" ] && builtin command -v conda >/dev/null 2>/dev/null && [ "${CONDA_DEFAULT_ENV}" != "$orig_conda_env" ]; then
             sourced="y"
             conda activate "${CONDA_DEFAULT_ENV}"
         fi; if _ksi_s_is_ok "env_var" && [[ -n "${KITTY_CLONE_SOURCE_CODE}" ]]; then
             sourced="y"
-            eval "${KITTY_CLONE_SOURCE_CODE}"
+            builtin eval "${KITTY_CLONE_SOURCE_CODE}"
         fi; if _ksi_s_is_ok "path" && [[ -r "${KITTY_CLONE_SOURCE_PATH}" ]]; then
             sourced="y"
             builtin source "${KITTY_CLONE_SOURCE_PATH}"

--- a/shell-integration/zsh/kitty-integration
+++ b/shell-integration/zsh/kitty-integration
@@ -369,7 +369,7 @@ _ksi_deferred_init() {
             conda activate "${CONDA_DEFAULT_ENV}"
         fi; if _ksi_s_is_ok "env_var" && [[ -n "${KITTY_CLONE_SOURCE_CODE}" ]]; then
             sourced="y"
-            eval "${KITTY_CLONE_SOURCE_CODE}"
+            builtin eval "${KITTY_CLONE_SOURCE_CODE}"
         fi; if _ksi_s_is_ok "path" && [[ -r "${KITTY_CLONE_SOURCE_PATH}" ]]; then
             sourced="y"
             builtin source "${KITTY_CLONE_SOURCE_PATH}"


### PR DESCRIPTION
- Remove CONDA_PREFIX_* env vars
- Remove duplicate PATH entries in fish implementation
- Docs: Mention show_key kitten in send_text docs

Please review, thanks.

Why `KITTY_CLONE_SOURCE_CODE / PATH` are no longer processed after activating venv?
It doesn't seem to conflict?