### PR TITLE
bash shell integration: Send STDERR of unsetting inherit_errexit to /dev/null

### DIFF
--- a/shell-integration/bash/kitty.bash
+++ b/shell-integration/bash/kitty.bash
@@ -23,7 +23,7 @@ if [[ -n "$KITTY_BASH_INJECT" ]]; then
         }
     else
         builtin set +o posix
-        builtin shopt -u inherit_errexit  # resetting posix does not clear this
+        builtin shopt -u inherit_errexit 2>/dev/null  # resetting posix does not clear this
         if [[ -n "$KITTY_BASH_UNEXPORT_HISTFILE" ]]; then
             builtin export -n HISTFILE
             builtin unset KITTY_BASH_UNEXPORT_HISTFILE


### PR DESCRIPTION
Some bash versions may not have that option and rather than checking if
they even have it or if it is set, just quiet the STDERR it may throw.

```
$ kssh myhost
bash: shopt: inherit_errexit: invalid shell option name
myhost:~$ bash --version
GNU bash, version 4.3.48(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```
