### PR TITLE
Only two arguments are required to create a marker

### DIFF
--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -329,13 +329,13 @@ def parse_marker_spec(ftype: str, parts: Sequence[str]) -> Tuple[str, Union[str,
         if ftype.startswith('i'):
             flags |= re.IGNORECASE
         if not parts or len(parts) % 2 != 0:
-            raise ValueError('No color specified in marker: {}'.format(' '.join(parts)))
+            raise ValueError('Mark group number and text/regex are not specified in pairs: {}'.format(' '.join(parts)))
         ans = []
         for i in range(0, len(parts), 2):
             try:
                 color = max(1, min(int(parts[i]), 3))
             except Exception:
-                raise ValueError(f'color {parts[i]} in marker specification is not an integer')
+                raise ValueError(f'Mark group in marker specification is not an integer: {parts[i]}')
             sspec = parts[i + 1]
             if 'regex' not in ftype:
                 sspec = re.escape(sspec)

--- a/kitty/rc/create_marker.py
+++ b/kitty/rc/create_marker.py
@@ -29,7 +29,7 @@ class CreateMarker(RemoteCommand):
 type=bool-set
 Apply marker to the window this command is run in, rather than the active window.
 '''
-    args = RemoteCommand.Args(spec='MARKER SPECIFICATION', json_field='marker_spec', minimum_count=3)
+    args = RemoteCommand.Args(spec='MARKER SPECIFICATION', json_field='marker_spec', minimum_count=2)
 
     def message_to_kitty(self, global_opts: RCOptions, opts: 'CLIOptions', args: ArgsType) -> PayloadType:
         if len(args) < 2:


### PR DESCRIPTION
The following will not work after recent commit.

```shell
kitty @ create-marker function mymarker.py
```

So revert that commit.

The `mark group` is used in the documentation to refer to that integer in the specification, so replace `color` with this in the error message to be consistent.

Fix `No color` error message when text is missing, e.g. `text 1`.

Related GitHub Issue:
https://github.com/kovidgoyal/kitty/issues/5937