### PR TITLE
Improve appearance of undercurl

### DIFF
--- a/kitty/fonts/render.py
+++ b/kitty/fonts/render.py
@@ -249,16 +249,8 @@ def add_dline(buf: CBufType, cell_width: int, position: int, thickness: int, cel
 
 def add_curl(buf: CBufType, cell_width: int, position: int, thickness: int, cell_height: int) -> None:
     max_x, max_y = cell_width - 1, cell_height - 1
-    xfactor = 2.0 * pi / max_x
-    thickness = max(1, thickness)
-    if thickness < 3:
-        half_height = thickness
-        thickness -= 1
-    elif thickness == 3:
-        half_height = thickness = 2
-    else:
-        half_height = thickness // 2
-        thickness -= 2
+    xfactor = 4.0 * pi / max_x
+    thickness = half_height = max(1, cell_height // 21)
 
     def add_intensity(x: int, y: int, val: int) -> None:
         y += position

--- a/kitty/fonts/render.py
+++ b/kitty/fonts/render.py
@@ -206,7 +206,7 @@ def set_font_family(opts: Optional[Options] = None, override_font_size: Optional
     if debug_font_matching:
         dump_faces(ftypes, indices)
     set_font_data(
-        render_box_drawing, lambda *a: prerender_function(*a, opts), descriptor_for_idx,
+        render_box_drawing, prerender_function, descriptor_for_idx,
         indices['bold'], indices['italic'], indices['bi'], num_symbol_fonts,
         sm, sz, font_features, ns
     )
@@ -247,8 +247,9 @@ def add_dline(buf: CBufType, cell_width: int, position: int, thickness: int, cel
         ctypes.memset(ctypes.addressof(buf) + (cell_width * y), 255, cell_width)
 
 
-def add_curl(buf: CBufType, cell_width: int, position: int, thickness: int, cell_height: int, opts: Options) -> None:
-    (thickness_opt, density_opt) = opts.undercurl_style
+def add_curl(buf: CBufType, cell_width: int, position: int, thickness: int, cell_height: int) -> None:
+    from kitty.fast_data_types import get_options
+    (thickness_opt, density_opt) = get_options().undercurl_style
 
     max_x, max_y = cell_width - 1, cell_height - 1
     xfactor = (2.0 if density_opt == 'sparse' else 4.0) * pi / max_x
@@ -310,8 +311,7 @@ def render_special(
     strikethrough_position: int = 0,
     strikethrough_thickness: int = 0,
     dpi_x: float = 96.,
-    dpi_y: float = 96.,
-    opts: Options = None
+    dpi_y: float = 96.
 ) -> CBufType:
     underline_position = min(underline_position, cell_height - sum(divmod(underline_thickness, 2)))
     CharTexture = ctypes.c_ubyte * (cell_width * cell_height)
@@ -333,7 +333,7 @@ def render_special(
         t = underline_thickness
         if underline > 1:
             t = max(1, min(cell_height - underline_position - 1, t))
-        dl([add_line, add_line, add_dline, lambda *a: add_curl(*a, opts), add_dots, add_dashes][underline], underline_position, t, cell_height)
+        dl([add_line, add_line, add_dline, add_curl, add_dots, add_dashes][underline], underline_position, t, cell_height)
     if strikethrough:
         dl(add_line, strikethrough_position, strikethrough_thickness, cell_height)
 
@@ -391,15 +391,14 @@ def prerender_function(
     cursor_beam_thickness: float,
     cursor_underline_thickness: float,
     dpi_x: float,
-    dpi_y: float,
-    opts: Options
+    dpi_y: float
 ) -> Tuple[Tuple[int, ...], Tuple[CBufType, ...]]:
     # Pre-render the special underline, strikethrough and missing and cursor cells
     f = partial(
         render_special, cell_width=cell_width, cell_height=cell_height, baseline=baseline,
         underline_position=underline_position, underline_thickness=underline_thickness,
         strikethrough_position=strikethrough_position, strikethrough_thickness=strikethrough_thickness,
-        dpi_x=dpi_x, dpi_y=dpi_y, opts=opts
+        dpi_x=dpi_x, dpi_y=dpi_y
     )
     c = partial(
         render_cursor, cursor_beam_thickness=cursor_beam_thickness,

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -224,7 +224,7 @@ lines.
     )
 
 opt('undercurl_style', 'thin-sparse',
-    option_type='undercurl_style',
+    choices=('thin-sparse', 'thin-dense', 'thick-sparse', 'thick-dense'),
     long_text='''
 The style with which undercurl is rendered. This option takes the form 
 :code:`(thin|thick)-(sparse|dense)`. Thin and thick control the thickness of the 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -222,6 +222,16 @@ There must be four values corresponding to thin, normal, thick, and very thick
 lines.
 '''
     )
+
+opt('undercurl_style', 'thin-sparse',
+    option_type='undercurl_style',
+    long_text='''
+The style with which undercurl is rendered. This option takes the form 
+:code:`(thin|thick)-(sparse|dense)`. Thin and thick control the thickness of the 
+undercurl. Sparse and dense control how often the curl oscillates. With sparse 
+the curl will peak once per character, with dense twice.  
+'''
+    )
 egr()  # }}}
 
 

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -17,8 +17,8 @@ from kitty.options.utils import (
     scrollback_lines, scrollback_pager_history_size, shell_integration, store_multiple, symbol_map,
     tab_activity_symbol, tab_bar_edge, tab_bar_margin_height, tab_bar_min_tabs, tab_fade,
     tab_font_style, tab_separator, tab_title_template, titlebar_color, to_cursor_shape, to_font_size,
-    to_layout_names, to_modifiers, url_prefixes, url_style, visual_window_select_characters,
-    window_border_width, window_size
+    to_layout_names, to_modifiers, undercurl_style, url_prefixes, url_style,
+    visual_window_select_characters, window_border_width, window_size
 )
 
 
@@ -1280,6 +1280,9 @@ class Parser:
 
     def touch_scroll_multiplier(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['touch_scroll_multiplier'] = float(val)
+
+    def undercurl_style(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        ans['undercurl_style'] = undercurl_style(val)
 
     def update_check_interval(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['update_check_interval'] = float(val)

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -442,6 +442,7 @@ option_names = (  # {{{
  'tab_title_template',
  'term',
  'touch_scroll_multiplier',
+ 'undercurl_style',
  'update_check_interval',
  'url_color',
  'url_excluded_characters',
@@ -592,6 +593,7 @@ class Options:
     tab_title_template: str = '{fmt.fg.red}{bell_symbol}{activity_symbol}{fmt.fg.tab}{title}'
     term: str = 'xterm-kitty'
     touch_scroll_multiplier: float = 1.0
+    undercurl_style: typing.Tuple[str, str] = ('thin', 'sparse')
     update_check_interval: float = 24.0
     url_color: Color = Color(0, 135, 189)
     url_excluded_characters: str = ''

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -507,15 +507,6 @@ def scrollback_lines(x: str) -> int:
 def scrollback_pager_history_size(x: str) -> int:
     ans = int(max(0, float(x)) * 1024 * 1024)
     return min(ans, 4096 * 1024 * 1024 - 1)
-
-
-def undercurl_style(x: str) -> Tuple[str, str]:
-    width, density = x.partition("-")[::2]
-    if width not in ('thin', 'thick'):
-        raise ValueError(f'Invalid undercurl thickness: {width!r} allowed values are thick and thin')
-    if density not in ('sparse', 'dense'):
-        raise ValueError(f'Invalid undercurl density: {density!r} allowed values are sparse and dense')
-    return width, density
     
 
 # "single" for backwards compat

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -509,6 +509,21 @@ def scrollback_pager_history_size(x: str) -> int:
     return min(ans, 4096 * 1024 * 1024 - 1)
 
 
+def undercurl_style(x: str) -> Tuple[str, str]:
+    splits = x.split("-")
+    if len(splits) != 2:
+        raise ValueError(
+            'Invalid undercurl style: {} allowed styles are of the form (thin|thick)-(sparse|dense)'
+            .format(x)
+        )
+    [width, density] = splits
+    if width != 'thin' and width != 'thick':
+        raise ValueError('Invalid undercurl thickness: {} allowed values are thick and thin'.format(width))
+    if density != 'sparse' and density != 'dense':
+        raise ValueError('Invalid undercurl density: {} allowed values are sparse and dense'.format(density))
+    return (width, density)
+    
+
 # "single" for backwards compat
 url_style_map = {'none': 0, 'single': 1, 'straight': 1, 'double': 2, 'curly': 3, 'dotted': 4, 'dashed': 5}
 

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -510,18 +510,12 @@ def scrollback_pager_history_size(x: str) -> int:
 
 
 def undercurl_style(x: str) -> Tuple[str, str]:
-    splits = x.split("-")
-    if len(splits) != 2:
-        raise ValueError(
-            'Invalid undercurl style: {} allowed styles are of the form (thin|thick)-(sparse|dense)'
-            .format(x)
-        )
-    [width, density] = splits
-    if width != 'thin' and width != 'thick':
-        raise ValueError('Invalid undercurl thickness: {} allowed values are thick and thin'.format(width))
-    if density != 'sparse' and density != 'dense':
-        raise ValueError('Invalid undercurl density: {} allowed values are sparse and dense'.format(density))
-    return (width, density)
+    width, density = x.partition("-")[::2]
+    if width not in ('thin', 'thick'):
+        raise ValueError(f'Invalid undercurl thickness: {width!r} allowed values are thick and thin')
+    if density not in ('sparse', 'dense'):
+        raise ValueError(f'Invalid undercurl density: {density!r} allowed values are sparse and dense')
+    return width, density
     
 
 # "single" for backwards compat


### PR DESCRIPTION
Make the undercurl thicker and have its amplitude scale more closely with font size. Also half the period so there are two peaks per character.

I feel that the way it is right now looks too flat and too thin. Imo this change will look far better for editors using the undercurl for error messages.

Before and After
![image](https://user-images.githubusercontent.com/64214386/212233794-7ec2f096-ed22-4819-a8cc-e9656011487d.png)

See also VSCode's undercurl. 
![image](https://user-images.githubusercontent.com/64214386/212234037-87886b2e-691e-43af-bd6b-34b44189dc0a.png)

I think this looks even better but the period isn't a multiple of the character width and so it can't be implemented using the current kitty rendering strategy. (Summary: ~1.5 curls / char > 2 curls / char > 1 curl / char).