### PR TITLE
Show error message when remote command arguments are invalid

### DIFF
--- a/kitty/rc/create_marker.py
+++ b/kitty/rc/create_marker.py
@@ -37,7 +37,10 @@ Apply marker to the window this command is run in, rather than the active window
     def message_to_kitty(self, global_opts: RCOptions, opts: 'CLIOptions', args: ArgsType) -> PayloadType:
         if len(args) < 2:
             self.fatal('Invalid marker specification: {}'.format(' '.join(args)))
-        parse_marker_spec(args[0], args[1:])
+        try:
+            parse_marker_spec(args[0], args[1:])
+        except Exception as err:
+            self.fatal(f"Failed to parse marker specification {' '.join(args)} with error: {err}")
         return {'match': opts.match, 'self': opts.self, 'marker_spec': args}
 
     def response_from_kitty(self, boss: Boss, window: Optional[Window], payload_get: PayloadGetType) -> ResponseType:

--- a/kitty/rc/scroll_window.py
+++ b/kitty/rc/scroll_window.py
@@ -35,6 +35,8 @@ class ScrollWindow(RemoteCommand):
     options_spec = MATCH_WINDOW_OPTION
 
     def message_to_kitty(self, global_opts: RCOptions, opts: 'CLIOptions', args: ArgsType) -> PayloadType:
+        if len(args) < 1:
+            self.fatal('Scroll amount must be specified')
         amt = args[0]
         amount: Tuple[Union[str, int], Optional[str]] = (amt, None)
         if amt not in ('start', 'end'):


### PR DESCRIPTION
I'm not sure how a `send-text` without a match should be handled properly.
If we simply check for empty matches, does that affect the broadcast function?

It seems that broadcast can first match an empty range, e.g. a focused tab with no windows (which should not report an error at this point), and later works for newly opened windows in the focused tab.