### PR TITLE
Make globinclude sort files before loading

### DIFF
--- a/kitty/conf/utils.py
+++ b/kitty/conf/utils.py
@@ -185,7 +185,7 @@ def parse_line(
         val = os.path.expandvars(os.path.expanduser(val.strip()))
         if key == 'globinclude':
             from pathlib import Path
-            vals = tuple(map(lambda x: str(os.fspath(x)), Path(base_path_for_includes).glob(val)))
+            vals = tuple(map(lambda x: str(os.fspath(x)), sorted(Path(base_path_for_includes).glob(val))))
         elif key == 'envinclude':
             from fnmatch import fnmatchcase
             for x in os.environ:


### PR DESCRIPTION
`Path.glob` gives no guarantee about the order results are returned in.
This means that if files included by `globinclude` override each other,
the resulting config was non-deterministic. Resolve this by sorting the
results from `glob` to give consistent, well-defined order.