### PR TITLE
Fix build on macOS High Sierra

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -29,6 +29,7 @@
 #include "internal.h"
 #include "../kitty/monotonic.h"
 
+#include <Availability.h>
 #include <float.h>
 #include <string.h>
 
@@ -1551,10 +1552,14 @@ void _glfwPlatformUpdateIMEState(_GLFWwindow *w, const GLFWIMEUpdateEvent *ev) {
     return NO;
 }
 
+#if (TARGET_OS_OSX && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101400)
+
 - (NSAccessibilityRole)accessibilityRole
 {
     return NSAccessibilityTextAreaRole;
 }
+
+#endif
 
 - (NSString *)accessibilitySelectedText
 {


### PR DESCRIPTION
Check for >= 10.14 using Availability.h to use the accessibilityRole
callback which does not seem to be available in 10.13.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>

I'm getting some test failures, I will try to look at that in a separate PR.