### PR TITLE
add support for out-of-source builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,55 +9,57 @@ ifdef FAIL_WARN
 export FAIL_WARN
 endif
 
-all:
-	python3 setup.py $(VVAL)
+THIS_MAKEFILE_DIR=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
-test:
-	python3 setup.py $(VVAL) test
+all: setup.py
+	python3 $< $(VVAL)
 
-clean:
-	python3 setup.py $(VVAL) clean
+test: setup.py
+	python3 $< $(VVAL) test
+
+clean: setup.py
+	python3 $< $(VVAL) clean
 
 # A debug build
-debug:
-	python3 setup.py build $(VVAL) --debug
+debug: setup.py
+	python3 $< build $(VVAL) --debug
 
-debug-event-loop:
-	python3 setup.py build $(VVAL) --debug --extra-logging=event-loop
+debug-event-loop: setup.py
+	python3 $< build $(VVAL) --debug --extra-logging=event-loop
 
 # Build with the ASAN and UBSAN sanitizers
-asan:
-	python3 setup.py build $(VVAL) --debug --sanitize
+asan: setup.py
+	python3 $< build $(VVAL) --debug --sanitize
 
-profile:
-	python3 setup.py build $(VVAL) --profile
+profile: setup.py
+	python3 $< build $(VVAL) --profile
 
-app:
-	python3 setup.py kitty.app $(VVAL)
+app: setup.py
+	python3 $< kitty.app $(VVAL)
 
-linux-package: FORCE
-	rm -rf linux-package
-	python3 setup.py linux-package
+linux-package: setup.py FORCE
+	rm -rf $(CURDIR)/linux-package
+	python3 $< linux-package
 
 FORCE:
 
 man:
-	$(MAKE) -C docs man
+	$(MAKE) -C $(THIS_MAKEFILE_DIR)docs man BUILDDIR=$(CURDIR)/docs/_build
 
 html:
-	$(MAKE) -C docs html
+	$(MAKE) -C $(THIS_MAKEFILE_DIR)docs html BUILDDIR=$(CURDIR)/docs/_build
 
 dirhtml:
-	$(MAKE) -C docs dirhtml
+	$(MAKE) -C $(THIS_MAKEFILE_DIR)docs dirhtml BUILDDIR=$(CURDIR)/docs/_build
 
 linkcheck:
-	$(MAKE) -C docs linkcheck
+	$(MAKE) -C $(THIS_MAKEFILE_DIR)docs linkcheck BUILDDIR=$(CURDIR)/docs/_build
 
-website:
-	./publish.py --only website
+website: publish.py
+	$< --only website
 
 docs: man html
 
 
 develop-docs:
-	$(MAKE) -C docs develop-docs
+	$(MAKE) -C $(THIS_MAKEFILE_DIR)docs develop-docs BUILDDIR=$(CURDIR)/docs/_build

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -160,7 +160,7 @@ While |kitty| does use Python, it is not a traditional Python package, so please
 do not install it in site-packages.
 Instead run::
 
-    python3 setup.py linux-package
+    make linux-package
 
 This will install |kitty| into the directory :file:`linux-package`. You can run
 |kitty| with :file:`linux-package/bin/kitty`. All the files needed to run kitty

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ sys.path.insert(0, base)
 del sys.path[0]
 
 verbose = False
-build_dir = 'build'
-constants = os.path.join('kitty', 'constants.py')
+build_dir = os.path.join(os.getcwd(), 'build')
+constants = os.path.join(base, 'kitty', 'constants.py')
 with open(constants, 'rb') as f:
     constants = f.read().decode('utf-8')
 appname = re.search(r"^appname: str = '([^']+)'", constants, re.MULTILINE).group(1)  # type: ignore
@@ -1406,7 +1406,7 @@ def clean() -> None:
         'build', 'compile_commands.json', 'link_commands.json',
         'linux-package', 'kitty.app', 'asan-launcher',
         'kitty-profile', 'docs/generated')
-    clean_launcher_dir('kitty/launcher')
+    clean_launcher_dir(os.path.join(build_dir, 'kitty/launcher'))
 
     def excluded(root: str, d: str) -> bool:
         q = os.path.relpath(os.path.join(root, d), base).replace(os.sep, '/')
@@ -1622,12 +1622,12 @@ def main() -> None:
     args.prefix = os.path.abspath(args.prefix)
     os.chdir(base)
     if args.action == 'test':
-        texe = os.path.abspath('kitty/launcher/kitty')
+        texe = os.path.join(build_dir, 'kitty/launcher/kitty')
         os.execl(texe, texe, '+launch', 'test.py')
     if args.action == 'clean':
         clean()
         return
-    launcher_dir = 'kitty/launcher'
+    launcher_dir = os.path.join(build_dir, 'kitty/launcher')
 
     with CompilationDatabase(args.incremental) as cdb:
         args.compilation_database = cdb


### PR DESCRIPTION
This is useful for scenarios where source directory cannot be modified, or for building in a different location than source.

Use VPATH to specify source search path, e.g.

`git clone https://github.com/kovidgoyal/kitty.git`
`VPATH=kitty make -f kitty/Makefile`

All build artifacts will be in **build** folder of current directory.

In-source builds can still be executed in the source directory with a simple `make`, but will also place build artifacts in a 'build' folder within the source directory.