### PR TITLE
macOS: Fix double-click the title bar to maximize the window does not occupy the full screen and others

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -1717,6 +1717,18 @@ void _glfwPlatformUpdateIMEState(_GLFWwindow *w, const GLFWIMEUpdateEvent *ev) {
     if (glfw_window && !glfw_window->decorated && glfw_window->ns.view) [self makeFirstResponder:glfw_window->ns.view];
 }
 
+- (void)zoom:(id)sender
+{
+    if (![self isZoomed]) {
+        const NSSize original = [self resizeIncrements];
+        [self setResizeIncrements:NSMakeSize(1.0, 1.0)];
+        [super zoom:sender];
+        [self setResizeIncrements:original];
+    } else {
+        [super zoom:sender];
+    }
+}
+
 @end
 // }}}
 
@@ -2065,10 +2077,7 @@ void _glfwPlatformRestoreWindow(_GLFWwindow* window)
 void _glfwPlatformMaximizeWindow(_GLFWwindow* window)
 {
     if (![window->ns.object isZoomed]) {
-        const NSSize original = [window->ns.object resizeIncrements];
-        [window->ns.object setResizeIncrements:NSMakeSize(1.0, 1.0)];
         [window->ns.object zoom:nil];
-        [window->ns.object setResizeIncrements:original];
     }
 }
 


### PR DESCRIPTION
- Fix resize_in_steps being applied when double-clicking on the title bar to maximize the window.
- Add comments to explain how to get the services related methods to be called and restore IME pre-edit text after inserting text from the service.

I've found one more annoying issue.

Using `launch --dont-take-focus` (`--keep-focus`) to create a new window, the `on_focus` callback will still be called. And there are four of these, the current window's as well as the new window, in and out.

And the side effect is not only this, it also causes IME composition to be cancelled.

I think any operation that creates, removes, changes the active window of an inactive tab, etc. should not trigger `on_focus_changed` as long as it does not actually change the current focus.

If you don't have time to debug this, where do you think is the best place to fix it?

I found that the KITTY_VCS_REV exists and is empty in the recent debug_config repots, which leads to `kitty 0.27.1 () ... ` a parenthesis with no content.
The related code has not been changed recently and the issue does not exist in the official release 0.26.5, is there a change in the build environment?