### PR TITLE
ssh kitten: Compile terminfo with tic coming from pkgsrc under NetBSD

### DIFF
--- a/shell-integration/ssh/bootstrap-utils.sh
+++ b/shell-integration/ssh/bootstrap-utils.sh
@@ -25,7 +25,14 @@ compile_terminfo() {
 
     if [ -e "/usr/share/misc/terminfo.cdb" ]; then
         # NetBSD requires this file, see https://github.com/kovidgoyal/kitty/issues/4622
-        command ln -sf "../../.terminfo.cdb" "$1/$tname/x/xterm-kitty"
+        # Also compile terminfo using tic installed via pkgsrc,
+        # so that programs that depend on the new version of ncurses automatically fall back to this one.
+        if [ -x "/usr/pkg/bin/tic" ]; then
+            /usr/pkg/bin/tic -x -o "$1/$tname" "$1/.terminfo/kitty.terminfo" 2>/dev/null
+        fi
+        if [ ! -e "$1/$tname/x/xterm-kitty" ]; then
+            command ln -sf "../../.terminfo.cdb" "$1/$tname/x/xterm-kitty"
+        fi
         tname=".terminfo.cdb"
     fi
 

--- a/shell-integration/ssh/bootstrap.sh
+++ b/shell-integration/ssh/bootstrap.sh
@@ -45,6 +45,9 @@ detect_perl() {
 if command -v base64 > /dev/null 2> /dev/null; then
     base64_encode() { command base64 | command tr -d \\n\\r; }
     base64_decode() { command base64 -d; }
+elif command -v openssl > /dev/null 2> /dev/null; then
+    base64_encode() { command openssl enc -A -base64; }
+    base64_decode() { command openssl enc -d -base64; }
 elif command -v b64encode > /dev/null 2> /dev/null; then
     base64_encode() { command b64encode - | command sed '1d;$d' | command tr -d \\n\\r; }
     base64_decode() { command fold -w 76 | command b64decode -r; }


### PR DESCRIPTION
Allow programs that depend on terminfo.cdb as well as programs installed via pkgsrc that depend on the new version of ncurses to run.

When the program fails with `~/.terminfo.cdb` as specified by TERMINFO, it will fall back to `~/.terminfo/x/xterm-kitty` compiled with the new version of tic.

Fixes #5814

Please review, thanks.

There is also a related problem, not limited to NetBSD, if the user compiles `~/.terminfo/x/xterm-kitty` with the new version of tic (`/whatever/path/to/tic`) and programs rely on the new version of ncurses, it will not work by default because ssh kitten overwrites terminfo unconditionally.
Should we check that `~/.terminfo/x/xterm-kitty` is older than `kitty.terminfo` before compiling and overwriting?

I don't really think too many checks should be added, as this can lead to added complexity in troubleshooting issues. And not many people will encounter this edge case.