### PR TITLE
Replace platform with sw_vers - Fixes #5051

### DIFF
--- a/kitty/ci.yml
+++ b/kitty/ci.yml
@@ -974,8 +974,9 @@ def path_from_osc7_url(url: str) -> str:
 
 @run_once
 def macos_version() -> Tuple[int, ...]:
-    import platform
-    return tuple(map(int, platform.mac_ver()[0].split('.')))
+    import subprocess
+    o = subprocess.check_output(['sw_vers', '-productVersion'], stderr=subprocess.STDOUT).decode()
+    return tuple(map(int, o.strip().split('.')))
 
 
 @lru_cache(maxsize=2)


### PR DESCRIPTION
The call to `platform.mac_ver()` fails in release builds because it relies on the `plistlib` module which isn't included in kitty. Instead use the builtin macOS tool `sw_vers` to determine the os version.