### PR TITLE
Send sequence events to child if they don't match kitty.

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -47,7 +47,7 @@ from .fast_data_types import (
     set_options, set_os_window_size, set_os_window_title, thread_write,
     toggle_fullscreen, toggle_maximized, toggle_secure_input,
 )
-from .key_encoding import get_name_to_functional_number_map
+from .key_encoding import get_name_to_functional_number_map, is_modifier_key
 from .keys import get_shortcut, shortcut_matches
 from .layout.base import set_layout_options
 from .notify import notification_activated
@@ -1193,9 +1193,10 @@ class Boss:
 
         if len(self.current_sequence):
             self.current_sequence.append(ev)
-        if ev.action == GLFW_RELEASE:
+        if ev.action == GLFW_RELEASE or is_modifier_key(ev.key):
             return True
-        # For a press/repeat event, try matching with kitty bindings:
+        # For a press/repeat event that's not a modifier, try matching with
+        # kitty bindings:
         remaining = {}
         matched_action = None
         for seq, key_action in self.pending_sequences.items():

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -40,14 +40,14 @@ from .fast_data_types import (
     cocoa_minimize_os_window, cocoa_set_menubar_title, create_os_window,
     current_application_quit_request, current_focused_os_window_id, current_os_window,
     destroy_global_data, focus_os_window, get_boss, get_options, get_os_window_size,
-    global_font_size, last_focused_os_window_id, mark_os_window_for_close,
+    glfw_is_modifier_key, global_font_size, last_focused_os_window_id, mark_os_window_for_close,
     os_window_font_size, patch_global_colors, redirect_mouse_handling, ring_bell,
     run_with_activation_token, safe_pipe, send_data_to_peer,
     set_application_quit_request, set_background_image, set_boss, set_in_sequence_mode,
     set_options, set_os_window_size, set_os_window_title, thread_write,
     toggle_fullscreen, toggle_maximized, toggle_secure_input,
 )
-from .key_encoding import get_name_to_functional_number_map, is_modifier_key
+from .key_encoding import get_name_to_functional_number_map
 from .keys import get_shortcut, shortcut_matches
 from .layout.base import set_layout_options
 from .notify import notification_activated
@@ -1193,7 +1193,7 @@ class Boss:
 
         if len(self.current_sequence):
             self.current_sequence.append(ev)
-        if ev.action == GLFW_RELEASE or is_modifier_key(ev.key):
+        if ev.action == GLFW_RELEASE or glfw_is_modifier_key(ev.key):
             return True
         # For a press/repeat event that's not a modifier, try matching with
         # kitty bindings:

--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -313,6 +313,10 @@ def glfw_get_key_name(key: int, native_key: int) -> Optional[str]:
     pass
 
 
+def glfw_is_modifier_key(key: int) -> bool:
+    pass
+
+
 StartupCtx = NewType('StartupCtx', int)
 Display = NewType('Display', int)
 

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -1256,6 +1256,33 @@ glfw_get_key_name(PyObject UNUSED *self, PyObject *args) {
     return Py_BuildValue("z", glfwGetKeyName(key, native_key));
 }
 
+
+bool
+is_modifier_key(const uint32_t key) {
+    START_ALLOW_CASE_RANGE
+    switch (key) {
+        case GLFW_FKEY_LEFT_SHIFT ... GLFW_FKEY_ISO_LEVEL5_SHIFT:
+        case GLFW_FKEY_CAPS_LOCK:
+        case GLFW_FKEY_SCROLL_LOCK:
+        case GLFW_FKEY_NUM_LOCK:
+            return true;
+        default:
+            return false;
+    }
+    END_ALLOW_CASE_RANGE
+}
+
+
+static PyObject*
+glfw_is_modifier_key(PyObject UNUSED *self, PyObject *args) {
+  uint32_t key;
+  if (!PyArg_ParseTuple(args, "I", &key)) return NULL;
+  PyObject *ans = is_modifier_key(key) ? Py_True : Py_False;
+  Py_INCREF(ans);
+  return ans;
+}
+
+
 static PyObject*
 glfw_window_hint(PyObject UNUSED *self, PyObject *args) {
     int key, val;
@@ -1762,6 +1789,7 @@ static PyMethodDef module_methods[] = {
     {"glfw_terminate", (PyCFunction)glfw_terminate, METH_NOARGS, ""},
     {"glfw_get_physical_dpi", (PyCFunction)glfw_get_physical_dpi, METH_NOARGS, ""},
     {"glfw_get_key_name", (PyCFunction)glfw_get_key_name, METH_VARARGS, ""},
+    METHODB(glfw_is_modifier_key, METH_VARARGS),
     {"glfw_primary_monitor_size", (PyCFunction)primary_monitor_size, METH_NOARGS, ""},
     {"glfw_primary_monitor_content_scale", (PyCFunction)primary_monitor_content_scale, METH_NOARGS, ""},
     {NULL, NULL, 0, NULL}        /* Sentinel */

--- a/kitty/key_encoding.c
+++ b/kitty/key_encoding.c
@@ -31,21 +31,6 @@ typedef struct {
     KeyAction action;
 } EncodingData;
 
-bool
-is_modifier_key(const uint32_t key) {
-    START_ALLOW_CASE_RANGE
-    switch (key) {
-        case GLFW_FKEY_LEFT_SHIFT ... GLFW_FKEY_ISO_LEVEL5_SHIFT:
-        case GLFW_FKEY_CAPS_LOCK:
-        case GLFW_FKEY_SCROLL_LOCK:
-        case GLFW_FKEY_NUM_LOCK:
-            return true;
-        default:
-            return false;
-    }
-    END_ALLOW_CASE_RANGE
-}
-
 static void
 convert_glfw_mods(int mods, KeyEvent *ev, const unsigned key_encoding_flags) {
     if (!key_encoding_flags) mods &= ~GLFW_LOCK_MASK;

--- a/kitty/key_encoding.py
+++ b/kitty/key_encoding.py
@@ -426,3 +426,14 @@ def decode_key_event_as_window_system_key(text: str) -> Optional[WindowSystemKey
     except Exception:
         return None
     return k.as_window_system_event()
+
+
+# The same as `bool is_modifier_key(key)` in key_encoding.c
+def is_modifier_key(key: int) -> bool:
+    if defines.GLFW_FKEY_LEFT_SHIFT <= key <= defines.GLFW_FKEY_ISO_LEVEL5_SHIFT:
+        return True
+    if key == defines.GLFW_FKEY_CAPS_LOCK or \
+            key == defines.GLFW_FKEY_SCROLL_LOCK or \
+            key == defines.GLFW_FKEY_NUM_LOCK:
+        return True
+    return False

--- a/kitty/key_encoding.py
+++ b/kitty/key_encoding.py
@@ -426,14 +426,3 @@ def decode_key_event_as_window_system_key(text: str) -> Optional[WindowSystemKey
     except Exception:
         return None
     return k.as_window_system_event()
-
-
-# The same as `bool is_modifier_key(key)` in key_encoding.c
-def is_modifier_key(key: int) -> bool:
-    if defines.GLFW_FKEY_LEFT_SHIFT <= key <= defines.GLFW_FKEY_ISO_LEVEL5_SHIFT:
-        return True
-    if key == defines.GLFW_FKEY_CAPS_LOCK or \
-            key == defines.GLFW_FKEY_SCROLL_LOCK or \
-            key == defines.GLFW_FKEY_NUM_LOCK:
-        return True
-    return False

--- a/kitty/keys.c
+++ b/kitty/keys.c
@@ -167,14 +167,20 @@ on_key_input(GLFWkeyevent *ev) {
     PyObject *ke = NULL;
 #define create_key_event() { ke = convert_glfw_key_event_to_python(ev); if (!ke) { PyErr_Print(); return; } }
     if (global_state.in_sequence_mode) {
-        debug("in sequence mode, handling as shortcut\n");
-        if (
-            action != GLFW_RELEASE && !is_modifier_key(key)
-        ) {
-            w->last_special_key_pressed = key;
+        debug("in sequence mode, handling as a potential shortcut\n");
+        if (!is_modifier_key(key)) {
             create_key_event();
-            call_boss(process_sequence, "O", ke);
+            PyObject *ret = PyObject_CallMethod(
+                global_state.boss, "process_sequence", "O", ke);
             Py_CLEAR(ke);
+            if (ret == NULL) { PyErr_Print(); }
+            else {
+              bool consumed = ret == Py_True;
+              Py_DECREF(ret);
+              if (consumed && action != GLFW_RELEASE && w) {
+                w->last_special_key_pressed = key;
+              }
+            }
         }
         return;
     }

--- a/kitty/keys.c
+++ b/kitty/keys.c
@@ -172,6 +172,9 @@ on_key_input(GLFWkeyevent *ev) {
         PyObject *ret = PyObject_CallMethod(
             global_state.boss, "process_sequence", "O", ke);
         Py_CLEAR(ke);
+        // the shortcut could have created a new window or closed the
+        // window, rendering the pointer no longer valid
+        w = window_for_window_id(active_window_id);
         if (ret == NULL) { PyErr_Print(); }
         else {
           bool consumed = ret == Py_True;

--- a/kitty/keys.c
+++ b/kitty/keys.c
@@ -168,19 +168,17 @@ on_key_input(GLFWkeyevent *ev) {
 #define create_key_event() { ke = convert_glfw_key_event_to_python(ev); if (!ke) { PyErr_Print(); return; } }
     if (global_state.in_sequence_mode) {
         debug("in sequence mode, handling as a potential shortcut\n");
-        if (!is_modifier_key(key)) {
-            create_key_event();
-            PyObject *ret = PyObject_CallMethod(
-                global_state.boss, "process_sequence", "O", ke);
-            Py_CLEAR(ke);
-            if (ret == NULL) { PyErr_Print(); }
-            else {
-              bool consumed = ret == Py_True;
-              Py_DECREF(ret);
-              if (consumed && action != GLFW_RELEASE && w) {
-                w->last_special_key_pressed = key;
-              }
-            }
+        create_key_event();
+        PyObject *ret = PyObject_CallMethod(
+            global_state.boss, "process_sequence", "O", ke);
+        Py_CLEAR(ke);
+        if (ret == NULL) { PyErr_Print(); }
+        else {
+          bool consumed = ret == Py_True;
+          Py_DECREF(ret);
+          if (consumed && action != GLFW_RELEASE && w) {
+            w->last_special_key_pressed = key;
+          }
         }
         return;
     }

--- a/kitty/keys.h
+++ b/kitty/keys.h
@@ -18,5 +18,6 @@
 int
 encode_glfw_key_event(const GLFWkeyevent *e, const bool cursor_key_mode, const unsigned flags, char *output);
 
-bool
+// Defined in glfw.c
+extern bool
 is_modifier_key(const uint32_t key);


### PR DESCRIPTION
Fix #5840

Applications that use key sequences:
* tmux works, tested by the `Ctrl+b>c` case in #5840 
* vim works, tested by `inoremap <C-b>e abcde` in vimrc
* modifier sequence is replayed correctly: https://github.com/kovidgoyal/kitty/pull/5841#issuecomment-1368175233