### PR TITLE
Fix completion for fish

### DIFF
--- a/shell-integration/fish/vendor_completions.d/clone-in-kitty.fish
+++ b/shell-integration/fish/vendor_completions.d/clone-in-kitty.fish
@@ -1,7 +1,7 @@
 function __ksi_completions
     set --local ct (commandline --current-token)
     set --local tokens (commandline --tokenize --cut-at-cursor --current-process)
-    printf "%s\n" $tokens $ct | command kitty-tool __complete__ fish
+    printf "%s\n" $tokens $ct | command kitty-tool __complete__ fish | source -
 end
 
 complete -f -c clone-in-kitty -a "(__ksi_completions)"

--- a/shell-integration/fish/vendor_completions.d/edit-in-kitty.fish
+++ b/shell-integration/fish/vendor_completions.d/edit-in-kitty.fish
@@ -1,7 +1,7 @@
 function __ksi_completions
     set --local ct (commandline --current-token)
     set --local tokens (commandline --tokenize --cut-at-cursor --current-process)
-    printf "%s\n" $tokens $ct | command kitty-tool __complete__ fish
+    printf "%s\n" $tokens $ct | command kitty-tool __complete__ fish | source -
 end
 
 complete -f -c edit-in-kitty -a "(__ksi_completions)"

--- a/shell-integration/fish/vendor_completions.d/kitty-tool.fish
+++ b/shell-integration/fish/vendor_completions.d/kitty-tool.fish
@@ -1,7 +1,7 @@
 function __ksi_completions
     set --local ct (commandline --current-token)
     set --local tokens (commandline --tokenize --cut-at-cursor --current-process)
-    printf "%s\n" $tokens $ct | command kitty-tool __complete__ fish
+    printf "%s\n" $tokens $ct | command kitty-tool __complete__ fish | source -
 end
 
 complete -f -c kitty-tool -a "(__ksi_completions)"


### PR DESCRIPTION
I also noticed that `kitty --help` and `kitty-tool --version` etc. are not listed.

For `kitty-tool`, it looks like `kitty-tool update-self` should not take effect under macOS, as it will break the signature of the entire application bundle.

I think it's best to run `kitty +update-self` to update the whole macOS bundle.
If anyone is interested in implementing this, replace the package downloaded via `kitty +update-self` the next time the user launches kitty via launchd, and run kitty again when the upgrade is complete.
Updates will not take effect when running kitty via CLI or `open` to avoid complications with handling envs, stdin, args, etc.