### PR TITLE
Fix link formatting in docs

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -31,7 +31,7 @@ Some programs and libraries that use the kitty graphics protocol:
 * `ranger <https://github.com/ranger/ranger>`_ - a terminal file manager, with
   image previews, see this `PR <https://github.com/ranger/ranger/pull/1077>`_
 * :doc:`kitty-diff <kittens/diff>` - a side-by-side terminal diff program with support for images
-* `tpix <https://github.com/jesvedberg/tpix>` - a statically compiled binary that can be used to display images and easily installed on remote servers without root access
+* `tpix <https://github.com/jesvedberg/tpix>`_ - a statically compiled binary that can be used to display images and easily installed on remote servers without root access
 * `pixcat <https://github.com/mirukana/pixcat>`_ - a third party CLI and python library that wraps the graphics protocol
 * `neofetch <https://github.com/dylanaraps/neofetch>`_ - A command line system
   information tool


### PR DESCRIPTION
Missed in 3eb5320e297c8de4bad8ff2bab62bb8fceaebe77