### PR TITLE
Add `tab_bar_always_update` option.

### DIFF
--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -619,7 +619,7 @@ prepare_to_render_os_window(OSWindow *os_window, monotonic_t now, unsigned int *
     bool needs_render = os_window->needs_render;
     os_window->needs_render = false;
     if (TD.screen && os_window->num_tabs >= OPT(tab_bar_min_tabs)) {
-        if (!os_window->tab_bar_data_updated) {
+        if (OPT(tab_bar_always_update) || !os_window->tab_bar_data_updated) {
             call_boss(update_tab_bar_data, "K", os_window->id);
             os_window->tab_bar_data_updated = true;
         }

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -1231,6 +1231,13 @@ Color for the tab bar margin area. Defaults to using the terminal background
 color.
 '''
     )
+
+opt('tab_bar_always_update', 'no',
+    option_type='to_bool', ctype='bool',
+    long_text='''
+Update tab bar whenever os window is rerendered.
+'''
+    )
 egr()  # }}}
 
 

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -1210,6 +1210,9 @@ class Parser:
 
     choices_for_tab_bar_align = frozenset(('left', 'center', 'right'))
 
+    def tab_bar_always_update(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        ans['tab_bar_always_update'] = to_bool(val)
+
     def tab_bar_background(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['tab_bar_background'] = to_color_or_none(val)
 

--- a/kitty/options/to-c-generated.h
+++ b/kitty/options/to-c-generated.h
@@ -617,6 +617,19 @@ convert_from_opts_resize_in_steps(PyObject *py_opts, Options *opts) {
 }
 
 static void
+convert_from_python_tab_bar_always_update(PyObject *val, Options *opts) {
+    opts->tab_bar_always_update = PyObject_IsTrue(val);
+}
+
+static void
+convert_from_opts_tab_bar_always_update(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "tab_bar_always_update");
+    if (ret == NULL) return;
+    convert_from_python_tab_bar_always_update(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
 convert_from_python_tab_bar_edge(PyObject *val, Options *opts) {
     opts->tab_bar_edge = PyLong_AsLong(val);
 }
@@ -1127,6 +1140,8 @@ convert_opts_from_python_opts(PyObject *py_opts, Options *opts) {
     convert_from_opts_resize_draw_strategy(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_resize_in_steps(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_tab_bar_always_update(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_tab_bar_edge(py_opts, opts);
     if (PyErr_Occurred()) return false;

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -423,6 +423,7 @@ option_names = (  # {{{
  'sync_to_monitor',
  'tab_activity_symbol',
  'tab_bar_align',
+ 'tab_bar_always_update',
  'tab_bar_background',
  'tab_bar_edge',
  'tab_bar_margin_color',
@@ -573,6 +574,7 @@ class Options:
     sync_to_monitor: bool = True
     tab_activity_symbol: str = ''
     tab_bar_align: choices_for_tab_bar_align = 'left'
+    tab_bar_always_update: bool = False
     tab_bar_background: typing.Optional[kitty.fast_data_types.Color] = None
     tab_bar_edge: int = 3
     tab_bar_margin_color: typing.Optional[kitty.fast_data_types.Color] = None

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -78,6 +78,7 @@ typedef struct {
     char_type *url_excluded_characters;
     bool detect_urls;
     bool tab_bar_hidden;
+    bool tab_bar_always_update;
     double font_size;
     struct {
         double outer, inner;


### PR DESCRIPTION
Hi,

I added a `tab_bar_always_update` option, that updates the tab bar whenever the os window is redrawn. This obviously has a negative performance impact when set, but it allows to render things that update independent ot the tab state, such as a clock.

Unfortunately, I was unable to run `gen-config.py` because of a sigsegv when importing `fast_data_types` that I didn't resolve in reasonable time. Instead, I manually edited the option files in line with what would have been generated