### PR TITLE
Add send_mouse_event to fast_data_types.pyi

### DIFF
--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -1338,6 +1338,10 @@ def mouse_selection(os_window_id: int, tab_id: int, window_id: int, code: int, b
     pass
 
 
+def send_mouse_event(screen: Screen, x: int, y: int, button: int, action: int, mods: int) -> bool:
+    pass
+
+
 def set_window_logo(os_window_id: int, tab_id: int, window_id: int, path: str, position: str, alpha: float) -> None:
     pass
 


### PR DESCRIPTION
I wanted to add types to my kitten using this function, and realized it was missing.