### PR TITLE
Refactor: Use a consistent name for beam cursor shape

### DIFF
--- a/kittens/diff/main.py
+++ b/kittens/diff/main.py
@@ -319,7 +319,7 @@ class DiffHandler(Handler):
             fg=self.opts.foreground, bg=self.opts.background,
             cursor=self.opts.foreground, select_fg=self.opts.select_fg,
             select_bg=self.opts.select_bg)
-        self.cmd.set_cursor_shape('bar')
+        self.cmd.set_cursor_shape('beam')
 
     def finalize(self) -> None:
         self.cmd.set_default_colors()

--- a/kittens/themes/main.py
+++ b/kittens/themes/main.py
@@ -180,7 +180,7 @@ class ThemesHandler(Handler):
         self.cmd.save_colors()
         self.cmd.set_line_wrapping(False)
         self.cmd.set_window_title('Choose a theme for kitty')
-        self.cmd.set_cursor_shape('bar')
+        self.cmd.set_cursor_shape('beam')
 
     def initialize(self) -> None:
         self.init_terminal_state()

--- a/kittens/tui/line_edit.py
+++ b/kittens/tui/line_edit.py
@@ -53,7 +53,7 @@ class LineEdit:
             write('\r')
             if cursor_pos:
                 write(move_cursor_by(cursor_pos, 'right'))
-            write(set_cursor_shape('bar'))
+            write(set_cursor_shape('beam'))
 
     def add_text(self, text: str) -> None:
         if self.current_input:

--- a/kittens/tui/operations.py
+++ b/kittens/tui/operations.py
@@ -141,7 +141,7 @@ def move_cursor_by(amt: int, direction: str) -> str:
 
 @cmd
 def set_cursor_shape(shape: str = 'block', blink: bool = True) -> str:
-    val = {'block': 1, 'underline': 3, 'bar': 5}.get(shape, 1)
+    val = {'block': 1, 'underline': 3, 'beam': 5}.get(shape, 1)
     if not blink:
         val += 1
     return f'\033[{val} q'


### PR DESCRIPTION
I noticed that `set_cursor_shape('beam')` is used in ask kitten, however there is no such value (it will be set to **block** shape).

I remember asking you before whether it was `bar` or `beam`, and your choice was to maintain backward compatibility using `beam`.
So do the same in this PR.

No alias `bar` is provided to keep the code maintainable, rather than a mix of names.