### PR TITLE
Replace the deprecated imghdr module

### DIFF
--- a/kittens/show_error/main.py
+++ b/kittens/show_error/main.py
@@ -55,7 +55,7 @@ def real_main(args: List[str]) -> None:
         tb = data['tb']
         for ln in tb.splitlines():
             print('\r\n', ln, sep='', end='')
-        print(flush=True)
+        print(end='\r\n', flush=True)
     hold_till_enter()
 
 

--- a/kitty/rc/set_background_image.py
+++ b/kitty/rc/set_background_image.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 # License: GPLv3 Copyright: 2020, Kovid Goyal <kovid at kovidgoyal.net>
 
-import imghdr
 import os
 from base64 import standard_b64decode, standard_b64encode
 from typing import TYPE_CHECKING, Optional
 
 from kitty.types import AsyncResponse
+from kitty.utils import is_png
 
 from .base import (
     MATCH_WINDOW_OPTION,
@@ -89,7 +89,7 @@ failed, the command will exit with a success code.
         if path.lower() == 'none':
             ret['data'] = '-'
             return ret
-        if imghdr.what(path) != 'png':
+        if not is_png(path):
             self.fatal(f'{path} is not a PNG image')
 
         def file_pipe(path: str) -> CmdGenerator:

--- a/kitty/rc/set_window_logo.py
+++ b/kitty/rc/set_window_logo.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
 # License: GPLv3 Copyright: 2020, Kovid Goyal <kovid at kovidgoyal.net>
 
-
-import imghdr
 import os
 from base64 import standard_b64decode, standard_b64encode
 from typing import TYPE_CHECKING, Optional
 
 from kitty.types import AsyncResponse
+from kitty.utils import is_png
 
 from .base import (
     MATCH_WINDOW_OPTION,
@@ -85,7 +84,7 @@ failed, the command will exit with a success code.
         if path.lower() == 'none':
             ret['data'] = '-'
             return ret
-        if imghdr.what(path) != 'png':
+        if not is_png(path):
             self.fatal(f'{path} is not a PNG image')
 
         def file_pipe(path: str) -> CmdGenerator:

--- a/kitty/utils.py
+++ b/kitty/utils.py
@@ -1137,3 +1137,11 @@ def extract_all_from_tarfile_safely(tf: 'tarfile.TarFile', dest: str) -> None:
         tar.extractall(path, tar.getmembers(), numeric_owner=numeric_owner)
 
     safe_extract(tf, dest)
+
+
+def is_png(path: str) -> bool:
+    if path:
+        with suppress(Exception), open(path, 'rb') as f:
+            header = f.read(8)
+            return header.startswith(b'\211PNG\r\n\032\n')
+    return False


### PR DESCRIPTION
When running `. /tests.py mypy`, it shows the following message and fails (exit code 1).

```log
DeprecationWarning: 'imghdr' is deprecated and slated for removal in Python 3.13
```

I noticed that the relevant remote control commands cannot be executed via shortcuts.

```shell
kitty -o 'map f1 remote_control set-window-logo /path/to/png'
```

```log
kitty.rc.base.StreamError: No stream_id in rc payload
```

Since this is related to the remote control protocol, could you update the documentation if you have some time? (And maybe the async part, such as `async_id`)
https://sw.kovidgoyal.net/kitty/rc_protocol/

The detailed traceback is printed before the `Press e to see detailed traceback ...` line. This minor issue is not important.

I see the use of `NamedTemporaryFile` in setting the background image and logo, is it possible to use SHM to avoid higher file system IO (writes) when setting dynamically generated images in high frequency?

Is it intentional not to reload the background image after reloading the configuration?