### PR TITLE
Ignore Fig OSC codes

### DIFF
--- a/kitty/parser.c
+++ b/kitty/parser.c
@@ -460,6 +460,9 @@ dispatch_osc(Screen *screen, PyObject DUMP_UNUSED *dump_callback) {
             REPORT_COMMAND(screen_pop_dynamic_colors);
             screen_pop_colors(screen, 0);
             break;
+        // OSC 697 is used by Fig and can be ignored
+        case 697:
+            break;
         default:
             REPORT_ERROR("Unknown OSC code: %u", code);
             break;

--- a/kitty/parser.c
+++ b/kitty/parser.c
@@ -460,8 +460,8 @@ dispatch_osc(Screen *screen, PyObject DUMP_UNUSED *dump_callback) {
             REPORT_COMMAND(screen_pop_dynamic_colors);
             screen_pop_colors(screen, 0);
             break;
-        // OSC 697 is used by Fig and can be ignored
         case 697:
+            REPORT_ERROR("Ignoring OSC 697, typically used by Fig for shell integration");
             break;
         default:
             REPORT_ERROR("Unknown OSC code: %u", code);


### PR DESCRIPTION
[Fig](https://fig.io) uses OSC 697 for its shell integrations, currently Kitty reports this as `[PARSE ERROR] Unknown OSC code: 697`, this PR will simply suppress those errors.