### PR TITLE
Add "user" tab to themes kitten

### DIFF
--- a/kittens/themes/collection.py
+++ b/kittens/themes/collection.py
@@ -494,6 +494,7 @@ class Theme:
     is_dark: bool = False
     blurb: str = ''
     num_settings: int = 0
+    is_user_defined: bool = False
 
     def apply_dict(self, d: Dict[str, Any]) -> None:
         self.name = str(d['name'])
@@ -501,7 +502,7 @@ class Theme:
             a = d.get(x)
             if isinstance(a, str):
                 setattr(self, x, a)
-        for x in ('is_dark', 'num_settings'):
+        for x in ('is_dark', 'num_settings', 'is_user_defined'):
             a = d.get(x)
             if isinstance(a, int):
                 setattr(self, x, a)
@@ -594,6 +595,7 @@ class Themes:
                     d = parse_theme(name, raw)
                 except (Exception, SystemExit):
                     continue
+                d['is_user_defined'] = True
                 t = Theme(raw.__str__)
                 t.apply_dict(d)
                 if t.name:

--- a/kittens/themes/main.py
+++ b/kittens/themes/main.py
@@ -69,6 +69,10 @@ def create_recent_filter(names: Iterable[str]) -> Callable[[Theme], bool]:
     return recent_filter
 
 
+def user_filter(q: Theme) -> bool:
+    return q.is_user_defined
+
+
 def mark_shortcut(text: str, acc: str) -> str:
     acc_idx = text.lower().index(acc.lower())
     return text[:acc_idx] + styled(text[acc_idx], underline='straight', bold=True, fg_intense=True) + text[acc_idx+1:]
@@ -153,12 +157,13 @@ class ThemesHandler(Handler):
         self.report_traceback_on_exit: Optional[str] = None
         self.filter_map: Dict[str, Callable[[Theme], bool]] = {
             'dark': dark_filter, 'light': light_filter, 'all': all_filter,
-            'recent': create_recent_filter(self.cached_values.get('recent', ()))
+            'recent': create_recent_filter(self.cached_values.get('recent', ())),
+            'user': user_filter
         }
         self.themes_list = ThemesList()
         self.colors_set_once = False
         self.line_edit = LineEdit()
-        self.tabs = tuple('all dark light recent'.split())
+        self.tabs = tuple('all dark light recent user'.split())
         self.quit_on_next_key_release = -1
 
     def update_recent(self) -> None:

--- a/kittens/themes/main.py
+++ b/kittens/themes/main.py
@@ -389,7 +389,7 @@ class ThemesHandler(Handler):
         if key_event.matches('esc') or key_event.matches_text('q'):
             self.quit_on_next_key_release = 0
             return
-        for cat in 'all dark light recent'.split():
+        for cat in self.tabs:
             if key_event.matches_text(cat[0]) or key_event.matches(f'alt+{cat[0]}'):
                 if cat != self.current_category:
                     self.current_category = cat


### PR DESCRIPTION
### Purpose
Add new tab named "user" to the built-in themes kitten - new tab filters and displays only user-defined color themes, and ignores all themes defined in the kitty-themes repository (https://github.com/kovidgoyal/kitty-themes)

Useful for:
* restricting search results to display user-defined themes without the userhaving to resort to naming themes using a custom prefix such as "@my-custom-theme.conf"
* easily visually browsing user-defined themes given that there are now well over 200 themes in the kitty-themes repository
* easily finding user-defined duplicates/modifications of existing themes
### Remarks
* pull request also replaces a duplicate hard coded tab string with an equivalent reference which was defined elsewhere in the same file