### PR TITLE
[docs]: don't show config codeblocks that only has a name

### DIFF
--- a/kitty/conf/types.py
+++ b/kitty/conf/types.py
@@ -268,11 +268,12 @@ class Option:
             return ans
         mopts = [self] + option_group
         a('.. opt:: ' + ', '.join(f'{conf_name}.{mo.name}' for mo in mopts))
-        a('.. code-block:: conf')
-        a('')
-        sz = max(len(x.name) for x in mopts)
-        for mo in mopts:
-            a(('    {:%ds} {}' % sz).format(mo.name, mo.defval_as_string))
+        if any(mo.defval_as_string for mo in mopts):
+            a('.. code-block:: conf')
+            a('')
+            sz = max(len(x.name) for x in mopts)
+            for mo in mopts:
+                a(('    {:%ds} {}' % sz).format(mo.name, mo.defval_as_string))
         a('')
         if self.long_text:
             a(expand_opt_references(conf_name, self.long_text))
@@ -330,11 +331,12 @@ class MultiOption:
         ans: List[str] = []
         a = ans.append
         a(f'.. opt:: {conf_name}.{self.name}')
-        a('.. code-block:: conf')
-        a('')
-        for k in self.items:
-            if k.documented:
-                a(f'    {self.name:s} {k.defval_as_str}'.rstrip())
+        if any(k.defval_as_str for k in self.items):
+            a('.. code-block:: conf')
+            a('')
+            for k in self.items:
+                if k.documented:
+                    a(f'    {self.name:s} {k.defval_as_str}'.rstrip())
         a('')
         if self.long_text:
             a(expand_opt_references(conf_name, self.long_text))


### PR DESCRIPTION
# Before this PR:
![2022-11-17_00-08](https://user-images.githubusercontent.com/1381301/202391245-01859f4e-1800-4034-8278-6f73067f5f62.png)

I understand that the second line means the "default value is empty", but showing two lines with same content feels a bit ugly. If the default is empty, maybe there is not much reason to show it at all.

# After this PR:
![2022-11-17_00-10](https://user-images.githubusercontent.com/1381301/202391532-2d14ca60-d9c7-42d8-ac7b-b2abfb3b707b.png)


I ran a diff of before vs after on the `docs` directory and verified that nothing else has changed except for a few cases like what's shown in the image.