### PR TITLE
Get go version from go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ env:
     ASAN_OPTIONS: leak_check_at_exit=0
     LC_ALL: en_US.UTF-8
     LANG: en_US.UTF-8
-    GO_INSTALL_VERSION: ">=1.20.0"
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -58,7 +57,7 @@ jobs:
           - name: Install Go
             uses: actions/setup-go@v3
             with:
-              go-version: ${{ env.GO_INSTALL_VERSION }}
+              go-version-file: go.mod
 
           - name: Build kitty
             run: python .github/workflows/ci.py build
@@ -88,7 +87,7 @@ jobs:
           - name: Install Go
             uses: actions/setup-go@v3
             with:
-              go-version: ${{ env.GO_INSTALL_VERSION }}
+              go-version-file: go.mod
 
           - name: Install build-only deps
             run: python -m pip install -r docs/requirements.txt ruff mypy types-requests types-docutils
@@ -137,7 +136,7 @@ jobs:
           - name: Install Go
             uses: actions/setup-go@v3
             with:
-              go-version: ${{ env.GO_INSTALL_VERSION }}
+              go-version-file: go.mod
 
           - name: Build kitty
             run: which python3 && python3 .github/workflows/ci.py build
@@ -162,7 +161,7 @@ jobs:
           - name: Install Go
             uses: actions/setup-go@v3
             with:
-              go-version: ${{ env.GO_INSTALL_VERSION }}
+              go-version-file: go.mod
 
           - name: Build kitty
             run: python3 .github/workflows/ci.py build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
               fetch-depth: 10
 
           - name: Set up Python ${{ matrix.pyver }}
-            uses: actions/setup-python@v3
+            uses: actions/setup-python@v4
             with:
               python-version: ${{ matrix.pyver }}
 
@@ -80,7 +80,7 @@ jobs:
             run: if grep -Inr '\s$' kitty kitty_tests kittens docs *.py *.asciidoc *.rst *.go .gitattributes .gitignore; then echo Trailing whitespace found, aborting.; exit 1; fi
 
           - name: Set up Python
-            uses: actions/setup-python@v3
+            uses: actions/setup-python@v4
             with:
               python-version: "3.10"
 
@@ -104,7 +104,7 @@ jobs:
           - name: Build kitty
             run: python setup.py build --debug
 
-          - name: Build static kitty-tool
+          - name: Build static kitten
             run: python setup.py build-static-binaries
 
           - name: Run mypy
@@ -129,7 +129,7 @@ jobs:
             KITTY_BUNDLE: 1
         steps:
           - name: Checkout source code
-            uses: actions/checkout@master
+            uses: actions/checkout@v3
             with:
               fetch-depth: 10
 
@@ -149,12 +149,12 @@ jobs:
         runs-on: macos-latest
         steps:
           - name: Checkout source code
-            uses: actions/checkout@master
+            uses: actions/checkout@v3
             with:
               fetch-depth: 0  # needed for :commit: docs role
 
           - name: Set up Python
-            uses: actions/setup-python@v3
+            uses: actions/setup-python@v4
             with:
               python-version: "3.10"
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,17 +23,17 @@ jobs:
 
     steps:
 
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version-file: go.mod
-
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
         fetch-depth: 2
+
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: go.mod
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
-        languages: python, c
+        languages: python, c, go
         setup-python-dependencies: false
 
     - name: Build kitty
       run: python3 .github/workflows/ci.py build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: ">=1.20.0"
+        go-version-file: go.mod
 
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -46,7 +46,7 @@ Run-time dependencies:
 Build-time dependencies:
 
 * ``gcc`` or ``clang``
-* ``go >= 1.20`` (see :file:`go.mod` for go packages used during building)
+* ``go`` >= _build_go_version (see :file:`go.mod` for go packages used during building)
 * ``pkg-config``
 * For building on Linux in addition to the above dependencies you might also
   need to install the following packages, if they are not already installed by

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -40,7 +40,7 @@ Detailed list of changes
 
 - Text rendering: Use sRGB correct linear gamma blending for nicer font rendering and better color accuracy with transparent windows. See the option :opt:`text_composition_strategy` for details. The obsolete :opt:`macos_thicken_font` will make the font too thick and needs to be removed manually if it is configured. (:pull:`5969`)
 
-- Fix a regression in 0.27.0 that broke kitty @ set-font-size 0 (:iss:`5992`)
+- Fix a regression in 0.27.0 that broke ``kitty @ set-font-size 0`` (:iss:`5992`)
 
 - launch: When using ``--cwd=current`` for a remote system support running non shell commands as well (:disc:`5987`)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,8 +106,17 @@ rst_prolog = '''
 '''.replace('VERSION', str_version)
 smartquotes_action = 'qe'  # educate quotes and ellipses but not dashes
 
+def go_version(go_mod_path: str) -> str:  # {{{
+    with open(go_mod_path) as f:
+        for line in f:
+            if line.startswith('go '):
+                return line.strip().split()[1]
+    raise SystemExit(f'No Go version in {go_mod_path}')
+# }}}
+
 string_replacements = {
     '_kitty_install_cmd': 'curl -L https://sw.kovidgoyal.net/kitty/installer.sh | sh /dev/stdin',
+    '_build_go_version': go_version('../go.mod'),
 }
 
 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -248,20 +248,20 @@ are composited. This will make dark text on light backgrounds look thicker and
 light text on dark backgrounds thinner. It might also make some text appear like
 the strokes are uneven.
 
-You can fine tune the actual contrast curve used for glyph composition
-by specifying two space separated numbers for this setting.
+You can fine tune the actual contrast curve used for glyph composition by
+specifying two space separated numbers for this setting.
 
 The first number is the gamma adjustment, which controls the thickness of dark
 text on light backgrounds. Increasing the value will make text appear thicker.
 The default value for this is :code:`1.0` on Linux and :code:`1.7` on macOS.
-Valid values are :code:`0.01` and above. The result is scaled based on the luminance
-difference between the background and the foreground.  Dark text on light
-backgrounds receives the full impact of the curve while light text on dark
+Valid values are :code:`0.01` and above. The result is scaled based on the
+luminance difference between the background and the foreground. Dark text on
+light backgrounds receives the full impact of the curve while light text on dark
 backgrounds is affected very little.
 
 The second number is an additional multiplicative contrast. It is percentage
-ranging from 0 to 100. The default value is :code:`0` on Linux and :code:`30`
-on macOS.
+ranging from :code:`0` to :code:`100`. The default value is :code:`0` on Linux
+and :code:`30` on macOS.
 ''')
 
 egr()  # }}}


### PR DESCRIPTION
No need to update multiple places when bumping the go version.
Also bump versions of the deprecated github actions to the latest.