### PR TITLE
Fix image distortion when switching between screens

### DIFF
--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -977,6 +977,7 @@ screen_toggle_screen_buffer(Screen *self, bool save_cursor, bool clear_alt_scree
     }
     screen_history_scroll(self, SCROLL_FULL, false);
     self->is_dirty = true;
+    self->grman->layers_dirty = true;
     clear_selection(&self->selections);
     global_state.check_for_active_animated_images = true;
 }


### PR DESCRIPTION
This PR fixes a bug when images appear in wrong places when switching from the alternate screen back to the main screen.
Not sure if it's the best way to fix the bug though, maybe there is actually a deeper problem underlying it.

To reproduce the bug:

1) Display an image `kitten icat logo/kitty.png`
2) Switch to the alternate screen `tput smcup`
3) Display another image (it should be in a different position or have a different size)
4) Switch back to the main screen `tput rmcup`

Image 1 will appear in the wrong location (actually in the location of image 2).