### PR TITLE
IME: Render overlay at the last visible cursor position and improvements under macOS

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -46,7 +46,7 @@ Detailed list of changes
 
 - When changing the cursor color via escape codes or remote control to a fixed color, do not reset cursor_text_color (:iss:`5994`)
 
-- Input Method Extensions: Fix incorrect rendering of IME in-progress text in some situations (:pull:`6002`)
+- Input Method Extensions: Fix incorrect rendering of IME in-progress and commited text in some situations (:pull:`6049`)
 
 - Linux: Reduce minimum required OpenGL version from 3.3 to 3.1 + extensions (:iss:`2790`)
 

--- a/glfw/glfw3.h
+++ b/glfw/glfw3.h
@@ -1732,6 +1732,7 @@ typedef enum {
 } GLFWClipboardType;
 typedef GLFWDataChunk (* GLFWclipboarditerfun)(const char *mime_type, void *iter, GLFWClipboardType ctype);
 typedef bool (* GLFWclipboardwritedatafun)(void *object, const char *data, size_t sz);
+typedef bool (* GLFWimecursorpositionfun)(GLFWwindow *window, GLFWIMEUpdateEvent *ev);
 
 /*! @brief Video mode type.
  *
@@ -1891,6 +1892,7 @@ GLFWAPI void glfwRemoveTimer(unsigned long long);
 GLFWAPI GLFWdrawtextfun glfwSetDrawTextFunction(GLFWdrawtextfun function);
 GLFWAPI GLFWcurrentselectionfun glfwSetCurrentSelectionCallback(GLFWcurrentselectionfun callback);
 GLFWAPI GLFWhascurrentselectionfun glfwSetHasCurrentSelectionCallback(GLFWhascurrentselectionfun callback);
+GLFWAPI GLFWimecursorpositionfun glfwSetIMECursorPositionCallback(GLFWimecursorpositionfun callback);
 
 /*! @brief Terminates the GLFW library.
  *

--- a/glfw/init.c
+++ b/glfw/init.c
@@ -402,3 +402,10 @@ GLFWAPI GLFWhascurrentselectionfun glfwSetHasCurrentSelectionCallback(GLFWhascur
     _GLFW_SWAP_POINTERS(_glfw.callbacks.has_current_selection, cbfun);
     return cbfun;
 }
+
+GLFWAPI GLFWimecursorpositionfun glfwSetIMECursorPositionCallback(GLFWimecursorpositionfun cbfun)
+{
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFW_SWAP_POINTERS(_glfw.callbacks.get_ime_cursor_position, cbfun);
+    return cbfun;
+}

--- a/glfw/internal.h
+++ b/glfw/internal.h
@@ -635,6 +635,7 @@ struct _GLFWlibrary
         GLFWdrawtextfun draw_text;
         GLFWcurrentselectionfun get_current_selection;
         GLFWhascurrentselectionfun has_current_selection;
+        GLFWimecursorpositionfun get_ime_cursor_position;
     } callbacks;
 
 

--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -626,8 +626,16 @@ cursor_needs_render(Window *w) {
 static bool
 collect_cursor_info(CursorRenderInfo *ans, Window *w, monotonic_t now, OSWindow *os_window) {
     ScreenRenderData *rd = &w->render_data;
-    Cursor *cursor = rd->screen->cursor;
-    ans->x = cursor->x; ans->y = cursor->y;
+    Cursor *cursor;
+    if (screen_is_overlay_active(rd->screen)) {
+        // Do not force the cursor to be visible here for the sake of some programs that prefer it hidden
+        cursor = &(rd->screen->overlay_line.original_line.cursor);
+        ans->x = rd->screen->overlay_line.cursor_x;
+        ans->y = rd->screen->overlay_line.ynum;
+    } else {
+        cursor = rd->screen->cursor;
+        ans->x = cursor->x; ans->y = cursor->y;
+    }
     ans->is_visible = false;
     if (rd->screen->scrolled_by || !screen_is_cursor_visible(rd->screen)) return cursor_needs_render(w);
     monotonic_t time_since_start_blink = now - os_window->cursor_blink_zero_time;

--- a/kitty/glfw-wrapper.c
+++ b/kitty/glfw-wrapper.c
@@ -44,6 +44,9 @@ load_glfw(const char* path) {
     *(void **) (&glfwSetHasCurrentSelectionCallback_impl) = dlsym(handle, "glfwSetHasCurrentSelectionCallback");
     if (glfwSetHasCurrentSelectionCallback_impl == NULL) fail("Failed to load glfw function glfwSetHasCurrentSelectionCallback with error: %s", dlerror());
 
+    *(void **) (&glfwSetIMECursorPositionCallback_impl) = dlsym(handle, "glfwSetIMECursorPositionCallback");
+    if (glfwSetIMECursorPositionCallback_impl == NULL) fail("Failed to load glfw function glfwSetIMECursorPositionCallback with error: %s", dlerror());
+
     *(void **) (&glfwTerminate_impl) = dlsym(handle, "glfwTerminate");
     if (glfwTerminate_impl == NULL) fail("Failed to load glfw function glfwTerminate with error: %s", dlerror());
 

--- a/kitty/glfw-wrapper.h
+++ b/kitty/glfw-wrapper.h
@@ -1470,6 +1470,7 @@ typedef enum {
 } GLFWClipboardType;
 typedef GLFWDataChunk (* GLFWclipboarditerfun)(const char *mime_type, void *iter, GLFWClipboardType ctype);
 typedef bool (* GLFWclipboardwritedatafun)(void *object, const char *data, size_t sz);
+typedef bool (* GLFWimecursorpositionfun)(GLFWwindow *window, GLFWIMEUpdateEvent *ev);
 
 /*! @brief Video mode type.
  *
@@ -1666,6 +1667,10 @@ GFW_EXTERN glfwSetCurrentSelectionCallback_func glfwSetCurrentSelectionCallback_
 typedef GLFWhascurrentselectionfun (*glfwSetHasCurrentSelectionCallback_func)(GLFWhascurrentselectionfun);
 GFW_EXTERN glfwSetHasCurrentSelectionCallback_func glfwSetHasCurrentSelectionCallback_impl;
 #define glfwSetHasCurrentSelectionCallback glfwSetHasCurrentSelectionCallback_impl
+
+typedef GLFWimecursorpositionfun (*glfwSetIMECursorPositionCallback_func)(GLFWimecursorpositionfun);
+GFW_EXTERN glfwSetIMECursorPositionCallback_func glfwSetIMECursorPositionCallback_impl;
+#define glfwSetIMECursorPositionCallback glfwSetIMECursorPositionCallback_impl
 
 typedef void (*glfwTerminate_func)(void);
 GFW_EXTERN glfwTerminate_func glfwTerminate_impl;

--- a/kitty/keys.c
+++ b/kitty/keys.c
@@ -102,8 +102,8 @@ update_ime_focus(OSWindow *osw, bool focused) {
 }
 
 void
-update_ime_position(Window* w, Screen *screen) {
-    unsigned int cell_width = global_state.callback_os_window->fonts_data->cell_width, cell_height = global_state.callback_os_window->fonts_data->cell_height;
+prepare_ime_position_update_event(OSWindow *osw, Window *w, Screen *screen, GLFWIMEUpdateEvent *ev) {
+    unsigned int cell_width = osw->fonts_data->cell_width, cell_height = osw->fonts_data->cell_height;
     unsigned int left = w->geometry.left, top = w->geometry.top;
     if (screen_is_overlay_active(screen)) {
         left += screen->overlay_line.cursor_x * cell_width;
@@ -112,8 +112,15 @@ update_ime_position(Window* w, Screen *screen) {
         left += screen->cursor->x * cell_width;
         top += screen->cursor->y * cell_height;
     }
+    ev->cursor.left = left; ev->cursor.top = top; ev->cursor.width = cell_width; ev->cursor.height = cell_height;
+}
+
+void
+update_ime_position(Window* w UNUSED, Screen *screen UNUSED) {
     GLFWIMEUpdateEvent ev = { .type = GLFW_IME_UPDATE_CURSOR_POSITION };
-    ev.cursor.left = left; ev.cursor.top = top; ev.cursor.width = cell_width; ev.cursor.height = cell_height;
+#ifndef __APPLE__
+    prepare_ime_position_update_event(global_state.callback_os_window, w, screen, &ev);
+#endif
     glfwUpdateIMEState(global_state.callback_os_window->handle, &ev);
 }
 

--- a/kitty/screen.h
+++ b/kitty/screen.h
@@ -68,15 +68,20 @@ typedef struct {
 
 
 typedef struct {
+    PyObject *overlay_text;
     CPUCell *cpu_cells;
     GPUCell *gpu_cells;
+    index_type xstart, ynum, xnum, cursor_x;
     bool is_active;
-    index_type xstart, ynum, xnum;
-
+    bool is_dirty;
     struct {
-        PyObject *overlay_text;
-        const char *func_name;
-    } save;
+        CPUCell *cpu_cells;
+        GPUCell *gpu_cells;
+        Cursor cursor;
+    } original_line;
+    struct {
+        index_type x, y;
+    } last_ime_pos;
 } OverlayLine;
 
 typedef struct {
@@ -264,7 +269,8 @@ void screen_dirty_sprite_positions(Screen *self);
 void screen_rescale_images(Screen *self);
 void screen_report_size(Screen *, unsigned int which);
 void screen_manipulate_title_stack(Screen *, unsigned int op, unsigned int which);
-void screen_draw_overlay_text(Screen *self, const char *utf8_text);
+bool screen_is_overlay_active(Screen *self);
+void screen_update_overlay_text(Screen *self, const char *utf8_text);
 void screen_set_key_encoding_flags(Screen *self, uint32_t val, uint32_t how);
 void screen_push_key_encoding_flags(Screen *self, uint32_t val);
 void screen_pop_key_encoding_flags(Screen *self, uint32_t num);

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -329,7 +329,7 @@ cell_update_uniform_block(ssize_t vao_idx, Screen *screen, int uniform_buffer, c
     // Cursor position
     enum { BLOCK_IDX = 0, BEAM_IDX = NUM_UNDERLINE_STYLES + 3, UNDERLINE_IDX = NUM_UNDERLINE_STYLES + 4, UNFOCUSED_IDX = NUM_UNDERLINE_STYLES + 5 };
     if (cursor->is_visible) {
-        rd->cursor_x = screen->cursor->x, rd->cursor_y = screen->cursor->y;
+        rd->cursor_x = cursor->x, rd->cursor_y = cursor->y;
         if (cursor->is_focused) {
             switch(cursor->shape) {
                 default:
@@ -341,11 +341,11 @@ cell_update_uniform_block(ssize_t vao_idx, Screen *screen, int uniform_buffer, c
             }
         } else rd->cursor_fg_sprite_idx = UNFOCUSED_IDX;
         color_type cell_fg = rd->default_fg, cell_bg = rd->default_bg;
-        index_type cell_color_x = screen->cursor->x;
-        bool cursor_ok = screen->cursor->x < screen->columns && screen->cursor->y < screen->lines;
+        index_type cell_color_x = cursor->x;
+        bool cursor_ok = cursor->x < screen->columns && cursor->y < screen->lines;
         bool reversed = false;
         if (cursor_ok) {
-            linebuf_init_line(screen->linebuf, screen->cursor->y);
+            linebuf_init_line(screen->linebuf, cursor->y);
             colors_for_cell(screen->linebuf->line, screen->color_profile, &cell_color_x, &cell_fg, &cell_bg, &reversed);
         }
         if (IS_SPECIAL_COLOR(cursor_color)) {


### PR DESCRIPTION
Render overlay at the last visible cursor position with a separate cursor.

Fix the problem caused by wrong cursor coordinates. No more messing with the main cursor, instead the cursor is saved when receiving a pre-edit text update and used for drawing later.

Update the overlay to the last visible cursor position before rendering to ensure it always moves with the cursor. Finally, draw the overlay after line rendering is complete, and restore the line buffer after updating the rendered data to ensure that the line text being read is correct at all times.

This also improves performance by only rendering once when changes are made, eliminating the need to repeatedly disable and draw after various commands and not even comprehensively.

Allow IME to actively get the cursor position in real time on macOS.

IME will automatically get the display position when needed, which keeps it consistent with the overlay as much as possible.
Fix the issue that when IME is activated after mouse click, it is displayed at the wrong position.

After the window is created, the initial activation of the IME will be in whatever position the cursor is located, not in the upper left corner.

Tested on:
- macOS, builtin CJK IME
- Linux X11/Wayland, IBUS/Fcitx5, RIME

Supersedes:
https://github.com/kovidgoyal/kitty/pull/6002

Please review, thank you.