### PR TITLE
Docs: Mention again that kitty.conf will be created if not present

### DIFF
--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -7,9 +7,11 @@ kitty.conf
 rendering frames-per-second. See below for an overview of all customization
 possibilities.
 
-You can open the config file within kitty by pressing :sc:`edit_config_file` (:kbd:`⌘+,` on macOS).
-You can reload the config file within kitty by pressing
-:sc:`reload_config_file` (:kbd:`⌃+⌘+,` on macOS) or sending kitty the ``SIGUSR1`` signal.
+You can open the config file within kitty by pressing :sc:`edit_config_file`
+(:kbd:`⌘+,` on macOS). A :file:`kitty.conf` with commented default
+configurations and descriptions will be created if the file does not exist.
+You can reload the config file within kitty by pressing :sc:`reload_config_file`
+(:kbd:`⌃+⌘+,` on macOS) or sending kitty the ``SIGUSR1`` signal.
 You can also display the current configuration by pressing :sc:`debug_config`
 (:kbd:`⌥+⌘+,` on macOS).
 


### PR DESCRIPTION
The question of default configuration has been answered several times.
Mention it at the beginning of the documentation, hopefully users who need it will notice that.

Please review, thanks.