### PR TITLE
Fix `kitty +kitten themes` crashing without network

### DIFF
--- a/kittens/themes/collection.py
+++ b/kittens/themes/collection.py
@@ -13,7 +13,7 @@ import tempfile
 import zipfile
 from contextlib import suppress
 from typing import Any, Callable, Dict, Iterator, Match, Optional, Tuple, Type, Union
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from kitty.config import atomic_save, parse_config
@@ -643,6 +643,8 @@ def load_themes(cache_age: float = 1., ignore_no_cache: bool = False) -> Themes:
     except NoCacheFound:
         if not ignore_no_cache:
             raise
+    except URLError:
+        print("Cannot update themes, please check your internet connection", file=sys.stderr)
     else:
         ans.load_from_zip(fetched)
     ans.load_from_dir(os.path.join(config_dir, 'themes'))


### PR DESCRIPTION
Right now it exits with an error:
```
Traceback (most recent call last):
  File "lib/python3.9/urllib/request.py", line 1346, in do_open
  File "lib/python3.9/http/client.py", line 1253, in request
  File "lib/python3.9/http/client.py", line 1299, in _send_request
  File "lib/python3.9/http/client.py", line 1248, in endheaders
  File "lib/python3.9/http/client.py", line 1008, in _send_output
  File "lib/python3.9/http/client.py", line 948, in send
  File "lib/python3.9/http/client.py", line 1415, in connect
  File "lib/python3.9/http/client.py", line 919, in connect
  File "lib/python3.9/socket.py", line 822, in create_connection
  File "lib/python3.9/socket.py", line 953, in getaddrinfo
socket.gaierror: [Errno 8] nodename nor servname provided, or not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "lib/python3.9/kittens/themes/main.py", line 239, in fetch
  File "lib/python3.9/kittens/themes/collection.py", line 641, in load_themes
  File "lib/python3.9/kittens/themes/collection.py", line 369, in fetch_themes
  File "lib/python3.9/urllib/request.py", line 214, in urlopen
  File "lib/python3.9/urllib/request.py", line 517, in open
  File "lib/python3.9/urllib/request.py", line 534, in _open
  File "lib/python3.9/urllib/request.py", line 494, in _call_chain
  File "lib/python3.9/urllib/request.py", line 1389, in https_open
  File "lib/python3.9/urllib/request.py", line 1349, in do_open
urllib.error.URLError: <urlopen error [Errno 8] nodename nor servname provided, or not known>

Failed to download themes
Press Enter to quit.^CTraceback (most recent call last):
  File "lib/python3.9/runpy.py", line 197, in _run_module_as_main
  File "lib/python3.9/runpy.py", line 87, in _run_code
  File "lib/python3.9/kitty_main.py", line 7, in <module>
  File "lib/python3.9/kitty/entry_points.py", line 201, in main
  File "lib/python3.9/kitty/entry_points.py", line 152, in namespaced
  File "lib/python3.9/kitty/entry_points.py", line 133, in run_kitten
  File "lib/python3.9/kittens/runner.py", line 112, in run_kitten
  File "lib/python3.9/runpy.py", line 213, in run_module
  File "lib/python3.9/runpy.py", line 87, in _run_code
  File "lib/python3.9/kittens/themes/main.py", line 613, in <module>
  File "lib/python3.9/kittens/themes/main.py", line 603, in main
KeyboardInterrupt
```

Please let me know if the PR can be improved, for example, in the way
network error is logged.
