### PR TITLE
Add `term-image` to projects using kitty graphics protocol

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -43,6 +43,7 @@ Some programs and libraries that use the kitty graphics protocol:
 * `rasterm <https://github.com/BourgeoisBear/rasterm>`_  - Go library to display images in the terminal
 * `chafa <https://github.com/hpjansson/chafa>`_  - a terminal image viewer
 * `hologram.nvim <https://github.com/edluffy/hologram.nvim>`_  - view images inside nvim
+* `term-image <https://github.com/AnonymouX47/term-image>`_  - A Python library, CLI and TUI to display and browse images in the terminal
 
 Other terminals that have implemented the graphics protocol:
 


### PR DESCRIPTION
Hello! 😃

I've just released a [new version](https://github.com/AnonymouX47/term-image/releases/tag/v0.4.0) of my project [term-image](https://github.com/AnonymouX47/term-image) with kitty graphics support.