### PR TITLE
Allow remote control to launch a new OS window when there is none

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -47,6 +47,8 @@ Detailed list of changes
 
 - Fix horizontal wheel events not being reported to client programs when they grab the mouse (:iss:`2819`)
 
+- Remote control: Fix unable to launch a new OS window or background process when there is no OS window (:iss:`5210`)
+
 
 0.25.2 [2022-06-07]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/kitty/rc/launch.py
+++ b/kitty/rc/launch.py
@@ -81,11 +81,14 @@ instead of the active tab
             if val is None:
                 val = default_value
             setattr(opts, key, val)
+        target_tab = None
         tabs = self.tabs_for_match_payload(boss, window, payload_get)
         if tabs and tabs[0]:
-            w = do_launch(boss, opts, payload_get('args') or [], target_tab=tabs[0])
-            return None if payload_get('no_response') else str(getattr(w, 'id', 0))
-        return None
+            target_tab = tabs[0]
+        elif payload_get('type') not in ('os-window', 'background'):
+            return None
+        w = do_launch(boss, opts, payload_get('args') or [], target_tab=target_tab)
+        return None if payload_get('no_response') else str(getattr(w, 'id', 0))
 
 
 launch = Launch()


### PR DESCRIPTION
When the match argument is provided, an error will be reported if there is no match.
This does not seem to break backward compatibility.

Fixes #5210

Please review, thank you.