### PR TITLE
Expose wakeup main loop in python api.

### DIFF
--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -892,6 +892,10 @@ def cell_size_for_window(os_window_id: int) -> Tuple[int, int]:
     pass
 
 
+def wakeup_main_loop() -> None:
+    pass
+
+
 class Region:
     left: int
     top: int

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -1128,6 +1128,11 @@ PYWRAP0(destroy_global_data) {
     Py_RETURN_NONE;
 }
 
+PYWRAP0(wakeup_main_loop) {
+    wakeup_main_loop();
+    Py_RETURN_NONE;
+}
+
 static void
 destroy_mock_window(PyObject *capsule) {
     Window *w = PyCapsule_GetPointer(capsule, "Window");
@@ -1305,6 +1310,7 @@ static PyMethodDef module_methods[] = {
     MW(patch_global_colors, METH_VARARGS),
     MW(create_mock_window, METH_VARARGS),
     MW(destroy_global_data, METH_NOARGS),
+    MW(wakeup_main_loop, METH_NOARGS),
 
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };


### PR DESCRIPTION
Thanks for discussing the issue with me and giving many hints on possible solutions.

This PR exposes `wakeup_main_loop` to the python api in similar fashion as `mark_tab_bar_dirty`.