### PR TITLE
Show OSC8 link URL at bottom of screen on mouse hover

### DIFF
--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -340,8 +340,13 @@ handle_mouse_movement_in_kitty(Window *w, int button, bool mouse_cell_changed) {
 
 static void
 detect_url(Screen *screen, unsigned int x, unsigned int y) {
-    if (screen_detect_url(screen, x, y)) mouse_cursor_shape = HAND;
-    else set_mouse_cursor_for_screen(screen);
+    if (screen_detect_url(screen, x, y)) {
+      mouse_cursor_shape = HAND;
+      screen->mouse_on_url = true;
+    } else {
+      set_mouse_cursor_for_screen(screen);
+      screen->mouse_on_url = false;
+    }
 }
 
 static bool

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -2913,6 +2913,14 @@ link when clicked.
 '''
     )
 
+opt('preview_hyperlinks', 'yes',
+    option_type='to_bool', ctype='bool',
+    long_text='''
+Preview the URL of :term:`hyperlink <hyperlinks>` escape sequences (OSC 8)
+when mouse hovers on the link.
+'''
+    )
+
 opt('shell_integration', 'enabled',
     option_type='shell_integration',
     long_text='''

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -1136,6 +1136,9 @@ class Parser:
 
     choices_for_pointer_shape_when_grabbed = frozenset(('arrow', 'beam', 'hand'))
 
+    def preview_hyperlinks(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        ans['preview_hyperlinks'] = to_bool(val)
+
     def remember_window_size(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['remember_window_size'] = to_bool(val)
 

--- a/kitty/options/to-c-generated.h
+++ b/kitty/options/to-c-generated.h
@@ -903,6 +903,19 @@ convert_from_opts_allow_hyperlinks(PyObject *py_opts, Options *opts) {
 }
 
 static void
+convert_from_python_preview_hyperlinks(PyObject *val, Options *opts) {
+    opts->preview_hyperlinks = PyObject_IsTrue(val);
+}
+
+static void
+convert_from_opts_preview_hyperlinks(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "preview_hyperlinks");
+    if (ret == NULL) return;
+    convert_from_python_preview_hyperlinks(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
 convert_from_python_macos_option_as_alt(PyObject *val, Options *opts) {
     opts->macos_option_as_alt = PyLong_AsUnsignedLong(val);
 }
@@ -1158,6 +1171,8 @@ convert_opts_from_python_opts(PyObject *py_opts, Options *opts) {
     convert_from_opts_close_on_child_death(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_allow_hyperlinks(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_preview_hyperlinks(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_macos_option_as_alt(py_opts, opts);
     if (PyErr_Occurred()) return false;

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -402,6 +402,7 @@ option_names = (  # {{{
  'placement_strategy',
  'pointer_shape_when_dragging',
  'pointer_shape_when_grabbed',
+ 'preview_hyperlinks',
  'remember_window_size',
  'remote_control_password',
  'repaint_delay',
@@ -553,6 +554,7 @@ class Options:
     placement_strategy: choices_for_placement_strategy = 'center'
     pointer_shape_when_dragging: choices_for_pointer_shape_when_dragging = 'beam'
     pointer_shape_when_grabbed: choices_for_pointer_shape_when_grabbed = 'arrow'
+    preview_hyperlinks: bool = True
     remember_window_size: bool = True
     repaint_delay: int = 10
     resize_debounce_time: float = 0.1

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -2636,17 +2636,24 @@ error:
     return NULL;
 }
 
+const char* screen_current_hyperlink(Screen* self, hyperlink_id_type* hyperlink_id) {
+    if (!self->url_ranges.count) return NULL;
+    hyperlink_id_type hid = hyperlink_id_for_range(self, self->url_ranges.items);
+    if (hid) {
+        *hyperlink_id = hid;
+        return get_hyperlink_for_id(self->hyperlink_pool, hid, true);
+    }
+    return NULL;
+}
 
 bool
 screen_open_url(Screen *self) {
     if (!self->url_ranges.count) return false;
-    hyperlink_id_type hid = hyperlink_id_for_range(self, self->url_ranges.items);
-    if (hid) {
-        const char *url = get_hyperlink_for_id(self->hyperlink_pool, hid, true);
-        if (url) {
-            CALLBACK("open_url", "sH", url, hid);
-            return true;
-        }
+    hyperlink_id_type hid;
+    const char* url = screen_current_hyperlink(self, &hid);
+    if (url) {
+        CALLBACK("open_url", "sH", url, hid);
+        return true;
     }
     PyObject *text = current_url_text(self, NULL);
     if (!text) {

--- a/kitty/screen.h
+++ b/kitty/screen.h
@@ -150,6 +150,7 @@ typedef struct {
         bool is_set;
     } last_visited_prompt;
     PyObject *last_reported_cwd;
+    bool mouse_on_url;
 } Screen;
 
 
@@ -249,6 +250,7 @@ void set_active_hyperlink(Screen*, char*, char*);
 hyperlink_id_type screen_mark_hyperlink(Screen*, index_type, index_type);
 void screen_handle_graphics_command(Screen *self, const GraphicsCommand *cmd, const uint8_t *payload);
 bool screen_open_url(Screen*);
+const char* screen_current_hyperlink(Screen*, hyperlink_id_type*);
 bool screen_set_last_visited_prompt(Screen*, index_type);
 bool screen_select_cmd_output(Screen*, index_type);
 void screen_dirty_sprite_positions(Screen *self);

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -335,6 +335,7 @@ destroy_window(Window *w) {
     Py_CLEAR(w->render_data.screen); Py_CLEAR(w->title);
     Py_CLEAR(w->title_bar_data.last_drawn_title_object_id);
     free(w->title_bar_data.buf); w->title_bar_data.buf = NULL;
+    free(w->hyperlink_bar_data.buf); w->hyperlink_bar_data.buf = NULL;
     release_gpu_resources_for_window(w);
     if (w->window_logo.id) {
         decref_window_logo(global_state.all_window_logos, w->window_logo.id);

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -67,6 +67,7 @@ typedef struct {
     bool window_alert_on_bell;
     bool debug_keyboard;
     bool allow_hyperlinks;
+    bool preview_hyperlinks;
     monotonic_t resize_debounce_time;
     MouseShape pointer_shape_when_grabbed;
     MouseShape default_pointer_shape;
@@ -147,6 +148,11 @@ typedef struct {
         uint8_t *buf;
         PyObject *last_drawn_title_object_id;
     } title_bar_data;
+    struct {
+        unsigned width, height;
+        uint8_t *buf;
+        hyperlink_id_type last_drawn_hid;
+    } hyperlink_bar_data;
 } Window;
 
 typedef struct {


### PR DESCRIPTION
Fix #5827 

URL is displayed at bottom by default. If cursor is at the bottom, then URL is displayed at top. Below are screenshots of what it looks like in a terminal with two windows.

## Image 1
![2022-12-28_16-51](https://user-images.githubusercontent.com/1381301/209895964-8f42866c-7626-4c40-aa5c-363ae7da39b1.png)

## Image 2
![2022-12-28_16-51_1](https://user-images.githubusercontent.com/1381301/209895971-94b0e37d-e364-47ba-915d-3dd0cc7102cd.png)
