### PR TITLE
MacOS: allow non-1 background opacity with custom titlebar color

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-LDFLAGS=-L/opt/homebrew/lib \
-    python3 setup.py kitty.app \
-    --extra-include-dirs /opt/homebrew/Cellar/librsync/2.3.2/include
-rm -rf /Applications/kitty.app
-cp -r kitty.app /Applications/kitty.app

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+LDFLAGS=-L/opt/homebrew/lib \
+    python3 setup.py kitty.app \
+    --extra-include-dirs /opt/homebrew/Cellar/librsync/2.3.2/include
+rm -rf /Applications/kitty.app
+cp -r kitty.app /Applications/kitty.app

--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -1695,7 +1695,7 @@ static bool createNativeWindow(_GLFWwindow* window,
     if (fbconfig->transparent)
     {
         [window->ns.object setOpaque:NO];
-        [window->ns.object setHasShadow:NO];
+        [window->ns.object setHasShadow:YES];
         [window->ns.object setBackgroundColor:[NSColor clearColor]];
     }
 

--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -821,8 +821,9 @@ cocoa_set_titlebar_color(void *w, color_type titlebar_color)
                             green:green
                              blue:blue
                             alpha:1.0];
-    [window setTitlebarAppearsTransparent:YES];
+    [window setTitlebarAppearsTransparent:NO];
     [window setBackgroundColor:background];
+    [window setBackgroundColor:[NSColor clearColor]];
 
     double luma = 0.2126 * red + 0.7152 * green + 0.0722 * blue;
 

--- a/kitty/config.py
+++ b/kitty/config.py
@@ -178,9 +178,9 @@ def load_config(*paths: str, overrides: Optional[Iterable[str]] = None, accumula
     opts.action_alias = {}
     opts.mouse_map = []
     opts.map = []
-    if opts.background_opacity < 1.0 and opts.macos_titlebar_color > 0:
-        log_error('Cannot use both macos_titlebar_color and background_opacity')
-        opts.macos_titlebar_color = 0
+    # if opts.background_opacity < 1.0 and opts.macos_titlebar_color > 0:
+    #     log_error('Cannot use both macos_titlebar_color and background_opacity')
+    #     opts.macos_titlebar_color = 0
     opts.config_paths = paths
     opts.config_overrides = overrides
     return opts

--- a/kitty/config.py
+++ b/kitty/config.py
@@ -178,9 +178,6 @@ def load_config(*paths: str, overrides: Optional[Iterable[str]] = None, accumula
     opts.action_alias = {}
     opts.mouse_map = []
     opts.map = []
-    # if opts.background_opacity < 1.0 and opts.macos_titlebar_color > 0:
-    #     log_error('Cannot use both macos_titlebar_color and background_opacity')
-    #     opts.macos_titlebar_color = 0
     opts.config_paths = paths
     opts.config_overrides = overrides
     return opts


### PR DESCRIPTION
Previously, if the `background_opacity` took any value less than 1:
1. The window will have no shadow
2. The titlebar will be coerced to the default color (`macos_titlebar_color` will be overridden by an internal config)

With this PR, you should be able to set both a custom `macos_titlebar_color` and enjoy a non-1 `background-opacity`, and on top of that have the shadow.