### PR TITLE
Skip bash shell_integration tests if bash is a debug build

### DIFF
--- a/kitty_tests/shell_integration.py
+++ b/kitty_tests/shell_integration.py
@@ -25,8 +25,8 @@ def bash_ok():
     v = shutil.which('bash')
     if not v:
         return False
-    o = subprocess.check_output([v, '-c', 'echo "${BASH_VERSION}"']).decode('utf-8').strip()
-    if not o or int(o[0]) < 5:
+    o = subprocess.check_output([v, '-c', 'echo "${BASH_VERSINFO[0]}"']).decode('utf-8').strip()
+    if not o or int(o) < 5:
         return False
     return True
 

--- a/kitty_tests/shell_integration.py
+++ b/kitty_tests/shell_integration.py
@@ -25,10 +25,11 @@ def bash_ok():
     v = shutil.which('bash')
     if not v:
         return False
-    o = subprocess.check_output([v, '-c', 'echo "${BASH_VERSINFO[0]}"']).decode('utf-8').strip()
-    if not o or int(o) < 5:
+    o = subprocess.check_output([v, '-c', 'echo "${BASH_VERSINFO[0]}\n${BASH_VERSINFO[4]}"']).decode('utf-8').strip()
+    if not o:
         return False
-    return True
+    (major_ver, relstatus) = o.split(maxsplit=2)
+    return int(major_ver) >= 5 and relstatus == 'release'
 
 
 def basic_shell_env(home_dir):
@@ -240,7 +241,7 @@ function _set_status_prompt; function fish_prompt; echo -n "$pipestatus $status 
 
             pty.send_cmd_to_child('exit')
 
-    @unittest.skipUnless(bash_ok(), 'bash not installed or too old')
+    @unittest.skipUnless(bash_ok(), 'bash not installed, too old, or debug build')
     def test_bash_integration(self):
         ps1 = 'prompt> '
         with self.run_shell(


### PR DESCRIPTION
Switch to using BASH_VERSINFO rather than BASH_VERSION, since it
provides structured data.

    BASH_VERSINFO
           A readonly array variable whose members hold version information for this instance of bash.  The values assigned to the array members are as follows:
           BASH_VERSINFO[0]        The major version number (the release).
           BASH_VERSINFO[1]        The minor version number (the version).
           BASH_VERSINFO[2]        The patch level.
           BASH_VERSINFO[3]        The build version.
           BASH_VERSINFO[4]        The release status (e.g., beta1).
           BASH_VERSINFO[5]        The value of MACHTYPE.

When release status is not "release", bash builds are in debug mode and
output extra information which disturbs the integration.

Closes #5473