### PR TITLE
Add layout_action to toggle mirroring

### DIFF
--- a/docs/layouts.rst
+++ b/docs/layouts.rst
@@ -68,10 +68,11 @@ for the options is::
     └──────────────┴───────────────┘
 
 In addition, you can map keys to increase or decrease the number of full-height
-windows, for example::
+windows, or toggle the mirrored setting for example::
 
    map ctrl+[ layout_action decrease_num_full_size_windows
    map ctrl+] layout_action increase_num_full_size_windows
+   map ctrl+/ layout_action toggle_mirrored
 
 
 The Fat Layout

--- a/kitty/layout/tall.py
+++ b/kitty/layout/tall.py
@@ -196,6 +196,9 @@ class Tall(Layout):
         return neighbors_for_tall_window(self.num_full_size_windows, window, windows, self.layout_opts.mirrored, self.main_is_horizontal)
 
     def layout_action(self, action_name: str, args: Sequence[str], all_windows: WindowList) -> Optional[bool]:
+        if action_name == 'toggle_mirrored':
+            self.layout_opts.mirrored = not self.layout_opts.mirrored
+            return True
         if action_name == 'increase_num_full_size_windows':
             self.layout_opts.full_size += 1
             return True


### PR DESCRIPTION
Super small change so I can bind a key to flip flop to my heart's content. Maybe others would like to flip?

Commit message contains brainfart, sorry.

Kept it simple, so didn't also add `layout_action mirror` or `layout_action unmirror` to set it absolutely, but those would be as trivial to add.