### PR TITLE
Support the short pretty flag (-p) in hyperlinked_grep kitten

### DIFF
--- a/kittens/hyperlinked_grep/main.py
+++ b/kittens/hyperlinked_grep/main.py
@@ -20,7 +20,7 @@ def write_hyperlink(write: Callable[[bytes], None], url: bytes, line: bytes, fra
 
 
 def main() -> None:
-    if not sys.stdout.isatty() and '--pretty' not in sys.argv:
+    if not sys.stdout.isatty() and '--pretty' not in sys.argv and '-p' not in sys.argv:
         os.execlp('rg', 'rg', *sys.argv[1:])
     cmdline = ['rg', '--pretty', '--with-filename'] + sys.argv[1:]
     try:


### PR DESCRIPTION
From the manual:
```
    -p, --pretty                                 
            This is a convenience alias for '--color always --heading --line-number'. This
            flag is useful when you still want pretty output even if you're piping ripgrep
            to another program or file. For example: 'rg -p foo | less -R'.
```

Took me a while to figure out that it's the kitten at fault and not less lacking hyperlink support :)