### PR TITLE
macOS: Update window button visibility after toggling full screen

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -50,6 +50,8 @@ Detailed list of changes
 
 - Linux: Reduce minimum required OpenGL version from 3.3 to 3.1 + extensions (:iss:`2790`)
 
+- macOS: Fix the window buttons not being hidden after exiting the traditional full screen (:iss:`6009`)
+
 
 0.27.1 [2023-02-07]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -2568,6 +2568,19 @@ bool _glfwPlatformToggleFullscreen(_GLFWwindow* w, unsigned int flags) {
         if (in_fullscreen) made_fullscreen = false;
         [window toggleFullScreen: nil];
     }
+    // Update window button visibility
+    if (w->ns.titlebar_hidden) {
+        // The hidden buttons might be automatically reset to be visible after going full screen
+        // to show up in the auto-hide title bar, so they need to be set back to hidden.
+        BOOL button_hidden = YES;
+        // When title bar is configured to be hidden, it should be shown with buttons (auto-hide) after going to full screen.
+        if (!traditional) {
+            button_hidden = (BOOL) !made_fullscreen;
+        }
+        [[window standardWindowButton: NSWindowCloseButton] setHidden:button_hidden];
+        [[window standardWindowButton: NSWindowMiniaturizeButton] setHidden:button_hidden];
+        [[window standardWindowButton: NSWindowZoomButton] setHidden:button_hidden];
+    }
     return made_fullscreen;
 }
 


### PR DESCRIPTION
When the window title bar is configured to be hidden, the window control buttons should be displayed on the auto-hide title bar instead of a blank title bar when going to full screen.

When full screen is in traditional mode, hide the window button after exiting full screen.

Fixes https://github.com/kovidgoyal/kitty/issues/6009

It may still report `ruff` errors, but I don't bother to add an explicit E704 ignore.