### PR TITLE
musl: fixes compilation due to missing includes

### DIFF
--- a/kitty/keys.c
+++ b/kitty/keys.c
@@ -10,6 +10,7 @@
 #include "screen.h"
 #include "glfw-wrapper.h"
 #include "control-codes.h"
+#include <sys/types.h>
 #include <structmember.h>
 
 // python KeyEvent object {{{

--- a/kitty/launcher/main.c
+++ b/kitty/launcher/main.c
@@ -15,6 +15,7 @@
 #endif
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 #include <wchar.h>
 #include <Python.h>
 #include <fcntl.h>


### PR DESCRIPTION
Hello. I'm maintaining the kitty package for Alpine Linux, which uses musl.
There are some issue that I've fixed with the following patches.

`kitty/keys.c`: fix musl compilation
without this include, compilation fails with:
`error: 'u_int32_t' undeclared (first use in this function)`

`kitty/launcher/main`.c: fix muls compilation
The fortify header for wchar.h seems to assume that string.h is included beforehand. Otherwise it fails with the following error:
```
/usr/include/fortify/string.h:144:1: error: 'mempcpy' undeclared here (not in a funct 144 | _FORTIFY_FN(mempcpy) void *mempcpy(void *__d, const void *__s, size_t __n)
    | ^~~~~~~~~~~
```
Including `string.h` fixes the error.


We have included these patches in Alpine, but would be nice to have it merged upstream:
https://git.alpinelinux.org/aports/commit/?id=cb61c2ad5fed

Thanks for considering.

.: Francesco

