### PR TITLE
Docs: Fix mixed tab and space indentation in the example code

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -94,7 +94,7 @@ code to demonstrate its use
 
         import "golang.org/x/sys/unix"
         fd, err := unix.Open(fd, unix.O_NOCTTY|unix.O_CLOEXEC|unix.O_NDELAY|unix.O_RDWR, 0666)
-		sz, err := unix.IoctlGetWinsize(fd, unix.TIOCGWINSZ)
+        sz, err := unix.IoctlGetWinsize(fd, unix.TIOCGWINSZ)
         fmt.Println("rows: %v columns: %v width: %v height %v", sz.Row, sz.Col, sz.Xpixel, sz.Ypixel)
 
 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -2768,23 +2768,22 @@ this even works over SSH connections. The default setting of :code:`no`
 prevents any form of remote control. The meaning of the various values are:
 
 :code:`password`
-   Remote control requests received over both the TTY device and the socket are
-   confirmed based on passwords, see :opt:`remote_control_password`.
+    Remote control requests received over both the TTY device and the socket are
+    confirmed based on passwords, see :opt:`remote_control_password`.
 
 :code:`socket-only`
-   Remote control requests received over a socket are accepted unconditionally.
-   Requests received over the TTY are denied. See :opt:`listen_on`.
+    Remote control requests received over a socket are accepted unconditionally.
+    Requests received over the TTY are denied. See :opt:`listen_on`.
 
 :code:`socket`
-   Remote control requests received over a socket are accepted unconditionally.
-   Requests received over the TTY are confirmed based on password.
+    Remote control requests received over a socket are accepted unconditionally.
+    Requests received over the TTY are confirmed based on password.
 
 :code:`no`
-   Remote control is completely disabled.
+    Remote control is completely disabled.
 
 :code:`yes`
-   Remote control requests are always accepted.
-
+    Remote control requests are always accepted.
 '''
     )
 


### PR DESCRIPTION
Although Go uses tab indentation by default, for consistency, space indentation is used in the source code of the documentation.

Anyone who has copied the code directly can format it themselves with gofmt.