### PR TITLE
Docs: Some improvements to the docs for recent changes

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -23,6 +23,10 @@ following dependencies are installed first.
    should use a version of the source that matches the binary version as closely
    as possible, since the two are tightly coupled.
 
+   You may need to unset the :envvar:`KITTY_PREWARM_SOCKET` environment variable,
+   otherwise your modified code will not be executed, when running some of the
+   ``kitty +`` and ``kitty @`` commands.
+
 
 Dependencies
 ----------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -82,7 +82,7 @@ Detailed list of changes
 - ssh kitten: A new option :code:`--symlink-strategy` to control how symlinks
   are copied to the remote machine (:iss:`5249`)
 
-- ssh kitten: Allow pressing Ctrl-C to abort ssh before the connection is
+- ssh kitten: Allow pressing :kbd:`Ctrl+C` to abort ssh before the connection is
   completed (:iss:`5271`)
 
 - Bash integration: Fix declare not creating global variables in .bashrc (:iss:`5254`)

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -145,7 +145,8 @@ Variables that kitty sets when running child programs
 .. envvar:: KITTY_PREWARM_SOCKET
 
    Path to a UNIX domain socket used to avoid Python interpreter startup
-   latency when running kittens, or remote control or using kitty +launch or kitty +runpy.
+   latency when running kittens, or remote control or using ``kitty +launch`` or
+   ``kitty +runpy``.
 
 .. envvar:: KITTY_PREWARM_SOCKET_REAL_TTY
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -121,18 +121,15 @@ Variables that kitty sets when running child programs
    This is only set on macOS. If the country and language from the macOS user
    settings form an invalid locale, it will be set to :code:`en_US.UTF-8`.
 
-
 .. envvar:: PATH
 
    kitty prepends itself to the PATH of its own environment to ensure the
    functions calling :program:`kitty` will work properly.
 
-
 .. envvar:: KITTY_WINDOW_ID
 
    An integer that is the id for the kitty :term:`window` the program is running in.
    Can be used with the :doc:`kitty remote control facility <remote-control>`.
-
 
 .. envvar:: KITTY_PID
 
@@ -150,7 +147,6 @@ Variables that kitty sets when running child programs
    Path to a UNIX domain socket used to avoid Python interpreter startup
    latency when running kittens, or remote control or using kitty +launch or kitty +runpy.
 
-
 .. envvar:: KITTY_PREWARM_SOCKET_REAL_TTY
 
    Path to the the PTY used to run the prewarmed process in when using
@@ -161,27 +157,22 @@ Variables that kitty sets when running child programs
    The id for the :term:`OS Window <os_window>` the program is running in. Only available
    on platforms that have ids for their windows, such as X11 and macOS.
 
-
 .. envvar:: TERM
 
    The name of the terminal, defaults to ``xterm-kitty``. See :opt:`term`.
-
 
 .. envvar:: TERMINFO
 
    Path to a directory containing the kitty terminfo database.
 
-
 .. envvar:: KITTY_INSTALLATION_DIR
 
    Path to the kitty installation directory.
-
 
 .. envvar:: COLORTERM
 
    Set to the value ``truecolor`` to indicate that kitty supports 16 million
    colors.
-
 
 .. envvar:: KITTY_LISTEN_ON
 
@@ -190,13 +181,11 @@ Variables that kitty sets when running child programs
    Contains the path to the socket. Avoid the need to use :option:`kitty @ --to` when
    issuing remote control commands.
 
-
 .. envvar:: KITTY_PIPE_DATA
 
    Set to data describing the layout of the screen when running child
    programs using :option:`launch --stdin-source` with the contents of the
    screen/scrollback piped to them.
-
 
 .. envvar:: KITTY_CHILD_CMDLINE
 
@@ -204,30 +193,25 @@ Variables that kitty sets when running child programs
    window when calling the notification callback program on terminal bell, see
    :opt:`command_on_bell`.
 
-
 .. envvar:: KITTY_COMMON_OPTS
 
    Set with the values of some common kitty options when running
    kittens, so kittens can use them without needing to load :file:`kitty.conf`.
-
 
 .. envvar:: KITTY_SHELL_INTEGRATION
 
    Set when enabling :ref:`shell_integration`. It is automatically removed by
    the shell integration scripts.
 
-
 .. envvar:: ZDOTDIR
 
    Set when enabling :ref:`shell_integration` with :program:`zsh`, allowing
    :program:`zsh` to automatically load the integration script.
 
-
 .. envvar:: XDG_DATA_DIRS
 
    Set when enabling :ref:`shell_integration` with :program:`fish`, allowing
    :program:`fish` to automatically load the integration script.
-
 
 .. envvar:: ENV
 

--- a/kittens/show_key/main.py
+++ b/kittens/show_key/main.py
@@ -45,7 +45,7 @@ def read_keys() -> None:
 
 
 def legacy_main() -> None:
-    print('Press any keys - Ctrl-D will terminate this program', end='\r\n', flush=True)
+    print('Press any keys - Ctrl+D will terminate this program', end='\r\n', flush=True)
     print(styled('UNIX', italic=True, fg='green'), styled('send_text', italic=True, fg='green'), sep='\t\t', end='\r\n')
 
     with raw_mode():

--- a/kitty/kittens.c
+++ b/kitty/kittens.c
@@ -54,7 +54,7 @@ read_response(int fd, monotonic_t timeout, PyObject *ans) {
         switch(state) {
             case START:
                 if (ch == 0x1b) state = STARTING_ESC;
-                if (ch == 0x03) { PyErr_SetString(PyExc_KeyboardInterrupt, "User pressed Ctrl-c"); return false; }
+                if (ch == 0x03) { PyErr_SetString(PyExc_KeyboardInterrupt, "User pressed Ctrl+C"); return false; }
                 break;
 #define CASE(curr, q, next) case curr: state = ch == q ? next : START; break;
             CASE(STARTING_ESC, 'P', P);

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -1165,13 +1165,21 @@ well, use something like: :code:`{index}:{title}`. Useful if you have shortcuts
 mapped for :code:`goto_tab N`. If you prefer to see the index as a superscript,
 use :code:`{sup.index}`. All data available is:
 
-* :code:`title` - the current tab title
-* :code:`index` - the tab index useable with :code:`goto_tab N` shortcuts
-* :code:`layout_name` - the current layout name
-* :code:`num_windows` - the number of windows in the tab
-* :code:`num_window_groups` - the number of window groups (not counting overlay windows) in the tab
-* :code:`tab.active_wd` - the working directory of the currently active window in the tab (expensive, requires syscall)
-* :code:`max_title_length` - the maximum title length available
+:code:`title`
+    The current tab title.
+:code:`index`
+    The tab index useable with :ac:`goto_tab N <goto_tab>` shortcuts.
+:code:`layout_name`
+    The current layout name.
+:code:`num_windows`
+    The number of windows in the tab.
+:code:`num_window_groups`
+    The number of window groups (not counting overlay windows) in the tab.
+:code:`tab.active_wd`
+    The working directory of the currently active window in the tab (expensive,
+    requires syscall).
+:code:`max_title_length`
+    The maximum title length available.
 
 Note that formatting is done by Python's string formatting machinery, so you can
 use, for instance, :code:`{layout_name[:2].upper()}` to show only the first two

--- a/kitty/remote_control.py
+++ b/kitty/remote_control.py
@@ -223,7 +223,7 @@ Used if no :option:`kitty @ --password` is supplied. Defaults to checking for th
 default=KITTY_RC_PASSWORD
 The name of an environment variable to read the password from.
 Used if no :option:`kitty @ --password-file` is supplied. Defaults
-to checking the KITTY_RC_PASSWORD.
+to checking the :envvar:`KITTY_RC_PASSWORD`.
 
 
 --use-password


### PR DESCRIPTION
- Env var `KITTY_PREWARM_SOCKET` may need to be unset.
- Improve the list of data names in the commented config file for `tab_title_template`.
- Use the plus sign to connect shortcut keys consistently.

Please review, thanks.