### PR TITLE
IME: Fix IME commit text and update pre-edit at the same time

### DIFF
--- a/kitty/screen.h
+++ b/kitty/screen.h
@@ -74,8 +74,8 @@ typedef struct {
     index_type xstart, ynum, xnum;
 
     struct {
-      PyObject *overlay_text;
-      const char *func_name;
+        PyObject *overlay_text;
+        const char *func_name;
     } save;
 } OverlayLine;
 


### PR DESCRIPTION
Fix the bug when IME uses single key to confirm and update pre-edit text.

- Correctly update the overlay position when cursor visibility changes.
- Restore the overlay line only when the cursor is visible.
- Clear the saved overlay when drawing new pre-edit text.
- Also update the cursor position when screen size changes.
- Use four spaces to indent instead of two.

When IME confirming text with a single key and updating the pre-edit text, the overlay is drawn at the initial x coordinate since the cursor position is not updated. Saving the overlay at this point will deactivate it and update cursor->x.
When deactivated, the line is marked as dirty and immediately redrawn, and it will appear that the confirmed text is drawn after the current pre-edit text.

So when the confirmed text is `kitty` and the next pre-edit text is `t`, the cursor->x will be updated to follow the current overlay, i.e. `cursor->x = 1`. `kitty` will be drawn from the second cell, and `tkitt|y` will appear (the cursor is in the sixth cell).

Before this PR, although the overlay text was saved when entering the cursor hiding mode, the overlay was restored immediately due to SGR and cursor movement that followed. The cursor x was incorrectly updated to xstart, the initial position, when it was saved (deactivate was called), so the second confirmed text position drawn next is also wrong.

When the second confirmed text is `terminal`, even if the program has asked to move the cursor to `1,6`, `terminal` still draws from the first cell and overwrites `kitty`, and finally moves the cursor to `1,14`.

See: https://github.com/kovidgoyal/kitty/issues/5996#issuecomment-1423084528

Related:
https://github.com/kovidgoyal/kitty/pull/5886
https://github.com/kovidgoyal/kitty/issues/5716

Slightly tested:
- the built-in CJK input methods on macOS Ventura 13.2
- RIME on macOS and Linux X11 IBus, Wayland Fcitx5
- VIM v9.0.981
- Neovim v0.8.3
- Kakoune v2022.10.31

@astralhpi @YaQia
I don't want to break anyone else's IME, and it would be nice if you could test to see whether it works for you.
Especially on Linux platforms, enabling status line for vim/neovim, e.g. `vim --clean`, `nvim --clean`, let the cursor change position and draw text when hidden.

Thank you!