### PR TITLE
Document kitty-terminfo package for getting terminfo to work with sudo when SSH'd

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -135,6 +135,12 @@ command to apply your change (on the server)::
 
     cap_mkdb /usr/share/misc/termcap
 
+For terminfo to work with :program:`sudo` on the server, you'll need to either
+install the Linux distribution's |kitty-terminfo| package on the server, or copy
+:file:`~/.terminfo/x/xterm-kitty` to the server's system path::
+
+    sudo cp ~/.terminfo/x/xterm-kitty /usr/share/terminfo/x/
+
 
 Keys such as arrow keys, backspace, delete, home/end, etc. do not work when using su or sudo?
 -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I'd followed the instructions for using the SSH kitten ages ago, but I've always had trouble with it when SSH-ing to my server, e.g.:

```
➜ sudo systemctl status crashplan-pro
WARNING: terminal is not fully functional
Press RETURN to continue
```

I only realised today that it was only `sudo` commands that were failing this way. In Googling, I came across [this post](https://bbs.archlinux.org/viewtopic.php?id=181907) by @EvanPurkhiser. In case the thread gets removed, here's the content:

> Hey guys,
>
> I use the termite terminal which uses the termcap file 'xterm-termite'. Since this is non-standard I have to copy over the termcap file to remote machines I commonly work on. I put this file in `$HOME/.local/share/terminfo/x/xterm-termite` and set my $TERMINFO environment variable to `$HOME/.local/share/terminfo`.
>
> When I use sudo -E or sudoedit it looks like the TERMINFO environment variable is getting lost. So vim won't display things properly (no colors) and other silly problems (LESS 'Warning terminal is not fully functional").
>
> Why does the TERMINFO get dropped when my other environment variables stick around?
>
> Edit: Looking at the [TROUBLESHOOTING](http://www.sudo.ws/sudo/troubleshooting.html) document, I see that TERMINFO is removed "to guard against shared library spoofing, shell voodoo, and kerberos server spoofing."
>
> What are my options? I would really rather not copy my termcap file into /usr/share/terminfo since I might not always have root access on my remote machines.
>
> Edit 2: I feel a little silly. I just said I may not have root access. But if I'm using sudo it's almost guaranteed for root access! I'll leave this thread open for other solutions though.

Copying the file into the system path did indeed solve my issue! But I wondered if there was a package for it instead; and [it turns out there is](https://github.com/kovidgoyal/kitty/issues/2053#issuecomment-995349712) - `kitty-terminfo`.

Unfortunately, it doesn't appear to be documented anywhere - the [only mention of the package is in the 'Build from source' page](https://github.com/search?q=repo%3Akovidgoyal%2Fkitty%20kitty-terminfo&type=code). I thought documenting this package would be a valuable addition to the SSH FAQ section; hence this PR.

I considered whether putting it in the section below would be more appropriate since it's talking about `sudo`, but it seems to be addressing a slightly different problem around environment variables; and given the title is not SSH-related, I had not realised it might be applicable to my problem.

The sudo troubleshooting page linked from the above post no longer mentions terminfo, so I have not included reference to that.

I'm not familiar with reStructuredText, so I hope I got the syntax right and to your liking.

Edit: Perhaps this should also be mentioned on the [SSH kitten page](https://sw.kovidgoyal.net/kitty/kittens/ssh/)?