### PR TITLE
Docs: Fix missing backslashes

### DIFF
--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -27,7 +27,7 @@ line.
 
 .. _include:
 
-You can include secondary config files via the :code:`include` directive.  If
+You can include secondary config files via the :code:`include` directive. If
 you use a relative path for :code:`include`, it is resolved with respect to the
 location of the current config file. Note that environment variables are
 expanded, so :code:`${USER}.conf` becomes :file:`name.conf` if

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -3969,7 +3969,7 @@ when pressing specified shortcut keys. For example::
 
 This will send "Special text" when you press the :kbd:`Ctrl+Alt+A` key
 combination. The text to be sent is a python string literal so you can use
-escapes like :code:`\\x1b` to send control codes or :code:`\\u21fb` to send
+escapes like :code:`\\\\x1b` to send control codes or :code:`\\\\u21fb` to send
 Unicode characters (or you can just input the Unicode characters directly as
 UTF-8 text). You can use ``kitty +kitten show_key`` to get the key escape
 codes you want to emulate.

--- a/kitty/rc/send_text.py
+++ b/kitty/rc/send_text.py
@@ -74,8 +74,8 @@ class SendText(RemoteCommand):
     short_desc = 'Send arbitrary text to specified windows'
     desc = (
         'Send arbitrary text to specified windows. The text follows Python'
-        ' escaping rules. So you can use escapes like :code:`\\x1b` to send control codes'
-        ' and :code:`\\u21fa` to send unicode characters. If you use the :option:`kitty @ send-text --match` option'
+        ' escaping rules. So you can use escapes like :code:`\\\\x1b` to send control codes'
+        ' and :code:`\\\\u21fa` to send unicode characters. If you use the :option:`kitty @ send-text --match` option'
         ' the text will be sent to all matched windows. By default, text is sent to'
         ' only the currently active window.'
     )


### PR DESCRIPTION
https://sw.kovidgoyal.net/kitty/conf/#shortcut-kitty.Send-arbitrary-text-on-key-presses
https://sw.kovidgoyal.net/kitty/remote-control/#kitty-send-text

Two backslashes are needed in Python, and two backslashes are needed in the generated rst, for a total of four.

However, `kitty-tool @ send-text --help` ends up with an extra backslash, and needs a little help here.

> ... The text follows Python escaping rules. ...

Also I noticed that `send-text -m id:1 "\x7f"` worked fine in the previous version of the kitty shell, but now it doesn't escape and send properly in the version implemented in Go.

When a command is executed without any output, a blank line is output in the kitty shell, while in previous versions the behavior is the same as in the regular shell, which prints the next prompt if there is no output.