### PR TITLE
Docs: Slightly adjust the description of tab_title_max_length add the associated PR to changelog

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -57,7 +57,7 @@ Detailed list of changes
 
 - Wayland GNOME: Workaround for latest mutter release breaking full screen for semi-transparent kitty windows (:iss:`5677`)
 
-- A new option :opt:`tab_title_max_length` to limit the length of tab titles
+- A new option :opt:`tab_title_max_length` to limit the length of tab (:iss:`5718`)
 
 
 0.26.5 [2022-11-07]

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -1065,13 +1065,6 @@ margin between the tab bar and the contents of the current tab.
 '''
     )
 
-opt('tab_title_max_length', '0', option_type='positive_int',
-    long_text='''
-The maximum number of characters a tab title can have.
-A value of zero means that no limit is applied.
-'''
-    )
-
 opt('tab_bar_style', 'fade',
     choices=('fade', 'hidden', 'powerline', 'separator', 'slant', 'custom'), ctype='!tab_bar_style',
     long_text='''
@@ -1159,6 +1152,13 @@ Some text or a Unicode symbol to show on the tab if a window in the tab that
 does not have focus has some activity. If you want to use leading or trailing
 spaces, surround the text with quotes. See :opt:`tab_title_template` for how
 this is rendered.
+'''
+    )
+
+opt('tab_title_max_length', '0', option_type='positive_int',
+    long_text='''
+The maximum number of cells that can be used to render a tab. A value of zero
+means that no limit is applied.
 '''
     )
 


### PR DESCRIPTION
The new option will limit the tab visual width instead of the number of characters.
Place this new option alongside the tab title related ones for convenience.
Log the missing associated GitHub PR in the changelog.