### PR TITLE
Only when using the new remote control password option KITTY_LISTEN_ON is no longer set

### DIFF
--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -446,7 +446,7 @@ class Tab:  # {{{
     ) -> Window:
         child = self.launch_child(
             use_shell=use_shell, cmd=cmd, stdin=stdin, cwd_from=cwd_from, cwd=cwd, env=env,
-            is_clone_launch=is_clone_launch, add_listen_on_env_var=not allow_remote_control
+            is_clone_launch=is_clone_launch, add_listen_on_env_var=False if allow_remote_control and remote_control_passwords else True
         )
         window = Window(
             self, child, self.args, override_title=override_title,


### PR DESCRIPTION
In previous versions, `launch --allow-remote-control` was used to allow remote control with TTY in the window.
The following use case is supported in both windows. (previously supported)

```shell
kitty -o allow_remote_control=socket-only
kitty @ launch --allow-remote-control
kitty @ launch
```

```shell
kitty @ --to "$KITTY_LISTEN_ON" ls
```

This PR will only stop setting `KITTY_LISTEN_ON` when using the new launch option `--remote-control-password`, without breaking backwards compatibility.

Please review, thanks.

---

In the future it might be possible to add window id+passwd authentication for socket.

> If you send your remote control over the socket, there is no associated window,
> so window based passwords cannot work. This is a technical limitation ...

```shell
kitty @ launch --remote-control-password ... --explicitly-allow-window-rc-password-with-socket
```

I believe that when `KITTY_WINDOW_ID=2 KITTY_LISTEN_ON=... kitty @ --auth-window-id=2` also sends the window id for authentication `{"cmd":"...", "auth_window_id":2}`, when the window rc password is valid, we can optimistically assume that the source of the rc command is the specified window id.
When falling back to the globally configured remote control password (auth passed), it is assumed that there is no source window id.

That said, I still think it's good enough now without all the unnecessary hassle.