### PR TITLE
Fix for FreeBSD with static_assert

### DIFF
--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -172,14 +172,22 @@ typedef struct {
     sprite_index sprite_x, sprite_y, sprite_z;
     CellAttrs attrs;
 } GPUCell;
+#ifdef IS_FREEBSD
+_Static_assert(sizeof(GPUCell) == 20, "Fix the ordering of GPUCell");
+#else
 static_assert(sizeof(GPUCell) == 20, "Fix the ordering of GPUCell");
+#endif
 
 typedef struct {
     char_type ch;
     hyperlink_id_type hyperlink_id;
     combining_type cc_idx[3];
 } CPUCell;
+#ifdef IS_FREEBSD
+_Static_assert(sizeof(CPUCell) == 12, "Fix the ordering of CPUCell");
+#else
 static_assert(sizeof(CPUCell) == 12, "Fix the ordering of CPUCell");
+#endif
 
 typedef enum { UNKNOWN_PROMPT_KIND = 0, PROMPT_START = 1, SECONDARY_PROMPT = 2, OUTPUT_START = 3 } PromptKind;
 typedef union LineAttrs {

--- a/setup.py
+++ b/setup.py
@@ -437,6 +437,8 @@ def kitty_env() -> Env:
     ans = env.copy()
     cflags = ans.cflags
     cflags.append('-pthread')
+    if is_freebsd:
+        cflags.append('-DIS_FREEBSD')
     # We add 4000 to the primary version because vim turns on SGR mouse mode
     # automatically if this version is high enough
     libcrypto_cflags, libcrypto_ldflags = libcrypto_flags()


### PR DESCRIPTION
On FreeBSD kitty fails to build due to "type specifier missing" in
static_assert.
We currently patch it to replace it with _Static_assert.
This pull requests aims to take the change upstream .
Discussion here https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=265393