### PR TITLE
DRYer: Get hostname

### DIFF
--- a/kittens/hyperlinked_grep/main.py
+++ b/kittens/hyperlinked_grep/main.py
@@ -4,11 +4,12 @@
 import os
 import re
 import signal
-import socket
 import subprocess
 import sys
 from typing import Callable, cast
 from urllib.parse import quote_from_bytes
+
+from kitty.utils import get_hostname
 
 
 def write_hyperlink(write: Callable[[bytes], None], url: bytes, line: bytes, frag: bytes = b'') -> None:
@@ -76,7 +77,7 @@ def main() -> None:
     num_pat = re.compile(br'^(\d+)([:-])')
 
     in_result: bytes = b''
-    hostname = socket.gethostname().encode('utf-8')
+    hostname = get_hostname().encode('utf-8')
 
     try:
         for line in p.stdout:

--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -4,7 +4,6 @@
 import os
 import re
 import shlex
-import socket
 import sys
 from collections import deque
 from enum import Enum, auto
@@ -305,6 +304,12 @@ def env(x: str) -> str:
 role_map['envvar'] = role_map['env']
 
 
+@run_once
+def hostname() -> str:
+    from .utils import get_hostname
+    return get_hostname(fallback='localhost')
+
+
 def hyperlink_for_url(url: str, text: str) -> str:
     if sys.stdout.isatty():
         return f'\x1b]8;;{url}\x1b\\\x1b[4:3;58:5:4m{text}\x1b[4:0;59m\x1b]8;;\x1b\\'
@@ -315,7 +320,7 @@ def hyperlink_for_path(path: str, text: str) -> str:
     path = os.path.abspath(path).replace(os.sep, "/")
     if os.path.isdir(path):
         path += path.rstrip("/") + "/"
-    return hyperlink_for_url(f'file://{socket.gethostname()}{path}', text)
+    return hyperlink_for_url(f'file://{hostname()}{path}', text)
 
 
 @role
@@ -335,12 +340,6 @@ def doc(x: str) -> str:
         if q in m:
             x = f'{m[q]} <{t}>'
     return ref_hyperlink(x, 'doc-')
-
-
-@run_once
-def hostname() -> str:
-    import socket
-    return socket.gethostname() or 'localhost'
 
 
 def ref_hyperlink(x: str, prefix: str = '') -> str:

--- a/kitty/utils.py
+++ b/kitty/utils.py
@@ -595,6 +595,14 @@ def natsort_ints(iterable: Iterable[str]) -> List[str]:
     return sorted(iterable, key=alphanum_key)
 
 
+def get_hostname(fallback: str = '') -> str:
+    import socket
+    try:
+        return socket.gethostname() or fallback
+    except Exception:
+        return fallback
+
+
 def resolve_editor_cmd(editor: str, shell_env: Mapping[str, str]) -> Optional[str]:
     import shlex
     editor_cmd = shlex.split(editor)

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -853,11 +853,8 @@ class Window:
                 return
             if (not purl.scheme or purl.scheme == 'file'):
                 if purl.netloc:
-                    from socket import gethostname
-                    try:
-                        hostname = gethostname()
-                    except Exception:
-                        hostname = ''
+                    from .utils import get_hostname
+                    hostname = get_hostname()
                     remote_hostname = purl.netloc.partition(':')[0]
                     if remote_hostname and remote_hostname != hostname and remote_hostname != 'localhost':
                         self.handle_remote_file(purl.netloc, unquote(purl.path))


### PR DESCRIPTION
The cached hostname cannot be used in `open_url` as it may have been changed.

---

About launching with current cwd, I found an issue.

```shell
kitty --config=NONE -d=/tmp -o 'shell zsh' -o 'map f1 new_window_with_cwd'

ssh ksi-enabled-remote
# Ctrl+D
# F1
```

After ssh disconnects, create a new window with the current cwd, which will then use the remote cwd.
The remote path probably does not exist locally and the shell starts at `/`, which is annoying.

I can think of a few ways to improve this user experience.

Check if the hostname matches the local hostname before `return reported_cwd`.

```python
def hostname_from_osc7_url(url: str) -> str:
    netloc = ''
    if url.startswith('kitty-shell-cwd://'):
        netloc = url.split('/', 3)[2]
    if url.startswith('file://'):
        from urllib.parse import urlparse
        netloc = urlparse(url).netloc
    return netloc.partition(':')[0]
```

Provide more information when reporting cwd in shell integration. For example:
```text
# local
kitty-shell-cwd://host/path#kitty-pid=$KITTY_PID
# ssh kitten
kitty-shell-cwd://host/path#kitty-ssh-kitten=yes
# ssh (with shell integration)
kitty-shell-cwd://host/path
# ssh
file://host/path
```

Store to `last_reported_local_cwd` when the reported kitty-pid is the same as the current one when processing cwd notifications.
When `window.child_is_remote` is False and the last reported cwd explicitly has `kitty-ssh-kitten` or no `kitty-pid`, it falls back to the last recorded `last_reported_local_cwd`.

Outputting the current cwd in prompt would be more accurate, but repeated output of the same cwd is too wasteful of resources and not really worth it for me.

Do you have a better idea?