### PR TITLE
Docs: Improve usage and help documents for kitten

### DIFF
--- a/tools/cmd/at/shell.go
+++ b/tools/cmd/at/shell.go
@@ -110,6 +110,8 @@ func show_basic_help() {
 			fmt.Fprintln(&output, "   ", sc.ShortDescription)
 		}
 	}
+	fmt.Fprintln(&output, " ", formatter.Green("help"))
+	fmt.Fprintln(&output, "   ", "Show this help")
 	fmt.Fprintln(&output, " ", formatter.Green("exit"))
 	fmt.Fprintln(&output, "   ", "Exit this shell")
 	cli.ShowHelpInPager(output.String())

--- a/tools/cmd/completion/kitty.go
+++ b/tools/cmd/completion/kitty.go
@@ -87,7 +87,7 @@ func EntryPoint(tool_root *cli.Command) {
 		Name: "__complete__", Hidden: true,
 		Usage:            "output_type [shell state...]",
 		ShortDescription: "Generate completions for kitty commands",
-		HelpText:         "Generate completion candidates for kitty commands. The command line is read from STDIN. output_type can be one of the supported  shells or 'json' for JSON output.",
+		HelpText:         "Generate completion candidates for kitty commands. The command line is read from STDIN. output_type can be one of the supported shells or :code:`json` for JSON output.",
 		Run: func(cmd *cli.Command, args []string) (ret int, err error) {
 			return ret, cli.GenerateCompletions(args)
 		},

--- a/tools/cmd/update_self/main.go
+++ b/tools/cmd/update_self/main.go
@@ -71,7 +71,7 @@ func update_self(version string) (err error) {
 func EntryPoint(root *cli.Command) *cli.Command {
 	sc := root.AddSubCommand(&cli.Command{
 		Name:             "update-self",
-		Usage:            "update-self [options ...]",
+		Usage:            "[options]",
 		ShortDescription: "Update this kitten binary",
 		HelpText:         "Update this kitten binary in place to the latest available version.",
 		Run: func(cmd *cli.Command, args []string) (ret int, err error) {
@@ -89,7 +89,7 @@ func EntryPoint(root *cli.Command) *cli.Command {
 	sc.Add(cli.OptionSpec{
 		Name:    "--fetch-version",
 		Default: "latest",
-		Help:    "The version to fetch. The special words :code:`latest` and :code:`nightly` fetch the latest stable and nightly release respectively. Other values can be, for example: 0.27.1.",
+		Help:    fmt.Sprintf("The version to fetch. The special words :code:`latest` and :code:`nightly` fetch the latest stable and nightly release respectively. Other values can be, for example: :code:`%s`.", kitty.VersionString),
 	})
 	return sc
 }


### PR DESCRIPTION
- The fix from a previous PR that was submitted but not merged, duplicate subcommand name `update-self` in usage.
- Show `help` in the kitty shell help, just for completeness.
- Adds a text role to the available value to apply the color.
- Use the current version in the example, so you don't need to maintain this every time you update the version in the future, otherwise it will look outdated.