### PR TITLE
Fix the base path for envinclude and minor docs improvements

### DIFF
--- a/kitty/conf/types.py
+++ b/kitty/conf/types.py
@@ -113,6 +113,8 @@ def remove_markup(text: str) -> str:
         if key in ('ac', 'opt'):
             t, q = extract(m)
             return f'{t} {q}' if q and q != t else t
+        if key == 'code':
+            return m.group(2).replace('\\\\', '\\')
 
         return str(m.group(2))
 

--- a/kitty/conf/utils.py
+++ b/kitty/conf/utils.py
@@ -206,7 +206,12 @@ def parse_line(
             for x in os.environ:
                 if fnmatchcase(x, val):
                     with currently_parsing.set_file(f'<env var: {x}>'):
-                        _parse(NamedLineIterator(base_path_for_includes, iter(os.environ[x].splitlines())), parse_conf_item, ans, accumulate_bad_lines)
+                        _parse(
+                            NamedLineIterator(os.path.join(base_path_for_includes, ''), iter(os.environ[x].splitlines())),
+                            parse_conf_item,
+                            ans,
+                            accumulate_bad_lines
+                        )
             return
         else:
             if not os.path.isabs(val):
@@ -240,7 +245,7 @@ def _parse(
 ) -> None:
     name = getattr(lines, 'name', None)
     if name:
-        base_path_for_includes = os.path.dirname(os.path.abspath(name))
+        base_path_for_includes = os.path.abspath(name) if name.endswith(os.path.sep) else os.path.dirname(os.path.abspath(name))
     else:
         from ..constants import config_dir
         base_path_for_includes = config_dir

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -3991,8 +3991,8 @@ keyboard protocol. The special value :code:`all` means all of them.
 Some more examples::
 
     # Output a word and move the cursor to the start of the line (like typing and pressing Home)
-    map ctrl+alt+a send_text normal Word\\x1b[H
-    map ctrl+alt+a send_text application Word\\x1bOH
+    map ctrl+alt+a send_text normal Word\\e[H
+    map ctrl+alt+a send_text application Word\\eOH
     # Run a command at a shell prompt (like typing the command and pressing Enter)
     map ctrl+alt+a send_text normal,application some command with arguments\\r
 '''


### PR DESCRIPTION
Remove extra backslashes from commented config.
Update docs to use `\e` in the example.
Fix the base path for envinclude.

```log
TEST='include target.conf' kitty -o 'envinclude TEST'

Could not find included config file: ~/.config/target.conf, ignoring
```

Do you think the base path in all environment variables should default to the kitty config file path regardless of where the config file uses envinclude?
So in the following example the `target.conf` file in the configuration folder will be loaded instead of `a/b/target.conf`.

```shell
TEST='include target.conf' kitty -o 'include a/b/envinclude-test.conf'

# -> ~/.config/kitty/target.conf
```

The current logic is equivalent to inserting environment variables as configuration lines into the line where `envinclude` is located, which is also understandable and reasonable for the user. I'm not sure which one you prefer.

Also, would you reject a PR that allows kitty to be configured via Python scripts?
For example by adding `pyinclude myconfig.py`. The function in the script will output configuration lines that will be backward compatible.