### PR TITLE
Fix hints sometimes matching next line as part of URL

### DIFF
--- a/kittens/hints/main.py
+++ b/kittens/hints/main.py
@@ -411,7 +411,8 @@ def convert_text(text: str, cols: int) -> str:
             appended = False
             for line in full_line.split('\r'):
                 if line:
-                    lines.append(line.ljust(cols, '\0'))
+                    escape_codes_len = sum([len(match) for match in kitty_ansi_sanitizer_pat().findall(line)])
+                    lines.append(line.ljust(cols + escape_codes_len, '\0'))
                     lines.append('\r')
                     appended = True
             if appended:

--- a/kitty_tests/hints.py
+++ b/kitty_tests/hints.py
@@ -10,13 +10,14 @@ class TestHints(BaseTest):
     def test_url_hints(self):
         from kittens.hints.main import (
             Mark, convert_text, functions_for, linenum_marks,
-            linenum_process_result, mark, parse_hints_args
+            linenum_process_result, mark, parse_hints_args, process_escape_codes
         )
         args = parse_hints_args([])[0]
         pattern, post_processors = functions_for(args)
 
         def create_marks(text, cols=20, mark=mark):
             text = convert_text(text, cols)
+            text, _ = process_escape_codes(text)
             return tuple(mark(pattern, post_processors, text, args))
 
         def t(text, url, cols=20):
@@ -32,6 +33,8 @@ class TestHints(BaseTest):
         t(f'link:{u}[xxx]', u)
         t(f'`xyz <{u}>`_.', u)
         t(f'<a href="{u}">moo', u)
+        t('\x1b[mhttp://test.me/1234\n\x1b[mx', 'http://test.me/1234')
+        t('\x1b[mhttp://test.me/12345\r\x1b[m6\n\x1b[mx', 'http://test.me/123456')
 
         def m(text, path, line, cols=20):
 


### PR DESCRIPTION
For URLs where there's fewer characters left to the right edge of the
window than the number of escape characters in the line, the next line
would be included in the URL, as if the URL went all the way to the
right edge.

For example with a 40 chars wide terminal, if you run:

    echo -e '\e[31m1\e[m https://github.com/kovidgoyal/kitty\ntest'

And launch the hints kitten, you'll see that test on the next line will
be included in the URL.

This happened because the calculation for filling the rest of the line
with NUL characters counted the escape characters as well as the visible
characters, so it filled in too few characters.

This is a regression introduced in commit 91966712.