### PR TITLE
Fix SHELL env var in open-actions.conf and launch-actions.conf

### DIFF
--- a/docs/open_actions.rst
+++ b/docs/open_actions.rst
@@ -68,6 +68,13 @@ some special variables, documented below:
     The path, query and fragment portions of the URL, without any
     unquoting.
 
+``EDITOR``
+    The terminal based text editor. The configured :opt:`editor` in
+    :file:`kitty.conf` is preferred.
+
+``SHELL``
+    The path to the shell. The configured :opt:`shell` in :file:`kitty.conf` is
+    preferred, without arguments.
 
 .. note::
    You can use the :opt:`action_alias` option just as in :file:`kitty.conf` to

--- a/kitty/open_actions.py
+++ b/kitty/open_actions.py
@@ -74,7 +74,7 @@ def parse(lines: Iterable[str]) -> Iterator[OpenAction]:
     with to_cmdline_implementation.filter_env_vars(
         'URL', 'FILE_PATH', 'FILE', 'FRAGMENT', 'URL_PATH',
         EDITOR=shlex.join(get_editor()),
-        SHELL=shlex.join(resolved_shell(get_options()))
+        SHELL=resolved_shell(get_options())[0]
     ):
         for (mc, action_defns) in entries:
             actions: List[KeyAction] = []
@@ -234,12 +234,11 @@ action show_kitty_doc $URL_PATH
 
 @run_once
 def default_launch_actions() -> Tuple[OpenAction, ...]:
-    SHELL = resolved_shell(get_options())
-    return tuple(parse(f'''\
+    return tuple(parse('''\
 # Open script files
 protocol file
 ext sh,command,tool
-action launch --hold --type=os-window kitty +shebang $FILE_PATH {SHELL}
+action launch --hold --type=os-window kitty +shebang $FILE_PATH $SHELL
 
 # Open shell specific script files
 protocol file


### PR DESCRIPTION
When `shell` is configured as `bash --login`, `kitty +shebang $FILE_PATH $SHELL` will not work.
The PR fixes this.

- Only the executable path is used when expanding `$SHELL`.
- Also fix the non-working example `{SHELL}` in [the documentation](https://sw.kovidgoyal.net/kitty/open_actions/#scripting-the-opening-of-files-with-kitty-on-macos).

I actually tried to fix the problem of not being able to open image files with kitty under macOS.
However I don't know when the next version will be released, so it's better to let you know.

Steps to reproduce:
- Right click on the image file to open it via kitty.app, or drag and drop the file onto the Dock.
- Or run `kitty @ launch --type=os-window kitty +kitten icat --hold /path/to/image`.
- The new process ends and the new OS window is immediately closed. （`This should be run as kitten icat`)

Issues:
- `icat --hold` is not respected in the python placeholder (`raise SystemExit()`), causing the window to close directly.
- `launch` uses the prewarmed process to run kitten. I think for all `wrapped_kitten_names()` the `prewarm` should be skipped.
- The `launch --hold` uses a python kitten to wrap, so it will run the process independently. `launch --hold kitty +kitten icat` will work fine. I'm not sure if we can use `prewarm` in this case (to make the kitten after `launch --hold` run faster), it seems infeasible and unnecessary. This `hold_till_enter` then looks like it can be implemented in golang.

Lastly, how to add `help` and `exit` auto-completion to the kitty shell?

Thank you.