### PR TITLE
Add x-scheme-handler/ssh to mimetypes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1126,7 +1126,7 @@ Exec=kitty +open %U
 Icon=kitty
 Categories=System;TerminalEmulator;
 NoDisplay=true
-MimeType=image/*;application/x-sh;application/x-shellscript;inode/directory;text/*;x-scheme-handler/kitty;
+MimeType=image/*;application/x-sh;application/x-shellscript;inode/directory;text/*;x-scheme-handler/kitty;x-scheme-handler/ssh;
 '''
             )
 


### PR DESCRIPTION
Add x-scheme-handler/ssh to mimetypes so that kitty open can be used to open ssh links by default.