### PR TITLE
Docs: Remove the extra backslashes from the install commands

### DIFF
--- a/docs/binary.rst
+++ b/docs/binary.rst
@@ -85,7 +85,7 @@ Customizing the installation
 
   .. code-block:: sh
 
-     _kitty_install_cmd \\
+     _kitty_install_cmd \
          installer=nightly
 
   If you want to install it in parallel to the released kitty specify a
@@ -93,14 +93,14 @@ Customizing the installation
 
   .. code-block:: sh
 
-     _kitty_install_cmd \\
+     _kitty_install_cmd \
          installer=nightly dest=/some/other/location
 
 * You can specify a different install location, with ``dest``:
 
   .. code-block:: sh
 
-     _kitty_install_cmd \\
+     _kitty_install_cmd \
          dest=/some/other/location
 
 * You can tell the installer not to launch |kitty| after installing it with
@@ -108,14 +108,14 @@ Customizing the installation
 
   .. code-block:: sh
 
-     _kitty_install_cmd \\
+     _kitty_install_cmd \
          launch=n
 
 * You can use a previously downloaded dmg/tarball, with ``installer``:
 
   .. code-block:: sh
 
-     _kitty_install_cmd \\
+     _kitty_install_cmd \
          installer=/path/to/dmg or tarball
 
 

--- a/kitty/rc/focus_tab.py
+++ b/kitty/rc/focus_tab.py
@@ -17,6 +17,7 @@ class FocusTab(RemoteCommand):
 
     '''
     match/str: The tab to focus
+    no_response/bool: Boolean indicating whether to wait for a response
     '''
 
     short_desc = 'Focus the specified tab'
@@ -32,7 +33,7 @@ using this option means that you will not be notified of failures.
     argspec = ''
 
     def message_to_kitty(self, global_opts: RCOptions, opts: 'CLIOptions', args: ArgsType) -> PayloadType:
-        return {'match': opts.match}
+        return {'match': opts.match, 'no_response': opts.no_response}
 
     def response_from_kitty(self, boss: Boss, window: Optional[Window], payload_get: PayloadGetType) -> ResponseType:
         for tab in self.tabs_for_match_payload(boss, window, payload_get):

--- a/kitty/rc/focus_window.py
+++ b/kitty/rc/focus_window.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 class FocusWindow(RemoteCommand):
     '''
     match/str: The window to focus
+    no_response/bool: Boolean indicating whether to wait for a response
     '''
 
     short_desc = 'Focus the specified window'

--- a/kitty/rc/last_used_layout.py
+++ b/kitty/rc/last_used_layout.py
@@ -17,6 +17,7 @@ class LastUsedLayout(RemoteCommand):
     '''
     match/str: Which tab to change the layout of
     all/bool: Boolean to match all tabs
+    no_response/bool: Boolean indicating whether to wait for a response
     '''
 
     short_desc = 'Switch to the last used layout'
@@ -37,7 +38,7 @@ the command will exit with a success code.
 ''' + '\n\n\n' + MATCH_TAB_OPTION
 
     def message_to_kitty(self, global_opts: RCOptions, opts: 'CLIOptions', args: ArgsType) -> PayloadType:
-        return {'match': opts.match, 'all': opts.all}
+        return {'match': opts.match, 'all': opts.all, 'no_response': opts.no_response}
 
     def response_from_kitty(self, boss: Boss, window: Optional[Window], payload_get: PayloadGetType) -> ResponseType:
         for tab in self.tabs_for_match_payload(boss, window, payload_get):


### PR DESCRIPTION
The user should be able to execute the installation command correctly when copying (e.g. pressing the Copy to Clipboard button) on the document page.
https://sw.kovidgoyal.net/kitty/binary/#customizing-the-installation

Also add the missing no_response for some remote control commands.