### PR TITLE
fix typo in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-indent_style = spaces
+indent_style = space
 indent_size = 4
 end_of_line = lf
 trim_trailing_whitespace = true


### PR DESCRIPTION
According to https://editorconfig.org/#file-format-details:

> indent_style: set to tab or space to use hard tabs or soft tabs respectively.

Apologies if this is known and the previous `spaces` syntax is preferred. In that case of course please just close the PR.

Thanks for kitty :cat: