### PR TITLE
Remote control: Add the missing option value overlay-main

### DIFF
--- a/kitty/rc/launch.py
+++ b/kitty/rc/launch.py
@@ -28,7 +28,7 @@ class Launch(RemoteCommand):
     cwd/str: Working directory for the new window
     env/list.str: List of environment variables of the form NAME=VALUE
     tab_title/str: Title for the new tab
-    type/choices.window.tab.os-window.overlay.background.clipboard.primary: The type of window to open
+    type/choices.window.tab.os-window.overlay.overlay-main.background.clipboard.primary: The type of window to open
     keep_focus/bool: Boolean indicating whether the current window should retain focus or not
     copy_colors/bool: Boolean indicating whether to copy the colors from the current window
     copy_cmdline/bool: Boolean indicating whether to copy the cmdline from the current window


### PR DESCRIPTION
I don't quite remember where the option values defined here are used.
It looks like the protocol specification here is used in gen-go-code.py, but is not reflected in features like completion (which uses option_spec).