### PR TITLE
Docs: Remove the text role target that is no longer needed

### DIFF
--- a/kitty/launch.py
+++ b/kitty/launch.py
@@ -58,7 +58,7 @@ Where to launch the child process:
 :code:`tab`
     A new :term:`tab` in the current OS window
 
-:code:`os-window <os_window>`
+:code:`os-window`
     A new :term:`operating system window <os_window>`
 
 :code:`overlay`


### PR DESCRIPTION
Forgot to remove the text role target when changing `term` to `code`.