### PR TITLE
fish integration: Ensure kitten works even if it is not in PATH

### DIFF
--- a/kitty/constants.py
+++ b/kitty/constants.py
@@ -79,6 +79,7 @@ def kitty_exe() -> str:
     return os.path.join(rpath, 'kitty')
 
 
+@run_once
 def kitten_exe() -> str:
     return os.path.join(os.path.dirname(kitty_exe()), 'kitten')
 

--- a/shell-integration/fish/vendor_completions.d/clone-in-kitty.fish
+++ b/shell-integration/fish/vendor_completions.d/clone-in-kitty.fish
@@ -1,7 +1,7 @@
 function __ksi_completions
     set --local ct (commandline --current-token)
     set --local tokens (commandline --tokenize --cut-at-cursor --current-process)
-    printf "%s\n" $tokens $ct | command kitten __complete__ fish | source -
+    printf "%s\n" $tokens $ct | kitten __complete__ fish | source -
 end
 
 complete -f -c clone-in-kitty -a "(__ksi_completions)"

--- a/shell-integration/fish/vendor_completions.d/kitten.fish
+++ b/shell-integration/fish/vendor_completions.d/kitten.fish
@@ -1,7 +1,7 @@
 function __ksi_completions
     set --local ct (commandline --current-token)
     set --local tokens (commandline --tokenize --cut-at-cursor --current-process)
-    printf "%s\n" $tokens $ct | command kitten __complete__ fish | source -
+    printf "%s\n" $tokens $ct | kitten __complete__ fish | source -
 end
 
 complete -f -c kitten -a "(__ksi_completions)"

--- a/shell-integration/fish/vendor_completions.d/kitty.fish
+++ b/shell-integration/fish/vendor_completions.d/kitty.fish
@@ -1,7 +1,7 @@
 function __ksi_completions
     set --local ct (commandline --current-token)
     set --local tokens (commandline --tokenize --cut-at-cursor --current-process)
-    printf "%s\n" $tokens $ct | command kitten __complete__ fish | source -
+    printf "%s\n" $tokens $ct | kitten __complete__ fish | source -
 end
 
 complete -f -c kitty -a "(__ksi_completions)"

--- a/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
+++ b/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
@@ -154,9 +154,19 @@ function __ksi_schedule --on-event fish_prompt -d "Setup kitty integration after
         test (count $new_path) -eq (count $PATH)
         or set --global --export --path PATH $new_path
     end
+
+    # Setup kitten wrapper
+    if not type -q kitten
+        and test -x "$KITTY_KITTEN_EXE"
+        set --global __ksi_kitten_exe $KITTY_KITTEN_EXE
+        function kitten -d "Command line tools for use with kitty"
+            command $__ksi_kitten_exe $argv
+        end
+    end
+    set --erase KITTY_KITTEN_EXE
 end
 
-function edit-in-kitty --wraps "kitten edit-in-kitty"
+function edit-in-kitty --wraps "kitten edit-in-kitty" -d "Edit the specified file in a kitty overlay window"
     kitten edit-in-kitty $argv
 end
 

--- a/tools/cmd/edit_in_kitty/main.go
+++ b/tools/cmd/edit_in_kitty/main.go
@@ -235,7 +235,7 @@ type Options struct {
 func EntryPoint(parent *cli.Command) *cli.Command {
 	sc := parent.AddSubCommand(&cli.Command{
 		Name:             "edit-in-kitty",
-		Usage:            "edit-in-kitty [options] file-to-edit",
+		Usage:            "[options] file-to-edit",
 		ShortDescription: "Edit a file in a kitty overlay window",
 		HelpText: "Edit the specified file in a kitty overlay window. Works over SSH as well.\n\n" +
 			"For usage instructions see: https://sw.kovidgoyal.net/kitty/shell-integration/#edit-file",

--- a/tools/cmd/tool/main.go
+++ b/tools/cmd/tool/main.go
@@ -18,7 +18,7 @@ var _ = fmt.Print
 
 func KittyToolEntryPoints(root *cli.Command) {
 	root.Add(cli.OptionSpec{
-		Name: "--version", Type: "bool-set", Help: "The current kitty version."})
+		Name: "--version", Type: "bool-set", Help: "The current kitten version."})
 	// @
 	at.EntryPoint(root)
 	// update-self

--- a/tools/cmd/update_self/main.go
+++ b/tools/cmd/update_self/main.go
@@ -71,7 +71,7 @@ func update_self(version string) (err error) {
 func EntryPoint(root *cli.Command) *cli.Command {
 	sc := root.AddSubCommand(&cli.Command{
 		Name:             "update-self",
-		Usage:            "update-self [options ...]",
+		Usage:            "[options]",
 		ShortDescription: "Update this kitten binary",
 		HelpText:         "Update this kitten binary in place to the latest available version.",
 		Run: func(cmd *cli.Command, args []string) (ret int, err error) {


### PR DESCRIPTION
Also fix duplicate subcommand names in `Usage`.
```text
Usage: kitten edit-in-kitty edit-in-kitty [options] file-to-edit
```

Env var `KITTY_KITTEN_EXE` is not available when shell integration is **manually enabled**, is this intentional?

Why not use `KITTY_BIN_DIR` and add the bin directory to the PATH?
This will make `kitty` also available, are you not wanting to deal with "don't ever touch my PATH"?

I'll leave the bash/zsh completion to you.

`KITTY_KITTEN_EXE` is used only if `kitten` is not defined by the user or is not in the PATH.
If you think this env var should override the user's `kitten` function or path (like prepending KITTY_BIN_DIR to PATH), please let me know.

Related issue:
https://github.com/kovidgoyal/kitty/issues/5956