### PR TITLE
Use strict function prototypes

### DIFF
--- a/glfw/dbus_glfw.c
+++ b/glfw/dbus_glfw.c
@@ -174,7 +174,7 @@ glfw_dbus_dispatch(DBusConnection *conn) {
 }
 
 void
-glfw_dbus_session_bus_dispatch() {
+glfw_dbus_session_bus_dispatch(void) {
     if (session_bus) glfw_dbus_dispatch(session_bus);
 }
 
@@ -344,7 +344,7 @@ glfw_dbus_connect_to_session_bus(void) {
 }
 
 DBusConnection *
-glfw_dbus_session_bus() {
+glfw_dbus_session_bus(void) {
     if (!session_bus) glfw_dbus_connect_to_session_bus();
     return session_bus;
 }

--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -1952,12 +1952,12 @@ primary_selection_copy_callback_done(void *data, struct wl_callback *callback, u
     wl_callback_destroy(callback);
 }
 
-void _glfwSetupWaylandDataDevice() {
+void _glfwSetupWaylandDataDevice(void) {
     _glfw.wl.dataDevice = wl_data_device_manager_get_data_device(_glfw.wl.dataDeviceManager, _glfw.wl.seat);
     if (_glfw.wl.dataDevice) wl_data_device_add_listener(_glfw.wl.dataDevice, &data_device_listener, NULL);
 }
 
-void _glfwSetupWaylandPrimarySelectionDevice() {
+void _glfwSetupWaylandPrimarySelectionDevice(void) {
     _glfw.wl.primarySelectionDevice = zwp_primary_selection_device_manager_v1_get_device(_glfw.wl.primarySelectionDeviceManager, _glfw.wl.seat);
     if (_glfw.wl.primarySelectionDevice) zwp_primary_selection_device_v1_add_listener(_glfw.wl.primarySelectionDevice, &primary_selection_device_listener, NULL);
 }

--- a/kittens/choose/unix_compat.c
+++ b/kittens/choose/unix_compat.c
@@ -19,7 +19,7 @@
 #endif
 
 int
-cpu_count() {
+cpu_count(void) {
     return sysconf(_SC_NPROCESSORS_ONLN);
 }
 

--- a/kitty/cursor.c
+++ b/kitty/cursor.c
@@ -321,7 +321,7 @@ copy(Cursor *self, PyObject *a UNUSED) {
     return (PyObject*)cursor_copy(self);
 }
 
-Cursor *alloc_cursor() {
+Cursor *alloc_cursor(void) {
     return (Cursor*)new(&Cursor_Type, NULL, NULL);
 }
 

--- a/kitty/gl-wrapper.h
+++ b/kitty/gl-wrapper.h
@@ -6146,7 +6146,7 @@ int gladLoadGLUserPtr( GLADuserptrloadfunc load, void *userptr) {
 int gladLoadGL( GLADloadfunc load) {
     return gladLoadGLUserPtr( glad_gl_get_proc_from_userptr, GLAD_GNUC_EXTENSION (void*) load);
 }
-void gladInstallGLDebug() {
+void gladInstallGLDebug(void) {
     glad_debug_glActiveTexture = glad_debug_impl_glActiveTexture;
     glad_debug_glAttachShader = glad_debug_impl_glAttachShader;
     glad_debug_glBeginConditionalRender = glad_debug_impl_glBeginConditionalRender;
@@ -6517,7 +6517,7 @@ void gladInstallGLDebug() {
     glad_debug_glViewport = glad_debug_impl_glViewport;
     glad_debug_glWaitSync = glad_debug_impl_glWaitSync;
 }
-void gladUninstallGLDebug() {
+void gladUninstallGLDebug(void) {
     glad_debug_glActiveTexture = glad_glActiveTexture;
     glad_debug_glAttachShader = glad_glAttachShader;
     glad_debug_glBeginConditionalRender = glad_glBeginConditionalRender;

--- a/kitty/gl.c
+++ b/kitty/gl.c
@@ -39,7 +39,7 @@ check_for_gl_error(void UNUSED *ret, const char *name, GLADapiproc UNUSED funcpt
 }
 
 void
-gl_init() {
+gl_init(void) {
     static bool glad_loaded = false;
     if (!glad_loaded) {
         int gl_version = gladLoadGL(glfwGetProcAddress);

--- a/kitty/line.c
+++ b/kitty/line.c
@@ -954,7 +954,7 @@ PyTypeObject Line_Type = {
     .tp_new = new
 };
 
-Line *alloc_line() {
+Line *alloc_line(void) {
     Line *ans = (Line*)PyType_GenericAlloc(&Line_Type, 0);
     ans->needs_free = 0;
     return ans;

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -647,7 +647,7 @@ closest_window_for_event(unsigned int *window_idx) {
 }
 
 void
-focus_in_event() {
+focus_in_event(void) {
     // Ensure that no URL is highlighted and the mouse cursor is in default shape
     bool in_tab_bar;
     unsigned int window_idx = 0;
@@ -661,7 +661,7 @@ focus_in_event() {
 }
 
 void
-enter_event() {
+enter_event(void) {
 #ifdef __APPLE__
     // On cocoa there is no way to configure the window manager to
     // focus windows on mouse enter, so we do it ourselves

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -187,7 +187,7 @@ free_bgimage(BackgroundImage **bgimage, bool release_texture) {
 }
 
 OSWindow*
-add_os_window() {
+add_os_window(void) {
     WITH_OS_WINDOW_REFS
     ensure_space_for(&global_state, os_windows, OSWindow, global_state.num_os_windows + 1, capacity, 1, true);
     OSWindow *ans = global_state.os_windows + global_state.num_os_windows++;


### PR DESCRIPTION
Fixes clang error:
error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]