### PR TITLE
IME: Fix overlay rendering when the pre-edit text to be displayed exceeds the screen

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -50,7 +50,7 @@ Detailed list of changes
 
 - When changing the cursor color via escape codes or remote control to a fixed color, do not reset cursor_text_color (:iss:`5994`)
 
-- Input Method Extensions: Fix incorrect rendering of IME in-progress and committed text in some situations (:pull:`6049`)
+- Input Method Extensions: Fix incorrect rendering of IME in-progress and committed text in some situations (:pull:`6049`, :pull:`6087`)
 
 - Linux: Reduce minimum required OpenGL version from 3.3 to 3.1 + extensions (:iss:`2790`)
 

--- a/kitty/screen.h
+++ b/kitty/screen.h
@@ -71,7 +71,7 @@ typedef struct {
     PyObject *overlay_text;
     CPUCell *cpu_cells;
     GPUCell *gpu_cells;
-    index_type xstart, ynum, xnum, cursor_x;
+    index_type xstart, ynum, xnum, cursor_x, text_len;
     bool is_active;
     bool is_dirty;
     struct {


### PR DESCRIPTION
Right align overlay when typing at the edge of the screen.
When the cursor is at the right edge of the screen, push the overlay to the left to display the pre-edit text just entered.

Some of the combining characters may be cut off at the beginning of the line, but it doesn't matter.

This is one of the last two IME-related issues I'd like to fix.
Please review, thanks.