### PR TITLE
feat(options): add modify_font option

### DIFF
--- a/kitty/core_text.m
+++ b/kitty/core_text.m
@@ -332,7 +332,7 @@ adjust_ypos(unsigned int pos, unsigned int cell_height, int adjustment) {
 }
 
 void
-cell_metrics(PyObject *s, unsigned int* cell_width, unsigned int* cell_height, unsigned int* baseline, unsigned int* underline_position, unsigned int* underline_thickness, unsigned int* strikethrough_position, unsigned int* strikethrough_thickness) {
+cell_metrics(PyObject *s, unsigned int* cell_width, unsigned int* cell_height, unsigned int* baseline, unsigned int* underline_position, unsigned int* underline_thickness, unsigned int* strikethrough_position, unsigned int* strikethrough_thickness, unsigned int* modified_thickness, unsigned int* modified_underline_y, unsigned int* modified_strikethrough_y) {
     // See https://developer.apple.com/library/content/documentation/StringsTextFonts/Conceptual/TextAndWebiPhoneOS/TypoFeatures/TextSystemFeatures.html
     CTFace *self = (CTFace*)s;
 #define count (128 - 32)
@@ -349,7 +349,9 @@ cell_metrics(PyObject *s, unsigned int* cell_width, unsigned int* cell_height, u
         }
     }
     *cell_width = MAX(1u, width);
-    *underline_thickness = (unsigned int)ceil(MAX(0.1, self->underline_thickness));
+    if (modified_thickness != NULL) *underline_thickness = *modified_thickness;
+    else *underline_thickness = (unsigned int)ceil(MAX(0.1, self->underline_thickness));
+
     *strikethrough_thickness = *underline_thickness;
     // float line_height = MAX(1, floor(self->ascent + self->descent + MAX(0, self->leading) + 0.5));
     // Let CoreText's layout engine calculate the line height. Slower, but hopefully more accurate.
@@ -398,6 +400,9 @@ cell_metrics(PyObject *s, unsigned int* cell_width, unsigned int* cell_height, u
         *underline_position = adjust_ypos(*underline_position, *cell_height, baseline_offset);
         *strikethrough_position = adjust_ypos(*strikethrough_position, *cell_height, baseline_offset);
     }
+
+    if (modified_underline_y) *underline_position = adjust_ypos(*underline_position, *cell_height, baseline_offset);
+    if (modified_strikethrough_y) *strikethrough_position = adjust_ypos(*strikethrough_position, *cell_height, baseline_offset);
 
     CFRelease(test_frame); CFRelease(path); CFRelease(framesetter);
 

--- a/kitty/core_text.m
+++ b/kitty/core_text.m
@@ -401,8 +401,8 @@ cell_metrics(PyObject *s, unsigned int* cell_width, unsigned int* cell_height, u
         *strikethrough_position = adjust_ypos(*strikethrough_position, *cell_height, baseline_offset);
     }
 
-    if (modified_underline_y) *underline_position = adjust_ypos(*underline_position, *cell_height, baseline_offset);
-    if (modified_strikethrough_y) *strikethrough_position = adjust_ypos(*strikethrough_position, *cell_height, baseline_offset);
+    if (modified_underline_y) *underline_position = adjust_ypos(*underline_position, *cell_height, *modified_underline_y);
+    if (modified_strikethrough_y) *strikethrough_position = adjust_ypos(*strikethrough_position, *cell_height, *modified_strikethrough_y);
 
     CFRelease(test_frame); CFRelease(path); CFRelease(framesetter);
 

--- a/kitty/core_text.m
+++ b/kitty/core_text.m
@@ -332,7 +332,7 @@ adjust_ypos(unsigned int pos, unsigned int cell_height, int adjustment) {
 }
 
 void
-cell_metrics(PyObject *s, unsigned int* cell_width, unsigned int* cell_height, unsigned int* baseline, unsigned int* underline_position, unsigned int* underline_thickness, unsigned int* strikethrough_position, unsigned int* strikethrough_thickness, unsigned int* modified_thickness, unsigned int* modified_underline_y, unsigned int* modified_strikethrough_y) {
+cell_metrics(PyObject *s, unsigned int* cell_width, unsigned int* cell_height, unsigned int* baseline, unsigned int* underline_position, unsigned int* underline_thickness, unsigned int* strikethrough_position, unsigned int* strikethrough_thickness, int* modified_thickness, int* modified_underline_y, int* modified_strikethrough_y) {
     // See https://developer.apple.com/library/content/documentation/StringsTextFonts/Conceptual/TextAndWebiPhoneOS/TypoFeatures/TextSystemFeatures.html
     CTFace *self = (CTFace*)s;
 #define count (128 - 32)

--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -978,6 +978,7 @@ def set_font_data(
     bold: int, italic: int, bold_italic: int, num_symbol_fonts: int,
     symbol_maps: Tuple[Tuple[int, int, int], ...], font_sz_in_pts: float,
     font_feature_settings: Dict[str, Tuple[FontFeature, ...]],
+    font_modifications: Dict[str, int],
     narrow_symbols: Tuple[Tuple[int, int, int], ...],
 ) -> None:
     pass

--- a/kitty/fonts.c
+++ b/kitty/fonts.c
@@ -44,6 +44,7 @@ static char_type shape_buffer[4096] = {0};
 static size_t max_texture_size = 1024, max_array_len = 1024;
 typedef enum { LIGA_FEATURE, DLIG_FEATURE, CALT_FEATURE } HBFeature;
 static PyObject* font_feature_settings = NULL;
+static PyObject* font_modifications = NULL;
 
 typedef struct {
     char_type left, right;
@@ -1360,12 +1361,12 @@ set_symbol_maps(SymbolMap **maps, size_t *num, const PyObject *sm) {
 static PyObject*
 set_font_data(PyObject UNUSED *m, PyObject *args) {
     PyObject *sm, *ns;
-    Py_CLEAR(box_drawing_function); Py_CLEAR(prerender_function); Py_CLEAR(descriptor_for_idx); Py_CLEAR(font_feature_settings);
-    if (!PyArg_ParseTuple(args, "OOOIIIIO!dOO!",
+    Py_CLEAR(box_drawing_function); Py_CLEAR(prerender_function); Py_CLEAR(descriptor_for_idx); Py_CLEAR(font_feature_settings); Py_CLEAR(font_modifications);
+    if (!PyArg_ParseTuple(args, "OOOIIIIO!dOOO!",
                 &box_drawing_function, &prerender_function, &descriptor_for_idx,
                 &descriptor_indices.bold, &descriptor_indices.italic, &descriptor_indices.bi, &descriptor_indices.num_symbol_fonts,
-                &PyTuple_Type, &sm, &OPT(font_size), &font_feature_settings, &PyTuple_Type, &ns)) return NULL;
-    Py_INCREF(box_drawing_function); Py_INCREF(prerender_function); Py_INCREF(descriptor_for_idx); Py_INCREF(font_feature_settings);
+                &PyTuple_Type, &sm, &OPT(font_size), &font_feature_settings, &font_modifications, &PyTuple_Type, &ns)) return NULL;
+    Py_INCREF(box_drawing_function); Py_INCREF(prerender_function); Py_INCREF(descriptor_for_idx); Py_INCREF(font_feature_settings); Py_IncRef(font_modifications);
     free_font_groups();
     clear_symbol_maps();
     set_symbol_maps(&symbol_maps, &num_symbol_maps, sm);

--- a/kitty/fonts.c
+++ b/kitty/fonts.c
@@ -337,7 +337,7 @@ static void
 calc_cell_metrics(FontGroup *fg) {
     unsigned int cell_height, cell_width, baseline, underline_position, underline_thickness, strikethrough_position, strikethrough_thickness;
 
-    unsigned int modified_thickness, modified_underline_y, modified_strikethrough_y;
+    int modified_thickness, modified_underline_y, modified_strikethrough_y;
     PyObject* o = PyDict_GetItemString(font_modifications, "underline_thickness");
     if (o != NULL) modified_thickness = PyLong_AsLong(o);
     PyObject* p = PyDict_GetItemString(font_modifications, "underline_position");

--- a/kitty/fonts.c
+++ b/kitty/fonts.c
@@ -336,7 +336,28 @@ python_send_to_gpu(FONTS_DATA_HANDLE fg, unsigned int x, unsigned int y, unsigne
 static void
 calc_cell_metrics(FontGroup *fg) {
     unsigned int cell_height, cell_width, baseline, underline_position, underline_thickness, strikethrough_position, strikethrough_thickness;
-    cell_metrics(fg->fonts[fg->medium_font_idx].face, &cell_width, &cell_height, &baseline, &underline_position, &underline_thickness, &strikethrough_position, &strikethrough_thickness);
+
+    unsigned int modified_thickness, modified_underline_y, modified_strikethrough_y;
+    PyObject* o = PyDict_GetItemString(font_modifications, "underline_thickness");
+    if (o != NULL) modified_thickness = PyLong_AsLong(o);
+    PyObject* p = PyDict_GetItemString(font_modifications, "underline_position");
+    if (p != NULL) modified_underline_y = PyLong_AsLong(p);
+    PyObject* s = PyDict_GetItemString(font_modifications, "strikethrough_position");
+    if (s != NULL) modified_strikethrough_y = PyLong_AsLong(s);
+
+    cell_metrics(
+        fg->fonts[fg->medium_font_idx].face,
+        &cell_width,
+        &cell_height,
+        &baseline,
+        &underline_position,
+        &underline_thickness,
+        &strikethrough_position,
+        &strikethrough_thickness,
+        &modified_thickness,
+        &modified_underline_y,
+        &modified_strikethrough_y
+    );
     if (!cell_width) fatal("Failed to calculate cell width for the specified font");
     unsigned int before_cell_height = cell_height;
     int cw = cell_width, ch = cell_height;

--- a/kitty/fonts.h
+++ b/kitty/fonts.h
@@ -24,7 +24,7 @@ int get_glyph_width(PyObject *, glyph_index);
 bool is_glyph_empty(PyObject *, glyph_index);
 hb_font_t* harfbuzz_font_for_face(PyObject*);
 bool set_size_for_face(PyObject*, unsigned int, bool, FONTS_DATA_HANDLE);
-void cell_metrics(PyObject*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*);
+void cell_metrics(PyObject*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*);
 bool render_glyphs_in_cells(PyObject *f, bool bold, bool italic, hb_glyph_info_t *info, hb_glyph_position_t *positions, unsigned int num_glyphs, pixel *canvas, unsigned int cell_width, unsigned int cell_height, unsigned int num_cells, unsigned int baseline, bool *was_colored, FONTS_DATA_HANDLE, bool center_glyph);
 PyObject* create_fallback_face(PyObject *base_face, CPUCell* cell, bool bold, bool italic, bool emoji_presentation, FONTS_DATA_HANDLE fg);
 PyObject* specialize_font_descriptor(PyObject *base_descriptor, FONTS_DATA_HANDLE);

--- a/kitty/fonts.h
+++ b/kitty/fonts.h
@@ -24,7 +24,7 @@ int get_glyph_width(PyObject *, glyph_index);
 bool is_glyph_empty(PyObject *, glyph_index);
 hb_font_t* harfbuzz_font_for_face(PyObject*);
 bool set_size_for_face(PyObject*, unsigned int, bool, FONTS_DATA_HANDLE);
-void cell_metrics(PyObject*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*);
+void cell_metrics(PyObject*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*, int*, int*, int*);
 bool render_glyphs_in_cells(PyObject *f, bool bold, bool italic, hb_glyph_info_t *info, hb_glyph_position_t *positions, unsigned int num_glyphs, pixel *canvas, unsigned int cell_width, unsigned int cell_height, unsigned int num_cells, unsigned int baseline, bool *was_colored, FONTS_DATA_HANDLE, bool center_glyph);
 PyObject* create_fallback_face(PyObject *base_face, CPUCell* cell, bool bold, bool italic, bool emoji_presentation, FONTS_DATA_HANDLE fg);
 PyObject* specialize_font_descriptor(PyObject *base_descriptor, FONTS_DATA_HANDLE);

--- a/kitty/fonts/render.py
+++ b/kitty/fonts/render.py
@@ -200,6 +200,11 @@ def set_font_family(opts: Optional[Options] = None, override_font_size: Optional
     ns = create_narrow_symbols(opts)
     num_symbol_fonts = len(current_faces) - before
     font_features = {}
+    font_modifications = {}
+    for font_name in opts.modify_font:
+        fields = opts.modify_font[font_name]
+        font_modifications = fields
+
     for face, _, _ in current_faces:
         font_features[face['postscript_name']] = find_font_features(face['postscript_name'])
     font_features.update(opts.font_features)
@@ -208,7 +213,7 @@ def set_font_family(opts: Optional[Options] = None, override_font_size: Optional
     set_font_data(
         render_box_drawing, prerender_function, descriptor_for_idx,
         indices['bold'], indices['italic'], indices['bi'], num_symbol_fonts,
-        sm, sz, font_features, ns
+        sm, sz, font_features, font_modifications, ns
     )
 
 

--- a/kitty/fonts/render.py
+++ b/kitty/fonts/render.py
@@ -201,12 +201,14 @@ def set_font_family(opts: Optional[Options] = None, override_font_size: Optional
     num_symbol_fonts = len(current_faces) - before
     font_features = {}
     font_modifications = {}
-    for font_name in opts.modify_font:
-        fields = opts.modify_font[font_name]
-        font_modifications = fields
+
+    if opts.modify_font["*"]:
+        font_modifications = opts.modify_font["*"]
 
     for face, _, _ in current_faces:
         font_features[face['postscript_name']] = find_font_features(face['postscript_name'])
+        if not font_modifications and face['postscript_name'] in opts.modify_font:
+            font_modifications = opts.modify_font[face['postscript_name']]
     font_features.update(opts.font_features)
     if debug_font_matching:
         dump_faces(ftypes, indices)

--- a/kitty/freetype.c
+++ b/kitty/freetype.c
@@ -314,7 +314,17 @@ adjust_ypos(unsigned int pos, unsigned int cell_height, int adjustment) {
 }
 
 void
-cell_metrics(PyObject *s, unsigned int* cell_width, unsigned int* cell_height, unsigned int* baseline, unsigned int* underline_position, unsigned int* underline_thickness, unsigned int* strikethrough_position, unsigned int* strikethrough_thickness) {
+cell_metrics(PyObject *s,
+             unsigned int* cell_width,
+             unsigned int* cell_height,
+             unsigned int* baseline,
+             unsigned int* underline_position,
+             unsigned int* underline_thickness,
+             unsigned int* strikethrough_position,
+             unsigned int* strikethrough_thickness,
+             unsigned int* modified_thickness,
+             unsigned int* modified_underline_y,
+             unsigned int* modified_strikethrough_y) {
     Face *self = (Face*)s;
     *cell_width = calc_cell_width(self);
     *cell_height = calc_cell_height(self, true);
@@ -323,7 +333,11 @@ cell_metrics(PyObject *s, unsigned int* cell_width, unsigned int* cell_height, u
     else if (OPT(adjust_baseline_frac) != 0) baseline_offset = (int)(*cell_height * OPT(adjust_baseline_frac));
     *baseline = font_units_to_pixels_y(self, self->ascender);
     *underline_position = MIN(*cell_height - 1, (unsigned int)font_units_to_pixels_y(self, MAX(0, self->ascender - self->underline_position)));
-    *underline_thickness = MAX(1, font_units_to_pixels_y(self, self->underline_thickness));
+    if (modified_thickness != NULL) {
+        *underline_thickness = *modified_thickness;
+    } else {
+        *underline_thickness = MAX(1, font_units_to_pixels_y(self, self->underline_thickness));
+    }
 
     if (self->strikethrough_position != 0) {
       *strikethrough_position = MIN(*cell_height - 1, (unsigned int)font_units_to_pixels_y(self, MAX(0, self->ascender - self->strikethrough_position)));
@@ -339,6 +353,13 @@ cell_metrics(PyObject *s, unsigned int* cell_width, unsigned int* cell_height, u
         *baseline = adjust_ypos(*baseline, *cell_height, baseline_offset);
         *underline_position = adjust_ypos(*underline_position, *cell_height, baseline_offset);
         *strikethrough_position = adjust_ypos(*strikethrough_position, *cell_height, baseline_offset);
+    }
+
+    if (modified_underline_y) {
+        *underline_position = adjust_ypos(*underline_position, *cell_height, *modified_underline_y);
+    }
+    if (modified_strikethrough_y) {
+        *strikethrough_position = adjust_ypos(*strikethrough_position, *cell_height, *modified_strikethrough_y);
     }
 }
 

--- a/kitty/freetype.c
+++ b/kitty/freetype.c
@@ -322,9 +322,9 @@ cell_metrics(PyObject *s,
              unsigned int* underline_thickness,
              unsigned int* strikethrough_position,
              unsigned int* strikethrough_thickness,
-             unsigned int* modified_thickness,
-             unsigned int* modified_underline_y,
-             unsigned int* modified_strikethrough_y) {
+             int* modified_thickness,
+             int* modified_underline_y,
+             int* modified_strikethrough_y) {
     Face *self = (Face*)s;
     *cell_width = calc_cell_width(self);
     *cell_height = calc_cell_height(self, true);

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -159,6 +159,13 @@ Note that this refers to programming ligatures, typically implemented using the
 '''
     )
 
+opt('+modify_font', 'none',
+    option_type='modify_font',
+    add_to_default=False,
+    long_text='''
+    <SOMETHING THAT EXPLAINS THE FEATURE HERE>
+    ''')
+
 opt('+font_features', 'none',
     option_type='font_features',
     add_to_default=False,

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -163,7 +163,12 @@ opt('+modify_font', 'none',
     option_type='modify_font',
     add_to_default=False,
     long_text='''
-    <SOMETHING THAT EXPLAINS THE FEATURE HERE>
+Modify the appearance of a font. This setting is useful for changing the
+thickness of the underline or undercurl of a font, the position of the
+strikethrough or the underline or undercurl. It accepts the attribute you wish
+to change as well as a number representing pts. For example::
+
+    modify_font underline_thickness 2 underline_position 4
     ''')
 
 opt('+font_features', 'none',

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -12,7 +12,7 @@ from kitty.options.utils import (
     cursor_text_color, deprecated_hide_window_decorations_aliases,
     deprecated_macos_show_window_title_in_menubar_alias, deprecated_send_text, disable_ligatures,
     edge_width, env, font_features, hide_window_decorations, macos_option_as_alt, macos_titlebar_color,
-    narrow_symbols, optional_edge_width, parse_map, parse_mouse_map, paste_actions,
+    modify_font, narrow_symbols, optional_edge_width, parse_map, parse_mouse_map, paste_actions,
     resize_draw_strategy, scrollback_lines, scrollback_pager_history_size, shell_integration,
     store_multiple, symbol_map, tab_activity_symbol, tab_bar_edge, tab_bar_margin_height,
     tab_bar_min_tabs, tab_fade, tab_font_style, tab_separator, tab_title_template, titlebar_color,
@@ -1096,6 +1096,10 @@ class Parser:
     def mark3_foreground(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['mark3_foreground'] = to_color(val)
 
+    def modify_font(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        for k, v in modify_font(val):
+            ans["modify_font"][k] = v
+
     def mouse_hide_wait(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['mouse_hide_wait'] = float(val)
 
@@ -1364,6 +1368,7 @@ def create_result_dict() -> typing.Dict[str, typing.Any]:
         'exe_search_path': {},
         'font_features': {},
         'kitten_alias': {},
+        'modify_font': {},
         'narrow_symbols': {},
         'symbol_map': {},
         'watcher': {},

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -393,6 +393,7 @@ option_names = (  # {{{
  'mark2_foreground',
  'mark3_background',
  'mark3_foreground',
+ 'modify_font',
  'mouse_hide_wait',
  'mouse_map',
  'narrow_symbols',
@@ -612,6 +613,7 @@ class Options:
     exe_search_path: typing.Dict[str, str] = {}
     font_features: typing.Dict[str, typing.Tuple[kitty.fonts.FontFeature, ...]] = {}
     kitten_alias: typing.Dict[str, str] = {}
+    modify_font: typing.Dict[str, typing.Tuple[str, int]] = {}
     narrow_symbols: typing.Dict[typing.Tuple[int, int], int] = {}
     symbol_map: typing.Dict[typing.Tuple[int, int], str] = {}
     watcher: typing.Dict[str, str] = {}
@@ -731,6 +733,7 @@ defaults.env = {}
 defaults.exe_search_path = {}
 defaults.font_features = {}
 defaults.kitten_alias = {}
+defaults.modify_font = {}
 defaults.narrow_symbols = {}
 defaults.symbol_map = {}
 defaults.watcher = {}

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -613,7 +613,7 @@ class Options:
     exe_search_path: typing.Dict[str, str] = {}
     font_features: typing.Dict[str, typing.Tuple[kitty.fonts.FontFeature, ...]] = {}
     kitten_alias: typing.Dict[str, str] = {}
-    modify_font: typing.Dict[str, typing.Tuple[str, int]] = {}
+    modify_font: typing.Dict[str, typing.Dict[str, int]] = {}
     narrow_symbols: typing.Dict[typing.Tuple[int, int], int] = {}
     symbol_map: typing.Dict[typing.Tuple[int, int], str] = {}
     watcher: typing.Dict[str, str] = {}

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -796,6 +796,27 @@ def font_features(val: str) -> Iterable[Tuple[str, Tuple[FontFeature, ...]]]:
                 features.append(FontFeature(feat, parsed))
         yield parts[0], tuple(features)
 
+def modify_font(val: str) -> Iterable[Tuple[str, Tuple[str, int]]]:
+    if val == 'none':
+        return
+    parts = val.split()
+    if len(parts) < 2:
+        log_error(f"Ignoring invalid modify_font {val}")
+        return
+    if parts[0]:
+        modifications = []
+        for mod in parts[1:]:
+            try:
+                key, v = val.split(" ")
+                key, v = key.strip(), v.strip()
+                parsed = [key, int(val)]
+            except ValueError:
+                log_error(f'Ignoring invalid font modification: {mod}')
+            else:
+                modifications.append([mod, parsed])
+        print(modifications)
+        yield parts[0], tuple(modifications)
+
 
 def env(val: str, current_val: Dict[str, str]) -> Iterable[Tuple[str, str]]:
     val = val.strip()

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -805,9 +805,12 @@ def modify_font(val: str) -> Iterable[Tuple[str, Dict[str, int]]]:
         return
     if parts[0]:
         modifications = {}
+        mod_key = ["underline_thickness", "underline_position", "strikethrough_position"]
         for i in range(1, len(parts), 2):
             key = parts[i].strip()
             try:
+                if key not in mod_key:
+                    raise ValueError(f'{key} is not a valid font modification')
                 modifications[key] = int(parts[i + 1])
             except ValueError:
                 log_error(f'Ignoring invalid font modification: {key}')

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -796,7 +796,7 @@ def font_features(val: str) -> Iterable[Tuple[str, Tuple[FontFeature, ...]]]:
                 features.append(FontFeature(feat, parsed))
         yield parts[0], tuple(features)
 
-def modify_font(val: str) -> Iterable[Tuple[str, Tuple[str, int]]]:
+def modify_font(val: str) -> Iterable[Tuple[str, Dict[str, int]]]:
     if val == 'none':
         return
     parts = val.split()
@@ -804,18 +804,14 @@ def modify_font(val: str) -> Iterable[Tuple[str, Tuple[str, int]]]:
         log_error(f"Ignoring invalid modify_font {val}")
         return
     if parts[0]:
-        modifications = []
-        for mod in parts[1:]:
+        modifications = {}
+        for i in range(1, len(parts), 2):
+            key = parts[i].strip()
             try:
-                key, v = val.split(" ")
-                key, v = key.strip(), v.strip()
-                parsed = [key, int(val)]
+                modifications[key] = int(parts[i + 1])
             except ValueError:
-                log_error(f'Ignoring invalid font modification: {mod}')
-            else:
-                modifications.append([mod, parsed])
-        print(modifications)
-        yield parts[0], tuple(modifications)
+                log_error(f'Ignoring invalid font modification: {key}')
+        yield parts[0], modifications
 
 
 def env(val: str, current_val: Dict[str, str]) -> Iterable[Tuple[str, str]]:


### PR DESCRIPTION
This fixes the issue of not being able to modify a font attributes, namely the `underline_thickness`, `strikethrough_position`, `underline_position` and (eventually) `size`. It supersedes #4723.

# To-do:
- [x] add validation of the arguments for `modify_font`
- [x] Handle specifying postscript font name
- [x] fix handling of `*_position` as neither currently move the line down nor up.
- [ ] Handle size... (not entirely sure where to start with this)
	- [ ] Units are specified as `int` but maybe should accept `%` for `size`
- [x] Fix bug with strikethrough positioning

## Notes for review:
I'm largely new to python and c so any formatting issues or method usages etc. feel free to correct as I've just focused on getting something working and don't know what the best practices are.