### PR TITLE
Implement macOS accessibility protocol to provide selected text

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -1540,6 +1540,36 @@ void _glfwPlatformUpdateIMEState(_GLFWwindow *w, const GLFWIMEUpdateEvent *ev) {
     debug_key("\n\tdoCommandBySelector: (%s)\n", [NSStringFromSelector(selector) UTF8String]);
 }
 
+- (BOOL)isAccessibilityElement
+{
+    return YES;
+}
+
+- (BOOL)isAccessibilitySelectorAllowed:(SEL)selector
+{
+    if (selector == @selector(accessibilityRole) || selector == @selector(accessibilitySelectedText)) return YES;
+    return NO;
+}
+
+- (NSAccessibilityRole)accessibilityRole
+{
+    return NSAccessibilityTextAreaRole;
+}
+
+- (NSString *)accessibilitySelectedText
+{
+    if (_glfw.callbacks.get_current_selection) {
+        NSString *text = nil;
+        const char *s = _glfw.callbacks.get_current_selection();
+        if (s) {
+            text = [NSString stringWithUTF8String:s];
+            free((void*) s);
+            return text;
+        }
+    }
+    return nil;
+}
+
 @end
 // }}}
 


### PR DESCRIPTION
Allow "Speak selection" (Option+Esc) to work properly.
Thanks for the last building block.

Fixes https://github.com/kovidgoyal/kitty/issues/5357

Minor improvements for code style:
Use spaces as indentation consistently.

EDIT:
The improvements about indentation have been picked to the master branch.
https://github.com/kovidgoyal/kitty/commit/06108d66b14c78456268622be285e7e5b11feb12
https://github.com/kovidgoyal/kitty/commit/0d116e6ef0f176bec053907920dd9c3655113562
