### PR TITLE
Also move the overlay line when DECTCEM mode is turned off and on

### DIFF
--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -751,7 +751,7 @@ struct SaveOverlayLine {
 
 static void
 save_overlay_line(struct SaveOverlayLine *sol) {
-    if (sol->screen->overlay_line.is_active && screen_is_cursor_visible(sol->screen)) {
+    if (sol->screen->overlay_line.is_active) {
         sol->overlay_text = get_overlay_text(sol->screen);
         deactivate_overlay_line(sol->screen);
     }

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -751,7 +751,7 @@ struct SaveOverlayLine {
 
 static void
 save_overlay_line(struct SaveOverlayLine *sol) {
-    if (sol->screen->overlay_line.is_active) {
+    if (sol->screen->overlay_line.is_active && screen_is_cursor_visible(sol->screen)) {
         sol->overlay_text = get_overlay_text(sol->screen);
         deactivate_overlay_line(sol->screen);
     }

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -743,31 +743,34 @@ get_overlay_text(Screen *self) {
 #undef ol
 }
 
-struct SaveOverlayLine {
-    PyObject *overlay_text;
-    Screen *screen;
-    const char *func_name;
-};
-
 static void
-save_overlay_line(struct SaveOverlayLine *sol) {
-    if (sol->screen->overlay_line.is_active && screen_is_cursor_visible(sol->screen)) {
-        sol->overlay_text = get_overlay_text(sol->screen);
-        deactivate_overlay_line(sol->screen);
+save_overlay_line(Screen *self, const char* func_name) {
+    if (self->overlay_line.is_active && screen_is_cursor_visible(self)) {
+        if (self->overlay_line.save.overlay_text) {
+          Py_DECREF(self->overlay_line.save.overlay_text);
+        }
+        self->overlay_line.save.overlay_text = get_overlay_text(self);
+        self->overlay_line.save.func_name = func_name;
+        deactivate_overlay_line(self);
     }
 }
 
 static void
-restore_overlay_line(struct SaveOverlayLine *sol) {
-    if (sol->overlay_text) {
-        debug("Received input from child (%s) while overlay active. Overlay contents: %s\n", sol->func_name, PyUnicode_AsUTF8(sol->overlay_text));
-        screen_draw_overlay_text(sol->screen, PyUnicode_AsUTF8(sol->overlay_text));
-        Py_DECREF(sol->overlay_text);
-        update_ime_position_for_window(sol->screen->window_id, false, 0);
+restore_overlay_line(Screen *self) {
+    if (self->overlay_line.save.overlay_text) {
+        debug("Received input from child (%s) while overlay active. Overlay contents: %s\n", self->overlay_line.save.func_name, PyUnicode_AsUTF8(self->overlay_line.save.overlay_text));
+        screen_draw_overlay_text(self, PyUnicode_AsUTF8(self->overlay_line.save.overlay_text));
+        Py_DECREF(self->overlay_line.save.overlay_text);
+        self->overlay_line.save.overlay_text = NULL;
+        update_ime_position_for_window(self->window_id, false, 0);
     }
 }
 
-#define MOVE_OVERLAY_LINE_WITH_CURSOR struct SaveOverlayLine __attribute__ ((__cleanup__(restore_overlay_line))) _sol_ = {.screen=self,.func_name=__func__}; save_overlay_line(&_sol_);
+static void restore_overlay_line_from_cleanup(Screen **self) {
+  restore_overlay_line(*self);
+}
+
+#define MOVE_OVERLAY_LINE_WITH_CURSOR Screen __attribute__ ((__cleanup__(restore_overlay_line_from_cleanup))) *_sol_ = self; save_overlay_line(_sol_, __func__);
 
 void
 screen_draw(Screen *self, uint32_t och, bool from_input_stream) {
@@ -999,6 +1002,12 @@ set_mode_from_const(Screen *self, unsigned int mode, bool val) {
             self->modes.mDECCKM = val;
             break;
         case DECTCEM:
+            if(!val) {
+              save_overlay_line(self,  __func__);
+            }
+            else {
+              restore_overlay_line(self);
+            }
             self->modes.mDECTCEM = val;
             break;
         case DECSCNM:

--- a/kitty/screen.h
+++ b/kitty/screen.h
@@ -72,6 +72,11 @@ typedef struct {
     GPUCell *gpu_cells;
     bool is_active;
     index_type xstart, ynum, xnum;
+
+    struct {
+      PyObject *overlay_text;
+      const char *func_name;
+    } save;
 } OverlayLine;
 
 typedef struct {

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@ with pkgs;
 let
   inherit (lib) optional optionals;
   inherit (xorg) libX11 libXrandr libXinerama libXcursor libXi libXext;
-  inherit (darwin.apple_sdk.frameworks) Cocoa CoreGraphics Foundation IOKit Kernel OpenGL;
+  inherit (darwin.apple_sdk.frameworks) Cocoa CoreGraphics Foundation IOKit Kernel OpenGL UniformTypeIdentifiers;
   harfbuzzWithCoreText = harfbuzz.override { withCoreText = stdenv.isDarwin; };
 in
 with python3Packages;
@@ -21,6 +21,7 @@ mkShell rec {
     IOKit
     Kernel
     OpenGL
+    UniformTypeIdentifiers
     libpng
     python3
     zlib


### PR DESCRIPTION
When we type something in vim, it send following commands to the terminal.

1. screen_reset_mode 25 1 (Turn off DECTCEM mode)
2. draw {charater}
3. screen_set_mode 25 1 (Turn on DECTCEM mode)

This flow causes an issue when using some IMEs like Korean in Kitty. Korean IMEs generate character confirmation and overlay update with a single key press. However, due to that flow, the overlay position is not updated at the time of the draw key.

To solve this, I modified it to save the overlay line when DECTCEM mode is turned off, and restore it when the mode is turned back on.

Related issues: #5716  #5027

### before
https://user-images.githubusercontent.com/1402102/212526561-3ea62086-a731-447d-af27-8de30a1e9c20.mov

### after
https://user-images.githubusercontent.com/1402102/212526569-ee08fea1-0749-48c9-bf9a-83f44d4c1896.mov



