### PR TITLE
Update go.mod to use 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kitty
 
-go 1.19
+go 1.20
 
 require (
 	github.com/ALTree/bigfloat v0.0.0-20220102081255-38c8b72a9924


### PR DESCRIPTION
unsafeutil_modern.go has a feature that requires go 1.20