### PR TITLE
Add ability to use custom kitten dir in config dir 

### DIFF
--- a/kittens/runner.py
+++ b/kittens/runner.py
@@ -28,6 +28,8 @@ def resolved_kitten(k: str) -> str:
 
 
 def path_to_custom_kitten(config_dir: str, kitten: str) -> str:
+    if kitten.startswith('@'):
+        kitten = 'kittens/' + kitten.split('.')[0][1:] + '/main.py'
     path = resolve_abs_or_config_path(kitten, conf_dir=config_dir)
     return os.path.abspath(path)
 


### PR DESCRIPTION
### Purpose
This change adds the ability for users to structure their custom kittens in the same way as built in kittens are structured inside a "./kittens" subdirectory, rather than polluting the root directory of their kitty config with multiple custom kitten files.
### Current options
The current resolution of custom kittens implies that users must store an entry point (of one form or another) to the custom kitten in the root directory of their kitty config:
* for simple custom kittens, users must have an entry point at "/CONFIG_DIR/CUSTOM_KITTEN_NAME.py" for example "~/.config/kitty/my_custom_kitten.py"
* for more complex custom kittens, users may adopt some different approaches 
    * pollute the top level root config directory with multiple custom kitten files
    * create a subdirectory for code relating to custom kittens, and use the entry point in the root config directory to import the required files
    * create a subdirectory for custom kittens similar to that found for built-in kittens in the kitty repo, and utilise symlinks to reference the custom kitten entry point from the root config directory
### Proposed addition
Allow users to better organise their custom kittens by storing them in a "./kittens" subdirectory as is used in the kitty repo to define built-in kittens (https://github.com/kovidgoyal/kitty/tree/master/kittens)

To use custom kittens structured in this way, users can:
* create an entry point for the custom kitten at "/CONFIG_DIR/kitten/CUSTOM_KITTEN_NAME/main.py" for example "~/.config/kitty/kittens/my_custom_kitten/main.py"
* call custom kitten by prepending @ symbol to the name of the custom kitten, for example "kitty +kitten @my_custom_kitten"
* customs kittens should still be written as specified by the kitty docs (https://sw.kovidgoyal.net/kitty/kittens/custom/)

For example:
```
# initialise new directory structure for custom kittens
cd ~/.config/kitty
mkdir kittens
cd kittens

# make a subdirectory with the name of your custom kitten
mkdir my_custom_kitten
cd my_custom_kitten

# write custom kitten inside main.py
vim main.py
# alternatively move file(s) for existing custom kittens
mv ~/.config/kitty/my_custom_kitten.py ~/.config/kitty/kittens/my_custom_kitten/main.py

# run custom kitten by prepending @ to the kitten name
kitty +kitten @my_custom_kitten
```
### Remarks
* This change requires users to prepend an @ symbol to the kitten name when calling custom kittens formatted in this way, as such users with custom kittens with entry points at "/CONFIG_DIR/CUSTOM_KITTEN_NAME.py" will not be affected, and may continue calling  their custom kittens in the normal manner, for example "kitty +kitten my_custom_kitten"
* This change allows the creation and running of custom kittens that share their name with existing built-in kittens provided that the custom kitten is formatted using the proposed directory structure, allowing users to potentially add to, change, or override behaviour of built-in kittens by making their own modifications, but maintaining the same name
