### PR TITLE
Add "modern whiskers" alternative icon to FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -283,6 +283,10 @@ homepage:
    :target: https://github.com/igrmk/whiskers
    :width: 256
 
+.. image:: https://github.com/samholmes/whiskers/raw/main/whiskers.png
+   :target: https://github.com/samholmes/whiskers
+   :width: 256
+
 On macOS you can change the icon by following the steps:
 
 #. Find :file:`kitty.app` in the Applications folder, select it and press :kbd:`⌘+I`


### PR DESCRIPTION
This is a request to add to the alternative app icons list on the FAQ.

### Modern Whiskers (Inspired by the existing Whiskers icon)

![Modern Whiskers](https://raw.githubusercontent.com/samholmes/whiskers/main/whiskers.png)