### PR TITLE
Docs: Show copy button for installation command snippets

### DIFF
--- a/docs/binary.rst
+++ b/docs/binary.rst
@@ -4,17 +4,14 @@ Install kitty
 Binary install
 ----------------
 
-.. |ins| replace:: curl -L :literal:`https://sw.kovidgoyal.net/kitty/installer.sh` | sh /dev/stdin
-
 .. highlight:: sh
 
 You can install pre-built binaries of |kitty| if you are on macOS or Linux using
 the following simple command:
 
-.. parsed-literal::
-    :class: pre
+.. code-block:: sh
 
-    |ins|
+    _kitty_install_cmd
 
 
 The binaries will be installed in the standard location for your OS,
@@ -75,44 +72,39 @@ Customizing the installation
 
 * You can install the latest nightly kitty build with ``installer``:
 
-  .. parsed-literal::
-     :class: pre
+  .. code-block:: sh
 
-     |ins| \\
+     _kitty_install_cmd \\
          installer=nightly
 
   If you want to install it in parallel to the released kitty specify a
   different install locations with ``dest``:
 
-  .. parsed-literal::
-     :class: pre
+  .. code-block:: sh
 
-     |ins| \\
+     _kitty_install_cmd \\
          installer=nightly dest=/some/other/location
 
 * You can specify a different install location, with ``dest``:
 
-  .. parsed-literal::
-     :class: pre
+  .. code-block:: sh
 
-     |ins| \\
+     _kitty_install_cmd \\
          dest=/some/other/location
 
 * You can tell the installer not to launch |kitty| after installing it with
   ``launch=n``:
 
-  .. parsed-literal::
-     :class: pre
+  .. code-block:: sh
 
-     |ins| \\
+     _kitty_install_cmd \\
          launch=n
 
 * You can use a previously downloaded dmg/tarball, with ``installer``:
 
-  .. parsed-literal::
-     :class: pre
+  .. code-block:: sh
 
-     |ins| \\
+     _kitty_install_cmd \\
          installer=/path/to/dmg or tarball
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,6 +104,10 @@ rst_prolog = '''
 '''.replace('VERSION', str_version)
 smartquotes_action = 'qe'  # educate quotes and ellipses but not dashes
 
+string_replacements = {
+    '_kitty_install_cmd': 'curl -L https://sw.kovidgoyal.net/kitty/installer.sh | sh /dev/stdin',
+}
+
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -299,6 +303,12 @@ def write_remote_control_protocol_docs() -> None:  # {{{
             format_cmd(p, name, cmd)
 # }}}
 
+def replace_string(app: Any, docname: str, source: List[str]) -> None:  # {{{
+    src = source[0]
+    for k, v in app.config.string_replacements.items():
+        src = src.replace(k, v)
+    source[0] = src
+# }}}
 
 # config file docs {{{
 
@@ -516,6 +526,8 @@ def setup(app: Any) -> None:
     write_cli_docs(kn)
     write_remote_control_protocol_docs()
     write_conf_docs(app, kn)
+    app.add_config_value('string_replacements', {}, True)
+    app.connect('source-read', replace_string)
     app.add_config_value('analytics_id', '', 'env')
     app.connect('html-page-context', add_html_context)
     app.add_lexer('session', SessionLexer() if version_info[0] < 3 else SessionLexer)


### PR DESCRIPTION
The `parsed-literal` in the document does not display the copy button.
Put the install command snippets in `code-block` with string substitution.

I know little about Sphinx. Please review, thanks.