### PR TITLE
Fixes the ssh kitten

### DIFF
--- a/kittens/ssh/main.py
+++ b/kittens/ssh/main.py
@@ -50,9 +50,6 @@ def read_data_from_shared_memory(shm_name: str) -> Any:
         shm.unlink()
         if shm.stats.st_uid != os.geteuid() or shm.stats.st_gid != os.getegid():
             raise ValueError('Incorrect owner on pwfile')
-        mode = stat.S_IMODE(shm.stats.st_mode)
-        if mode != stat.S_IREAD:
-            raise ValueError('Incorrect permissions on pwfile')
         return json.loads(shm.read_data_with_size())
 
 


### PR DESCRIPTION
kovidgoyal@5e645a7 fixes the password file creation, allowing it to be unlinked, but read_data_from_shared_memory/1 rejects the shared object if it is not read only, and will break the ssh kitten for all platforms.

This change removes the read only check, relying only on the file ownership check.

This fully fixes #5928

Signed-off-by: Loren Schlomer <me@schlomie.com>