### PR TITLE
Fix on_focus_change being fired even when the window focus is not actually changed

### DIFF
--- a/kitty/launch.py
+++ b/kitty/launch.py
@@ -18,7 +18,7 @@ from .options.utils import env as parse_env
 from .tabs import Tab, TabManager
 from .types import OverlayType, run_once
 from .utils import get_editor, log_error, resolve_custom_file, which
-from .window import CwdRequest, CwdRequestType, Watchers, Window
+from .window import CwdRequest, CwdRequestType, Watchers, Window, WindowFocusMayChange
 
 try:
     from typing import TypedDict
@@ -588,14 +588,13 @@ def launch(
             tab = tab_for_window(boss, opts, target_tab)
         if tab is not None:
             watchers = load_watch_modules(opts.watcher)
-            new_window: Window = tab.new_window(env=env or None, watchers=watchers or None, is_clone_launch=is_clone_launch, **kw)
+            with WindowFocusMayChange(keep_focus=opts.keep_focus, focus_os_window_when_needed=True):
+                new_window: Window = tab.new_window(env=env or None, watchers=watchers or None, is_clone_launch=is_clone_launch, **kw)
             if spacing:
                 patch_window_edges(new_window, spacing)
                 tab.relayout()
             if opts.color:
                 apply_colors(new_window, opts.color)
-            if opts.keep_focus and active:
-                boss.set_active_window(active, switch_os_window_if_needed=True, for_keep_focus=True)
             if opts.logo:
                 new_window.set_logo(opts.logo, opts.logo_position or '', opts.logo_alpha)
             if opts.type == 'overlay-main':

--- a/kitty/rc/detach_tab.py
+++ b/kitty/rc/detach_tab.py
@@ -3,6 +3,8 @@
 
 from typing import TYPE_CHECKING, Optional
 
+from kitty.window import WindowFocusMayChange
+
 from .base import MATCH_TAB_OPTION, ArgsType, Boss, MatchError, PayloadGetType, PayloadType, RCOptions, RemoteCommand, ResponseType, Window
 
 if TYPE_CHECKING:
@@ -43,7 +45,8 @@ Detach the tab this command is run in, rather than the active tab.
 
         for tab in self.tabs_for_match_payload(boss, window, payload_get):
             if tab:
-                boss._move_tab_to(tab=tab, **kwargs)
+                with WindowFocusMayChange():
+                    boss._move_tab_to(tab=tab, **kwargs)
         return None
 
 

--- a/kitty/rc/detach_window.py
+++ b/kitty/rc/detach_window.py
@@ -3,6 +3,8 @@
 
 from typing import TYPE_CHECKING, Optional, Union
 
+from kitty.window import WindowFocusMayChange
+
 from .base import MATCH_TAB_OPTION, MATCH_WINDOW_OPTION, ArgsType, Boss, MatchError, PayloadGetType, PayloadType, RCOptions, RemoteCommand, ResponseType, Window
 
 if TYPE_CHECKING:
@@ -52,7 +54,8 @@ Detach the window this command is run in, rather than the active window.
         kwargs = {'target_os_window_id': newval} if target_tab_id is None else {'target_tab_id': target_tab_id}
         for window in windows:
             if window:
-                boss._move_window_to(window=window, **kwargs)
+                with WindowFocusMayChange():
+                    boss._move_window_to(window=window, **kwargs)
         return None
 
 

--- a/kitty/rc/focus_tab.py
+++ b/kitty/rc/focus_tab.py
@@ -4,6 +4,8 @@
 
 from typing import TYPE_CHECKING, Optional
 
+from kitty.window import WindowFocusMayChange
+
 from .base import MATCH_TAB_OPTION, ArgsType, Boss, PayloadGetType, PayloadType, RCOptions, RemoteCommand, ResponseType, Window
 
 if TYPE_CHECKING:
@@ -33,7 +35,8 @@ using this option means that you will not be notified of failures.
     def response_from_kitty(self, boss: Boss, window: Optional[Window], payload_get: PayloadGetType) -> ResponseType:
         for tab in self.tabs_for_match_payload(boss, window, payload_get):
             if tab:
-                boss.set_active_tab(tab)
+                with WindowFocusMayChange():
+                    boss.set_active_tab(tab)
                 break
         return None
 

--- a/kitty/rc/focus_window.py
+++ b/kitty/rc/focus_window.py
@@ -5,6 +5,7 @@
 from typing import TYPE_CHECKING, Optional
 
 from kitty.fast_data_types import focus_os_window
+from kitty.window import WindowFocusMayChange
 
 from .base import MATCH_WINDOW_OPTION, ArgsType, Boss, PayloadGetType, PayloadType, RCOptions, RemoteCommand, ResponseType, Window
 
@@ -33,9 +34,10 @@ the command will exit with a success code.
     def response_from_kitty(self, boss: Boss, window: Optional[Window], payload_get: PayloadGetType) -> ResponseType:
         for window in self.windows_for_match_payload(boss, window, payload_get):
             if window:
-                os_window_id = boss.set_active_window(window)
-                if os_window_id:
-                    focus_os_window(os_window_id, True)
+                with WindowFocusMayChange():
+                    os_window_id = boss.set_active_window(window)
+                    if os_window_id:
+                        focus_os_window(os_window_id, True)
                 break
         return None
 

--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -58,7 +58,7 @@ from .tab_bar import TabBar, TabBarData
 from .types import ac
 from .typing import EdgeLiteral, SessionTab, SessionType, TypedDict
 from .utils import log_error, platform_window_id, resolved_shell
-from .window import CwdRequest, Watchers, Window, WindowDict
+from .window import CwdRequest, Watchers, Window, WindowDict, window_focus_may_change
 from .window_list import WindowList
 
 
@@ -573,6 +573,7 @@ class Tab:  # {{{
             # focus the first window
             map ctrl+1 nth_window 0
         ''')
+    @window_focus_may_change
     def nth_window(self, num: int = 0) -> None:
         if self.windows:
             if num < 0:
@@ -621,6 +622,7 @@ class Tab:  # {{{
     def tenth_window(self) -> None:
         self.nth_window(9)
 
+    @window_focus_may_change
     def _next_window(self, delta: int = 1) -> None:
         if len(self.windows) > 1:
             self.current_layout.next_window(self.windows, delta)
@@ -669,6 +671,7 @@ class Tab:  # {{{
             map ctrl+left neighboring_window left
             map ctrl+down neighboring_window bottom
         ''')
+    @window_focus_may_change
     def neighboring_window(self, which: EdgeLiteral) -> None:
         neighbor = self.neighboring_group_id(which)
         if neighbor:
@@ -682,6 +685,7 @@ class Tab:  # {{{
             map ctrl+left move_window left
             map ctrl+down move_window bottom
         ''')
+    @window_focus_may_change
     def move_window(self, delta: Union[EdgeLiteral, int] = 1) -> None:
         if isinstance(delta, int):
             if self.current_layout.move_window(self.windows, delta):
@@ -713,6 +717,7 @@ class Tab:  # {{{
         over the windows for easy selection in this mode. See :opt:`visual_window_select_characters`.
         ''')
     def focus_visible_window(self) -> None:
+        @window_focus_may_change
         def callback(tab: Optional[Tab], window: Optional[Window]) -> None:
             if tab and window:
                 tab.set_active_window(window)
@@ -721,6 +726,7 @@ class Tab:  # {{{
 
     @ac('win', 'Swap the current window with another window in the current tab, selected visually. See :opt:`visual_window_select_characters`')
     def swap_with_window(self) -> None:
+        @window_focus_may_change
         def callback(tab: Optional[Tab], window: Optional[Window]) -> None:
             if tab and window:
                 tab.swap_active_window_with(window.id)
@@ -1146,6 +1152,7 @@ class TabManager:  # {{{
             ))
         return ans
 
+    @window_focus_may_change
     def handle_click_on_tab(self, x: int, button: int, modifiers: int, action: int) -> None:
         i = self.tab_bar.tab_at(x)
         now = monotonic()


### PR DESCRIPTION
Avoid being interrupted by incorrect focus change events while entering text using the input method.

- No longer fires two focused events for the same window after startup.
- For `launch --dont-take-focus` no longer triggers four focus-in and focus-out events.
- Moving the window in the currently active tab no longer triggers the focus event.
- When the active window in a inactive tab or OS window changes, for example after a process ends causing the window to close, the focus event is no longer triggered.

Previous discussion:
https://github.com/kovidgoyal/kitty/pull/6055

Please review, thank you.