### PR TITLE
hyperlink_grep kitten: Fix the hyperlinks when listing files

### DIFF
--- a/docs/kittens/hyperlinked_grep.rst
+++ b/docs/kittens/hyperlinked_grep.rst
@@ -67,7 +67,7 @@ the need for this kitten.
    output formatting as the kitten works by parsing the output from ripgrep.
    The unsupported options are: :code:`--context-separator`,
    :code:`--field-context-separator`, :code:`--field-match-separator`,
-   :code:`--json`, :code:`-I --no-filename`, :code:`--no-heading`,
-   :code:`-0 --null`, :code:`--null-data`, :code:`--path-separator`.
-   If you specify options via configuration file, then any changes to the
-   default output format will not be supported, not just the ones listed above.
+   :code:`--json`, :code:`-I --no-filename`, :code:`-0 --null`,
+   :code:`--null-data`, :code:`--path-separator`. If you specify options via
+   configuration file, then any changes to the default output format will not be
+   supported, not just the ones listed.


### PR DESCRIPTION
URLs starting with `file://` should be used instead of paths.

Also I noticed in the recent FAQ update:

> Here X will the keys you press on the keyboard.

Is there a typo here?