### PR TITLE
Reload mime.types custom MIME config

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -50,6 +50,8 @@ Detailed list of changes
 
 - Linux: Reduce minimum required OpenGL version from 3.3 to 3.1 + extensions (:iss:`2790`)
 
+- When reloading configuration, also reload custom MIME types from :file:`mime.types` config file (:pull:`6012`)
+
 
 0.27.1 [2023-02-07]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/kittens/transfer/utils.py
+++ b/kittens/transfer/utils.py
@@ -5,10 +5,10 @@ import os
 import secrets
 from contextlib import contextmanager
 from datetime import timedelta
-from mimetypes import guess_type
 from typing import Generator, Union
 
 from kitty.fast_data_types import truncate_point_for_length, wcswidth
+from kitty.guess_mime_type import guess_type
 
 from ..tui.operations import styled
 from ..tui.progress import render_progress_bar
@@ -121,7 +121,7 @@ def should_be_compressed(path: str) -> bool:
     ext = path.rpartition(os.extsep)[-1].lower()
     if ext in ('zip', 'odt', 'odp', 'pptx', 'docx', 'gz', 'bz2', 'xz', 'svgz'):
         return False
-    mt = guess_type(path)[0] or ''
+    mt = guess_type(path) or ''
     if mt:
         if mt.endswith('+zip'):
             return False

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -2385,6 +2385,8 @@ class Boss:
         self.apply_new_options(opts)
         from .open_actions import clear_caches
         clear_caches()
+        from .guess_mime_type import clear_mime_cache
+        clear_mime_cache()
 
     def safe_delete_temp_file(self, path: str) -> None:
         if is_path_in_temp_dir(path):

--- a/kitty/guess_mime_type.py
+++ b/kitty/guess_mime_type.py
@@ -60,6 +60,11 @@ def initialize_mime_database() -> None:
         init((local_defs,))
 
 
+def clear_mime_cache() -> None:
+    if hasattr(initialize_mime_database, 'inited'):
+        delattr(initialize_mime_database, 'inited')
+
+
 def guess_type(path: str, allow_filesystem_access: bool = False) -> Optional[str]:
     is_dir = is_exe = False
 


### PR DESCRIPTION
- When reloading configuration, also reload `mime.types`
- transfer kitten: Use guess_type with custom MIME

After modifying `mime.types`, reloading the configuration will take effect immediately without having to end the kitty process and restart it.