### PR TITLE
Docs: Improvements to the configuration documentation

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -45,6 +45,7 @@ Environment variables
 ------------------------
 
 Variables that influence kitty behavior
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. envvar:: KITTY_CONFIG_DIRECTORY
 
@@ -68,7 +69,6 @@ Variables that influence kitty behavior
    The terminal editor (such as ``vi`` or ``nano``) kitty uses, when, for
    instance, opening :file:`kitty.conf` in response to :sc:`edit_config_file`.
 
-
 .. envvar:: EDITOR
 
    Same as :envvar:`VISUAL`. Used if :envvar:`VISUAL` is not set.
@@ -84,13 +84,24 @@ Variables that influence kitty behavior
    is possible for the autodiscovery to fail; the default Wayland XKB mappings
    are used in this case. See :pull:`3943` for details.
 
+.. envvar:: KITTY_CLONE_SOURCE_CODE
+
+   Set this to some shell code that will be executed in the cloned window with
+   :code:`eval` when :ref:`clone-in-kitty <clone_shell>` is used.
+
+.. envvar:: KITTY_CLONE_SOURCE_PATH
+
+   Set this to the path of a file that will be sourced in the cloned window when
+   :ref:`clone-in-kitty <clone_shell>` is used.
+
 
 Variables that kitty sets when running child programs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. envvar:: LANG
 
-   This is set only on macOS, and only if the country and language from the
-   macOS user settings form a valid locale.
+   This is only set on macOS. If the country and language from the macOS user
+   settings form an invalid locale, it will be set to :code:`en_US.UTF-8`.
 
 
 .. envvar:: KITTY_WINDOW_ID
@@ -137,7 +148,7 @@ Variables that kitty sets when running child programs
 
    Set when the :doc:`remote control <remote-control>` facility is enabled and
    the a socket is used for control via :option:`kitty --listen-on` or :opt:`listen_on`.
-   Contains the path to the socket. Avoids needs to use :option:`kitty @ --to` when
+   Contains the path to the socket. Avoid the need to use :option:`kitty @ --to` when
    issuing remote control commands.
 
 
@@ -158,7 +169,7 @@ Variables that kitty sets when running child programs
 .. envvar:: KITTY_COMMON_OPTS
 
    Set with the values of some common kitty options when running
-   kittens, so kittens can use them without needing to load kitty.conf.
+   kittens, so kittens can use them without needing to load :file:`kitty.conf`.
 
 
 .. envvar:: KITTY_SHELL_INTEGRATION

--- a/docs/shell-integration.rst
+++ b/docs/shell-integration.rst
@@ -223,7 +223,7 @@ Clone the current shell into a new window
 -----------------------------------------------
 
 You can clone the current shell into a new kitty window by simply running the
-:code:`clone-in-kitty` command, for example:
+:command:`clone-in-kitty` command, for example:
 
 .. code-block:: sh
 
@@ -235,24 +235,27 @@ This will open a new window running a new shell instance but with all
 environment variables and the current working directory copied. This even
 works over SSH when using :doc:`kittens/ssh`.
 
-The :file:`clone-in-kitty` command takes almost all the same arguments as the
+The :command:`clone-in-kitty` command takes almost all the same arguments as the
 :doc:`launch <launch>` command, so you can open a new tab instead or a new OS
 window, etc. Arguments of launch that can cause code execution or that don't
-make sense when cloning are ignored. Most prominently, the following options
-are ignored: :option:`launch --allow-remote-control`, :option:`launch
---copy-cmdline`, :option:`launch --copy-env`, :option:`launch --stdin-source`,
-:option:`launch --marker` and :option:`launch --watcher`.
+make sense when cloning are ignored. Most prominently, the following options are
+ignored: :option:`--allow-remote-control <launch --allow-remote-control>`,
+:option:`--copy-cmdline <launch --copy-cmdline>`, :option:`--copy-env <launch
+--copy-env>`, :option:`--stdin-source <launch --stdin-source>`,
+:option:`--marker <launch --marker>` and :option:`--watcher <launch --watcher>`.
 
-:file:`clone-in-kitty` can be configured to source arbitrary code in the
+:command:`clone-in-kitty` can be configured to source arbitrary code in the
 cloned window using environment variables. It will automatically clone virtual
-environments created by the python venv module or conda. In addition, setting the
-env var :file:`KITTY_CLONE_SOURCE_PATH` to the path of a file will cause
-that file to be sourced in the cloned window. Similarly, setting
-:file:`KITTY_CLONE_SOURCE_CODE` to some shell code will cause that code to be
-run in the cloned window with :code:`eval`. This can be controlled by
+environments created by the :link:`Python venv module
+<https://docs.python.org/3/library/venv.html>` or :link:`Conda
+<https://conda.io/>`. In addition, setting the
+env var :envvar:`KITTY_CLONE_SOURCE_CODE` to some shell code will cause that
+code to be run in the cloned window with :code:`eval`. Similarly, setting
+:envvar:`KITTY_CLONE_SOURCE_PATH` to the path of a file will cause that file to
+be sourced in the cloned window. This can be controlled by
 :opt:`clone_source_strategies`.
 
-:file:`clone-in-kitty` works by asking the shell to serialize its internal
+:command:`clone-in-kitty` works by asking the shell to serialize its internal
 state (mainly CWD and env vars) and this state is transmitted to kitty and
 restored by the shell integration scripts in the cloned window.
 

--- a/kittens/hints/main.py
+++ b/kittens/hints/main.py
@@ -525,10 +525,10 @@ OPTIONS = r'''
 --program
 type=list
 What program to use to open matched text. Defaults to the default open program
-for the operating system. Use a value of :file:`-` to paste the match into the
-terminal window instead. A value of :file:`@` will copy the match to the
-clipboard. A value of :file:`*` will copy the match to the primary selection
-(on systems that support primary selections). A value of :file:`default` will
+for the operating system. Use a value of :code:`-` to paste the match into the
+terminal window instead. A value of :code:`@` will copy the match to the
+clipboard. A value of :code:`*` will copy the match to the primary selection
+(on systems that support primary selections). A value of :code:`default` will
 run the default open program. Can be specified multiple times to run multiple
 programs.
 
@@ -538,22 +538,22 @@ default=url
 choices=url,regex,path,line,hash,word,linenum,hyperlink,ip
 The type of text to search for. A value of :code:`linenum` is special, it looks
 for error messages using the pattern specified with :option:`--regex`, which
-must have the named groups, :code:`path` and :code:`line`. If not specified,
+must have the named groups: :code:`path` and :code:`line`. If not specified,
 will look for :code:`path:line`. The :option:`--linenum-action` option
 controls where to display the selected error message, other options are ignored.
 
 
 --regex
 default={default_regex}
-The regular expression to use when :option:`kitty +kitten hints --type`=regex.
-The regular expression is in python syntax. If you specify a numbered group in
-the regular expression only the group will be matched. This allow you to match
-text ignoring a prefix/suffix, as needed. The default expression matches lines.
-To match text over multiple lines you should prefix the regular expression with
+The regular expression to use when option :option:`--type` is set to
+:code:`regex`, in python syntax. If you specify a numbered group in the regular
+expression, only the group will be matched. This allow you to match text
+ignoring a prefix/suffix, as needed. The default expression matches lines. To
+match text over multiple lines, you should prefix the regular expression with
 :code:`(?ms)`, which turns on MULTILINE and DOTALL modes for the regex engine.
-If you specify named groups and a :option:`kitty +kitten hints --program` then
-the program will be passed arguments corresponding to each named group of
-the form key=value.
+If you specify named groups and a :option:`--program`, then the program will be
+passed arguments corresponding to each named group of the form
+:code:`key=value`.
 
 
 --linenum-action
@@ -565,22 +565,22 @@ window, :code:`window` a new kitty window, :code:`tab` a new tab,
 :code:`os_window` a new OS window and :code:`background` run in the background.
 The actual action is whatever arguments are provided to the kitten, for
 example:
-:code:`kitty + kitten hints --type=linenum --linenum-action=tab vim +{line} {path}`
+:code:`kitty +kitten hints --type=linenum --linenum-action=tab vim +{line} {path}`
 will open the matched path at the matched line number in vim in
-a new kitty tab. Note that only when using :code:`self` are the special values for
-:option:`kitty +kitten hints --program` to copy/paste the text respected.
+a new kitty tab. Note that in order to use :option:`--program` to copy or paste
+text, you need to use the special value :code:`self`.
 
 
 --url-prefixes
 default=default
-Comma separated list of recognized URL prefixes. Defaults, to
-the list of prefixes defined in kitty.conf.
+Comma separated list of recognized URL prefixes. Defaults to the list of
+prefixes defined by the :opt:`url_prefixes` option in :file:`kitty.conf`.
 
 
 --word-characters
 Characters to consider as part of a word. In addition, all characters marked as
-alphanumeric in the unicode database will be considered as word characters.
-Defaults to the select_by_word_characters setting from kitty.conf.
+alphanumeric in the Unicode database will be considered as word characters.
+Defaults to the :opt:`select_by_word_characters` option from :file:`kitty.conf`.
 
 
 --minimum-match-length
@@ -591,26 +591,26 @@ The minimum number of characters to consider a match.
 
 --multiple
 type=bool-set
-Select multiple matches and perform the action on all of them together at the end.
-In this mode, press :kbd:`Esc` to finish selecting.
+Select multiple matches and perform the action on all of them together at the
+end. In this mode, press :kbd:`Esc` to finish selecting.
 
 
 --multiple-joiner
 default=auto
-String to use to join multiple selections when copying to the clipboard or
-inserting into the terminal. The special strings: "space", "newline", "empty",
-"json" and "auto" are interpreted as a space character, a newline an empty
-joiner, a JSON serialized list and an automatic choice, based on the type of
-text being selected. In addition, integers are interpreted as zero-based
-indices into the list of selections. You can use 0 for the first selection and
--1 for the last.
+String for joining multiple selections when copying to the clipboard or
+inserting into the terminal. The special values are: :code:`space` - a space
+character, :code:`newline` - a newline, :code:`empty` - an empty joiner,
+:code:`json` - a JSON serialized list, :code:`auto` - an automatic choice, based
+on the type of text being selected. In addition, integers are interpreted as
+zero-based indices into the list of selections. You can use :code:`0` for the
+first selection and :code:`-1` for the last.
 
 
 --add-trailing-space
 default=auto
 choices=auto,always,never
-Add trailing space after matched text. Defaults to auto, which adds the space
-when used together with :option:`--multiple`.
+Add trailing space after matched text. Defaults to :code:`auto`, which adds the
+space when used together with :option:`--multiple`.
 
 
 --hints-offset
@@ -621,45 +621,47 @@ greater than or equal to zero are respected.
 
 
 --alphabet
-The list of characters to use for hints. The default is to use numbers and lowercase
-English alphabets. Specify your preference as a string of characters. Note that
-unless you specify the hints offset as zero the first match will be highlighted with
-the second character you specify.
+The list of characters to use for hints. The default is to use numbers and
+lowercase English alphabets. Specify your preference as a string of characters.
+Note that you need to specify the :option:`--hints-offset` as zero to use the
+first character to highlight the first match, otherwise it will start with the
+second character by default.
 
 
 --ascending
 type=bool-set
-Have the hints increase from top to bottom instead of decreasing from top to bottom.
+Make the hints increase from top to bottom, instead of decreasing from top to
+bottom.
 
 
 --hints-foreground-color
 default=black
 type=str
-The foreground color for hints
+The foreground color for hints.
 
 
 --hints-background-color
 default=green
 type=str
-The background color for hints
+The background color for hints.
 
 
 --hints-text-color
 default=gray
 type=str
-The foreground color for text pointed to by the hints
+The foreground color for text pointed to by the hints.
 
 
 --customize-processing
-Name of a python file in the kitty config directory which will be imported to provide
-custom implementations for pattern finding and performing actions
-on selected matches. See {hints_url}
-for details. You can also specify absolute paths to load the script from elsewhere.
+Name of a python file in the kitty config directory which will be imported to
+provide custom implementations for pattern finding and performing actions
+on selected matches. You can also specify absolute paths to load the script from
+elsewhere. See {hints_url} for details.
 
 
 --window-title
-The window title for the hints window, default title is selected based on
-the type of text being hinted.
+The title for the hints window, default title is based on the type of text being
+hinted.
 '''.format(
     default_regex=DEFAULT_REGEX,
     line='{{line}}', path='{{path}}',

--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -28,26 +28,27 @@ class OptionDict(TypedDict):
 
 CONFIG_HELP = '''\
 Specify a path to the configuration file(s) to use. All configuration files are
-merged onto the builtin {conf_name}.conf, overriding the builtin values. This option
-can be specified multiple times to read multiple configuration files in
-sequence, which are merged. Use the special value NONE to not load a config
-file.
+merged onto the builtin :file:`{conf_name}.conf`, overriding the builtin values.
+This option can be specified multiple times to read multiple configuration files
+in sequence, which are merged. Use the special value :code:`NONE` to not load
+any config file.
 
 If this option is not specified, config files are searched for in the order:
-:file:`$XDG_CONFIG_HOME/{appname}/{conf_name}.conf`, :file:`~/.config/{appname}/{conf_name}.conf`, {macos_confpath}
-:file:`$XDG_CONFIG_DIRS/{appname}/{conf_name}.conf`. The first one that exists is used as the
-config file.
+:file:`$XDG_CONFIG_HOME/{appname}/{conf_name}.conf`,
+:file:`~/.config/{appname}/{conf_name}.conf`,{macos_confpath}
+:file:`$XDG_CONFIG_DIRS/{appname}/{conf_name}.conf`. The first one that exists
+is used as the config file.
 
 If the environment variable :envvar:`KITTY_CONFIG_DIRECTORY` is specified, that
 directory is always used and the above searching does not happen.
 
-If :file:`/etc/xdg/{appname}/{conf_name}.conf` exists it is merged before (i.e. with lower
-priority) than any user config files. It can be used to specify system-wide
-defaults for all users. You can use either :code:`-` or :code:`/dev/stdin` to read the
-config from STDIN.
+If :file:`/etc/xdg/{appname}/{conf_name}.conf` exists, it is merged before (i.e.
+with lower priority) than any user config files. It can be used to specify
+system-wide defaults for all users. You can use either :code:`-` or
+:file:`/dev/stdin` to read the config from STDIN.
 '''.replace(
     '{macos_confpath}',
-    (':file:`~/Library/Preferences/{appname}/{conf_name}.conf`,' if is_macos else ''), 1
+    (' :file:`~/Library/Preferences/{appname}/{conf_name}.conf`,' if is_macos else ''), 1
 )
 
 
@@ -294,9 +295,10 @@ def get_defaults_from_seq(seq: OptionSpecSeq) -> Dict[str, Any]:
 
 
 default_msg = ('''\
-Run the :italic:`{appname}` terminal emulator. You can also specify the :italic:`program`
-to run inside :italic:`{appname}` as normal arguments following the :italic:`options`.
-For example: {appname} sh -c "echo hello, world. Press ENTER to quit; read"
+Run the :italic:`{appname}` terminal emulator. You can also specify the
+:italic:`program` to run inside :italic:`{appname}` as normal arguments
+following the :italic:`options`.
+For example: {appname} --hold sh -c "echo hello, world"
 
 For comprehensive documentation for kitty, please see: {url}''').format(
     appname=appname, url=website_url())
@@ -583,17 +585,20 @@ def options_spec() -> str:
 dest=cls
 default={appname}
 condition=not is_macos
-Set the class part of the :italic:`WM_CLASS` window property. On Wayland, it sets the app id.
+Set the class part of the :italic:`WM_CLASS` window property. On Wayland, it
+sets the app id.
 
 
 --name
 condition=not is_macos
-Set the name part of the :italic:`WM_CLASS` property (defaults to using the value from :option:`{appname} --class`)
+Set the name part of the :italic:`WM_CLASS` property. Defaults to using the
+value from :option:`{appname} --class`.
 
 
 --title -T
-Set the OS window title. This will override any title set by the program running inside kitty, permanently
-fixing the OS Window's title. So only use this if you are running a program that does not set titles.
+Set the OS window title. This will override any title set by the program running
+inside kitty, permanently fixing the OS window's title. So only use this if you
+are running a program that does not set titles.
 
 
 --config -c
@@ -604,68 +609,74 @@ type=list
 --override -o
 type=list
 Override individual configuration options, can be specified multiple times.
-Syntax: :italic:`name=value`. For example: :option:`kitty -o` font_size=20
+Syntax: :italic:`name=value`. For example: :option:`{appname} -o` font_size=20
 
 
 --directory --working-directory -d
 default=.
-Change to the specified directory when launching
+Change to the specified directory when launching.
 
 
 --detach
 type=bool-set
 condition=not is_macos
-Detach from the controlling terminal, if any
+Detach from the controlling terminal, if any.
 
 
 --session
-Path to a file containing the startup :italic:`session` (tabs, windows, layout, programs).
-Use - to read from STDIN. See the README file for details and an example.
+Path to a file containing the startup :italic:`session` (tabs, windows, layout,
+programs). Use - to read from STDIN. See the :file:`README` file for details and
+an example.
 
 
 --hold
 type=bool-set
 Remain open after child process exits. Note that this only affects the first
-window. You can quit by either using the close window shortcut or pressing any key.
+window. You can quit by either using the close window shortcut or pressing any
+key.
 
 
 --single-instance -1
 type=bool-set
-If specified only a single instance of :italic:`{appname}` will run. New invocations will
-instead create a new top-level window in the existing :italic:`{appname}` instance. This
-allows :italic:`{appname}` to share a single sprite cache on the GPU and also reduces
-startup time. You can also have separate groups of :italic:`{appname}` instances by using the
-:option:`kitty --instance-group` option
+If specified only a single instance of :italic:`{appname}` will run. New
+invocations will instead create a new top-level window in the existing
+:italic:`{appname}` instance. This allows :italic:`{appname}` to share a single
+sprite cache on the GPU and also reduces startup time. You can also have
+separate groups of :italic:`{appname}` instances by using the :option:`{appname}
+--instance-group` option.
 
 
 --instance-group
-Used in combination with the :option:`kitty --single-instance` option. All :italic:`{appname}` invocations
-with the same :option:`kitty --instance-group` will result in new windows being created
-in the first :italic:`{appname}` instance within that group
+Used in combination with the :option:`{appname} --single-instance` option. All
+:italic:`{appname}` invocations with the same :option:`{appname}
+--instance-group` will result in new windows being created in the first
+:italic:`{appname}` instance within that group.
 
 
 --wait-for-single-instance-window-close
 type=bool-set
-Normally, when using :option:`--single-instance`, :italic:`{appname}` will open a new window in an existing
-instance and quit immediately. With this option, it will not quit till the newly opened
-window is closed. Note that if no previous instance is found, then :italic:`{appname}` will wait anyway,
+Normally, when using :option:`{appname} --single-instance`, :italic:`{appname}`
+will open a new window in an existing instance and quit immediately. With this
+option, it will not quit till the newly opened window is closed. Note that if no
+previous instance is found, then :italic:`{appname}` will wait anyway,
 regardless of this option.
 
 
 --listen-on
-Tell kitty to listen on the specified address for control
-messages. For example, :option:`{appname} --listen-on`=unix:/tmp/mykitty or
+Listen on the specified socket address for control messages. For example,
+:option:`{appname} --listen-on`=unix:/tmp/mykitty or
 :option:`{appname} --listen-on`=tcp:localhost:12345. On Linux systems, you can
 also use abstract UNIX sockets, not associated with a file, like this:
-:option:`{appname} --listen-on`=unix:@mykitty. Environment variables
-in the setting are expanded and relative paths are resolved with
-respect to the temporary directory. To control kitty, you can send
-it commands with :italic:`kitty @` using the :option:`kitty @ --to` option to
-specify this address. This option will be ignored, unless you set
-:opt:`allow_remote_control` to yes in :file:`kitty.conf`. Note that if you run
-:italic:`kitty @` within a kitty window, there is no need to specify the :option:`kitty @ --to`
-option as it is read automatically from the environment. For UNIX sockets, this
-can also be specified in :file:`kitty.conf`.
+:option:`{appname} --listen-on`=unix:@mykitty. Environment variables are
+expanded and relative paths are resolved with respect to the temporary
+directory. To control kitty, you can send commands to it with
+:italic:`{appname} @` using the :option:`{appname} @ --to` option to specify
+this address. Unless you enabled :opt:`allow_remote_control` in
+:file:`{conf_name}.conf`, this option will be ignored. Note that if you run
+:italic:`{appname} @` within a kitty window, there is
+no need to specify the :option:`{appname} @ --to` option as it will
+automatically read from the environment. For UNIX sockets, this can also be
+specified in :file:`{conf_name}.conf`.
 
 
 --start-as
@@ -679,45 +690,48 @@ Control how the initial kitty window is created.
 
 --version -v
 type=bool-set
-The current {appname} version
+The current {appname} version.
 
 
 --dump-commands
 type=bool-set
-Output commands received from child process to stdout
+Output commands received from child process to STDOUT.
 
 
 --replay-commands
-Replay previously dumped commands. Specify the path to a dump file previously created by :option:`kitty --dump-commands`. You
+Replay previously dumped commands. Specify the path to a dump file previously
+created by :option:`{appname} --dump-commands`. You
 can open a new kitty window to replay the commands with::
 
-    kitty sh -c "kitty --replay-commands /path/to/dump/file; read"
+    {appname} --hold {appname} --replay-commands /path/to/dump/file
 
 
 --dump-bytes
-Path to file in which to store the raw bytes received from the child process
+Path to file in which to store the raw bytes received from the child process.
 
 
 --debug-rendering --debug-gl
 type=bool-set
 Debug rendering commands. This will cause all OpenGL calls to check for errors
 instead of ignoring them. Also prints out miscellaneous debug information.
-Useful when debugging rendering problems
+Useful when debugging rendering problems.
 
 
 --debug-input --debug-keyboard
 dest=debug_keyboard
 type=bool-set
-This option will cause kitty to print out key and mouse events as they are received
+Print out key and mouse events as they are received.
 
 
 --debug-font-fallback
 type=bool-set
-Print out information about the selection of fallback fonts for characters not present in the main font.
+Print out information about the selection of fallback fonts for characters not
+present in the main font.
 
 
 --watcher
-This option is deprecated in favor of the :opt:`watcher` option in kitty.conf and should not be used.
+This option is deprecated in favor of the :opt:`watcher` option in
+:file:`{conf_name}.conf` and should not be used.
 
 
 --execute -e
@@ -725,7 +739,8 @@ type=bool-set
 !
 '''
         setattr(options_spec, 'ans', OPTIONS.format(
-            appname=appname, config_help=CONFIG_HELP.format(appname=appname, conf_name=appname),
+            appname=appname, conf_name=appname,
+            config_help=CONFIG_HELP.format(appname=appname, conf_name=appname),
         ))
     ans: str = getattr(options_spec, 'ans')
     return ans
@@ -769,7 +784,7 @@ def parse_args(
     return ans, parse_cmdline(oc, disabled, ans, args=args)
 
 
-SYSTEM_CONF = '/etc/xdg/kitty/kitty.conf'
+SYSTEM_CONF = f'/etc/xdg/{appname}/{appname}.conf'
 
 
 def create_opts(args: CLIOptions, accumulate_bad_lines: Optional[List[BadLineType]] = None) -> KittyOpts:

--- a/kitty/conf/types.py
+++ b/kitty/conf/types.py
@@ -55,6 +55,7 @@ def ref_map() -> Dict[str, str]:
         'functional': f'{website_url("keyboard-protocol")}#functional-key-definitions',
         'ssh_copy_command': f'{website_url("kittens/ssh")}#ssh-copy-command',
         'shell_integration': website_url("shell-integration"),
+        'clone_shell': f'{website_url("shell-integration")}#clone-shell',
         'github_discussions': 'https://github.com/kovidgoyal/kitty/discussions',
     }
     for actions in get_all_actions().values():
@@ -65,17 +66,30 @@ def ref_map() -> Dict[str, str]:
 
 def remove_markup(text: str) -> str:
 
+    def extract(m: 'Match[str]') -> Tuple[str, str]:
+        parts = m.group(2).split('<')
+        t = parts[0].strip()
+        q = parts[-1].rstrip('>')
+        return t, q
+
     def sub(m: 'Match[str]') -> str:
         if m.group(1) == 'ref':
-            q = m.group(2).split('<')[-1].rstrip('>')
-            return ref_map()[q]
+            t, q = extract(m)
+            return f'{t} <{ref_map()[q]}>'
+        if m.group(1) == 'doc':
+            t, q = extract(m)
+            return f'{t} <{website_url(q.lstrip("/"))}>'
         if m.group(1) == 'ac':
             q = m.group(2).split('<')[-1].rstrip('>')
-            return ref_map()[f'action-{q}']
+            return q
+        if m.group(1) == 'term':
+            t, _ = extract(m)
+            return t
+        if m.group(1) == 'option':
+            t, _ = extract(m)
+            return t
         if m.group(1) == 'disc':
-            parts = m.group(2).split('<')
-            t = parts[0].strip()
-            q = parts[-1].rstrip('>')
+            t, q = extract(m)
             return f'{t} {ref_map()["github_discussions"]}/{q}'
         return str(m.group(2))
 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -34,11 +34,12 @@ and even specify special fonts for particular characters.
 opt('font_family', 'monospace',
     long_text='''
 You can specify different fonts for the bold/italic/bold-italic variants.
-To get a full list of supported fonts use the `kitty +list-fonts` command.
+To get a full list of supported fonts use the :code:`kitty +list-fonts` command.
 By default they are derived automatically, by the OSes font system. When
-bold_font or bold_italic_font is set to :code:`auto` on macOS, the priority of
-bold fonts is semi-bold, bold, heavy. Setting them manually is useful for font
-families that have many weight variants like Book, Medium, Thick, etc.
+:opt:`bold_font` or :opt:`bold_italic_font` is set to :code:`auto` on macOS, the
+priority of bold fonts is semi-bold, bold, heavy. Setting them manually is
+useful for font families that have many weight variants like Book, Medium,
+Thick, etc.
 For example::
 
     font_family      Operator Mono Book
@@ -48,14 +49,11 @@ For example::
 '''
     )
 
-opt('bold_font', 'auto',
-    )
+opt('bold_font', 'auto')
 
-opt('italic_font', 'auto',
-    )
+opt('italic_font', 'auto')
 
-opt('bold_italic_font', 'auto',
-    )
+opt('bold_italic_font', 'auto')
 
 opt('font_size', '11.0',
     option_type='to_font_size', ctype='double',
@@ -102,7 +100,7 @@ opt('adjust_baseline', '0',
     add_to_default=False,
     long_text='''
 Adjust the vertical alignment of text (the height in the cell at which text is
-positioned). You can use either numbers, which are interpreted as pixels or a
+positioned). You can use either numbers, which are interpreted as pixels or
 percentages (number followed by %), which are interpreted as the percentage of
 the line height. A positive value moves the baseline up, and a negative value
 moves them down. The underline and strikethrough positions are adjusted
@@ -114,12 +112,12 @@ opt('+symbol_map', 'U+E0A0-U+E0A3,U+E0C0-U+E0C7 PowerlineSymbols',
     option_type='symbol_map',
     add_to_default=False,
     long_text='''
-Map the specified unicode codepoints to a particular font. Useful if you need
+Map the specified Unicode codepoints to a particular font. Useful if you need
 special rendering for some symbols, such as for Powerline. Avoids the need for
-patched fonts. Each unicode code point is specified in the form :code:`U+<code point
-in hexadecimal>`. You can specify multiple code points, separated by commas and
-ranges separated by hyphens. :code:`symbol_map` itself can be specified multiple times.
-Syntax is::
+patched fonts. Each Unicode code point is specified in the form :code:`U+<code
+point in hexadecimal>`. You can specify multiple code points, separated by
+commas and ranges separated by hyphens. This option can be specified multiple
+times. The syntax is::
 
     symbol_map codepoints Font Family Name
 '''
@@ -130,11 +128,11 @@ opt('+narrow_symbols', 'U+E0A0-U+E0A3,U+E0C0-U+E0C7 1',
     add_to_default=False,
     long_text='''
 Usually, for Private Use Unicode characters and some symbol/dingbat characters,
-if the character is followed by one or more spaces, kitty will use those extra cells
-to render the character larger, if the character in the font has a wide aspect ratio.
-Using this setting you can force kitty to restrict the specified code points to render in
-the specified number of cells (defaulting to one cell).
-Syntax is::
+if the character is followed by one or more spaces, kitty will use those extra
+cells to render the character larger, if the character in the font has a wide
+aspect ratio. Using this option you can force kitty to restrict the specified
+code points to render in the specified number of cells (defaulting to one cell).
+This option can be specified multiple times. The syntax is::
 
     narrow_symbols codepoints Optionally the number of cells
 '''
@@ -145,11 +143,11 @@ opt('disable_ligatures', 'never',
     option_type='disable_ligatures', ctype='int',
     long_text='''
 Choose how you want to handle multi-character ligatures. The default is to
-always render them.  You can tell kitty to not render them when the cursor is
+always render them. You can tell kitty to not render them when the cursor is
 over them by using :code:`cursor` to make editing easier, or have kitty never
 render them at all by using :code:`always`, if you don't like them. The ligature
 strategy can be set per-window either using the kitty remote control facility
-or by defining shortcuts for it in kitty.conf, for example::
+or by defining shortcuts for it in :file:`kitty.conf`, for example::
 
     map alt+1 disable_ligatures_in active always
     map alt+2 disable_ligatures_in all never
@@ -157,7 +155,7 @@ or by defining shortcuts for it in kitty.conf, for example::
 
 Note that this refers to programming ligatures, typically implemented using the
 :code:`calt` OpenType feature. For disabling general ligatures, use the
-:opt:`font_features` setting.
+:opt:`font_features` option.
 '''
     )
 
@@ -166,22 +164,22 @@ opt('+font_features', 'none',
     add_to_default=False,
     long_text='''
 Choose exactly which OpenType features to enable or disable. This is useful as
-some fonts might have features worthwhile in a terminal. For example, Fira
-Code Retina includes a discretionary feature, :code:`zero`, which in that font
-changes the appearance of the zero (0), to make it more easily distinguishable
-from Ø. Fira Code Retina also includes other discretionary features known as
-Stylistic Sets which have the tags :code:`ss01` through :code:`ss20`.
+some fonts might have features worthwhile in a terminal. For example, Fira Code
+includes a discretionary feature, :code:`zero`, which in that font changes the
+appearance of the zero (0), to make it more easily distinguishable from Ø. Fira
+Code also includes other discretionary features known as Stylistic Sets which
+have the tags :code:`ss01` through :code:`ss20`.
 
 For the exact syntax to use for individual features, see the
-:link:`Harfbuzz documentation
+:link:`HarfBuzz documentation
 <https://harfbuzz.github.io/harfbuzz-hb-common.html#hb-feature-from-string>`.
 
-Note that this code is indexed by PostScript name, and not the font
-family. This allows you to define very precise feature settings; e.g. you can
-disable a feature in the italic font but not in the regular font.
+Note that this code is indexed by PostScript name, and not the font family. This
+allows you to define very precise feature settings; e.g. you can disable a
+feature in the italic font but not in the regular font.
 
-On Linux, these are read from the FontConfig database first and then this,
-setting is applied, so they can be configured in a single, central place.
+On Linux, font features are first read from the FontConfig database and then
+this option is applied, so they can be configured in a single, central place.
 
 To get the PostScript name for a font, use :code:`kitty +list-fonts --psnames`:
 
@@ -201,9 +199,9 @@ Enable alternate zero and oldstyle numerals::
 
     font_features FiraCode-Retina +zero +onum
 
-Enable only alternate zero::
+Enable only alternate zero in the bold font::
 
-    font_features FiraCode-Retina +zero
+    font_features FiraCode-Bold +zero
 
 Disable the normal ligatures, but keep the :code:`calt` feature which (in this
 font) breaks up monotony::
@@ -221,13 +219,14 @@ You can do this with e.g.::
 opt('box_drawing_scale', '0.001, 1, 1.5, 2',
     option_type='box_drawing_scale',
     long_text='''
-Change the sizes of the lines used for the box drawing unicode characters These
-values are in pts. They will be scaled by the monitor DPI to arrive at a pixel
-value. There must be four values corresponding to thin, normal, thick, and very
-thick lines.
+The sizes of the lines used for the box drawing Unicode characters. These values
+are in pts. They will be scaled by the monitor DPI to arrive at a pixel value.
+There must be four values corresponding to thin, normal, thick, and very thick
+lines.
 '''
     )
 egr()  # }}}
+
 
 # cursor {{{
 agr('cursor', 'Cursor customization')
@@ -237,7 +236,7 @@ opt('cursor', '#cccccc',
 Default cursor color. If set to the special value :code:`none` the cursor will
 be rendered with a "reverse video" effect. It's color will be the color of the
 text in the cell it is over and the text will be rendered with the background
-color of the cell.  Note that if the program running in the terminal sets a
+color of the cell. Note that if the program running in the terminal sets a
 cursor color, this takes precedence. Also, the cursor colors are modified if
 the cell background and foreground colors have very low contrast.
 '''
@@ -246,39 +245,41 @@ the cell background and foreground colors have very low contrast.
 opt('cursor_text_color', '#111111',
     option_type='cursor_text_color',
     long_text='''
-Choose the color of text under the cursor. If you want it rendered with the
+The color of text under the cursor. If you want it rendered with the
 background color of the cell underneath instead, use the special keyword:
-background. Note that if :opt:`cursor` is set to :code:`none` then this setting
+background. Note that if :opt:`cursor` is set to :code:`none` then this option
 is ignored.
 '''
     )
 
 opt('cursor_shape', 'block',
     option_type='to_cursor_shape', ctype='int',
-    long_text='The cursor shape can be one of (block, beam, underline).'
-    ' Note that when reloading the config this will be changed only if the'
-    ' cursor shape has not been set by the program running in the terminal.'
-    ' This sets the default cursor shape. Applications running in the terminal'
-    ' can override it. In particular, :ref:`shell_integration` in kitty'
-    ' sets the cursor shape to :code:`beam` at shell prompts. You can avoid this'
-    ' by setting :opt:`shell_integration` to :code:`no-cursor`.'
+    long_text='''
+The cursor shape can be one of :code:`block`, :code:`beam`, :code:`underline`.
+Note that when reloading the config this will be changed only if the cursor
+shape has not been set by the program running in the terminal. This sets the
+default cursor shape, applications running in the terminal can override it. In
+particular, :ref:`shell_integration` in kitty sets the cursor shape to
+:code:`beam` at shell prompts. You can avoid this by setting
+:opt:`shell_integration` to :code:`no-cursor`.
+'''
     )
 
 opt('cursor_beam_thickness', '1.5',
     option_type='positive_float', ctype='float',
-    long_text='Defines the thickness of the beam cursor (in pts)'
+    long_text='The thickness of the beam cursor (in pts).'
     )
 
 opt('cursor_underline_thickness', '2.0',
     option_type='positive_float', ctype='float',
-    long_text='Defines the thickness of the underline cursor (in pts)'
+    long_text='The thickness of the underline cursor (in pts).'
     )
 
 opt('cursor_blink_interval', '-1',
     option_type='float', ctype='time',
     long_text='''
-The interval (in seconds) at which to blink the cursor. Set to zero to disable
-blinking. Negative values mean use system default. Note that numbers smaller
+The interval to blink the cursor (in seconds). Set to zero to disable blinking.
+Negative values mean use system default. Note that numbers smaller
 than :opt:`repaint_delay` will be limited to :opt:`repaint_delay`.
 '''
     )
@@ -287,10 +288,11 @@ opt('cursor_stop_blinking_after', '15.0',
     option_type='positive_float', ctype='time',
     long_text='''
 Stop blinking cursor after the specified number of seconds of keyboard
-inactivity.  Set to zero to never stop blinking.
+inactivity. Set to zero to never stop blinking.
 '''
     )
 egr()  # }}}
+
 
 # scrollback {{{
 agr('scrollback', 'Scrollback')
@@ -316,21 +318,22 @@ can handle ANSI escape sequences for colors and text formatting.
 INPUT_LINE_NUMBER in the command line above will be replaced by an integer
 representing which line should be at the top of the screen. Similarly
 CURSOR_LINE and CURSOR_COLUMN will be replaced by the current cursor position or
-set to 0 if there is no cursor, for example, when showing the last command output.
+set to 0 if there is no cursor, for example, when showing the last command
+output.
 '''
     )
 
 opt('scrollback_pager_history_size', '0',
     option_type='scrollback_pager_history_size', ctype='uint',
     long_text='''
-Separate scrollback history size, used only for browsing the scrollback buffer
-(in MB). This separate buffer is not available for interactive scrolling but
-will be piped to the pager program when viewing scrollback buffer in a separate
-window. The current implementation stores the data in UTF-8, so approximatively
-10000 lines per megabyte at 100 chars per line, for pure ASCII, unformatted
-text. A value of zero or less disables this feature. The maximum allowed size is
-4GB. Note that on config reload if this
-is changed it will only affect newly created windows, not existing ones.
+Separate scrollback history size (in MB), used only for browsing the scrollback
+buffer with pager. This separate buffer is not available for interactive
+scrolling but will be piped to the pager program when viewing scrollback buffer
+in a separate window. The current implementation stores the data in UTF-8, so
+approximatively 10000 lines per megabyte at 100 chars per line, for pure ASCII,
+unformatted text. A value of zero or less disables this feature. The maximum
+allowed size is 4GB. Note that on config reload if this is changed it will only
+affect newly created windows, not existing ones.
 '''
     )
 
@@ -342,32 +345,34 @@ opt('scrollback_fill_enlarged_window', 'no',
 opt('wheel_scroll_multiplier', '5.0',
     option_type='float', ctype='double',
     long_text='''
-Modify the amount scrolled by the mouse wheel. Note this is only used for low
-precision scrolling devices, not for high precision scrolling on platforms such
-as macOS and Wayland. Use negative numbers to change scroll direction. See also
-:opt:`wheel_scroll_min_lines`.
+Multiplier for the number of lines scrolled by the mouse wheel. Note that this
+is only used for low precision scrolling devices, not for high precision
+scrolling devices on platforms such as macOS and Wayland. Use negative numbers
+to change scroll direction. See also :opt:`wheel_scroll_min_lines`.
 '''
     )
 
 opt('wheel_scroll_min_lines', '1',
     option_type='int', ctype='int',
     long_text='''
-The minimum number of lines scrolled by the mouse wheel. The :opt:`scroll multiplier <wheel_scroll_multiplier>`
-only takes effect after it reaches this number. Note that this is only used for
-low precision scrolling devices like wheel mice that scroll by very small amounts when using the wheel.
-With a negative number, the minimum number of lines will always be added.
+The minimum number of lines scrolled by the mouse wheel. The :opt:`scroll
+multiplier <wheel_scroll_multiplier>` only takes effect after it reaches this
+number. Note that this is only used for low precision scrolling devices like
+wheel mice that scroll by very small amounts when using the wheel. With a
+negative number, the minimum number of lines will always be added.
 '''
     )
 
 opt('touch_scroll_multiplier', '1.0',
     option_type='float', ctype='double',
     long_text='''
-Modify the amount scrolled by a touchpad. Note this is only used for high
-precision scrolling devices on platforms such as macOS and Wayland. Use negative
-numbers to change scroll direction.
+Multiplier for the number of lines scrolled by a touchpad. Note that this is
+only used for high precision scrolling devices on platforms such as macOS and
+Wayland. Use negative numbers to change scroll direction.
 '''
     )
 egr()  # }}}
+
 
 # mouse {{{
 agr('mouse', 'Mouse')
@@ -387,8 +392,9 @@ is too much effort.
 opt('url_color', '#0087bd',
     option_type='to_color', ctype='color_as_int',
     long_text='''
-The color and style for highlighting URLs on mouse-over. :code:`url_style` can
-be one of: none, straight, double, curly, dotted, dashed
+The color and style for highlighting URLs on mouse-over. :opt:`url_style` can
+be one of: :code:`none`, :code:`straight`, :code:`double`, :code:`curly`,
+:code:`dotted`, :code:`dashed`.
 '''
     )
 
@@ -399,9 +405,9 @@ opt('url_style', 'curly',
 opt('open_url_with', 'default',
     option_type='to_cmdline',
     long_text='''
-The program with which to open URLs that are clicked on. The special value
-:code:`default` means to use the operating system's default URL handler
-(:file:`open` on macOS and :file:`xdg-open` on Linux).
+The program to open the clicked URLs. The special value :code:`default` means to
+use the operating system's default URL handler (:program:`open` on macOS and
+:program:`xdg-open` on Linux).
 '''
     )
 
@@ -425,7 +431,7 @@ opt('url_excluded_characters', '',
     ctype='!url_excluded_characters',
     long_text='''
 Additional characters to be disallowed from URLs, when detecting URLs under the
-mouse cursor. By default, all characters legal in URLs are allowed.
+mouse cursor. By default, all legal characters in URL are allowed.
 '''
     )
 
@@ -433,18 +439,19 @@ opt('copy_on_select', 'no',
     option_type='copy_on_select',
     long_text='''
 Copy to clipboard or a private buffer on select. With this set to
-:code:`clipboard`, simply selecting text with the mouse will cause the text to
-be copied to clipboard. Useful on platforms such as macOS that do not have the
-concept of primary selections. You can instead specify a name such as :code:`a1` to
-copy to a private kitty buffer instead. Map a shortcut with the
+:code:`clipboard`, selecting text with the mouse will cause the text to be
+copied to clipboard. Useful on platforms such as macOS that do not have the
+concept of primary selection. You can instead specify a name such as :code:`a1`
+to copy to a private kitty buffer. Map a shortcut with the
 :code:`paste_from_buffer` action to paste from this private buffer.
 For example::
 
+    copy_on_select a1
     map shift+cmd+v paste_from_buffer a1
 
 Note that copying to the clipboard is a security risk, as all programs,
-including websites open in your browser can read the contents of the
-system clipboard.
+including websites open in your browser can read the contents of the system
+clipboard.
 '''
     )
 
@@ -464,7 +471,8 @@ Possibilities are:
     Run the filter_paste() function from the file :file:`paste-actions.py` in
     the kitty config directory on the pasted text. The text returned by the
     function will be actually pasted.
-''')
+'''
+    )
 
 opt('strip_trailing_spaces', 'never',
     choices=('always', 'never', 'smart'),
@@ -480,7 +488,7 @@ opt('select_by_word_characters', '@-./_~?&=%+#',
     long_text='''
 Characters considered part of a word when double clicking. In addition to these
 characters any character that is marked as an alphanumeric character in the
-unicode database will be matched.
+Unicode database will be matched.
 '''
     )
 
@@ -496,7 +504,7 @@ fallback to 0.5.
 opt('focus_follows_mouse', 'no',
     option_type='to_bool', ctype='bool',
     long_text='''
-Set the active window to the window under the mouse when moving the mouse around
+Set the active window to the window under the mouse when moving the mouse around.
 '''
     )
 
@@ -504,7 +512,7 @@ opt('pointer_shape_when_grabbed', 'arrow',
     choices=('arrow', 'beam', 'hand'), ctype='pointer_shape',
     long_text='''
 The shape of the mouse pointer when the program running in the terminal grabs
-the mouse. Valid values are: :code:`arrow`, :code:`beam` and :code:`hand`
+the mouse. Valid values are: :code:`arrow`, :code:`beam` and :code:`hand`.
 '''
     )
 
@@ -512,7 +520,7 @@ opt('default_pointer_shape', 'beam',
     choices=('arrow', 'beam', 'hand'), ctype='pointer_shape',
     long_text='''
 The default shape of the mouse pointer. Valid values are: :code:`arrow`,
-:code:`beam` and :code:`hand`
+:code:`beam` and :code:`hand`.
 '''
     )
 
@@ -520,40 +528,44 @@ opt('pointer_shape_when_dragging', 'beam',
     choices=('arrow', 'beam', 'hand'), ctype='pointer_shape',
     long_text='''
 The default shape of the mouse pointer when dragging across text. Valid values
-are: :code:`arrow`, :code:`beam` and :code:`hand`
+are: :code:`arrow`, :code:`beam` and :code:`hand`.
 '''
     )
 
 
 # mouse.mousemap {{{
 agr('mouse.mousemap', 'Mouse actions', '''
-Mouse buttons can be remapped to perform arbitrary actions. The syntax for
-doing so is:
+Mouse buttons can be mapped to perform arbitrary actions. The syntax is:
 
 .. code-block:: none
 
     mouse_map button-name event-type modes action
 
-Where ``button-name`` is one of ``left``, ``middle``, ``right`` or ``b1 ... b8``
-with added keyboard modifiers, for example: ``ctrl+shift+left`` refers to holding
-the :kbd:`ctrl+shift` keys while clicking with the left mouse button. The
-number ``b1 ... b8`` can be used to refer to upto eight buttons on a mouse.
+Where :code:`button-name` is one of :code:`left`, :code:`middle`, :code:`right`,
+:code:`b1` ... :code:`b8` with added keyboard modifiers. For example:
+:code:`ctrl+shift+left` refers to holding the :kbd:`Ctrl+Shift` keys while
+clicking with the left mouse button. The value :code:`b1` ... :code:`b8` can be
+used to refer to up to eight buttons on a mouse.
 
-``event-type`` is one ``press``, ``release``, ``doublepress``, ``triplepress``,
-``click`` and ``doubleclick``.  ``modes`` indicates whether the action is
-performed when the mouse is grabbed by the program running in the terminal, or
-not. It can have one or more or the values, ``grabbed,ungrabbed``. ``grabbed``
-refers to when the program running in the terminal has requested mouse events.
-Note that the click and double click events have a delay of
+:code:`event-type` is one of :code:`press`, :code:`release`,
+:code:`doublepress`, :code:`triplepress`, :code:`click`, :code:`doubleclick`.
+:code:`modes` indicates whether the action is performed when the mouse is
+grabbed by the program running in the terminal, or not. The values are
+:code:`grabbed` or :code:`ungrabbed` or a comma separated combination of them.
+:code:`grabbed` refers to when the program running in the terminal has requested
+mouse events. Note that the click and double click events have a delay of
 :opt:`click_interval` to disambiguate from double and triple presses.
 
 You can run kitty with the :option:`kitty --debug-input` command line option
-to see mouse events. See the builtin actions below to get a sense of what is possible.
+to see mouse events. See the builtin actions below to get a sense of what is
+possible.
 
-If you want to unmap an action map it to ``no-op``. For example, to disable opening
-of URLs with a plain click::
+If you want to unmap an action, map it to :ac:`no_op`. For example, to disable
+opening of URLs with a plain click::
 
-    mouse_map left click ungrabbed no-op
+    mouse_map left click ungrabbed no_op
+
+See all the mappable actions including mouse actions :doc:`here </actions>`.
 
 .. note::
     Once a selection is started, releasing the button that started it will
@@ -563,8 +575,8 @@ of URLs with a plain click::
 opt('clear_all_mouse_actions', 'no',
     option_type='clear_all_mouse_actions',
     long_text='''
-You can have kitty remove all mouse actions seen up to this point.
-Useful, for instance, to remove the default mouse actions.
+Remove all mouse action definitions up to this point. Useful, for instance, to
+remove the default mouse actions.
 '''
     )
 
@@ -572,30 +584,35 @@ mma('Click the link under the mouse or move the cursor',
     'click_url_or_select left click ungrabbed mouse_handle_click selection link prompt',
     long_text='''
 First check for a selection and if one exists do nothing. Then check for a link
-under the mouse cursor and if one exists, click it. Finally check if the click happened at
-the current shell prompt and if so, move the cursor to the click location. Note that this
-requires :doc:`shell-integration` to work.
+under the mouse cursor and if one exists, click it. Finally check if the click
+happened at the current shell prompt and if so, move the cursor to the click
+location. Note that this requires :doc:`shell-integration` to work.
 '''
     )
 
 mma('Click the link under the mouse or move the cursor even when grabbed',
     'click_url_or_select_grabbed shift+left click grabbed,ungrabbed mouse_handle_click selection link prompt',
     long_text='''
-Same as above, except that the action is performed even when the mouse is grabbed
-by the program running in the terminal.
+Same as above, except that the action is performed even when the mouse is
+grabbed by the program running in the terminal.
 '''
     )
 
 mma('Click the link under the mouse cursor',
     'click_url ctrl+shift+left release grabbed,ungrabbed mouse_handle_click link',
-    long_text='Variant with :kbd:`ctrl+shift` is present because the simple'
-    ' click based version has an unavoidable delay of :opt:`click_interval`, to disambiguate clicks from double clicks.'
+    long_text='''
+Variant with :kbd:`Ctrl+Shift` is present because the simple click based version
+has an unavoidable delay of :opt:`click_interval`, to disambiguate clicks from
+double clicks.
+'''
     )
 
 mma('Discard press event for link click',
     'click_url_discard ctrl+shift+left press grabbed discard_event',
-    long_text='Prevent this press event from being sent to the program that has'
-    ' grabbed the mouse, as the corresponding release event is used to open a URL.'
+    long_text='''
+Prevent this press event from being sent to the program that has grabbed the
+mouse, as the corresponding release event is used to open a URL.
+'''
     )
 
 
@@ -617,17 +634,19 @@ mma('Select a word',
 
 mma('Select a line',
     'select_line left triplepress ungrabbed mouse_selection line',
-    long_text='Select the entire line'
     )
 
 mma('Select line from point',
     'select_line_from_point ctrl+alt+left triplepress ungrabbed mouse_selection line_from_point',
-    long_text='Select from the clicked point to the end of the line'
+    long_text='Select from the clicked point to the end of the line.'
     )
 
 mma('Extend the current selection',
     'extend_selection right press ungrabbed mouse_selection extend',
-    long_text='If you want only the end of the selection to be moved instead of the nearest boundary, use move-end instead of extend.'
+    long_text='''
+If you want only the end of the selection to be moved instead of the nearest
+boundary, use :code:`move-end` instead of :code:`extend`.
+'''
     )
 
 mma('Paste from the primary selection even when grabbed',
@@ -652,12 +671,11 @@ mma('Select a word even when grabbed',
 
 mma('Select a line even when grabbed',
     'select_line_grabbed shift+left triplepress ungrabbed,grabbed mouse_selection line',
-    long_text='Select the entire line'
     )
 
 mma('Select line from point even when grabbed',
     'select_line_from_point_grabbed ctrl+shift+alt+left triplepress ungrabbed,grabbed mouse_selection line_from_point',
-    long_text='Select from the clicked point to the end of the line'
+    long_text='Select from the clicked point to the end of the line even when grabbed.'
     )
 
 mma('Extend the current selection even when grabbed',
@@ -666,10 +684,11 @@ mma('Extend the current selection even when grabbed',
 
 mma('Show clicked command output in pager',
     'show_clicked_cmd_output_ungrabbed ctrl+shift+right press ungrabbed mouse_show_command_output',
-    long_text='Requires :ref:`shell_integration` to work'
+    long_text='Requires :ref:`shell_integration` to work.'
     )
 egr()  # }}}
 egr()  # }}}
+
 
 # performance {{{
 agr('performance', 'Performance tuning')
@@ -677,20 +696,20 @@ agr('performance', 'Performance tuning')
 opt('repaint_delay', '10',
     option_type='positive_int', ctype='time-ms',
     long_text='''
-Delay (in milliseconds) between screen updates. Decreasing it, increases frames-per-second
-(FPS) at the cost of more CPU usage. The default value yields ~100
-FPS which is more than sufficient for most uses. Note that to actually achieve
-100 FPS you have to either set :opt:`sync_to_monitor` to no or use a monitor
-with a high refresh rate. Also, to minimize latency when there is pending input
-to be processed, repaint_delay is ignored.
+Delay between screen updates (in milliseconds). Decreasing it, increases
+frames-per-second (FPS) at the cost of more CPU usage. The default value yields
+~100 FPS which is more than sufficient for most uses. Note that to actually
+achieve 100 FPS, you have to either set :opt:`sync_to_monitor` to :code:`no` or
+use a monitor with a high refresh rate. Also, to minimize latency when there is
+pending input to be processed, this option is ignored.
 '''
     )
 
 opt('input_delay', '3',
     option_type='positive_int', ctype='time-ms',
     long_text='''
-Delay (in milliseconds) before input from the program running in the terminal is
-processed. Note that decreasing it will increase responsiveness, but also
+Delay before input from the program running in the terminal is processed (in
+milliseconds). Note that decreasing it will increase responsiveness, but also
 increase CPU usage and might cause flicker in full screen programs that redraw
 the entire screen on each loop, because kitty is so fast that partial screen
 updates will be drawn.
@@ -700,28 +719,31 @@ updates will be drawn.
 opt('sync_to_monitor', 'yes',
     option_type='to_bool', ctype='bool',
     long_text='''
-Sync screen updates to the refresh rate of the monitor. This prevents tearing
-(https://en.wikipedia.org/wiki/Screen_tearing) when scrolling. However, it
-limits the rendering speed to the refresh rate of your monitor. With a very high
-speed mouse/high keyboard repeat rate, you may notice some slight input latency.
-If so, set this to no.
+Sync screen updates to the refresh rate of the monitor. This prevents
+:link:`screen tearing <https://en.wikipedia.org/wiki/Screen_tearing>` when
+scrolling. However, it limits the rendering speed to the refresh rate of your
+monitor. With a very high speed mouse/high keyboard repeat rate, you may notice
+some slight input latency. If so, set this to :code:`no`.
 '''
     )
 egr()  # }}}
+
 
 # bell {{{
 agr('bell', 'Terminal bell')
 
 opt('enable_audio_bell', 'yes',
     option_type='to_bool', ctype='bool',
-    long_text='Enable/disable the audio bell. Useful in environments that require silence.'
+    long_text='''
+The audio bell. Useful to disable it in environments that require silence.
+'''
     )
 
 opt('visual_bell_duration', '0.0',
     option_type='positive_float', ctype='time',
     long_text='''
-Visual bell duration. Flash the screen when a bell occurs for the specified
-number of seconds. Set to zero to disable.
+The visual bell duration (in seconds). Flash the screen when a bell occurs for
+the specified number of seconds. Set to zero to disable.
 '''
     )
 
@@ -731,7 +753,8 @@ opt('visual_bell_color', 'none',
 The color used by visual bell. Set to :code:`none` will fall back to selection
 background color. If you feel that the visual bell is too bright, you can
 set it to a darker color.
-''')
+'''
+    )
 
 opt('window_alert_on_bell', 'yes',
     option_type='to_bool', ctype='bool',
@@ -744,32 +767,38 @@ taskbar flash on linux.
 opt('bell_on_tab', '"🔔 "',
     option_type='bell_on_tab',
     long_text='''
-Some text or a unicode symbol to show on the tab if a window in the tab that
+Some text or a Unicode symbol to show on the tab if a window in the tab that
 does not have focus has a bell. If you want to use leading or trailing
-spaces surround the text with quotes. See :opt:`tab_title_template` for how
+spaces, surround the text with quotes. See :opt:`tab_title_template` for how
 this is rendered.
 
-For backwards compatibility, values of :code:`yes`, :code:`y`, :code:`true` are
-converted to the default bell symbol and :code:`no`, :code:`n`, :code:`false`,
-:code:`none` are converted to the empty string.
+For backwards compatibility, values of :code:`yes`, :code:`y` and :code:`true`
+are converted to the default bell symbol and :code:`no`, :code:`n`,
+:code:`false` and :code:`none` are converted to the empty string.
 '''
     )
 
 opt('command_on_bell', 'none',
     option_type='to_cmdline',
-    long_text='Program to run when a bell occurs.'
-    ' The environment variable :envvar:`KITTY_CHILD_CMDLINE` can be used to get the program running in'
-    ' the window in which the bell occurred.'
+    long_text='''
+Program to run when a bell occurs. The environment variable
+:envvar:`KITTY_CHILD_CMDLINE` can be used to get the program running in the
+window in which the bell occurred.
+'''
     )
 
 opt('bell_path', 'none',
     option_type='config_or_absolute_path', ctype='!bell_path',
-    long_text='Path to a sound file to play as the bell sound. If set to :code:`none`, the system default bell sound is used.'
-    ' Must be in a format supported by the operating systems sound API, such as WAV or OGA on Linux (libcanberra)'
-    ' or AIFF, MP3 or WAV on macOS (NSSound)'
+    long_text='''
+Path to a sound file to play as the bell sound. If set to :code:`none`, the
+system default bell sound is used. Must be in a format supported by the
+operating systems sound API, such as WAV or OGA on Linux (libcanberra) or AIFF,
+MP3 or WAV on macOS (NSSound)
+'''
     )
 
 egr()  # }}}
+
 
 # window {{{
 agr('window', 'Window layout')
@@ -806,9 +835,9 @@ a list of available layouts, see the :ref:`layouts`.
 opt('window_resize_step_cells', '2',
     option_type='positive_int',
     long_text='''
-The step size (in units of cell width/cell height) to use when resizing kitty windows
-in a layout with the keyboard (:sc:`start_resizing_window`).
-The cells value is used for horizontal resizing and the lines value for vertical
+The step size (in units of cell width/cell height) to use when resizing kitty
+windows in a layout with the shortcut :sc:`start_resizing_window`. The cells
+value is used for horizontal resizing, and the lines value is used for vertical
 resizing.
 '''
     )
@@ -822,7 +851,7 @@ opt('window_border_width', '0.5pt',
     long_text='''
 The width of window borders. Can be either in pixels (px) or pts (pt). Values in
 pts will be rounded to the nearest number of pixels based on screen resolution.
-If not specified the unit is assumed to be pts. Note that borders are displayed
+If not specified, the unit is assumed to be pts. Note that borders are displayed
 only when more than one window is visible. They are meant to separate multiple
 windows.
 '''
@@ -831,10 +860,10 @@ windows.
 opt('draw_minimal_borders', 'yes',
     option_type='to_bool',
     long_text='''
-Draw only the minimum borders needed. This means that only the minimum needed
-borders for inactive windows are drawn. That is only the borders that separate
-the inactive window from a neighbor. Note that setting a non-zero window margin
-overrides this and causes all borders to be drawn.
+Draw only the minimum borders needed. This means that only the borders that
+separate the inactive window from a neighbor are drawn. Note that setting a
+non-zero :opt:`window_margin_width` overrides this and causes all borders to be
+drawn.
 '''
     )
 
@@ -850,7 +879,7 @@ set top, horizontal and bottom. Four values set top, right, bottom and left.
 opt('single_window_margin_width', '-1',
     option_type='optional_edge_width',
     long_text='''
-The window margin (in pts) to use when only a single window is visible. Negative
+The window margin to use when only a single window is visible (in pts). Negative
 values will cause the value of :opt:`window_margin_width` to be used instead. A
 single value sets all four sides. Two values set the vertical and horizontal
 sides. Three values set top, horizontal and bottom. Four values set top, right,
@@ -875,26 +904,26 @@ When the window size is not an exact multiple of the cell size, the cell area of
 the terminal window will have some extra padding on the sides. You can control
 how that padding is distributed with this option. Using a value of
 :code:`center` means the cell area will be placed centrally. A value of
-:code:`top-left` means the padding will be on only the bottom and right edges.
+:code:`top-left` means the padding will be only at the bottom and right edges.
 '''
     )
 
 opt('active_border_color', '#00ff00',
     option_type='to_color_or_none', ctype='active_border_color',
     long_text='''
-The color for the border of the active window. Set this to none to not draw
-borders around the active window.
+The color for the border of the active window. Set this to :code:`none` to not
+draw borders around the active window.
 '''
     )
 
 opt('inactive_border_color', '#cccccc',
     option_type='to_color', ctype='color_as_int',
-    long_text='The color for the border of inactive windows'
+    long_text='The color for the border of inactive windows.'
     )
 
 opt('bell_border_color', '#ff5a00',
     option_type='to_color', ctype='color_as_int',
-    long_text='The color for the border of inactive windows in which a bell has occurred'
+    long_text='The color for the border of inactive windows in which a bell has occurred.'
     )
 
 opt('inactive_text_alpha', '1.0',
@@ -911,7 +940,7 @@ opt('hide_window_decorations', 'no',
 Hide the window decorations (title-bar and window borders) with :code:`yes`. On
 macOS, :code:`titlebar-only` can be used to only hide the titlebar. Whether this
 works and exactly what effect it has depends on the window manager/operating
-system. Note that the effects of changing this setting when reloading config
+system. Note that the effects of changing this option when reloading config
 are undefined.
 '''
     )
@@ -920,11 +949,12 @@ opt('window_logo_path', 'none',
     option_type='config_or_absolute_path', ctype='!window_logo_path',
     long_text='''
 Path to a logo image. Must be in PNG format. Relative paths are interpreted
-relative to the kitty config directory.  The logo is displayed in a corner of every
-kitty window. The position is controlled by :opt:`window_logo_position`.
+relative to the kitty config directory. The logo is displayed in a corner of
+every kitty window. The position is controlled by :opt:`window_logo_position`.
 Individual windows can be configured to have different logos either using the
-:doc:`launch` function or the :doc:`remote-control` facility.
-''')
+:ac:`launch` action or the :doc:`remote-control` facility.
+'''
+    )
 
 opt('window_logo_position', 'bottom-right',
     choices=('top-left', 'top', 'top-right', 'left', 'center', 'right', 'bottom-left', 'bottom', 'bottom-right'), ctype='bganchor',
@@ -935,16 +965,20 @@ Where to position the window logo in the window. The value can be one of:
 '''
     )
 
-opt('window_logo_alpha', 0.5, option_type='unit_float', ctype='float', long_text='''
-The amount the logo should be faded into the background. With zero being fully faded
-and one being fully opaque.''')
+opt('window_logo_alpha', '0.5',
+    option_type='unit_float', ctype='float',
+    long_text='''
+The amount the logo should be faded into the background. With zero being fully
+faded and one being fully opaque.
+'''
+    )
 
 
 opt('resize_debounce_time', '0.1',
     option_type='positive_float', ctype='time',
     long_text='''
-The time (in seconds) to wait before redrawing the screen when a resize event is
-received. On platforms such as macOS, where the operating system sends events
+The time to wait before redrawing the screen when a resize event is received (in
+seconds). On platforms such as macOS, where the operating system sends events
 corresponding to the start and end of a resize, this number is ignored.
 '''
     )
@@ -964,7 +998,7 @@ opt('resize_in_steps', 'no',
     option_type='to_bool', ctype='bool',
     long_text='''
 Resize the OS window in steps as large as the cells, instead of with the usual
-pixel accuracy. Combined with an :opt:`initial_window_width` and
+pixel accuracy. Combined with :opt:`initial_window_width` and
 :opt:`initial_window_height` in number of cells, this option can be used to keep
 the margins as small as possible when resizing the OS window. Note that this
 does not currently work on Wayland.
@@ -974,50 +1008,50 @@ does not currently work on Wayland.
 opt('visual_window_select_characters', defval=string.digits[1:] + '0' + string.ascii_uppercase,
     option_type='visual_window_select_characters',
     long_text='''
-The list of characters to use for visual window selection (for example for
-selecting a window to focus with :sc:`focus_visible_window`). The value should
-be a series of unique numbers or alphabets, case insensitive, from the set
-:code:`[0-9A-Z]`. Specify your preference as a string of characters.
+The list of characters for visual window selection. For example, for selecting a
+window to focus on with :sc:`focus_visible_window`. The value should be a series
+of unique numbers or alphabets, case insensitive, from the set :code:`[0-9A-Z]`.
+Specify your preference as a string of characters.
 '''
     )
 
 opt('confirm_os_window_close', '-1',
     option_type='int',
     long_text='''
-Ask for confirmation when closing an OS window or a Tab with at least this
+Ask for confirmation when closing an OS window or a tab with at least this
 number of kitty windows in it by window manager (e.g. clicking the window close
-button or pressing the Operating system shortcut to close windows) or by the
-:sc:`close_tab` action. A value of zero disables confirmation. This
-confirmation also applies to requests to quit the entire application (all OS
-windows, via the quit action). Negative values are converted to positive ones,
-however, with :ref:`shell_integration` enabled, using negative values means
-windows sitting at a shell prompt are not counted, only windows where some
-command is currently running. Note that if you want confirmation when closing
-individual windows, you can map the :ac:`close_window_with_confirmation` action.
+button or pressing the operating system shortcut to close windows) or by the
+:ac:`close_tab` action. A value of zero disables confirmation. This confirmation
+also applies to requests to quit the entire application (all OS windows, via the
+:ac:`quit` action). Negative values are converted to positive ones, however,
+with :opt:`shell_integration` enabled, using negative values means windows
+sitting at a shell prompt are not counted, only windows where some command is
+currently running. Note that if you want confirmation when closing individual
+windows, you can map the :ac:`close_window_with_confirmation` action.
 '''
     )
 egr()  # }}}
+
 
 # tabbar {{{
 agr('tabbar', 'Tab bar')
 
 opt('tab_bar_edge', 'bottom',
     option_type='tab_bar_edge', ctype='int',
-    long_text='Which edge to show the tab bar on, top or bottom'
+    long_text='The edge to show the tab bar on, :code:`top` or :code:`bottom`.'
     )
 
 opt('tab_bar_margin_width', '0.0',
     option_type='positive_float',
-    long_text='The margin to the left and right of the tab bar (in pts)'
+    long_text='The margin to the left and right of the tab bar (in pts).'
     )
 
 opt('tab_bar_margin_height', '0.0 0.0',
     option_type='tab_bar_margin_height', ctype='!tab_bar_margin_height',
     long_text='''
-The margin above and below the tab bar (in pts). The first number is the
-margin between the edge of the OS Window and the tab bar and the second
-number is the margin between the tab bar and the contents of the current
-tab.
+The margin above and below the tab bar (in pts). The first number is the margin
+between the edge of the OS Window and the tab bar. The second number is the
+margin between the tab bar and the contents of the current tab.
 '''
     )
 
@@ -1028,14 +1062,15 @@ opt('tab_bar_style', 'fade',
 The tab bar style, can be one of:
 
 :code:`fade`
-    Each tab's edges fade into the background color (see :opt:`tab_fade`)
+    Each tab's edges fade into the background color. (See also :opt:`tab_fade`)
 :code:`slant`
-    Tabs look like the tabs in a physical file
+    Tabs look like the tabs in a physical file.
 :code:`separator`
-    Tabs are separated by a configurable separator (see :opt:`tab_separator`)
+    Tabs are separated by a configurable separator. (See also
+    :opt:`tab_separator`)
 :code:`powerline`
-    Tabs are shown as a continuous line with "fancy" separators
-    (see :opt:`tab_powerline_style`)
+    Tabs are shown as a continuous line with "fancy" separators.
+    (See also :opt:`tab_powerline_style`)
 :code:`custom`
     A user-supplied Python function called draw_tab is loaded from the file
     :file:`tab_bar.py` in the kitty config directory. For examples of how to
@@ -1044,23 +1079,22 @@ The tab bar style, can be one of:
     :disc:`this discussion <4447>`
     for examples from kitty users.
 :code:`hidden`
-    The tab bar is hidden. If you use this, you might want to create a
-    mapping for the :ac:`select_tab`
-    action which presents you with a list of tabs and allows for easy
-    switching to a tab.
+    The tab bar is hidden. If you use this, you might want to create a mapping
+    for the :ac:`select_tab` action which presents you with a list of tabs and
+    allows for easy switching to a tab.
 '''
     )
 
 opt('tab_bar_align', 'left', choices=('left', 'center', 'right'),
     long_text='''
 The horizontal alignment of the tab bar, can be one of: :code:`left`,
-:code:`center`, or :code:`right`.
+:code:`center`, :code:`right`.
 '''
     )
 
 opt('tab_bar_min_tabs', '2',
     option_type='tab_bar_min_tabs', ctype='uint',
-    long_text='The minimum number of tabs that must exist before the tab bar is shown'
+    long_text='The minimum number of tabs that must exist before the tab bar is shown.'
     )
 
 opt('tab_switch_strategy', 'previous',
@@ -1098,53 +1132,55 @@ opt('tab_powerline_style', 'angled',
     long_text='''
 The powerline separator style between tabs in the tab bar when using
 :code:`powerline` as the :opt:`tab_bar_style`, can be one of: :code:`angled`,
-:code:`slanted`, or :code:`round`.
+:code:`slanted`, :code:`round`.
 '''
     )
 
 opt('tab_activity_symbol', 'none',
     option_type='tab_activity_symbol',
     long_text='''
-Some text or a unicode symbol to show on the tab if a window in the tab that
-does not have focus has some activity. If you want to use leading or trailing spaces
-surround the text with quotes. See :opt:`tab_title_template` for how this is rendered.
+Some text or a Unicode symbol to show on the tab if a window in the tab that
+does not have focus has some activity. If you want to use leading or trailing
+spaces, surround the text with quotes. See :opt:`tab_title_template` for how
+this is rendered.
 '''
     )
 
 opt('tab_title_template', '"{fmt.fg.red}{bell_symbol}{activity_symbol}{fmt.fg.tab}{title}"',
     option_type='tab_title_template',
     long_text='''
-A template to render the tab title. The default just renders the title with optional symbols for bell and activity.
-If you wish to include the tab-index as well, use something like: :code:`{index}:
-{title}`. Useful if you have shortcuts mapped for :code:`goto_tab N`. If you
-prefer to see the index as a superscript, use {sup.index}. In
-addition you can use :code:`{layout_name}` for the current layout name,
-:code:`{num_windows}` for the number of windows in the tab and
-:code:`{num_window_groups}` for the number of window groups
-(not counting overlay windows) in the tab. Note that formatting
-is done by Python's string formatting machinery, so you can use, for instance,
+A template to render the tab title. The default just renders the title with
+optional symbols for bell and activity. If you wish to include the tab-index as
+well, use something like: :code:`{index}:{title}`. Useful if you have shortcuts
+mapped for :code:`goto_tab N`. If you prefer to see the index as a superscript,
+use :code:`{sup.index}`. In addition you can use :code:`{layout_name}` for the
+current layout name, :code:`{num_windows}` for the number of windows in the tab
+and :code:`{num_window_groups}` for the number of window groups (not counting
+overlay windows) in the tab. Note that formatting is done by Python's string
+formatting machinery, so you can use, for instance,
 :code:`{layout_name[:2].upper()}` to show only the first two letters of the
 layout name, upper-cased. If you want to style the text, you can use styling
 directives, for example:
-:code:`{fmt.fg.red}red{fmt.fg.tab}normal{fmt.bg._00FF00}green
-bg{fmt.bg.tab}`. Similarly, for bold and italic:
+:code:`{fmt.fg.red}red{fmt.fg.tab}normal{fmt.bg._00FF00}greenbg{fmt.bg.tab}`.
+Similarly, for bold and italic:
 :code:`{fmt.bold}bold{fmt.nobold}normal{fmt.italic}italic{fmt.noitalic}`.
-Note that for backward compatibility, if :code:`{bell_symbol}` or :code:`{activity_symbol}`
-are not present in the template, they are prepended to it.
+Note that for backward compatibility, if :code:`{bell_symbol}` or
+:code:`{activity_symbol}` are not present in the template, they are prepended to
+it.
 '''
     )
 
 opt('active_tab_title_template', 'none',
     option_type='active_tab_title_template',
     long_text='''
-Template to use for active tabs, if not specified falls back to
+Template to use for active tabs. If not specified falls back to
 :opt:`tab_title_template`.
 '''
     )
 
 opt('active_tab_foreground', '#000',
     option_type='to_color',
-    long_text='Tab bar colors and styles'
+    long_text='Tab bar colors and styles.'
     )
 
 opt('active_tab_background', '#eee',
@@ -1184,12 +1220,13 @@ color.
     )
 egr()  # }}}
 
+
 # colors {{{
 agr('colors', 'Color scheme')
 
 opt('foreground', '#dddddd',
     option_type='to_color', ctype='color_as_int',
-    long_text='The foreground and background colors'
+    long_text='The foreground and background colors.'
     )
 
 opt('background', '#000000',
@@ -1199,22 +1236,22 @@ opt('background', '#000000',
 opt('background_opacity', '1.0',
     option_type='unit_float', ctype='float',
     long_text='''
-The opacity of the background. A number between 0 and 1, where 1 is opaque and 0
-is fully transparent.  This will only work if supported by the OS (for instance,
-when using a compositor under X11). Note that it only sets the background
-color's opacity in cells that have the same background color as the default
-terminal background. This is so that things like the status bar in vim,
-powerline prompts, etc. still look good.  But it means that if you use a color
+The opacity of the background. A number between zero and one, where one is
+opaque and zero is fully transparent. This will only work if supported by the OS
+(for instance, when using a compositor under X11). Note that it only sets the
+background color's opacity in cells that have the same background color as the
+default terminal background, so that things like the status bar in vim,
+powerline prompts, etc. still look good. But it means that if you use a color
 theme with a background color in your editor, it will not be rendered as
-transparent.  Instead you should change the default background color in your
+transparent. Instead you should change the default background color in your
 kitty config and not use a background color in the editor color scheme. Or use
 the escape codes to set the terminals default colors in a shell script to launch
-your editor.  Be aware that using a value less than 1.0 is a (possibly
-significant) performance hit.  If you want to dynamically change transparency of
-windows set :opt:`dynamic_background_opacity` to :code:`yes` (this is off by
-default as it has a performance cost). Changing this setting when reloading
-the config will only work if :opt:`dynamic_background_opacity` was enabled
-in the original config.
+your editor. Be aware that using a value less than 1.0 is a (possibly
+significant) performance hit. If you want to dynamically change transparency of
+windows, set :opt:`dynamic_background_opacity` to :code:`yes` (this is off by
+default as it has a performance cost). Changing this option when reloading the
+config will only work if :opt:`dynamic_background_opacity` was enabled in the
+original config.
 '''
     )
 
@@ -1242,7 +1279,7 @@ opt('dynamic_background_opacity', 'no',
 Allow changing of the :opt:`background_opacity` dynamically, using either
 keyboard shortcuts (:sc:`increase_background_opacity` and
 :sc:`decrease_background_opacity`) or the remote control facility. Changing
-this setting by reloading the config is not supported.
+this option by reloading the config is not supported.
 '''
     )
 
@@ -1250,10 +1287,10 @@ opt('background_tint', '0.0',
     option_type='unit_float', ctype='float',
     long_text='''
 How much to tint the background image by the background color. The tint is
-applied only under the text area, not margin/borders. Makes it easier to read
-the text. Tinting is done using the current background color for each window.
-This setting applies only if :opt:`background_opacity` is set and transparent
-windows are supported or :opt:`background_image` is set.
+applied only under the text area, not margin/borders. This option makes it
+easier to read the text. Tinting is done using the current background color for
+each window. This option applies only if :opt:`background_opacity` is set and
+transparent windows are supported or :opt:`background_image` is set.
 '''
     )
 
@@ -1268,14 +1305,18 @@ and zero means fully dimmed (i.e. invisible).
 opt('selection_foreground', '#000000',
     option_type='to_color_or_none',
     long_text='''
-The foreground and background colors for text selected with the mouse. Setting both of
-these to :code:`none` will cause a "reverse video" effect for selections, where the
-selection will be the cell text color and the text will become the cell background color.
-Setting only selection_foreground to :code:`none` will cause the foreground color to be
-used unchanged. Note that these colors can be overridden by the program running in the terminal.
-''')
+The foreground and background colors for text selected with the mouse. Setting
+both of these to :code:`none` will cause a "reverse video" effect for
+selections, where the selection will be the cell text color and the text will
+become the cell background color. Setting only selection_foreground to
+:code:`none` will cause the foreground color to be used unchanged. Note that
+these colors can be overridden by the program running in the terminal.
+'''
+    )
 
-opt('selection_background', '#fffacd', option_type='to_color_or_none',)
+opt('selection_background', '#fffacd',
+    option_type='to_color_or_none',
+    )
 
 
 # colors.table {{{
@@ -2589,70 +2630,77 @@ opt('color255', '#eeeeee',
 egr()  # }}}
 egr()  # }}}
 
+
 # advanced {{{
 agr('advanced', 'Advanced')
 
 opt('shell', '.',
     long_text='''
-The shell program to execute. The default value of . means to use whatever shell
-is set as the default shell for the current user. Note that on macOS if you
-change this, you might need to add :code:`--login` and :code:`--interactive`
-to ensure that the shell starts in interactive mode and reads its startup rc files.
+The shell program to execute. The default value of :code:`.` means to use
+whatever shell is set as the default shell for the current user. Note that on
+macOS if you change this, you might need to add :code:`--login` and
+:code:`--interactive` to ensure that the shell starts in interactive mode and
+reads its startup rc files.
 '''
     )
 
 opt('editor', '.',
     long_text='''
-The terminal editor (such as ``vim`` or ``nano``) to use when editing the kitty
-config file or similar tasks.
+The command-line text editor (such as :program:`vim` or :program:`nano`) to use
+when editing the kitty config file or similar tasks.
 
-The default value of :code:`.` means to use the environment variables :envvar:`VISUAL`
-and :envvar:`EDITOR` in that order. If these variables aren't set, kitty will
-run your :opt:`shell` (``$SHELL -l -i -c env``) to see if your shell config
-files set :envvar:`VISUAL` or :envvar:`EDITOR`. If that doesn't work, kitty
-will cycle through various known editors (``vim``, ``emacs``, etc) and take the
-first one that exists on your system.
-''')
+The default value of :code:`.` means to use the environment variables
+:envvar:`VISUAL` and :envvar:`EDITOR` in that order. If these variables aren't
+set, kitty will run your :opt:`shell` (:code:`$SHELL -l -i -c env`) to see if
+your shell startup rc files set :envvar:`VISUAL` or :envvar:`EDITOR`. If that
+doesn't work, kitty will cycle through various known editors (:program:`vim`,
+:program:`emacs`, etc.) and take the first one that exists on your system.
+'''
+    )
 
 opt('close_on_child_death', 'no',
     option_type='to_bool', ctype='bool',
     long_text='''
-Close the window when the child process (shell) exits. If no (the default), the
-terminal will remain open when the child exits as long as there are still
-processes outputting to the terminal (for example disowned or backgrounded
-processes). If yes, the window will close as soon as the child process exits.
-Note that setting it to yes means that any background processes still using the
-terminal can fail silently because their stdout/stderr/stdin no longer work.
+Close the window when the child process (shell) exits. With the default value
+:code:`no`, the terminal will remain open when the child exits as long as there
+are still processes outputting to the terminal (for example disowned or
+backgrounded processes). When enabled with :code:`yes`, the window will close as
+soon as the child process exits. Note that setting it to :code:`yes` means that
+any background processes still using the terminal can fail silently because
+their stdout/stderr/stdin no longer work.
 '''
     )
 
 opt('allow_remote_control', 'no',
     option_type='allow_remote_control',
     long_text='''
-Allow other programs to control kitty. If you turn this on other programs can
+Allow other programs to control kitty. If you turn this on, other programs can
 control all aspects of kitty, including sending text to kitty windows, opening
-new windows, closing windows, reading the content of windows, etc.  Note that
-this even works over ssh connections. You can chose to either allow any program
-running within kitty to control it, with :code:`yes` or only programs that
-connect to the socket specified with the :option:`kitty --listen-on` command
-line option, if you use the value :code:`socket-only`. The latter is useful if
-you want to prevent programs running on a remote computer over ssh from
-controlling kitty. Reloading the config will not affect this setting.
+new windows, closing windows, reading the content of windows, etc. Note that
+this even works over SSH connections. You can choose to either allow any program
+running within kitty to control it with :code:`yes`, or only allow programs that
+connect to the socket (specified with the :opt:`listen_on` config option or
+:option:`kitty --listen-on` command line option) with the value
+:code:`socket-only`. The latter is useful if you want to prevent programs
+running on a remote computer over SSH from controlling kitty. Reloading the
+config will not affect this option.
 '''
     )
 
 opt('listen_on', 'none',
     long_text='''
-Tell kitty to listen to the specified unix/tcp socket for remote control
-connections. Note that this will apply to all kitty instances. It can be
-overridden by the :option:`kitty --listen-on` command line flag. This option
-accepts only UNIX sockets, such as unix:${TEMP}/mykitty or (on Linux)
-unix:@mykitty. Environment variables are expanded. If {kitty_pid} is present
-then it is replaced by the PID of the kitty process, otherwise the PID of the
-kitty process is appended to the value, with a hyphen. This option is ignored
-unless you also set :opt:`allow_remote_control` to enable remote control. See
-the help for :option:`kitty --listen-on` for more details. Changing this option
-by reloading the config is not supported.
+Listen to the specified UNIX socket for remote control connections. Note
+that this will apply to all kitty instances. It can be overridden by the
+:option:`kitty --listen-on` command line option, which supports listening on TCP
+socket. This option accepts only UNIX sockets, such as
+:code:`unix:${TEMP}/mykitty` or :code:`unix:@mykitty` (on Linux). Environment
+variables are expanded and relative paths are resolved with respect to the
+temporary directory. If :code:`{kitty_pid}` is present, then it is replaced
+by the PID of the kitty process, otherwise the PID of the kitty process is
+appended to the value, with a hyphen. This option is ignored unless you also set
+:opt:`allow_remote_control` to enable remote control. See the help for
+:option:`kitty --listen-on` for more details. Changing this option by reloading
+the config is not supported.
 '''
     )
 
@@ -2660,15 +2708,16 @@ opt('+env', '',
     option_type='env',
     add_to_default=False,
     long_text='''
-Specify environment variables to set in all child processes. Note that
-environment variables are expanded recursively, so if you use::
+Specify the environment variables to be set in all child processes. Using the
+name with an equal sign (e.g. :code:`env VAR=`) will set it to the empty string.
+Specifying only the name (e.g. :code:`env VAR`) will remove the variable from
+the child process' environment. Note that environment variables are expanded
+recursively, for example::
 
-    env MYVAR1=a
-    env MYVAR2=${MYVAR1}/${HOME}/b
+    env VAR1=a
+    env VAR2=${HOME}/${VAR1}/b
 
-The value of MYVAR2 will be :code:`a/<path to home directory>/b`. Using
-:code:`VAR=` will set it to the empty string and using just :code:`VAR`
-will delete the variable from the child process' environment.
+The value of :code:`VAR2` will be :code:`<path to home directory>/a/b`.
 '''
     )
 
@@ -2676,44 +2725,47 @@ opt('+watcher', '',
     option_type='store_multiple',
     add_to_default=False,
     long_text='''
-Path to python file which will be loaded for :ref:`watchers`.
-Can be specified more than once to load multiple watchers.
-The watchers will be added to every kitty window. Relative
-paths are resolved relative to the kitty config directory.
-Note that reloading the config will only affect windows
-created after the reload.
-''')
+Path to python file which will be loaded for :ref:`watchers`. Can be specified
+more than once to load multiple watchers. The watchers will be added to every
+kitty window. Relative paths are resolved relative to the kitty config
+directory. Note that reloading the config will only affect windows created after
+the reload.
+'''
+    )
 
 opt('+exe_search_path', '',
     option_type='store_multiple',
     add_to_default=False,
     long_text='''
-Control where kitty looks to find programs to run. The default search order is:
-First search the system wide :code:`PATH`, then :file:`~/.local/bin` and :file:`~/bin`.
-If still not found, the :code:`PATH` defined in the login shell after sourcing
-all its startup files is tried. Finally, if present, the :code:`PATH` in the :opt:`env`
-option is tried.
+Control where kitty finds the programs to run. The default search order is:
+First search the system wide :code:`PATH`, then :file:`~/.local/bin` and
+:file:`~/bin`. If still not found, the :code:`PATH` defined in the login shell
+after sourcing all its startup files is tried. Finally, if present, the
+:code:`PATH` specified by the :opt:`env` option is tried.
 
-This option allows you to prepend, append, or remove paths from this search order.
-It can be specified multiple times for multiple paths. A simple path will be prepended
-to the search order. A path that starts with the :code:`+` sign will be append to the search
-order, after :file:`~/bin` above. A path that starts with the :code:`-` sign will be removed
-from the entire search order. For example::
+This option allows you to prepend, append, or remove paths from this search
+order. It can be specified multiple times for multiple paths. A simple path will
+be prepended to the search order. A path that starts with the :code:`+` sign
+will be append to the search order, after :file:`~/bin` above. A path that
+starts with the :code:`-` sign will be removed from the entire search order.
+For example::
 
     exe_search_path /some/prepended/path
     exe_search_path +/some/appended/path
     exe_search_path -/some/excluded/path
 
-''')
+'''
+    )
 
 opt('update_check_interval', '24',
     option_type='float',
     long_text='''
-Periodically check if an update to kitty is available. If an update is found a
-system notification is displayed informing you of the available update. The
-default is to check every 24 hrs, set to zero to disable. Update checking is
-only done by the official binary builds. Distro packages or source builds do not
-do update checking. Changing this option by reloading the config is not supported.
+The interval to periodically check if an update to kitty is available (in
+hours). If an update is found, a system notification is displayed informing you
+of the available update. The default is to check every 24 hours, set to zero to
+disable. Update checking is only done by the official binary builds. Distro
+packages or source builds do not do update checking. Changing this option by
+reloading the config is not supported.
 '''
     )
 
@@ -2724,8 +2776,8 @@ Path to a session file to use for all kitty instances. Can be overridden by
 using the :option:`kitty --session` command line option for individual
 instances. See :ref:`sessions` in the kitty documentation for details. Note that
 relative paths are interpreted with respect to the kitty config directory.
-Environment variables in the path are expanded. Changing this option by reloading
-the config is not supported.
+Environment variables in the path are expanded. Changing this option by
+reloading the config is not supported.
 '''
     )
 
@@ -2733,87 +2785,111 @@ opt('clipboard_control', 'write-clipboard write-primary read-clipboard-ask read-
     option_type='clipboard_control',
     long_text='''
 Allow programs running in kitty to read and write from the clipboard. You can
-control exactly which actions are allowed. The set of possible actions is:
-:code:`write-clipboard read-clipboard write-primary read-primary read-clipboard-ask read-primary-ask`.
-The default is to allow writing to the clipboard and primary selection and to
-ask for permission when a program tries to read from the clipboard. Note that
-disabling the read confirmation is a security risk as it means that any
-program, even one running on a remote server via SSH can read your clipboard.
-See also :opt:`clipboard_max_size`.
+control exactly which actions are allowed. The possible actions are:
+:code:`write-clipboard`, :code:`read-clipboard`, :code:`write-primary`,
+:code:`read-primary`, :code:`read-clipboard-ask`, :code:`read-primary-ask`. The
+default is to allow writing to the clipboard and primary selection and to ask
+for permission when a program tries to read from the clipboard. Note that
+disabling the read confirmation is a security risk as it means that any program,
+even the ones running on a remote server via SSH can read your clipboard. See
+also :opt:`clipboard_max_size`.
 '''
     )
 
-opt('clipboard_max_size', 64, option_type='positive_float', long_text='''
+opt('clipboard_max_size', '64',
+    option_type='positive_float',
+    long_text='''
 The maximum size (in MB) of data from programs running in kitty that will be
-stored for writing to the system clipboard. See also :opt:`clipboard_control`.
-A value of zero means no size limit is applied.
-''')
+stored for writing to the system clipboard. A value of zero means no size limit
+is applied. See also :opt:`clipboard_control`.
+'''
+    )
 
-opt('file_transfer_confirmation_bypass', '', long_text='''
-A password, that can be supplied to the file transfer kitten to skip the
-transfer confirmation prompt. This should only be used when initiating
-transfers from trusted computers, over trusted networks or encrypted
-transports, as it allows programs running on the remote machine to read/write
-to the local filesystem, without permission.
-''')
+opt('file_transfer_confirmation_bypass', '',
+    long_text='''
+The password that can be supplied to the :doc:`file transfer kitten
+</kittens/transfer>` to skip the transfer confirmation prompt. This should only
+be used when initiating transfers from trusted computers, over trusted networks
+or encrypted transports, as it allows any programs running on the remote machine
+to read/write to the local filesystem, without permission.
+'''
+    )
 
 opt('allow_hyperlinks', 'yes',
     option_type='allow_hyperlinks', ctype='bool',
     long_text='''
-Process hyperlink (OSC 8) escape sequences. If disabled OSC 8 escape sequences
-are ignored. Otherwise they become clickable links, that you can click by
-with the mouse or the :doc:`hints kitten </kittens/hints>`. The special value of
-``ask`` means that kitty will ask before opening the link when clicked.
+Process :term:`hyperlink <hyperlinks>` escape sequences (OSC 8). If disabled OSC
+8 escape sequences are ignored. Otherwise they become clickable links, that you
+can click with the mouse or by using the :doc:`hints kitten </kittens/hints>`.
+The special value of :code:`ask` means that kitty will ask before opening the
+link when clicked.
 '''
     )
 
-opt('shell_integration', 'enabled', option_type='shell_integration',
+opt('shell_integration', 'enabled',
+    option_type='shell_integration',
     long_text='''
 Enable shell integration on supported shells. This enables features such as
 jumping to previous prompts, browsing the output of the previous command in a
-pager, etc. on supported shells.  Set to ``disabled`` to turn off shell
-integration, completely. See :ref:`shell_integration` for details.
-''')
+pager, etc. on supported shells. Set to :code:`disabled` to turn off shell
+integration, completely. It is also possible to disable individual features, set
+to a space separated list of these values: :code:`no-rc`, :code:`no-cursor`,
+:code:`no-title`, :code:`no-cwd`, :code:`no-prompt-mark`, :code:`no-complete`.
+See :ref:`shell_integration` for details.
+'''
+    )
 
-opt('allow_cloning', 'ask', choices=('yes', 'y', 'true', 'no', 'n', 'false', 'ask'), long_text='''
-Control whether programs running in the terminal can request new
-windows to be created. The canonical example is :code:`clone-in-kitty`.
-By default, kitty will ask for permission for each clone request.
-Allowing cloning unconditionally gives programs running in the terminal
-(including over SSH) permission to execute arbitrary code as the user
-the terminal is running as on the computer the terminal is running on.
-''')
+opt('allow_cloning', 'ask',
+    choices=('yes', 'y', 'true', 'no', 'n', 'false', 'ask'),
+    long_text='''
+Control whether programs running in the terminal can request new windows to be
+created. The canonical example is :ref:`clone-in-kitty <clone_shell>`. By
+default, kitty will ask for permission for each clone request. Allowing cloning
+unconditionally gives programs running in the terminal (including over SSH)
+permission to execute arbitrary code, as the user who is running the terminal,
+on the computer that the terminal is running on.
+'''
+    )
 
-opt('clone_source_strategies', 'venv,conda,env_var,path', option_type='clone_source_strategies', long_text='''
-Control what shell code is sourced when running :code:`clone-in-kitty`
+opt('clone_source_strategies', 'venv,conda,env_var,path',
+    option_type='clone_source_strategies',
+    long_text='''
+Control what shell code is sourced when running :command:`clone-in-kitty`
 in the newly cloned window. The supported strategies are:
 
 :code:`venv`
-   Source the file :file:`$VIRTUAL_ENV/bin/activate` (this is used
-   by the Python stdlin venv module and allows cloning venvs automatically)
+    Source the file :file:`$VIRTUAL_ENV/bin/activate` (this is used by the
+    Python stdlib venv module and allows cloning venvs automatically)
 :code:`conda`
-  Run :code:`conda activate $CONDA_DEFAULT_ENV` this supports the virtual envs created by conda
+    Run :code:`conda activate $CONDA_DEFAULT_ENV` this supports the virtual envs
+    created by conda
 :code:`env_var`
-  Source the contents of the environment variable :code:`KITTY_CLONE_SOURCE_CODE`
+    Source the contents of the environment variable
+    :code:`KITTY_CLONE_SOURCE_CODE`
 :code:`path`
-  Source the file pointed to by the environment variable :code:`KITTY_CLONE_SOURCE_PATH`
+    Source the file pointed to by the environment variable
+    :code:`KITTY_CLONE_SOURCE_PATH`
 
-This setting must be a comma separated list of the above values.
-''')
+This option must be a comma separated list of the above values. This only
+source the first valid one in the above order.
+'''
+    )
 
 opt('term', 'xterm-kitty',
     long_text='''
-The value of the TERM environment variable to set. Changing this can break many
-terminal programs, only change it if you know what you are doing, not because
-you read some advice on Stack Overflow to change it. The TERM variable is used
-by various programs to get information about the capabilities and behavior of
-the terminal. If you change it, depending on what programs you run, and how
-different the terminal you are changing it to is, various things from key-presses,
-to colors, to various advanced features may not work. Changing this option by reloading
-the config will only affect newly created windows.
+The value of the :envvar:`TERM` environment variable to set. Changing this can
+break many terminal programs, only change it if you know what you are doing, not
+because you read some advice on "Stack Overflow" to change it. The
+:envvar:`TERM` variable is used by various programs to get information about the
+capabilities and behavior of the terminal. If you change it, depending on what
+programs you run, and how different the terminal you are changing it to is,
+various things from key-presses, to colors, to various advanced features may not
+work. Changing this option by reloading the config will only affect newly
+created windows.
 '''
     )
 egr()  # }}}
+
 
 # os {{{
 agr('os', 'OS specific tweaks')
@@ -2821,7 +2897,7 @@ agr('os', 'OS specific tweaks')
 opt('wayland_titlebar_color', 'system',
     option_type='titlebar_color',
     long_text='''
-Change the color of the kitty window's titlebar on Wayland systems with client
+The color of the kitty window's titlebar on Wayland systems with client
 side window decorations such as GNOME. A value of :code:`system` means to use
 the default system color, a value of :code:`background` means to use the
 background color of the currently active window and finally you can use an
@@ -2832,57 +2908,61 @@ arbitrary color, such as :code:`#12af59` or :code:`red`.
 opt('macos_titlebar_color', 'system',
     option_type='macos_titlebar_color',
     long_text='''
-Change the color of the kitty window's titlebar on macOS. A value of
+The color of the kitty window's titlebar on macOS. A value of
 :code:`system` means to use the default system color, :code:`light` or
 :code:`dark` can also be used to set it explicitly. A value of
 :code:`background` means to use the background color of the currently active
 window and finally you can use an arbitrary color, such as :code:`#12af59` or
-:code:`red`. WARNING: This option works by using a hack, as there is no proper
-Cocoa API for it. It sets the background color of the entire window and makes
-the titlebar transparent. As such it is incompatible with
-:opt:`background_opacity`. If you want to use both, you are probably better off
-just hiding the titlebar with :opt:`hide_window_decorations`.
+:code:`red`. WARNING: This option works by using a hack when arbitrary color (or
+:code:`background`) is configured, as there is no proper Cocoa API for it. It
+sets the background color of the entire window and makes the titlebar
+transparent. As such it is incompatible with :opt:`background_opacity`. If you
+want to use both, you are probably better off just hiding the titlebar with
+:opt:`hide_window_decorations`.
 '''
     )
 
 opt('macos_option_as_alt', 'no',
     option_type='macos_option_as_alt', ctype='uint',
     long_text='''
-Use the :kbd:`Option` key as an :kbd:`Alt` key. With this set to :code:`no`,
-kitty will use the macOS native :kbd:`Option+Key` = unicode character behavior.
-This will break any :kbd:`Alt+Key` keyboard shortcuts in your terminal programs,
-but you can use the macOS unicode input technique. You can use the values:
-:code:`left`, :code:`right`, or :code:`both` to use only the left, right or both
-:kbd:`Option` keys as :kbd:`Alt`, instead. Note that kitty itself always treats
-:kbd:`Option` the same as :kbd:`Alt`. This means you cannot use this setting to
-configure different kitty shortcuts for :kbd:`Option+Key` vs. `:kbd:`Alt+Key`.
-Also, any kitty shortcuts using :kbd:`Option/Alt+Key` will take priority, so
-that any such key presses will not be passed to terminal programs running inside
-kitty. Changing this setting by reloading the config is not supported.
+Use the :kbd:`Option` key as an :kbd:`Alt` key on macOS. With this set to
+:code:`no`, kitty will use the macOS native :kbd:`Option+Key` to enter Unicode
+character behavior. This will break any :kbd:`Alt+Key` keyboard shortcuts in
+your terminal programs, but you can use the macOS Unicode input technique. You
+can use the values: :code:`left`, :code:`right` or :code:`both` to use only the
+left, right or both :kbd:`Option` keys as :kbd:`Alt`, instead. Note that kitty
+itself always treats :kbd:`Option` the same as :kbd:`Alt`. This means you cannot
+use this option to configure different kitty shortcuts for :kbd:`Option+Key`
+vs. :kbd:`Alt+Key`. Also, any kitty shortcuts using :kbd:`Option/Alt+Key` will
+take priority, so that any such key presses will not be passed to terminal
+programs running inside kitty. Changing this option by reloading the config is
+not supported.
 '''
     )
 
 opt('macos_hide_from_tasks', 'no',
     option_type='to_bool', ctype='bool',
-    long_text='Hide the kitty window from running tasks (:kbd:`⌘+Tab`) on macOS.'
-    ' Changing this setting by reloading the config is not supported.'
+    long_text='''
+Hide the kitty window from running tasks on macOS (:kbd:`⌘+Tab` and the Dock).
+Changing this option by reloading the config is not supported.
+'''
     )
 
 opt('macos_quit_when_last_window_closed', 'no',
     option_type='to_bool', ctype='bool',
     long_text='''
-Have kitty quit when all the top-level windows are closed. By default, kitty
-will stay running, even with no open windows, as is the expected behavior on
-macOS.
+Have kitty quit when all the top-level windows are closed on macOS. By default,
+kitty will stay running, even with no open windows, as is the expected behavior
+on macOS.
 '''
     )
 
 opt('macos_window_resizable', 'yes',
     option_type='to_bool', ctype='bool',
     long_text='''
-Disable this if you want kitty top-level (OS) windows to not be resizable on
-macOS. Changing this setting by reloading the config will only affect newly
-created windows.
+Disable this if you want kitty top-level OS windows to not be resizable on
+macOS. Changing this option by reloading the config will only affect newly
+created OS windows.
 '''
     )
 
@@ -2890,39 +2970,48 @@ opt('macos_thicken_font', '0',
     option_type='positive_float', ctype='float',
     long_text='''
 Draw an extra border around the font with the given width, to increase
-legibility at small font sizes. For example, a value of 0.75 will result in
-rendering that looks similar to sub-pixel antialiasing at common font sizes.
+legibility at small font sizes on macOS. For example, a value of :code:`0.75`
+will result in rendering that looks similar to sub-pixel antialiasing at common
+font sizes.
 '''
     )
 
 opt('macos_traditional_fullscreen', 'no',
     option_type='to_bool', ctype='bool',
-    long_text='Use the traditional full-screen transition, that is faster, but less pretty.'
+    long_text='''
+Use the macOS traditional full-screen transition, that is faster, but less
+pretty.
+'''
     )
 
 opt('macos_show_window_title_in', 'all',
     choices=('all', 'menubar', 'none', 'window'), ctype='window_title_in',
     long_text='''
-Show or hide the window title in the macOS window or menu-bar. A value of
-:code:`window` will show the title of the currently active window at the top of
-the macOS window. A value of :code:`menubar` will show the title of the
-currently active window in the macOS menu-bar, making use of otherwise wasted
-space. :code:`all` will show the title everywhere and :code:`none` hides the
-title in the window and the menu-bar. See :opt`macos_menubar_title_max_length`
-for how to control the length of the title in the menu bar.
-''')
+Control where the window title is displayed on macOS. A value of :code:`window`
+will show the title of the currently active window at the top of the macOS
+window. A value of :code:`menubar` will show the title of the currently active
+window in the macOS global menu bar, making use of otherwise wasted space. A
+value of :code:`all` will show the title in both places, and :code:`none` hides
+the title. See :opt:`macos_menubar_title_max_length` for how to control the
+length of the title in the menu bar.
+'''
+    )
 
-opt('macos_menubar_title_max_length', '0', option_type='positive_int', ctype='int', long_text='''
-The maximum number of characters from the window title to show in the global menubar.
-Values less than one mean there is no maximum.
-''')
+opt('macos_menubar_title_max_length', '0',
+    option_type='positive_int', ctype='int',
+    long_text='''
+The maximum number of characters from the window title to show in the macOS
+global menu bar. Values less than one means that there is no maximum limit.
+'''
+    )
 
 opt('macos_custom_beam_cursor', 'no',
     option_type='to_bool',
     long_text='''
-Enable/disable custom mouse cursor for macOS that is easier to see on both light
-and dark backgrounds. WARNING: this might make your mouse cursor invisible on
-dual GPU machines. Changing this setting by reloading the config is not supported.
+Use a custom mouse cursor for macOS that is easier to see on both light
+and dark backgrounds. Nowadays, the default macOS cursor already comes with a
+white border. WARNING: this might make your mouse cursor invisible on
+dual GPU machines. Changing this option by reloading the config is not supported.
 '''
     )
 
@@ -2931,21 +3020,23 @@ opt('linux_display_server', 'auto',
     long_text='''
 Choose between Wayland and X11 backends. By default, an appropriate backend
 based on the system state is chosen automatically. Set it to :code:`x11` or
-:code:`wayland` to force the choice. Changing this setting by reloading the
+:code:`wayland` to force the choice. Changing this option by reloading the
 config is not supported.
 '''
     )
 egr()  # }}}
 
+
 # shortcuts {{{
 agr('shortcuts', 'Keyboard shortcuts', '''
-Keys are identified simply by their lowercase unicode characters. For example:
-``a`` for the A key, ``[`` for the left square bracket key, etc. For functional
-keys, such as ``Enter or Escape`` the names are present at :ref:`functional`.
-For modifier keys, the names are :kbd:`ctrl` (:kbd:`control`, :kbd:`⌃`),
-:kbd:`shift` (:kbd:`⇧`), :kbd:`alt` (:kbd:`opt`, :kbd:`option`, :kbd:`⌥`),
-:kbd:`super` (:kbd:`cmd`, :kbd:`command`, :kbd:`⌘`). See also:
-:link:`GLFW mods <https://www.glfw.org/docs/latest/group__mods.html>`
+Keys are identified simply by their lowercase Unicode characters. For example:
+:code:`a` for the :kbd:`A` key, :code:`[` for the left square bracket key, etc.
+For functional keys, such as :kbd:`Enter` or :kbd:`Escape`, the names are present
+at :ref:`Functional key definitions <functional>`. For modifier keys, the names
+are :kbd:`ctrl` (:kbd:`control`, :kbd:`⌃`), :kbd:`shift` (:kbd:`⇧`), :kbd:`alt`
+(:kbd:`opt`, :kbd:`option`, :kbd:`⌥`), :kbd:`super` (:kbd:`cmd`, :kbd:`command`,
+:kbd:`⌘`).
+See also: :link:`GLFW mods <https://www.glfw.org/docs/latest/group__mods.html>`
 
 On Linux you can also use XKB key names to bind keys that are not supported by
 GLFW. See :link:`XKB keys
@@ -2954,34 +3045,34 @@ for a list of key names. The name to use is the part after the :code:`XKB_KEY_`
 prefix. Note that you can only use an XKB key name for keys that are not known
 as GLFW keys.
 
-Finally, you can use raw system key codes to map keys, again only for keys that are not
-known as GLFW keys. To see the system key code
-for a key, start kitty with the :option:`kitty --debug-input` option. Then kitty will
-output some debug text for every key event. In that text look for ``native_code``
-the value of that becomes the key name in the shortcut. For example:
+Finally, you can use raw system key codes to map keys, again only for keys that
+are not known as GLFW keys. To see the system key code for a key, start kitty
+with the :option:`kitty --debug-input` option, kitty will output some debug text
+for every key event. In that text look for :code:`native_code`, the value
+of that becomes the key name in the shortcut. For example:
 
 .. code-block:: none
 
-    on_key_input: glfw key: 65 native_code: 0x61 action: PRESS mods: 0x0 text: 'a'
+    on_key_input: glfw key: 0x61 native_code: 0x61 action: PRESS mods: none text: 'a'
 
-Here, the key name for the :kbd:`A` key is :kbd:`0x61` and you can use it with::
+Here, the key name for the :kbd:`A` key is :code:`0x61` and you can use it with::
 
     map ctrl+0x61 something
 
-to map :kbd:`ctrl+a` to something.
+to map :kbd:`Ctrl+A` to something.
 
-You can use the special action :code:`no_op` to unmap a keyboard shortcut that is
+You can use the special action :ac:`no_op` to unmap a keyboard shortcut that is
 assigned in the default configuration::
 
     map kitty_mod+space no_op
 
 If you would like kitty to completely ignore a key event, not even sending it to
-the program running in the terminal, map it to :code:`discard_event`::
+the program running in the terminal, map it to :ac:`discard_event`::
 
     map kitty_mod+f1 discard_event
 
-You can combine multiple actions to be triggered by a single shortcut, using the
-syntax below::
+You can combine multiple actions to be triggered by a single shortcut with
+:ac:`combine` action, using the syntax below::
 
     map key combine <separator> action1 <separator> action2 <separator> action3 ...
 
@@ -2989,9 +3080,9 @@ For example::
 
     map kitty_mod+e combine : new_window : next_layout
 
-this will create a new window and switch to the next available layout
+This will create a new window and switch to the next available layout.
 
-You can use multi-key shortcuts using the syntax shown below::
+You can use multi-key shortcuts with the syntax shown below::
 
     map key1>key2>key3 action
 
@@ -3006,17 +3097,16 @@ The full list of actions that can be mapped to key presses is available
 opt('kitty_mod', 'ctrl+shift',
     option_type='to_modifiers',
     long_text='''
-The value of :code:`kitty_mod` is used as the modifier for all default
-shortcuts, you can change it in your kitty.conf to change the modifiers for all
-the default shortcuts.
+Special modifier key alias for default shortcuts. You can change the value of
+this option to alter all default shortcuts that use :opt:`kitty_mod`.
 '''
     )
 
 opt('clear_all_shortcuts', 'no',
     option_type='clear_all_shortcuts',
     long_text='''
-You can have kitty remove all shortcut definitions seen up to this point. Useful,
-for instance, to remove the default shortcuts.
+Remove all shortcut definitions up to this point. Useful, for instance, to
+remove the default shortcuts.
 '''
     )
 
@@ -3024,10 +3114,10 @@ opt('+action_alias', 'launch_tab launch --type=tab --cwd=current',
     option_type='action_alias',
     add_to_default=False,
     long_text='''
-Define aliases to avoid repeating the same options in multiple mappings. Aliases
-can be defined for any action. Aliases are expanded recursively.
-For example, the above alias allows you to create mappings to launch a new tab
-in the current working directory without duplication::
+Define action aliases to avoid repeating the same options in multiple mappings.
+Aliases can be defined for any action and will be expanded recursively. For
+example, the above alias allows you to create mappings to launch a new tab in
+the current working directory without duplication::
 
     map f1 launch_tab vim
     map f2 launch_tab emacs
@@ -3035,17 +3125,18 @@ in the current working directory without duplication::
 Similarly, to alias kitten invocation::
 
     action_alias hints kitten hints --hints-offset=0
-''')
+'''
+    )
 
 opt('+kitten_alias', 'hints hints --hints-offset=0',
     option_type='kitten_alias',
     add_to_default=False,
     long_text='''
-Like :opt:`action_alias` above but, specifically for kittens. Generally,
-prefer to use :opt:`action_alias`. This option is a legacy
-version, present for backwards compatibility. It causes all invocations
-of the aliased kitten to be substituted. So the example above will cause
-all invocations of the hints kitten to have the :code:`--hints-offset=0`
+Like :opt:`action_alias` above, but specifically for kittens. Generally, prefer
+to use :opt:`action_alias`. This option is a legacy version, present for
+backwards compatibility. It causes all invocations of the aliased kitten to be
+substituted. So the example above will cause all invocations of the hints kitten
+to have the :option:`--hints-offset=0 <kitty +kitten hints --hints-offset>`
 option applied.
 '''
     )
@@ -3057,16 +3148,15 @@ agr('shortcuts.clipboard', 'Clipboard')
 map('Copy to clipboard',
     'copy_to_clipboard kitty_mod+c copy_to_clipboard',
     long_text='''
-There is also a :code:`copy_or_interrupt` action that can be optionally mapped
-to :kbd:`Ctrl+c`. It will copy only if there is a selection and send an
-interrupt otherwise. Similarly, :code:`copy_and_clear_or_interrupt` will copy
+There is also a :ac:`copy_or_interrupt` action that can be optionally mapped
+to :kbd:`Ctrl+C`. It will copy only if there is a selection and send an
+interrupt otherwise. Similarly, :ac:`copy_and_clear_or_interrupt` will copy
 and clear the selection or send an interrupt if there is no selection.
 '''
     )
 map('Copy to clipboard',
     'copy_to_clipboard cmd+c copy_to_clipboard',
     only='macos',
-    documented=False,
     )
 
 map('Paste from clipboard',
@@ -3075,7 +3165,6 @@ map('Paste from clipboard',
 map('Paste from clipboard',
     'paste_from_clipboard cmd+v paste_from_clipboard',
     only='macos',
-    documented=False,
     )
 
 map('Paste from selection',
@@ -3088,15 +3177,15 @@ map('Paste from selection',
 map('Pass selection to program',
     'pass_selection_to_program kitty_mod+o pass_selection_to_program',
     long_text='''
-You can also pass the contents of the current selection to any program using
-:code:`pass_selection_to_program`. By default, the system's open program is used, but
-you can specify your own, the selection will be passed as a command line argument to the program,
-for example::
+You can also pass the contents of the current selection to any program with
+:ac:`pass_selection_to_program`. By default, the system's open program is used,
+but you can specify your own, the selection will be passed as a command line
+argument to the program. For example::
 
     map kitty_mod+o pass_selection_to_program firefox
 
 You can pass the current selection to a terminal program running in a new kitty
-window, by using the @selection placeholder::
+window, by using the :code:`@selection` placeholder::
 
     map kitty_mod+y new_window less @selection
 '''
@@ -3172,8 +3261,9 @@ map('Scroll to bottom',
 map('Scroll to previous shell prompt',
     'scroll_to_previous_prompt kitty_mod+z scroll_to_prompt -1',
     long_text='''
-Use a parameter of zero for :code:`scroll_to_prompt` to scroll to the last jumped
-to or the last clicked position. Requires :ref:`shell_integration` to work.
+Use a parameter of :code:`0` for :ac:`scroll_to_prompt` to scroll to the last
+jumped to or the last clicked position. Requires :ref:`shell_integration` to
+work.
 '''
     )
 
@@ -3182,9 +3272,10 @@ map('Scroll to next shell prompt', 'scroll_to_next_prompt kitty_mod+x scroll_to_
 map('Browse scrollback buffer in pager',
     'show_scrollback kitty_mod+h show_scrollback',
     long_text='''
-You can pipe the contents of the current screen + history buffer as
-:file:`STDIN` to an arbitrary program using the ``launch`` function. For example,
-the following opens the scrollback buffer in less in an overlay window::
+You can pipe the contents of the current screen and history buffer as
+:file:`STDIN` to an arbitrary program using :option:`launch --stdin-source`.
+For example, the following opens the scrollback buffer in less in an
+:term:`overlay` window::
 
     map f1 launch --stdin-source=@screen_scrollback --stdin-add-formatting --type=overlay less +G -R
 
@@ -3201,12 +3292,14 @@ For example, to get the first command output on screen::
 
     map f1 show_first_command_output_on_screen
 
-To get the command output that was last accessed by a keyboard action or mouse action::
+To get the command output that was last accessed by a keyboard action or mouse
+action::
 
     map f1 show_last_visited_command_output
 
-You can pipe the output of the last command run in the shell using the :doc:`launch` function.
-For example, the following opens the output in less in an overlay window::
+You can pipe the output of the last command run in the shell using the
+:ac:`launch` action. For example, the following opens the output in less in an
+:term:`overlay` window::
 
     map f1 launch --stdin-source=@last_cmd_output --stdin-add-formatting --type=overlay less +G -R
 
@@ -3214,7 +3307,8 @@ To get the output of the first command on the screen, use :code:`@first_cmd_outp
 To get the output of the last jumped to command, use :code:`@last_visited_cmd_output`.
 
 Requires :ref:`shell_integration` to work.
-''')
+'''
+    )
 egr()  # }}}
 
 
@@ -3224,27 +3318,28 @@ agr('shortcuts.window', 'Window management')
 map('New window',
     'new_window kitty_mod+enter new_window',
     long_text='''
-You can open a new window running an arbitrary program, for example::
+You can open a new :term:`kitty window <window>` running an arbitrary program,
+for example::
 
-    map kitty_mod+y      launch mutt
+    map kitty_mod+y launch mutt
 
-You can open a new window with the current working directory set to the
-working directory of the current window using::
+You can open a new window with the current working directory set to the working
+directory of the current window using::
 
-    map ctrl+alt+enter    launch --cwd=current
+    map ctrl+alt+enter launch --cwd=current
 
 You can open a new window that is allowed to control kitty via
-the kitty remote control facility by prefixing the command line with @.
+the kitty remote control facility with :option:`launch --allow-remote-control`.
 Any programs running in that window will be allowed to control kitty.
 For example::
 
     map ctrl+enter launch --allow-remote-control some_program
 
-You can open a new window next to the currently active window or as the first window,
-with::
+You can open a new window next to the currently active window or as the first
+window, with::
 
-    map ctrl+n launch --location=neighbor some_program
-    map ctrl+f launch --location=first some_program
+    map ctrl+n launch --location=neighbor
+    map ctrl+f launch --location=first
 
 For more details, see :doc:`launch`.
 '''
@@ -3257,9 +3352,9 @@ map('New window',
 map('New OS window',
     'new_os_window kitty_mod+n new_os_window',
     long_text='''
-Works like new_window above, except that it opens a top level OS kitty window.
-In particular you can use new_os_window_with_cwd to open a window with the
-current working directory.
+Works like :ac:`new_window` above, except that it opens a top-level :term:`OS
+window <os_window>`. In particular you can use :ac:`new_os_window_with_cwd` to
+open a window with the current working directory.
 '''
     )
 map('New OS window',
@@ -3379,8 +3474,19 @@ map('Tenth window',
     'tenth_window kitty_mod+0 tenth_window',
     )
 
-map('Visually select focus window', 'focus_visible_window kitty_mod+f7 focus_visible_window')
-map('Visually swap window with another', 'swap_with_window kitty_mod+f8 swap_with_window')
+map('Visually select and focus window', 'focus_visible_window kitty_mod+f7 focus_visible_window',
+    long_text='''
+Display overlay numbers and alphabets on the window, and switch the focus to the
+window when you press the key. When there are only two windows, the focus will
+be switched directly without displaying the overlay. You can change the overlay
+characters and their order with option :opt:`visual_window_select_characters`.
+'''
+    )
+map('Visually swap window with another', 'swap_with_window kitty_mod+f8 swap_with_window',
+    long_text='''
+Works like :ac:`focus_visible_window` above, but swaps the window.
+'''
+    )
 egr()  # }}}
 
 
@@ -3446,15 +3552,16 @@ map('Set tab title',
     only='macos',
     )
 egr('''
-You can also create shortcuts to go to specific tabs, with 1 being the first
-tab, 2 the second tab and -1 being the previously active tab, and any number
-larger than the last tab being the last tab::
+You can also create shortcuts to go to specific :term:`tabs <tab>`, with
+:code:`1` being the first tab, :code:`2` the second tab and :code:`-1` being the
+previously active tab, and any number larger than the last tab being the last
+tab::
 
     map ctrl+alt+1 goto_tab 1
     map ctrl+alt+2 goto_tab 2
 
-Just as with :code:`new_window` above, you can also pass the name of arbitrary
-commands to run when using new_tab and use :code:`new_tab_with_cwd`. Finally,
+Just as with :ac:`new_window` above, you can also pass the name of arbitrary
+commands to run when using :ac:`new_tab` and :ac:`new_tab_with_cwd`. Finally,
 if you want the new tab to open next to the current tab rather than at the
 end of the tabs list, use::
 
@@ -3469,7 +3576,7 @@ map('Next layout',
     'next_layout kitty_mod+l next_layout',
     )
 egr('''
-You can also create shortcuts to switch to specific layouts::
+You can also create shortcuts to switch to specific :term:`layouts <layout>`::
 
     map ctrl+alt+t goto_layout tall
     map ctrl+alt+s goto_layout stack
@@ -3478,10 +3585,9 @@ Similarly, to switch back to the previous layout::
 
    map ctrl+alt+p last_used_layout
 
-There is also a toggle layout function that switches
-to the named layout or back to the previous layout if
-in the named layout. Useful to temporarily "zoom" the
-active window by switching to the stack layout::
+There is also a :ac:`toggle_layout` action that switches to the named layout or
+back to the previous layout if in the named layout. Useful to temporarily "zoom"
+the active window by switching to the stack layout::
 
     map ctrl+alt+z toggle_layout stack
 ''')  # }}}
@@ -3566,7 +3672,8 @@ map('Insert selected path',
     'insert_selected_path kitty_mod+p>f kitten hints --type path --program -',
     long_text='''
 Select a path/filename and insert it into the terminal. Useful, for instance to
-run git commands on a filename output from a previous git command.
+run :program:`git` commands on a filename output from a previous :program:`git`
+command.
 '''
     )
 
@@ -3578,8 +3685,8 @@ map('Open selected path',
 map('Insert selected line',
     'insert_selected_line kitty_mod+p>l kitten hints --type line --program -',
     long_text='''
-Select a line of text and insert it into the terminal. Use for the output of
-things like: ls -1
+Select a line of text and insert it into the terminal. Useful for the output of
+things like: :code:`ls -1`.
 '''
     )
 
@@ -3592,28 +3699,28 @@ map('Insert selected hash',
     'insert_selected_hash kitty_mod+p>h kitten hints --type hash --program -',
     long_text='''
 Select something that looks like a hash and insert it into the terminal. Useful
-with git, which uses sha1 hashes to identify commits
+with :program:`git`, which uses SHA1 hashes to identify commits.
 '''
     )
 
 map('Open the selected file at the selected line',
     'goto_file_line kitty_mod+p>n kitten hints --type linenum',
     long_text='''
-Select something that looks like :code:`filename:linenum` and open it in vim at
-the specified line number.
+Select something that looks like :code:`filename:linenum` and open it in
+:program:`vim` at the specified line number.
 '''
     )
 
 map('Open the selected hyperlink',
     'open_selected_hyperlink kitty_mod+p>y kitten hints --type hyperlink',
     long_text='''
-Select a hyperlink (i.e. a URL that has been marked as such by the terminal
-program, for example, by :code:`ls --hyperlink=auto`).
+Select a :term:`hyperlink <hyperlinks>` (i.e. a URL that has been marked as such
+by the terminal program, for example, by :code:`ls --hyperlink=auto`).
 '''
     )
 egr('''
 The hints kitten has many more modes of operation that you can map to different
-shortcuts. For a full description see :doc:`kittens/hints`.
+shortcuts. For a full description see :doc:`hints kitten </kittens/hints>`.
 ''')  # }}}
 
 
@@ -3656,8 +3763,8 @@ map('Edit config file',
 map('Open the kitty command shell',
     'kitty_shell kitty_mod+escape kitty_shell window',
     long_text='''
-Open the kitty shell in a new window/tab/overlay/os_window to control kitty
-using commands.
+Open the kitty shell in a new :code:`window` / :code:`tab` / :code:`overlay` /
+:code:`os_window` to control kitty using commands.
 '''
     )
 
@@ -3693,14 +3800,14 @@ You can create shortcuts to clear/reset the terminal. For example::
     # Clear everything up to the line with the cursor
     map f1 clear_terminal to_cursor active
 
-If you want to operate on all windows instead of just the current one, use
+If you want to operate on all kitty windows instead of just the current one, use
 :italic:`all` instead of :italic:`active`.
 
-It is also possible to remap Ctrl+L to both scroll the current screen contents
-into the scrollback buffer and clear the screen, instead of just clearing the
-screen, for example, for ZSH add the following to :file:`~/.zshrc`:
+It is also possible to remap :kbd:`Ctrl+L` to both scroll the current screen
+contents into the scrollback buffer and clear the screen, instead of just
+clearing the screen, for example, for ZSH add the following to :file:`~/.zshrc`:
 
-.. code-block:: sh
+.. code-block:: zsh
 
     scroll-and-clear-screen() {
         printf '\\n%.0s' {1..$LINES}
@@ -3725,15 +3832,16 @@ map('Clear up to cursor line',
 map('Reload kitty.conf',
     'reload_config_file kitty_mod+f5 load_config_file',
     long_text='''
-Reload kitty.conf, applying any changes since the last time it was loaded.
-Note that a handful of settings cannot be dynamically changed and require a
-full restart of kitty.  You can also map a keybinding to load a different
-config file, for example::
+Reload :file:`kitty.conf`, applying any changes since the last time it was
+loaded. Note that a handful of options cannot be dynamically changed and
+require a full restart of kitty. Particularly, when changing shortcuts for
+actions located on the macOS global menu bar, a full restart is needed. You can
+also map a keybinding to load a different config file, for example::
 
     map f5 load_config /path/to/alternative/kitty.conf
 
-Note that all setting from the original kitty.conf are discarded, in other words
-the new conf settings *replace* the old ones.
+Note that all options from the original :file:`kitty.conf` are discarded, in
+other words the new configuration *replace* the old ones.
 '''
     )
 
@@ -3745,8 +3853,8 @@ map('Reload kitty.conf',
 map('Debug kitty configuration',
     'debug_config kitty_mod+f6 debug_config',
     long_text='''
-Show details about exactly what configuration kitty is running with and
-its host environment. Useful for debugging issues.
+Show details about exactly what configuration kitty is running with and its host
+environment. Useful for debugging issues.
 '''
     )
 
@@ -3760,23 +3868,24 @@ map('Send arbitrary text on key presses',
     'send_text ctrl+shift+alt+h send_text all Hello World',
     add_to_default=False,
     long_text='''
-You can tell kitty to send arbitrary (UTF-8) encoded text to
-the client program when pressing specified shortcut keys. For example::
+You can tell kitty to send arbitrary (UTF-8) encoded text to the client program
+when pressing specified shortcut keys. For example::
 
     map ctrl+alt+a send_text all Special text
 
-This will send "Special text" when you press the :kbd:`ctrl+alt+a` key
-combination.  The text to be sent is a python string literal so you can use
+This will send "Special text" when you press the :kbd:`Ctrl+Alt+A` key
+combination. The text to be sent is a python string literal so you can use
 escapes like :code:`\\x1b` to send control codes or :code:`\\u21fb` to send
-unicode characters (or you can just input the unicode characters directly as
-UTF-8 text). You can use the show_key kitten :code:`kitty +kitten show_key` to
-get the key escape codes you want to emulate. The first argument to
-:code:`send_text` is the keyboard modes in which to activate the shortcut. The
-possible values are :code:`normal` or :code:`application` or :code:`kitty` or a
-comma separated combination of them. The special keyword :code:`all` means all
-modes. The modes :code:`normal` and :code:`application` refer to the DECCKM
+Unicode characters (or you can just input the Unicode characters directly as
+UTF-8 text). You can use :code:`kitty +kitten show_key` to get the key escape
+codes you want to emulate.
+
+The first argument to :code:`send_text` is the keyboard modes in which to
+activate the shortcut. The possible values are :code:`normal`,
+:code:`application`, :code:`kitty` or a comma separated combination of them.
+The modes :code:`normal` and :code:`application` refer to the DECCKM
 cursor key mode for terminals, and :code:`kitty` refers to the kitty extended
-keyboard protocol.
+keyboard protocol. The special value :code:`all` means all of them.
 
 Some more examples::
 


### PR DESCRIPTION
Improve clone-in-kitty documentation and fix LANG descriptions
- Reduce duplicate `launch`.
- Add links to python venv and conda.
- Adjust the order of env vars, `.._CODE` takes precedence over `.._PATH`.
- Add clone-in-kitty env vars to glossary.
- Correct the description of the LANG env var.

Minor tweaks to the help documentation of hints kitten

Minor improvements to the kitty cli help documentation
- Add some text roles.
- Use `kitty --hold`.
- Use `appname` and `conf_name`.
- `appname` is also applied to the system-wide configuration path.

Improvements to the configuration documentation
- Slightly adjust and simplify the config option descriptions.
- Add more text roles.
- Initial capitalized key names.
- Change some examples to better demonstrate configurations.
- Fix listen_on description.
- Also document cmd+c and cmd+v.
- Fix doc text role links in commented out configuration file.

---

Go through the documentation for almost all configuration options.
Tested to generate dirhtml, man page, commented configuration file.

I have checked this several times and maybe there are still inappropriate changes.
Please review, thanks.