### PR TITLE
Themes kitty: change `current-theme` but not conf

### DIFF
--- a/kittens/themes/collection.py
+++ b/kittens/themes/collection.py
@@ -530,20 +530,21 @@ class Theme:
     def save_in_dir(self, dirpath: str) -> None:
         atomic_save(self.raw.encode('utf-8'), os.path.join(dirpath, f'{self.name}.conf'))
 
-    def save_in_conf(self, confdir: str, reload_in: str, config_file_name: str = 'kitty.conf') -> None:
+    def save_in_conf(self, confdir: str, reload_in: str, config_file_name: str = 'kitty.conf', modify_conf: bool=True) -> None:
         os.makedirs(confdir, exist_ok=True)
         atomic_save(self.raw.encode('utf-8'), os.path.join(confdir, 'current-theme.conf'))
-        confpath = os.path.realpath(os.path.join(confdir, config_file_name))
-        try:
-            with open(confpath) as f:
-                raw = f.read()
-        except FileNotFoundError:
-            raw = ''
-        nraw = patch_conf(raw, self.name)
-        if raw:
-            with open(f'{confpath}.bak', 'w') as f:
-                f.write(raw)
-        atomic_save(nraw.encode('utf-8'), confpath)
+        if modify_conf:
+            confpath = os.path.realpath(os.path.join(confdir, config_file_name))
+            try:
+                with open(confpath) as f:
+                    raw = f.read()
+            except FileNotFoundError:
+                raw = ''
+            nraw = patch_conf(raw, self.name)
+            if raw:
+                with open(f'{confpath}.bak', 'w') as f:
+                    f.write(raw)
+            atomic_save(nraw.encode('utf-8'), confpath)
         if reload_in == 'parent':
             if 'KITTY_PID' in os.environ:
                 os.kill(int(os.environ['KITTY_PID']), signal.SIGUSR1)

--- a/kittens/themes/main.py
+++ b/kittens/themes/main.py
@@ -549,6 +549,13 @@ When running non-interactively, dump the specified theme to STDOUT
 instead of changing kitty.conf.
 
 
+--update-current
+type=bool-set
+default=false
+When running non-interactively, update `current-theme.conf` but do not
+change kitty.conf.
+
+
 --config-file-name
 default=kitty.conf
 The name or path to the config file to edit. Relative paths are interpreted
@@ -577,7 +584,7 @@ def non_interactive(cli_opts: ThemesCLIOptions, theme_name: str) -> None:
     if cli_opts.dump_theme:
         print(theme.raw)
         return
-    theme.save_in_conf(config_dir, cli_opts.reload_in, cli_opts.config_file_name)
+    theme.save_in_conf(config_dir, cli_opts.reload_in, cli_opts.config_file_name, not cli_opts.update_current)
 
 
 def main(args: List[str]) -> None:


### PR DESCRIPTION
I change between themes often (twice a day). However, I also version-control my kitty config.
For this reason, I would like to change themes without having to update my kitty config.

This PR allows one to update only the `current-theme.conf` file when running `kitty +kitten themes`, and still have the ability to reload with the `--update-current` flag.