### PR TITLE
Some fixes and improvements to the documentation

### DIFF
--- a/docs/extract-rst-targets.py
+++ b/docs/extract-rst-targets.py
@@ -14,7 +14,7 @@ def find_explicit_targets(text: str) -> Iterator[str]:
 
 
 def main() -> Dict[str, str]:
-    refs = {'github_discussions': 'https://github.com/kovidgoyal/kitty/discussions'}
+    refs = {}
     base = os.path.dirname(os.path.abspath(__file__))
     for dirpath, dirnames, filenames in os.walk(base):
         if 'generated' in dirnames:

--- a/docs/extract-rst-targets.py
+++ b/docs/extract-rst-targets.py
@@ -25,7 +25,17 @@ def main() -> Dict[str, str]:
                     raw = stream.read()
                 href = os.path.relpath(stream.name, base).replace(os.sep, '/')
                 href = href.rpartition('.')[0] + '/'
+                first_line = raw.lstrip('\n').partition('\n')[0]
+                first_target_added = False
                 for explicit_target in find_explicit_targets(raw):
+                    # Shorten the reference link to the top of the page.
+                    # Note that anchor links should still be used in HTML docs
+                    # to allow jumping within the same page.
+                    if not first_target_added:
+                        first_target_added = True
+                        if first_line.startswith(f'.. _{explicit_target}:'):
+                            refs[explicit_target] = href
+                            continue
                     refs[explicit_target] = href + f'#{explicit_target.replace("_", "-")}'
     return {'ref': refs}
 

--- a/docs/remote-control.rst
+++ b/docs/remote-control.rst
@@ -193,7 +193,7 @@ The :opt:`remote_control_password` can be specified multiple times to create
 different passwords with different capabilities. Run the following to get a
 list of all action names::
 
-    kitty @ -h
+    kitty @ --help
 
 You can even use glob patterns to match action names, for example:
 

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -561,7 +561,7 @@ class Boss:
 
         For example::
 
-            map F1 remote_control set-spacing margin=30
+            map f1 remote_control set-spacing margin=30
 
         See :ref:`rc_mapping` for details.
         ''')

--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -779,7 +779,6 @@ Output commands received from child process to STDOUT.
 Replay previously dumped commands. Specify the path to a dump file previously
 created by :option:`{appname} --dump-commands`. You
 can open a new kitty window to replay the commands with::
-
     {appname} sh -c "{appname} --replay-commands /path/to/dump/file; read"
 
 

--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -168,7 +168,9 @@ def file(x: str) -> str:
 
 @role
 def doc(x: str) -> str:
-    return website_url(x)
+    t, q = text_and_target(x)
+    url = f'kitty+doc://{hostname()}/{q.lstrip("/")}'
+    return hyperlink_for_url(url, t)
 
 
 @run_once

--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -193,6 +193,21 @@ def ac(x: str) -> str:
     return ref_hyperlink(x, 'action-')
 
 
+@role
+def iss(x: str) -> str:
+    return ref_hyperlink(x, 'github-issue-')
+
+
+@role
+def pull(x: str) -> str:
+    return ref_hyperlink(x, 'github-pr-')
+
+
+@role
+def disc(x: str) -> str:
+    return ref_hyperlink(x, 'github-discussion-')
+
+
 OptionSpecSeq = List[Union[str, OptionDict]]
 
 

--- a/kitty/conf/types.py
+++ b/kitty/conf/types.py
@@ -109,7 +109,7 @@ def remove_markup(text: str) -> str:
             return f'{t} <{url}>'
         if m.group(1) == 'doc':
             t, q = extract(m)
-            return f'{t} <{website_url(q.lstrip("/"))}>'
+            return f'{t} <{website_url(q)}>'
         if m.group(1) in ('term', 'option'):
             t, _ = extract(m)
             return t

--- a/kitty/constants.py
+++ b/kitty/constants.py
@@ -237,7 +237,7 @@ def website_url(doc_name: str = '', website: str = 'https://sw.kovidgoyal.net/ki
         if base:
             base += '/'
         doc_name = base + (f'#{frag}' if frag else '')
-    return website + doc_name
+    return website + doc_name.lstrip('/')
 
 
 handled_signals: Set[int] = set()

--- a/kitty/launch.py
+++ b/kitty/launch.py
@@ -59,24 +59,24 @@ default=window
 choices=window,tab,os-window,overlay,background,clipboard,primary
 Where to launch the child process:
 
-:term:`window`
-    a new :term:`window` in the current tab,
+:code:`window`
+    A new :term:`kitty window <window>` in the current tab
 
-:term:`tab`
-    a new tab in the current :term:`OS Window <os_window>`
+:code:`tab`
+    A new :term:`tab` in the current OS window
 
-:term:`os-window <os_window>`
-    a new operating system window
+:code:`os-window <os_window>`
+    A new :term:`operating system window <os_window>`
 
-:term:`overlay`
-    an overlay window covering the current active window.
+:code:`overlay`
+    An :term:`overlay window <overlay>` covering the current active kitty window
 
-:italic:`background`
-    the process will be run in the background, without a window
+:code:`background`
+    The process will be run in the :italic:`background`, without a kitty window.
 
-:italic:`clipboard` and :italic:`primary`
-    are meant to work with :option:`--stdin-source <launch --stdin-source>` to copy
-    data to the system clipboard or primary selection.
+:code:`clipboard`, :code:`primary`
+    These two are meant to work with :option:`--stdin-source <launch --stdin-source>` to copy
+    data to the :italic:`system clipboard` or :italic:`primary selection`.
 
 #placeholder_for_formatting#
 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -2711,7 +2711,7 @@ Glob patterns can be used too, for example::
 
 To get a list of available actions, run::
 
-    kitty @ -h
+    kitty @ --help
 
 A set of actions to be allowed when no password is sent can be specified by using an empty
 password, for example::

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -1665,7 +1665,7 @@ class Window:
 
         For example::
 
-            map F1 signal_child SIGTERM
+            map f1 signal_child SIGTERM
         ''')
     def signal_child(self, *signals: int) -> None:
         pid = self.child.pid_for_cwd
@@ -1679,9 +1679,9 @@ class Window:
     For example::
 
         # show the config docs
-        map F1 show_kitty_doc conf
+        map f1 show_kitty_doc conf
         # show the ssh kitten docs
-        map F1 show_kitty_doc kittens/ssh
+        map f1 show_kitty_doc kittens/ssh
     ''')
     def show_kitty_doc(self, which: str = '') -> None:
         url = docs_url(which)


### PR DESCRIPTION
- Using the lowercase form of the key name consistently.
- Use kitty --help long option name in the document.
- Remove the extra empty line in the CLI help for `--replay-commands`.
- Fix GitHub links in commented configuration.
- Shorten the reference link to the top of the page. (E.g. `https://sw.kovidgoyal.net/kitty/shell-integration/`)
- Hyperlink doc text role.
- Fix doc website URL with duplicate slashes.
- Unify the list style of available values.

---

There are still some unresolved issues.

Text role: The line after the line break fails to be highlighted in color.
For example, see the `--color` description in `kitty @ launch --help`.
Not so sure the same problem exists with italics and other styles.

Can't get the document title, the `:doc:` link is weird.
See `kitty @ launch --help`, `--marker`: `... (see /marks)`

```text
--marker
...
... for the toggle_marker action (see /marks).

```
HTML version:
```text
... for the toggle_marker action (see Mark text on screen).
```

The path to check local documents is wrong under macOS.
`kitty/constants.py`, `local_docs()`
```python
if getattr(sys, 'kitty_run_data').get('from_source'):
    sq = os.path.join(d(base), 'docs', '_build', 'html')
    if os.path.isdir(sq):
        return sq
```

The following path does not exist.
```text
GIT_REPO/kitty/launcher/kitty.app/docs/_build/html
```

It looks like it needs to check if it is running in the source directory `kitty/launcher/kitty`, or run `kitty.app` generated by `make app`.

```text
../../../docs/_build/html/
kitty.app/Contents/Resources/doc/kitty/html/
```