### PR TITLE
Update to Nerd Fonts 2.3.3

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -260,9 +260,9 @@ fonts to be freely resizable, so it does not support bitmapped fonts.
    symbols from it automatically, and you can tell it to do so explicitly in
    case it doesn't with the :opt:`symbol_map` directive::
 
-        # Nerd Fonts v2.2.2
+        # Nerd Fonts v2.3.3
 
-        symbol_map U+23FB-U+23FE,U+2665,U+26A1,U+2B58,U+E000-U+E00A,U+E0A0-U+E0A3,U+E0B0-U+E0C8,U+E0CA,U+E0CC-U+E0D2,U+E0D4,U+E200-U+E2A9,U+E300-U+E3E3,U+E5FA-U+E634,U+E700-U+E7C5,U+EA60-U+EBEB,U+F000-U+F2E0,U+F300-U+F32F,U+F400-U+F4A9,U+F500-U+F8FF Symbols Nerd Font Mono
+        symbol_map U+23FB-U+23FE,U+2665,U+26A1,U+2B58,U+E000-U+E00A,U+E0A0-U+E0A3,U+E0B0-U+E0D4,U+E200-U+E2A9,U+E300-U+E3E3,U+E5FA-U+E6AA,U+E700-U+E7C5,U+EA60-U+EBEB,U+F000-U+F2E0,U+F300-U+F32F,U+F400-U+F4A9,U+F500-U+F8FF,U+F0001-U+F1AF0 Symbols Nerd Font Mono
 
    Those Unicode symbols beyond the ``E000-F8FF`` Unicode private use area are
    not included.

--- a/nerd-fonts-glyphs.txt
+++ b/nerd-fonts-glyphs.txt
@@ -391,6 +391,9 @@ e5fc custom folder config
 e5fd custom folder github
 e5fe custom folder open
 e5ff custom folder
+e602 custom play arrow
+e612 custom default text
+e617 custom home
 e61d custom cpp
 e61e custom c
 e626 custom go
@@ -1496,6 +1499,6886 @@ f32c linux snappy
 f32d linux solus
 f32e linux void
 f32f linux zorin
+f0001 md vector square
+f0002 md access point network
+f0003 md access point
+f0004 md account
+f0005 md account alert
+f0006 md account box
+f0007 md account box outline
+f0008 md account check
+f0009 md account circle
+f000a md account convert
+f000b md account key
+f000c md tooltip account
+f000d md account minus
+f000e md account multiple
+f000f md account multiple outline
+f0010 md account multiple plus
+f0011 md account network
+f0012 md account off
+f0013 md account outline
+f0014 md account plus
+f0015 md account remove
+f0016 md account search
+f0017 md account star
+f0018 md orbit
+f0019 md account switch
+f001a md adjust
+f001b md air conditioner
+f001c md airballoon
+f001d md airplane
+f001e md airplane off
+f001f md cast variant
+f0020 md alarm
+f0021 md alarm check
+f0022 md alarm multiple
+f0023 md alarm off
+f0024 md alarm plus
+f0025 md album
+f0026 md alert
+f0027 md alert box
+f0028 md alert circle
+f0029 md alert octagon
+f002a md alert outline
+f002b md alpha
+f002c md alphabetical
+f002d md greenhouse
+f002e md rollerblade off
+f002f md ambulance
+f0030 md amplifier
+f0031 md anchor
+f0032 md android
+f0033 md web plus
+f0034 md android studio
+f0035 md apple
+f0036 md apple finder
+f0037 md apple ios
+f0038 md apple icloud
+f0039 md apple safari
+f003a md font awesome
+f003b md apps
+f003c md archive
+f003d md arrange bring forward
+f003e md arrange bring to front
+f003f md arrange send backward
+f0040 md arrange send to back
+f0041 md arrow all
+f0042 md arrow bottom left
+f0043 md arrow bottom right
+f0044 md arrow collapse all
+f0045 md arrow down
+f0046 md arrow down thick
+f0047 md arrow down bold circle
+f0048 md arrow down bold circle outline
+f0049 md arrow down bold hexagon outline
+f004a md arrow down drop circle
+f004b md arrow down drop circle outline
+f004c md arrow expand all
+f004d md arrow left
+f004e md arrow left thick
+f004f md arrow left bold circle
+f0050 md arrow left bold circle outline
+f0051 md arrow left bold hexagon outline
+f0052 md arrow left drop circle
+f0053 md arrow left drop circle outline
+f0054 md arrow right
+f0055 md arrow right thick
+f0056 md arrow right bold circle
+f0057 md arrow right bold circle outline
+f0058 md arrow right bold hexagon outline
+f0059 md arrow right drop circle
+f005a md arrow right drop circle outline
+f005b md arrow top left
+f005c md arrow top right
+f005d md arrow up
+f005e md arrow up thick
+f005f md arrow up bold circle
+f0060 md arrow up bold circle outline
+f0061 md arrow up bold hexagon outline
+f0062 md arrow up drop circle
+f0063 md arrow up drop circle outline
+f0064 md assistant
+f0065 md at
+f0066 md attachment
+f0067 md book music
+f0068 md auto fix
+f0069 md auto upload
+f006a md autorenew
+f006b md av timer
+f006c md baby
+f006d md backburger
+f006e md backspace
+f006f md backup restore
+f0070 md bank
+f0071 md barcode
+f0072 md barcode scan
+f0073 md barley
+f0074 md barrel
+f0075 md incognito off
+f0076 md basket
+f0077 md basket fill
+f0078 md basket unfill
+f0079 md battery
+f007a md battery 10
+f007b md battery 20
+f007c md battery 30
+f007d md battery 40
+f007e md battery 50
+f007f md battery 60
+f0080 md battery 70
+f0081 md battery 80
+f0082 md battery 90
+f0083 md battery alert
+f0084 md battery charging
+f0085 md battery charging 100
+f0086 md battery charging 20
+f0087 md battery charging 30
+f0088 md battery charging 40
+f0089 md battery charging 60
+f008a md battery charging 80
+f008b md battery charging 90
+f008c md battery minus variant
+f008d md battery negative
+f008e md battery outline
+f008f md battery plus variant
+f0090 md battery positive
+f0091 md battery unknown
+f0092 md beach
+f0093 md flask
+f0094 md flask empty
+f0095 md flask empty outline
+f0096 md flask outline
+f0097 md bunk bed outline
+f0098 md beer
+f0099 md bed outline
+f009a md bell
+f009b md bell off
+f009c md bell outline
+f009d md bell plus
+f009e md bell ring
+f009f md bell ring outline
+f00a0 md bell sleep
+f00a1 md beta
+f00a2 md book cross
+f00a3 md bike
+f00a4 md microsoft bing
+f00a5 md binoculars
+f00a6 md bio
+f00a7 md biohazard
+f00a8 md bitbucket
+f00a9 md black mesa
+f00aa md shield refresh
+f00ab md blender software
+f00ac md blinds
+f00ad md block helper
+f00ae md application edit
+f00af md bluetooth
+f00b0 md bluetooth audio
+f00b1 md bluetooth connect
+f00b2 md bluetooth off
+f00b3 md bluetooth settings
+f00b4 md bluetooth transfer
+f00b5 md blur
+f00b6 md blur linear
+f00b7 md blur off
+f00b8 md blur radial
+f00b9 md bone
+f00ba md book
+f00bb md book multiple
+f00bc md book variant multiple
+f00bd md book open
+f00be md book open blank variant
+f00bf md book variant
+f00c0 md bookmark
+f00c1 md bookmark check
+f00c2 md bookmark music
+f00c3 md bookmark outline
+f00c4 md bookmark plus outline
+f00c5 md bookmark plus
+f00c6 md bookmark remove
+f00c7 md border all
+f00c8 md border bottom
+f00c9 md border color
+f00ca md border horizontal
+f00cb md border inside
+f00cc md border left
+f00cd md border none
+f00ce md border outside
+f00cf md border right
+f00d0 md border style
+f00d1 md border top
+f00d2 md border vertical
+f00d3 md bowling
+f00d4 md box
+f00d5 md box cutter
+f00d6 md briefcase
+f00d7 md briefcase check
+f00d8 md briefcase download
+f00d9 md briefcase upload
+f00da md brightness 1
+f00db md brightness 2
+f00dc md brightness 3
+f00dd md brightness 4
+f00de md brightness 5
+f00df md brightness 6
+f00e0 md brightness 7
+f00e1 md brightness auto
+f00e2 md broom
+f00e3 md brush
+f00e4 md bug
+f00e5 md bulletin board
+f00e6 md bullhorn
+f00e7 md bus
+f00e8 md cached
+f00e9 md cake
+f00ea md cake layered
+f00eb md cake variant
+f00ec md calculator
+f00ed md calendar
+f00ee md calendar blank
+f00ef md calendar check
+f00f0 md calendar clock
+f00f1 md calendar multiple
+f00f2 md calendar multiple check
+f00f3 md calendar plus
+f00f4 md calendar remove
+f00f5 md calendar text
+f00f6 md calendar today
+f00f7 md call made
+f00f8 md call merge
+f00f9 md call missed
+f00fa md call received
+f00fb md call split
+f00fc md camcorder
+f00fd md video box
+f00fe md video box off
+f00ff md camcorder off
+f0100 md camera
+f0101 md camera enhance
+f0102 md camera front
+f0103 md camera front variant
+f0104 md camera iris
+f0105 md camera party mode
+f0106 md camera rear
+f0107 md camera rear variant
+f0108 md camera switch
+f0109 md camera timer
+f010a md candycane
+f010b md car
+f010c md car battery
+f010d md car connected
+f010e md car wash
+f010f md carrot
+f0110 md cart
+f0111 md cart outline
+f0112 md cart plus
+f0113 md case sensitive alt
+f0114 md cash
+f0115 md cash 100
+f0116 md cash multiple
+f0117 md checkbox blank badge outline
+f0118 md cast
+f0119 md cast connected
+f011a md castle
+f011b md cat
+f011c md cellphone
+f011d md tray arrow up
+f011e md cellphone basic
+f011f md cellphone dock
+f0120 md tray arrow down
+f0121 md cellphone link
+f0122 md cellphone link off
+f0123 md cellphone settings
+f0124 md certificate
+f0125 md chair school
+f0126 md chart arc
+f0127 md chart areaspline
+f0128 md chart bar
+f0129 md chart histogram
+f012a md chart line
+f012b md chart pie
+f012c md check
+f012d md check all
+f012e md checkbox blank
+f0131 md checkbox blank outline
+f0132 md checkbox marked
+f0133 md checkbox marked circle
+f0134 md checkbox marked circle outline
+f0135 md checkbox marked outline
+f0136 md checkbox multiple blank
+f0137 md checkbox multiple blank outline
+f0138 md checkbox multiple marked
+f0139 md checkbox multiple marked outline
+f013a md checkerboard
+f013b md chemical weapon
+f013c md chevron double down
+f013d md chevron double left
+f013e md chevron double right
+f013f md chevron double up
+f0140 md chevron down
+f0141 md chevron left
+f0142 md chevron right
+f0143 md chevron up
+f0144 md church
+f0145 md roller skate off
+f0146 md city
+f0147 md clipboard
+f0148 md clipboard account
+f0149 md clipboard alert
+f014a md clipboard arrow down
+f014b md clipboard arrow left
+f014c md clipboard outline
+f014d md clipboard text
+f014e md clipboard check
+f014f md clippy
+f0150 md clock outline
+f0151 md clock end
+f0152 md clock fast
+f0153 md clock in
+f0154 md clock out
+f0155 md clock start
+f0156 md close
+f0157 md close box
+f0158 md close box outline
+f0159 md close circle
+f015a md close circle outline
+f015b md close network
+f015c md close octagon
+f015d md close octagon outline
+f015e md closed caption
+f015f md cloud
+f0160 md cloud check
+f0161 md cloud circle
+f0162 md cloud download
+f0163 md cloud outline
+f0164 md cloud off outline
+f0165 md cloud print
+f0166 md cloud print outline
+f0167 md cloud upload
+f0168 md code array
+f0169 md code braces
+f016a md code brackets
+f016b md code equal
+f016c md code greater than
+f016d md code greater than or equal
+f016e md code less than
+f016f md code less than or equal
+f0170 md code not equal
+f0171 md code not equal variant
+f0172 md code parentheses
+f0173 md code string
+f0174 md code tags
+f0175 md codepen
+f0176 md coffee
+f0177 md coffee to go
+f0178 md bell badge outline
+f0179 md color helper
+f017a md comment
+f017b md comment account
+f017c md comment account outline
+f017d md comment alert
+f017e md comment alert outline
+f017f md comment check
+f0180 md comment check outline
+f0181 md comment multiple outline
+f0182 md comment outline
+f0183 md comment plus outline
+f0184 md comment processing
+f0185 md comment processing outline
+f0186 md comment question outline
+f0187 md comment remove outline
+f0188 md comment text
+f0189 md comment text outline
+f018a md compare
+f018b md compass
+f018c md compass outline
+f018d md console
+f018e md card account mail
+f018f md content copy
+f0190 md content cut
+f0191 md content duplicate
+f0192 md content paste
+f0193 md content save
+f0194 md content save all
+f0195 md contrast
+f0196 md contrast box
+f0197 md contrast circle
+f0198 md cookie
+f0199 md counter
+f019a md cow
+f019b md credit card outline
+f019c md credit card multiple outline
+f019d md credit card scan outline
+f019e md crop
+f019f md crop free
+f01a0 md crop landscape
+f01a1 md crop portrait
+f01a2 md crop square
+f01a3 md crosshairs
+f01a4 md crosshairs gps
+f01a5 md crown
+f01a6 md cube
+f01a7 md cube outline
+f01a8 md cube send
+f01a9 md cube unfolded
+f01aa md cup
+f01ab md cup water
+f01ac md currency btc
+f01ad md currency eur
+f01ae md currency gbp
+f01af md currency inr
+f01b0 md currency ngn
+f01b1 md currency rub
+f01b2 md currency try
+f01b3 md delete variant
+f01b4 md delete
+f01b5 md decimal increase
+f01b6 md decimal decrease
+f01b7 md debug step over
+f01b8 md debug step out
+f01b9 md debug step into
+f01ba md database plus
+f01bb md database minus
+f01bc md database
+f01bd md cursor pointer
+f01be md cursor move
+f01bf md cursor default outline
+f01c0 md cursor default
+f01c1 md currency usd
+f01c2 md delta
+f01c3 md deskphone
+f01c4 md desktop mac
+f01c5 md desktop tower
+f01c6 md details
+f01c7 md deviantart
+f01c8 md diamond stone
+f01c9 md ab testing
+f01ca md dice 1
+f01cb md dice 2
+f01cc md dice 3
+f01cd md dice 4
+f01ce md dice 5
+f01cf md dice 6
+f01d0 md directions
+f01d1 md disc alert
+f01d2 md disqus
+f01d3 md video plus outline
+f01d4 md division
+f01d5 md division box
+f01d6 md dns
+f01d7 md domain
+f01d8 md dots horizontal
+f01d9 md dots vertical
+f01da md download
+f01db md drag
+f01dc md drag horizontal
+f01dd md drag vertical
+f01de md drawing
+f01df md drawing box
+f01e0 md shield refresh outline
+f01e1 md calendar refresh
+f01e2 md drone
+f01e3 md dropbox
+f01e4 md drupal
+f01e5 md duck
+f01e6 md dumbbell
+f01e7 md earth
+f01e8 md earth off
+f01e9 md microsoft edge
+f01ea md eject
+f01eb md elevation decline
+f01ec md elevation rise
+f01ed md elevator
+f01ee md email
+f01ef md email open
+f01f0 md email outline
+f01f1 md email lock
+f01f2 md emoticon outline
+f01f3 md emoticon cool outline
+f01f4 md emoticon devil outline
+f01f5 md emoticon happy outline
+f01f6 md emoticon neutral outline
+f01f7 md emoticon poop
+f01f8 md emoticon sad outline
+f01f9 md emoticon tongue
+f01fa md engine
+f01fb md engine outline
+f01fc md equal
+f01fd md equal box
+f01fe md eraser
+f01ff md escalator
+f0200 md ethernet
+f0201 md ethernet cable
+f0202 md ethernet cable off
+f0203 md calendar refresh outline
+f0204 md evernote
+f0205 md exclamation
+f0207 md export
+f0208 md eye
+f0209 md eye off
+f020a md eyedropper
+f020b md eyedropper variant
+f020c md facebook
+f020d md order alphabetical ascending
+f020e md facebook messenger
+f020f md factory
+f0210 md fan
+f0211 md fast forward
+f0212 md fax
+f0213 md ferry
+f0214 md file
+f0215 md file chart
+f0216 md file check
+f0217 md file cloud
+f0218 md file delimited
+f0219 md file document
+f021a md text box
+f021b md file excel
+f021c md file excel box
+f021d md file export
+f021e md file find
+f021f md file image
+f0220 md file import
+f0221 md file lock
+f0222 md file multiple
+f0223 md file music
+f0224 md file outline
+f0225 md file jpg box
+f0226 md file pdf box
+f0227 md file powerpoint
+f0228 md file powerpoint box
+f0229 md file presentation box
+f022a md file send
+f022b md file video
+f022c md file word
+f022d md file word box
+f022e md file code
+f022f md film
+f0230 md filmstrip
+f0231 md filmstrip off
+f0232 md filter
+f0233 md filter outline
+f0234 md filter remove
+f0235 md filter remove outline
+f0236 md filter variant
+f0237 md fingerprint
+f0238 md fire
+f0239 md firefox
+f023a md fish
+f023b md flag
+f023c md flag checkered
+f023d md flag outline
+f023e md flag variant outline
+f023f md flag triangle
+f0240 md flag variant
+f0241 md flash
+f0242 md flash auto
+f0243 md flash off
+f0244 md flashlight
+f0245 md flashlight off
+f0246 md star half
+f0247 md flip to back
+f0248 md flip to front
+f0249 md floppy
+f024a md flower
+f024b md folder
+f024c md folder account
+f024d md folder download
+f024e md folder google drive
+f024f md folder image
+f0250 md folder lock
+f0251 md folder lock open
+f0252 md folder move
+f0253 md folder multiple
+f0254 md folder multiple image
+f0255 md folder multiple outline
+f0256 md folder outline
+f0257 md folder plus
+f0258 md folder remove
+f0259 md folder upload
+f025a md food
+f025b md food apple
+f025c md food variant
+f025d md football
+f025e md football australian
+f025f md football helmet
+f0260 md format align center
+f0261 md format align justify
+f0262 md format align left
+f0263 md format align right
+f0264 md format bold
+f0265 md format clear
+f0266 md format color fill
+f0267 md format float center
+f0268 md format float left
+f0269 md format float none
+f026a md format float right
+f026b md format header 1
+f026c md format header 2
+f026d md format header 3
+f026e md format header 4
+f026f md format header 5
+f0270 md format header 6
+f0271 md format header decrease
+f0272 md format header equal
+f0273 md format header increase
+f0274 md format header pound
+f0275 md format indent decrease
+f0276 md format indent increase
+f0277 md format italic
+f0278 md format line spacing
+f0279 md format list bulleted
+f027a md format list bulleted type
+f027b md format list numbered
+f027c md format paint
+f027d md format paragraph
+f027e md format quote close
+f027f md format size
+f0280 md format strikethrough
+f0281 md format strikethrough variant
+f0282 md format subscript
+f0283 md format superscript
+f0284 md format text
+f0285 md format textdirection l to r
+f0286 md format textdirection r to l
+f0287 md format underline
+f0288 md format wrap inline
+f0289 md format wrap square
+f028a md format wrap tight
+f028b md format wrap top bottom
+f028c md forum
+f028d md forward
+f028e md bowl
+f028f md fridge outline
+f0290 md fridge
+f0291 md fridge top
+f0292 md fridge bottom
+f0293 md fullscreen
+f0294 md fullscreen exit
+f0295 md function
+f0296 md gamepad
+f0297 md gamepad variant
+f0298 md gas station
+f0299 md gate
+f029a md gauge
+f029b md gavel
+f029c md gender female
+f029d md gender male
+f029e md gender male female
+f029f md gender transgender
+f02a0 md ghost
+f02a1 md gift outline
+f02a2 md git
+f02a3 md card account details star
+f02a4 md github
+f02a5 md glass flute
+f02a6 md glass mug
+f02a7 md glass stange
+f02a8 md glass tulip
+f02a9 md bowl outline
+f02aa md glasses
+f02ab md gmail
+f02ac md gnome
+f02ad md google
+f02ae md google cardboard
+f02af md google chrome
+f02b0 md google circles
+f02b1 md google circles communities
+f02b2 md google circles extended
+f02b3 md google circles group
+f02b4 md google controller
+f02b5 md google controller off
+f02b6 md google drive
+f02b7 md google earth
+f02b8 md google glass
+f02b9 md google nearby
+f02ba md video minus outline
+f02bb md microsoft teams
+f02bc md google play
+f02bd md google plus
+f02be md order bool ascending
+f02bf md google translate
+f02c0 md google classroom
+f02c1 md grid
+f02c2 md grid off
+f02c3 md group
+f02c4 md guitar electric
+f02c5 md guitar pick
+f02c6 md guitar pick outline
+f02c7 md hand pointing right
+f02c8 md hanger
+f02c9 md google hangouts
+f02ca md harddisk
+f02cb md headphones
+f02cc md headphones box
+f02cd md headphones settings
+f02ce md headset
+f02cf md headset dock
+f02d0 md headset off
+f02d2 md heart box
+f02d3 md heart box outline
+f02d4 md heart broken
+f02d6 md help
+f02d7 md help circle
+f02d8 md hexagon
+f02d9 md hexagon outline
+f02da md history
+f02db md hololens
+f02dc md home
+f02dd md home modern
+f02de md home variant
+f02df md hops
+f02e0 md hospital box
+f02e1 md hospital building
+f02e2 md hospital marker
+f02e3 md bed
+f02e4 md bowl mix outline
+f02e5 md pot
+f02e6 md human
+f02e7 md human child
+f02e8 md human male female
+f02e9 md image
+f02ea md image album
+f02eb md image area
+f02ec md image area close
+f02ed md image broken
+f02ee md image broken variant
+f02ef md image multiple outline
+f02f0 md image filter black white
+f02f1 md image filter center focus
+f02f2 md image filter center focus weak
+f02f3 md image filter drama
+f02f4 md image filter frames
+f02f6 md image filter none
+f02f7 md image filter tilt shift
+f02f8 md image filter vintage
+f02f9 md image multiple
+f02fa md import
+f02fb md inbox arrow down
+f02fc md information
+f02fd md information outline
+f02fe md instagram
+f02ff md pot outline
+f0300 md microsoft internet explorer
+f0301 md invert colors
+f0302 md jeepney
+f0303 md jira
+f0304 md jsfiddle
+f0305 md keg
+f0306 md key
+f0307 md key change
+f0308 md key minus
+f0309 md key plus
+f030a md key remove
+f030b md key variant
+f030c md keyboard
+f030d md keyboard backspace
+f030e md keyboard caps
+f030f md keyboard close
+f0310 md keyboard off
+f0311 md keyboard return
+f0312 md keyboard tab
+f0313 md keyboard variant
+f0314 md kodi
+f0315 md label
+f0316 md label outline
+f0317 md lan
+f0318 md lan connect
+f0319 md lan disconnect
+f031a md lan pending
+f031b md language csharp
+f031c md language css3
+f031d md language html5
+f031e md language javascript
+f031f md language php
+f0320 md language python
+f0321 md contactless payment circle
+f0322 md laptop
+f0323 md magazine rifle
+f0324 md magazine pistol
+f0325 md keyboard tab reverse
+f0326 md pot steam outline
+f0327 md launch
+f0328 md layers
+f0329 md layers off
+f032a md leaf
+f032b md led off
+f032c md led on
+f032d md led outline
+f032e md led variant off
+f032f md led variant on
+f0330 md led variant outline
+f0331 md library
+f0332 md filmstrip box
+f0333 md music box multiple
+f0334 md plus box multiple
+f0335 md lightbulb
+f0336 md lightbulb outline
+f0337 md link
+f0338 md link off
+f0339 md link variant
+f033a md link variant off
+f033b md linkedin
+f033c md sort reverse variant
+f033d md linux
+f033e md lock
+f033f md lock open
+f0340 md lock open outline
+f0341 md lock outline
+f0342 md login
+f0343 md logout
+f0344 md looks
+f0345 md loupe
+f0346 md lumx
+f0347 md magnet
+f0348 md magnet on
+f0349 md magnify
+f034a md magnify minus
+f034b md magnify plus
+f034c md plus circle multiple
+f034d md map
+f034e md map marker
+f034f md map marker circle
+f0350 md map marker multiple
+f0351 md map marker off
+f0352 md map marker radius
+f0353 md margin
+f0354 md language markdown
+f0355 md marker check
+f0356 md glass cocktail
+f0357 md material ui
+f0358 md math compass
+f0359 md stackpath
+f035a md minus circle multiple
+f035b md memory
+f035c md menu
+f035d md menu down
+f035e md menu left
+f035f md menu right
+f0360 md menu up
+f0361 md message
+f0362 md message alert
+f0363 md message draw
+f0364 md message image
+f0365 md message outline
+f0366 md message processing
+f0367 md message reply
+f0368 md message reply text
+f0369 md message text
+f036a md message text outline
+f036b md message video
+f036c md microphone
+f036d md microphone off
+f036e md microphone outline
+f036f md microphone settings
+f0370 md microphone variant
+f0371 md microphone variant off
+f0372 md microsoft
+f0373 md minecraft
+f0374 md minus
+f0375 md minus box
+f0376 md minus circle
+f0377 md minus circle outline
+f0378 md minus network
+f0379 md monitor
+f037a md monitor multiple
+f037b md more
+f037c md motorbike
+f037d md mouse
+f037e md mouse off
+f037f md mouse variant
+f0380 md mouse variant off
+f0381 md movie
+f0382 md multiplication
+f0383 md multiplication box
+f0384 md music box
+f0385 md music box outline
+f0386 md music circle
+f0388 md music note
+f0389 md music note half
+f038a md music note off
+f038b md music note quarter
+f038c md music note sixteenth
+f038d md music note whole
+f038e md nature
+f038f md nature people
+f0390 md navigation
+f0391 md needle
+f0392 md smoke detector
+f0393 md thermostat
+f0394 md new box
+f0395 md newspaper
+f0396 md nfc
+f0397 md nfc tap
+f0398 md nfc variant
+f0399 md nodejs
+f039a md note
+f039b md note outline
+f039c md note plus
+f039d md note plus outline
+f039e md note text
+f039f md notification clear all
+f03a0 md numeric
+f03a1 md numeric 0 box
+f03a2 md numeric 0 box multiple outline
+f03a3 md numeric 0 box outline
+f03a4 md numeric 1 box
+f03a5 md numeric 1 box multiple outline
+f03a6 md numeric 1 box outline
+f03a7 md numeric 2 box
+f03a8 md numeric 2 box multiple outline
+f03a9 md numeric 2 box outline
+f03aa md numeric 3 box
+f03ab md numeric 3 box multiple outline
+f03ac md numeric 3 box outline
+f03ad md numeric 4 box
+f03ae md numeric 4 box outline
+f03af md numeric 5 box multiple outline
+f03b0 md numeric 5 box outline
+f03b1 md numeric 5 box
+f03b2 md numeric 4 box multiple outline
+f03b3 md numeric 6 box
+f03b4 md numeric 6 box multiple outline
+f03b5 md numeric 6 box outline
+f03b6 md numeric 7 box
+f03b7 md numeric 7 box multiple outline
+f03b8 md numeric 7 box outline
+f03b9 md numeric 8 box
+f03ba md numeric 8 box multiple outline
+f03bb md numeric 8 box outline
+f03bc md numeric 9 box
+f03bd md numeric 9 box multiple outline
+f03be md numeric 9 box outline
+f03bf md numeric 9 plus box
+f03c0 md numeric 9 plus box multiple outline
+f03c1 md numeric 9 plus box outline
+f03c2 md nutrition
+f03c3 md octagon
+f03c4 md octagon outline
+f03c5 md odnoklassniki
+f03c6 md microsoft office
+f03c7 md oil
+f03c8 md coolant temperature
+f03c9 md omega
+f03ca md microsoft onedrive
+f03cb md open in app
+f03cc md open in new
+f03cd md openid
+f03ce md opera
+f03cf md ornament
+f03d0 md ornament variant
+f03d1 md inbox arrow up
+f03d2 md owl
+f03d3 md package
+f03d4 md package down
+f03d5 md package up
+f03d6 md package variant
+f03d7 md package variant closed
+f03d8 md palette
+f03d9 md palette advanced
+f03da md panda
+f03db md pandora
+f03dc md panorama
+f03dd md panorama fisheye
+f03de md panorama horizontal outline
+f03df md panorama vertical outline
+f03e0 md panorama wide angle outline
+f03e1 md paper cut vertical
+f03e2 md paperclip
+f03e3 md parking
+f03e4 md pause
+f03e5 md pause circle
+f03e6 md pause circle outline
+f03e7 md pause octagon
+f03e8 md pause octagon outline
+f03e9 md paw
+f03ea md pen
+f03eb md pencil
+f03ec md pencil box
+f03ed md pencil box outline
+f03ee md pencil lock
+f03ef md pencil off
+f03f0 md percent
+f03f1 md mortar pestle plus
+f03f2 md phone
+f03f3 md phone bluetooth
+f03f4 md phone forward
+f03f5 md phone hangup
+f03f6 md phone in talk
+f03f7 md phone incoming
+f03f8 md phone lock
+f03f9 md phone log
+f03fa md phone missed
+f03fb md phone outgoing
+f03fc md phone paused
+f03fd md phone settings
+f03fe md phone voip
+f03ff md pi
+f0400 md pi box
+f0401 md pig
+f0402 md pill
+f0403 md pin
+f0404 md pin off
+f0405 md pine tree
+f0406 md pine tree box
+f0407 md pinterest
+f0408 md contactless payment circle outline
+f0409 md pizza
+f040a md play
+f040b md play box outline
+f040c md play circle
+f040d md play circle outline
+f040e md play pause
+f040f md play protected content
+f0410 md playlist minus
+f0411 md playlist play
+f0412 md playlist plus
+f0413 md playlist remove
+f0414 md sony playstation
+f0415 md plus
+f0416 md plus box
+f0417 md plus circle
+f0418 md plus circle multiple outline
+f0419 md plus circle outline
+f041a md plus network
+f041b md sledding
+f041c md wall sconce flat variant
+f041d md pokeball
+f041e md polaroid
+f041f md poll
+f0420 md account eye
+f0421 md polymer
+f0422 md popcorn
+f0423 md pound
+f0424 md pound box
+f0425 md power
+f0426 md power settings
+f0427 md power socket
+f0428 md presentation
+f0429 md presentation play
+f042a md printer
+f042b md printer 3d
+f042c md printer alert
+f042d md professional hexagon
+f042e md projector
+f042f md projector screen
+f0430 md pulse
+f0431 md puzzle
+f0432 md qrcode
+f0433 md qrcode scan
+f0434 md quadcopter
+f0435 md quality high
+f0436 md book multiple outline
+f0437 md radar
+f0438 md radiator
+f0439 md radio
+f043a md radio handheld
+f043b md radio tower
+f043c md radioactive
+f043e md radiobox marked
+f043f md raspberry pi
+f0440 md ray end
+f0441 md ray end arrow
+f0442 md ray start
+f0443 md ray start arrow
+f0444 md ray start end
+f0445 md ray vertex
+f0446 md lastpass
+f0447 md read
+f0448 md youtube tv
+f0449 md receipt
+f044a md record
+f044b md record rec
+f044c md recycle
+f044d md reddit
+f044e md redo
+f044f md redo variant
+f0450 md refresh
+f0451 md regex
+f0452 md relative scale
+f0453 md reload
+f0454 md remote
+f0455 md rename box
+f0456 md repeat
+f0457 md repeat off
+f0458 md repeat once
+f0459 md replay
+f045a md reply
+f045b md reply all
+f045c md reproduction
+f045d md resize bottom right
+f045e md responsive
+f045f md rewind
+f0460 md ribbon
+f0461 md road
+f0462 md road variant
+f0463 md rocket
+f0464 md rotate 3d variant
+f0465 md rotate left
+f0466 md rotate left variant
+f0467 md rotate right
+f0468 md rotate right variant
+f0469 md router wireless
+f046a md routes
+f046b md rss
+f046c md rss box
+f046d md ruler
+f046e md run fast
+f046f md sale
+f0470 md satellite
+f0471 md satellite variant
+f0472 md scale
+f0473 md scale bathroom
+f0474 md school
+f0475 md screen rotation
+f0476 md screwdriver
+f0477 md script outline
+f0478 md screen rotation lock
+f0479 md sd
+f047a md seal
+f047b md seat flat
+f047c md seat flat angled
+f047d md seat individual suite
+f047e md seat legroom extra
+f047f md seat legroom normal
+f0480 md seat legroom reduced
+f0481 md seat recline extra
+f0482 md seat recline normal
+f0483 md security
+f0484 md security network
+f0485 md select
+f0486 md select all
+f0487 md select inverse
+f0488 md select off
+f0489 md selection
+f048a md send
+f048b md server
+f048c md server minus
+f048d md server network
+f048e md server network off
+f048f md server off
+f0490 md server plus
+f0491 md server remove
+f0492 md server security
+f0493 md cog
+f0494 md cog box
+f0495 md shape plus
+f0496 md share
+f0497 md share variant
+f0498 md shield
+f0499 md shield outline
+f049a md shopping
+f049b md shopping music
+f049c md shredder
+f049d md shuffle
+f049e md shuffle disabled
+f049f md shuffle variant
+f04a0 md sigma
+f04a1 md sign caution
+f04a2 md signal
+f04a3 md silverware
+f04a4 md silverware fork
+f04a5 md silverware spoon
+f04a6 md silverware variant
+f04a7 md sim
+f04a8 md sim alert
+f04a9 md sim off
+f04aa md sitemap
+f04ab md skip backward
+f04ac md skip forward
+f04ad md skip next
+f04ae md skip previous
+f04af md skype
+f04b0 md skype business
+f04b1 md slack
+f04b2 md sleep
+f04b3 md sleep off
+f04b4 md smoking
+f04b5 md smoking off
+f04b6 md snapchat
+f04b7 md snowman
+f04b8 md soccer
+f04b9 md sofa
+f04ba md sort
+f04bb md sort alphabetical variant
+f04bc md sort ascending
+f04bd md sort descending
+f04be md sort numeric variant
+f04bf md sort variant
+f04c0 md soundcloud
+f04c1 md source fork
+f04c2 md source pull
+f04c3 md speaker
+f04c4 md speaker off
+f04c5 md speedometer
+f04c6 md spellcheck
+f04c7 md spotify
+f04c8 md spotlight
+f04c9 md spotlight beam
+f04ca md book remove multiple outline
+f04cb md account switch outline
+f04cc md stack overflow
+f04cd md stairs
+f04ce md star
+f04cf md star circle
+f04d0 md star half full
+f04d1 md star off
+f04d2 md star outline
+f04d3 md steam
+f04d4 md steering
+f04d5 md step backward
+f04d6 md step backward 2
+f04d7 md step forward
+f04d8 md step forward 2
+f04d9 md stethoscope
+f04da md stocking
+f04db md stop
+f04dc md store
+f04dd md store 24 hour
+f04de md stove
+f04df md subway variant
+f04e0 md sunglasses
+f04e1 md swap horizontal
+f04e2 md swap vertical
+f04e3 md swim
+f04e4 md switch
+f04e5 md sword
+f04e6 md sync
+f04e7 md sync alert
+f04e8 md sync off
+f04e9 md tab
+f04ea md tab unselected
+f04eb md table
+f04ec md table column plus after
+f04ed md table column plus before
+f04ee md table column remove
+f04ef md table column width
+f04f0 md table edit
+f04f1 md table large
+f04f2 md table row height
+f04f3 md table row plus after
+f04f4 md table row plus before
+f04f5 md table row remove
+f04f6 md tablet
+f04f7 md tablet android
+f04f8 md tangram
+f04f9 md tag
+f04fa md tag faces
+f04fb md tag multiple
+f04fc md tag outline
+f04fd md tag text outline
+f04fe md target
+f04ff md taxi
+f0500 md teamviewer
+f0501 md skateboarding
+f0502 md television
+f0503 md television guide
+f0504 md temperature celsius
+f0505 md temperature fahrenheit
+f0506 md temperature kelvin
+f0507 md tennis ball
+f0508 md tent
+f0509 md image filter hdr
+f050a md text to speech
+f050b md text to speech off
+f050c md texture
+f050d md theater
+f050e md theme light dark
+f050f md thermometer
+f0510 md thermometer lines
+f0511 md thumb down
+f0512 md thumb down outline
+f0513 md thumb up
+f0514 md thumb up outline
+f0515 md thumbs up down
+f0516 md ticket
+f0517 md ticket account
+f0518 md ticket confirmation
+f0519 md tie
+f051a md timelapse
+f051b md timer outline
+f051c md timer 10
+f051d md timer 3
+f051e md timer off outline
+f051f md timer sand
+f0520 md timetable
+f0521 md toggle switch
+f0522 md toggle switch off
+f0523 md tooltip
+f0524 md tooltip edit
+f0525 md tooltip image
+f0526 md tooltip outline
+f0527 md tooltip plus outline
+f0528 md tooltip text
+f0529 md tooth outline
+f052a md cloud refresh
+f052b md traffic light
+f052c md train
+f052d md tram
+f052e md transcribe
+f052f md transcribe close
+f0530 md transfer right
+f0531 md tree
+f0532 md trello
+f0533 md trending down
+f0534 md trending neutral
+f0535 md trending up
+f0536 md triangle
+f0537 md triangle outline
+f0538 md trophy
+f0539 md trophy award
+f053a md trophy outline
+f053b md trophy variant
+f053c md trophy variant outline
+f053d md truck
+f053e md truck delivery
+f053f md tshirt crew outline
+f0540 md tshirt v outline
+f0541 md file refresh outline
+f0542 md folder refresh outline
+f0543 md twitch
+f0544 md twitter
+f0545 md order numeric ascending
+f0546 md order numeric descending
+f0547 md repeat variant
+f0548 md ubuntu
+f0549 md umbraco
+f054a md umbrella
+f054b md umbrella outline
+f054c md undo
+f054d md undo variant
+f054e md unfold less horizontal
+f054f md unfold more horizontal
+f0550 md ungroup
+f0551 md web remove
+f0552 md upload
+f0553 md usb
+f0554 md vector arrange above
+f0555 md vector arrange below
+f0556 md vector circle
+f0557 md vector circle variant
+f0558 md vector combine
+f0559 md vector curve
+f055a md vector difference
+f055b md vector difference ab
+f055c md vector difference ba
+f055d md vector intersection
+f055e md vector line
+f055f md vector point
+f0560 md vector polygon
+f0561 md vector polyline
+f0562 md vector selection
+f0563 md vector triangle
+f0564 md vector union
+f0565 md shield check
+f0566 md vibrate
+f0567 md video
+f0568 md video off
+f0569 md video switch
+f056a md view agenda
+f056b md view array
+f056c md view carousel
+f056d md view column
+f056e md view dashboard
+f056f md view day
+f0570 md view grid
+f0571 md view headline
+f0572 md view list
+f0573 md view module
+f0574 md view quilt
+f0575 md view stream
+f0576 md view week
+f0577 md vimeo
+f0578 md buffet
+f0579 md hands pray
+f057a md credit card wireless off
+f057b md credit card wireless off outline
+f057c md vlc
+f057d md voicemail
+f057e md volume high
+f057f md volume low
+f0580 md volume medium
+f0581 md volume off
+f0582 md vpn
+f0583 md walk
+f0584 md wallet
+f0585 md wallet giftcard
+f0586 md wallet membership
+f0587 md wallet travel
+f0588 md wan
+f0589 md watch
+f058a md watch export
+f058b md watch import
+f058c md water
+f058d md water off
+f058e md water percent
+f058f md water pump
+f0590 md weather cloudy
+f0591 md weather fog
+f0592 md weather hail
+f0593 md weather lightning
+f0594 md weather night
+f0595 md weather partly cloudy
+f0596 md weather pouring
+f0597 md weather rainy
+f0598 md weather snowy
+f0599 md weather sunny
+f059a md weather sunset
+f059b md weather sunset down
+f059c md weather sunset up
+f059d md weather windy
+f059e md weather windy variant
+f059f md web
+f05a0 md webcam
+f05a1 md weight
+f05a2 md weight kilogram
+f05a3 md whatsapp
+f05a4 md wheelchair accessibility
+f05a5 md white balance auto
+f05a6 md white balance incandescent
+f05a7 md white balance iridescent
+f05a8 md white balance sunny
+f05a9 md wifi
+f05aa md wifi off
+f05ab md nintendo wii
+f05ac md wikipedia
+f05ad md window close
+f05ae md window closed
+f05af md window maximize
+f05b0 md window minimize
+f05b1 md window open
+f05b2 md window restore
+f05b3 md microsoft windows
+f05b4 md wordpress
+f05b5 md account hard hat
+f05b6 md wrap
+f05b7 md wrench
+f05b8 md contacts outline
+f05b9 md microsoft xbox
+f05ba md microsoft xbox controller
+f05bb md microsoft xbox controller off
+f05bc md table furniture
+f05bd md sort alphabetical ascending
+f05be md firewire
+f05bf md sort alphabetical descending
+f05c0 md xml
+f05c1 md yeast
+f05c2 md database refresh
+f05c3 md youtube
+f05c4 md zip box
+f05c5 md surround sound
+f05c6 md vector rectangle
+f05c7 md playlist check
+f05c8 md format line style
+f05c9 md format line weight
+f05ca md translate
+f05cb md account voice
+f05cc md opacity
+f05ce md clock alert outline
+f05cf md human pregnant
+f05d0 md sticker circle outline
+f05d1 md scale balance
+f05d2 md card account details
+f05d3 md account multiple minus
+f05d4 md airplane landing
+f05d5 md airplane takeoff
+f05d6 md alert circle outline
+f05d7 md altimeter
+f05d8 md animation
+f05d9 md book minus
+f05da md book open page variant
+f05db md book plus
+f05dc md boombox
+f05dd md bullseye
+f05de md comment remove
+f05df md camera off
+f05e0 md check circle
+f05e1 md check circle outline
+f05e2 md candle
+f05e3 md chart bubble
+f05e4 md credit card off outline
+f05e5 md cup off
+f05e6 md copyright
+f05e7 md cursor text
+f05e8 md delete forever
+f05e9 md delete sweep
+f05ea md dice d20 outline
+f05eb md dice d4 outline
+f05ec md dice d8 outline
+f05ed md dice d6 outline
+f05ee md disc
+f05ef md email open outline
+f05f0 md email variant
+f05f1 md ev station
+f05f2 md food fork drink
+f05f3 md food off
+f05f4 md format title
+f05f5 md google maps
+f05f6 md heart pulse
+f05f7 md highway
+f05f8 md home map marker
+f05f9 md incognito
+f05fa md kettle
+f05fb md lock plus
+f05fc md exit to app
+f05fd md logout variant
+f05fe md music note bluetooth
+f05ff md music note bluetooth off
+f0600 md page first
+f0601 md page last
+f0602 md phone classic
+f0603 md priority high
+f0604 md priority low
+f0605 md qqchat
+f0606 md pool
+f0607 md rounded corner
+f0608 md rowing
+f0609 md saxophone
+f060a md signal variant
+f060b md stack exchange
+f060c md subdirectory arrow left
+f060d md subdirectory arrow right
+f060e md form textbox
+f060f md violin
+f0610 md microsoft visual studio
+f0611 md wechat
+f0612 md watermark
+f0613 md file hidden
+f0614 md application outline
+f0615 md arrow collapse
+f0616 md arrow expand
+f0617 md bowl mix
+f0618 md bridge
+f0619 md application edit outline
+f061a md chip
+f061b md content save settings
+f061c md dialpad
+f061d md book alphabet
+f061e md format horizontal align center
+f061f md format horizontal align left
+f0620 md format horizontal align right
+f0621 md format vertical align bottom
+f0622 md format vertical align center
+f0623 md format vertical align top
+f0624 md line scan
+f0625 md help circle outline
+f0626 md code json
+f0627 md lambda
+f0628 md matrix
+f0629 md meteor
+f062a md close circle multiple
+f062b md sigma lower
+f062c md source branch
+f062d md source merge
+f062e md tune
+f062f md webhook
+f0630 md account settings
+f0631 md account details
+f0632 md apple keyboard caps
+f0633 md apple keyboard command
+f0634 md apple keyboard control
+f0635 md apple keyboard option
+f0636 md apple keyboard shift
+f0637 md box shadow
+f0638 md cards
+f0639 md cards outline
+f063a md cards playing outline
+f063b md checkbox multiple blank circle
+f063c md checkbox multiple blank circle outline
+f063d md checkbox multiple marked circle
+f063e md checkbox multiple marked circle outline
+f063f md cloud sync
+f0640 md collage
+f0641 md directions fork
+f0642 md eraser variant
+f0643 md face man
+f0644 md face man profile
+f0645 md file tree
+f0646 md format annotation plus
+f0647 md gas cylinder
+f0648 md grease pencil
+f0649 md human female
+f064a md human greeting variant
+f064b md human handsdown
+f064c md human handsup
+f064d md human male
+f064e md information variant
+f064f md lead pencil
+f0650 md map marker minus
+f0651 md map marker plus
+f0652 md marker
+f0653 md message plus
+f0654 md microscope
+f0655 md move resize
+f0656 md move resize variant
+f0657 md paw off
+f0658 md phone minus
+f0659 md phone plus
+f065a md pot steam
+f065b md pot mix
+f065c md serial port
+f065d md shape circle plus
+f065e md shape polygon plus
+f065f md shape rectangle plus
+f0660 md shape square plus
+f0661 md skip next circle
+f0662 md skip next circle outline
+f0663 md skip previous circle
+f0664 md skip previous circle outline
+f0665 md spray
+f0666 md stop circle
+f0667 md stop circle outline
+f0668 md test tube
+f0669 md text shadow
+f066a md tune vertical
+f066b md cart off
+f066c md chart gantt
+f066d md chart scatter plot hexbin
+f066e md chart timeline
+f066f md discord
+f0670 md file restore
+f0671 md language c
+f0672 md language cpp
+f0673 md language xaml
+f0674 md creation
+f0675 md application cog
+f0676 md credit card plus outline
+f0677 md pot mix outline
+f0678 md bow tie
+f0679 md calendar range
+f067a md currency usd off
+f067b md flash red eye
+f067c md oar
+f067d md piano
+f067e md weather lightning rainy
+f067f md weather snowy rainy
+f0680 md yin yang
+f0681 md tower beach
+f0682 md tower fire
+f0683 md delete circle
+f0684 md dna
+f0685 md hamburger
+f0686 md gondola
+f0687 md inbox
+f0688 md reorder horizontal
+f0689 md reorder vertical
+f068a md shield home
+f068b md tag heart
+f068c md skull
+f068d md solid
+f068e md alarm snooze
+f068f md baby carriage
+f0690 md beaker outline
+f0691 md bomb
+f0692 md calendar question
+f0693 md camera burst
+f0694 md code tags check
+f0695 md circle multiple outline
+f0696 md crop rotate
+f0697 md developer board
+f0698 md piano off
+f0699 md skate off
+f069a md message star
+f069b md emoticon dead outline
+f069c md emoticon excited outline
+f069d md folder star
+f069e md format color text
+f069f md format section
+f06a0 md gradient vertical
+f06a1 md home outline
+f06a2 md message bulleted
+f06a3 md message bulleted off
+f06a4 md nuke
+f06a5 md power plug
+f06a6 md power plug off
+f06a7 md publish
+f06a8 md credit card marker
+f06a9 md robot
+f06aa md format rotate 90
+f06ab md scanner
+f06ac md subway
+f06ad md timer sand empty
+f06ae md transit transfer
+f06af md unity
+f06b0 md update
+f06b1 md watch vibrate
+f06b2 md angular
+f06b3 md dolby
+f06b4 md emby
+f06b5 md lamp
+f06b6 md menu down outline
+f06b7 md menu up outline
+f06b8 md note multiple
+f06b9 md note multiple outline
+f06ba md plex
+f06bb md shield airplane
+f06bc md account edit
+f06bd md alert decagram
+f06be md all inclusive
+f06bf md angularjs
+f06c0 md arrow down box
+f06c1 md arrow left box
+f06c2 md arrow right box
+f06c3 md arrow up box
+f06c4 md asterisk
+f06c5 md bomb off
+f06c6 md bootstrap
+f06c7 md cards variant
+f06c8 md clipboard flow
+f06c9 md close outline
+f06ca md coffee outline
+f06cb md contacts
+f06cc md delete empty
+f06cd md earth box
+f06ce md earth box off
+f06cf md email alert
+f06d0 md eye outline
+f06d1 md eye off outline
+f06d2 md fast forward outline
+f06d3 md feather
+f06d4 md find replace
+f06d5 md flash outline
+f06d6 md format font
+f06d7 md format page break
+f06d8 md format pilcrow
+f06d9 md garage
+f06da md garage open
+f06db md card account details star outline
+f06dc md google keep
+f06dd md snowmobile
+f06de md heart half full
+f06df md heart half
+f06e0 md heart half outline
+f06e1 md hexagon multiple
+f06e2 md hook
+f06e3 md hook off
+f06e4 md infinity
+f06e5 md language swift
+f06e6 md language typescript
+f06e7 md laptop off
+f06e8 md lightbulb on
+f06e9 md lightbulb on outline
+f06ea md lock pattern
+f06eb md folder zip
+f06ec md magnify minus outline
+f06ed md magnify plus outline
+f06ee md mailbox
+f06ef md medical bag
+f06f0 md message settings
+f06f1 md message cog
+f06f2 md minus box outline
+f06f3 md network
+f06f4 md download network
+f06f5 md help network
+f06f6 md upload network
+f06f7 md npm
+f06f8 md nut
+f06f9 md octagram
+f06fa md page layout body
+f06fb md page layout footer
+f06fc md page layout header
+f06fd md page layout sidebar left
+f06fe md page layout sidebar right
+f06ff md pencil circle
+f0700 md pentagon outline
+f0701 md pentagon
+f0702 md pillar
+f0703 md pistol
+f0704 md plus box outline
+f0705 md plus outline
+f0706 md prescription
+f0707 md printer settings
+f0708 md react
+f0709 md restart
+f070a md rewind outline
+f070b md rhombus
+f070c md rhombus outline
+f070d md robot vacuum
+f070e md run
+f070f md search web
+f0710 md shovel
+f0711 md shovel off
+f0712 md signal 2g
+f0713 md signal 3g
+f0714 md signal 4g
+f0715 md signal hspa
+f0716 md signal hspa plus
+f0717 md snowflake
+f0718 md source commit
+f0719 md source commit end
+f071a md source commit end local
+f071b md source commit local
+f071c md source commit next local
+f071d md source commit start
+f071e md source commit start next local
+f071f md speaker wireless
+f0720 md stadium variant
+f0721 md svg
+f0722 md tag plus
+f0723 md tag remove
+f0724 md ticket percent
+f0725 md tilde
+f0726 md treasure chest
+f0727 md truck trailer
+f0728 md view parallel
+f0729 md view sequential
+f072a md washing machine
+f072b md webpack
+f072c md widgets
+f072d md nintendo wiiu
+f072e md arrow down bold
+f072f md arrow down bold box
+f0730 md arrow down bold box outline
+f0731 md arrow left bold
+f0732 md arrow left bold box
+f0733 md arrow left bold box outline
+f0734 md arrow right bold
+f0735 md arrow right bold box
+f0736 md arrow right bold box outline
+f0737 md arrow up bold
+f0738 md arrow up bold box
+f0739 md arrow up bold box outline
+f073a md cancel
+f073b md file account
+f073c md gesture double tap
+f073d md gesture swipe down
+f073e md gesture swipe left
+f073f md gesture swipe right
+f0740 md gesture swipe up
+f0741 md gesture tap
+f0742 md gesture two double tap
+f0743 md gesture two tap
+f0744 md humble bundle
+f0745 md kickstarter
+f0746 md netflix
+f0747 md microsoft onenote
+f0748 md wall sconce round
+f0749 md folder refresh
+f074a md vector radius
+f074b md microsoft xbox controller battery alert
+f074c md microsoft xbox controller battery empty
+f074d md microsoft xbox controller battery full
+f074e md microsoft xbox controller battery low
+f074f md microsoft xbox controller battery medium
+f0750 md microsoft xbox controller battery unknown
+f0751 md clipboard plus
+f0752 md file plus
+f0753 md format align bottom
+f0754 md format align middle
+f0755 md format align top
+f0756 md format list checks
+f0757 md format quote open
+f0758 md grid large
+f0759 md heart off
+f075a md music
+f075b md music off
+f075c md tab plus
+f075d md volume plus
+f075e md volume minus
+f075f md volume mute
+f0760 md unfold less vertical
+f0761 md unfold more vertical
+f0762 md taco
+f0763 md square outline
+f0764 md square
+f0765 md checkbox blank circle
+f0766 md checkbox blank circle outline
+f0767 md alert octagram
+f0768 md atom
+f0769 md ceiling light
+f076a md chart bar stacked
+f076b md chart line stacked
+f076c md decagram
+f076d md decagram outline
+f076e md dice multiple
+f076f md dice d10 outline
+f0770 md folder open
+f0771 md guitar acoustic
+f0772 md loading
+f0773 md lock reset
+f0774 md ninja
+f0775 md octagram outline
+f0776 md pencil circle outline
+f0777 md selection off
+f0778 md set all
+f0779 md set center
+f077a md set center right
+f077b md set left
+f077c md set left center
+f077d md set left right
+f077e md set none
+f077f md set right
+f0780 md shield half full
+f0781 md sign direction
+f0782 md sign text
+f0783 md signal off
+f0784 md square root
+f0785 md sticker emoji
+f0786 md summit
+f0787 md sword cross
+f0788 md truck fast
+f0789 md web check
+f078a md cast off
+f078b md help box
+f078c md timer sand full
+f078d md waves
+f078e md alarm bell
+f078f md alarm light
+f0790 md video switch outline
+f0791 md check decagram
+f0792 md arrow collapse down
+f0793 md arrow collapse left
+f0794 md arrow collapse right
+f0795 md arrow collapse up
+f0796 md arrow expand down
+f0797 md arrow expand left
+f0798 md arrow expand right
+f0799 md arrow expand up
+f079a md book lock
+f079b md book lock open
+f079c md bus articulated end
+f079d md bus articulated front
+f079e md bus double decker
+f079f md bus school
+f07a0 md bus side
+f07a1 md camera gopro
+f07a2 md camera metering center
+f07a3 md camera metering matrix
+f07a4 md camera metering partial
+f07a5 md camera metering spot
+f07a6 md cannabis
+f07a7 md car convertible
+f07a8 md car estate
+f07a9 md car hatchback
+f07aa md car pickup
+f07ab md car side
+f07ac md car sports
+f07ad md caravan
+f07ae md cctv
+f07af md chart donut
+f07b0 md chart donut variant
+f07b1 md chart line variant
+f07b2 md chili hot
+f07b3 md chili medium
+f07b4 md chili mild
+f07b5 md cloud braces
+f07b6 md cloud tags
+f07b7 md console line
+f07b8 md corn
+f07b9 md folder zip outline
+f07ba md currency cny
+f07bb md currency eth
+f07bc md currency jpy
+f07bd md currency krw
+f07be md currency sign
+f07bf md currency twd
+f07c0 md desktop classic
+f07c1 md dip switch
+f07c2 md donkey
+f07c3 md dots horizontal circle
+f07c4 md dots vertical circle
+f07c5 md ear hearing
+f07c6 md elephant
+f07c7 md storefront
+f07c8 md food croissant
+f07c9 md forklift
+f07ca md fuel
+f07cb md gesture
+f07cc md google analytics
+f07cd md google assistant
+f07ce md headphones off
+f07cf md high definition
+f07d0 md home assistant
+f07d1 md home automation
+f07d2 md home circle
+f07d3 md language go
+f07d4 md language r
+f07d5 md lava lamp
+f07d6 md led strip
+f07d7 md locker
+f07d8 md locker multiple
+f07d9 md map marker outline
+f07da md metronome
+f07db md metronome tick
+f07dc md micro sd
+f07dd md facebook gaming
+f07de md movie roll
+f07df md mushroom
+f07e0 md mushroom outline
+f07e1 md nintendo switch
+f07e2 md null
+f07e3 md passport
+f07e4 md molecule co2
+f07e5 md pipe
+f07e6 md pipe disconnected
+f07e7 md power socket eu
+f07e8 md power socket uk
+f07e9 md power socket us
+f07ea md rice
+f07eb md ring
+f07ec md sass
+f07ed md send lock
+f07ee md soy sauce
+f07ef md standard definition
+f07f0 md surround sound 2 0
+f07f1 md surround sound 3 1
+f07f2 md surround sound 5 1
+f07f3 md surround sound 7 1
+f07f4 md television classic
+f07f5 md form textbox password
+f07f6 md thought bubble
+f07f7 md thought bubble outline
+f07f8 md trackpad
+f07f9 md ultra high definition
+f07fa md van passenger
+f07fb md van utility
+f07fc md vanish
+f07fd md video 3d
+f07fe md wall
+f07ff md xmpp
+f0800 md account multiple plus outline
+f0801 md account plus outline
+f0802 md credit card wireless
+f0803 md account music
+f0804 md atlassian
+f0805 md microsoft azure
+f0806 md basketball
+f0807 md battery charging wireless
+f0808 md battery charging wireless 10
+f0809 md battery charging wireless 20
+f080a md battery charging wireless 30
+f080b md battery charging wireless 40
+f080c md battery charging wireless 50
+f080d md battery charging wireless 60
+f080e md battery charging wireless 70
+f080f md battery charging wireless 80
+f0810 md battery charging wireless 90
+f0811 md battery charging wireless alert
+f0812 md battery charging wireless outline
+f0813 md bitcoin
+f0814 md briefcase outline
+f0815 md cellphone wireless
+f0816 md clover
+f0817 md comment question
+f0818 md content save outline
+f0819 md delete restore
+f081a md door
+f081b md door closed
+f081c md door open
+f081d md fan off
+f081e md file percent
+f081f md finance
+f0820 md lightning bolt circle
+f0821 md floor plan
+f0822 md forum outline
+f0823 md golf
+f0824 md google home
+f0825 md guy fawkes mask
+f0826 md home account
+f0827 md home heart
+f0828 md hot tub
+f0829 md hulu
+f082a md ice cream
+f082b md image off
+f082c md karate
+f082d md ladybug
+f082e md notebook
+f082f md phone return
+f0830 md poker chip
+f0831 md shape
+f0832 md shape outline
+f0833 md ship wheel
+f0834 md soccer field
+f0835 md table column
+f0836 md table of contents
+f0837 md table row
+f0838 md table settings
+f0839 md television box
+f083a md television classic off
+f083b md television off
+f083c md tow truck
+f083d md upload multiple
+f083e md video 4k box
+f083f md video input antenna
+f0840 md video input component
+f0841 md video input hdmi
+f0842 md video input svideo
+f0843 md view dashboard variant
+f0844 md vuejs
+f0845 md xamarin
+f0846 md human male board poll
+f0847 md youtube studio
+f0848 md youtube gaming
+f0849 md account group
+f084a md camera switch outline
+f084b md airport
+f084c md arrow collapse horizontal
+f084d md arrow collapse vertical
+f084e md arrow expand horizontal
+f084f md arrow expand vertical
+f0850 md augmented reality
+f0851 md badminton
+f0852 md baseball
+f0853 md baseball bat
+f0854 md bottle wine
+f0855 md check outline
+f0856 md checkbox intermediate
+f0857 md chess king
+f0858 md chess knight
+f0859 md chess pawn
+f085a md chess queen
+f085b md chess rook
+f085c md chess bishop
+f085d md clipboard pulse
+f085e md clipboard pulse outline
+f085f md comment multiple
+f0860 md comment text multiple
+f0861 md comment text multiple outline
+f0862 md crane
+f0863 md curling
+f0864 md currency bdt
+f0865 md currency kzt
+f0866 md database search
+f0867 md dice d12 outline
+f0868 md docker
+f0869 md doorbell video
+f086a md ethereum
+f086b md eye plus
+f086c md eye plus outline
+f086d md eye settings
+f086e md eye settings outline
+f086f md file question
+f0870 md folder network
+f0871 md function variant
+f0872 md garage alert
+f0873 md gauge empty
+f0874 md gauge full
+f0875 md gauge low
+f0876 md glass wine
+f0877 md graphql
+f0878 md high definition box
+f0879 md hockey puck
+f087a md hockey sticks
+f087b md home alert
+f087c md image plus
+f087d md jquery
+f087e md lifebuoy
+f087f md mixed reality
+f0880 md nativescript
+f0881 md onepassword
+f0882 md patreon
+f0883 md close circle multiple outline
+f0884 md peace
+f0885 md phone rotate landscape
+f0886 md phone rotate portrait
+f0887 md pier
+f0888 md pier crane
+f0889 md pipe leak
+f088a md piston
+f088b md play network
+f088c md reminder
+f088d md room service
+f088e md salesforce
+f088f md shield account
+f0890 md human male board
+f0891 md thermostat box
+f0892 md tractor
+f0893 md vector ellipse
+f0894 md virtual reality
+f0895 md watch export variant
+f0896 md watch import variant
+f0897 md watch variant
+f0898 md weather hurricane
+f0899 md account heart
+f089a md alien
+f089b md anvil
+f089c md battery charging 10
+f089d md battery charging 50
+f089e md battery charging 70
+f089f md battery charging outline
+f08a0 md bed empty
+f08a1 md border all variant
+f08a2 md border bottom variant
+f08a3 md border left variant
+f08a4 md border none variant
+f08a5 md border right variant
+f08a6 md border top variant
+f08a7 md calendar edit
+f08a8 md clipboard check outline
+f08a9 md console network
+f08aa md file compare
+f08ab md fire truck
+f08ac md folder key
+f08ad md folder key network
+f08ae md expansion card
+f08af md kayaking
+f08b0 md inbox multiple
+f08b1 md language lua
+f08b2 md lock smart
+f08b3 md microphone minus
+f08b4 md microphone plus
+f08b5 md palette swatch
+f08b6 md periodic table
+f08b7 md pickaxe
+f08b8 md qrcode edit
+f08b9 md remote desktop
+f08ba md sausage
+f08bb md cog outline
+f08bc md signal cellular 1
+f08bd md signal cellular 2
+f08be md signal cellular 3
+f08bf md signal cellular outline
+f08c0 md ssh
+f08c1 md swap horizontal variant
+f08c2 md swap vertical variant
+f08c3 md tooth
+f08c4 md train variant
+f08c5 md account multiple check
+f08c6 md application
+f08c7 md arch
+f08c8 md axe
+f08c9 md bullseye arrow
+f08ca md bus clock
+f08cb md camera account
+f08cc md camera image
+f08cd md car limousine
+f08ce md cards club
+f08cf md cards diamond
+f08d0 md heart
+f08d1 md cards spade
+f08d2 md cellphone text
+f08d3 md cellphone message
+f08d4 md chart multiline
+f08d5 md circle edit outline
+f08d6 md cogs
+f08d7 md credit card settings outline
+f08d8 md death star
+f08d9 md death star variant
+f08da md debian
+f08db md fedora
+f08dc md file undo
+f08dd md floor lamp
+f08de md folder edit
+f08df md format columns
+f08e0 md freebsd
+f08e1 md gate and
+f08e2 md gate nand
+f08e3 md gate nor
+f08e4 md gate not
+f08e5 md gate or
+f08e6 md gate xnor
+f08e7 md gate xor
+f08e8 md gentoo
+f08e9 md globe model
+f08ea md hammer
+f08eb md home lock
+f08ec md home lock open
+f08ed md linux mint
+f08ee md lock alert
+f08ef md lock question
+f08f0 md map marker distance
+f08f1 md midi
+f08f2 md midi port
+f08f3 md nas
+f08f4 md network strength 1
+f08f5 md network strength 1 alert
+f08f6 md network strength 2
+f08f7 md network strength 2 alert
+f08f8 md network strength 3
+f08f9 md network strength 3 alert
+f08fa md network strength 4
+f08fb md network strength 4 alert
+f08fc md network strength off
+f08fd md network strength off outline
+f08fe md network strength outline
+f08ff md play speed
+f0900 md playlist edit
+f0901 md power cycle
+f0902 md power off
+f0903 md power on
+f0904 md power sleep
+f0905 md power socket au
+f0906 md power standby
+f0907 md rabbit
+f0908 md robot vacuum variant
+f0909 md satellite uplink
+f090a md scanner off
+f090b md book minus multiple outline
+f090c md square edit outline
+f090d md sort numeric ascending variant
+f090e md steering off
+f090f md table search
+f0910 md tag minus
+f0911 md test tube empty
+f0912 md test tube off
+f0913 md ticket outline
+f0914 md track light
+f0915 md transition
+f0916 md transition masked
+f0917 md tumble dryer
+f0918 md file refresh
+f0919 md video account
+f091a md video image
+f091b md video stabilization
+f091c md wall sconce
+f091d md wall sconce flat
+f091e md wall sconce round variant
+f091f md wifi strength 1
+f0920 md wifi strength 1 alert
+f0921 md wifi strength 1 lock
+f0922 md wifi strength 2
+f0923 md wifi strength 2 alert
+f0924 md wifi strength 2 lock
+f0925 md wifi strength 3
+f0926 md wifi strength 3 alert
+f0927 md wifi strength 3 lock
+f0928 md wifi strength 4
+f0929 md wifi strength 4 alert
+f092a md wifi strength 4 lock
+f092b md wifi strength alert outline
+f092c md wifi strength lock outline
+f092d md wifi strength off
+f092e md wifi strength off outline
+f092f md wifi strength outline
+f0930 md pin off outline
+f0931 md pin outline
+f0932 md share outline
+f0933 md trackpad lock
+f0934 md account box multiple
+f0935 md account search outline
+f0936 md account filter
+f0937 md angle acute
+f0938 md angle obtuse
+f0939 md angle right
+f093a md animation play
+f093b md arrow split horizontal
+f093c md arrow split vertical
+f093d md audio video
+f093e md battery 10 bluetooth
+f093f md battery 20 bluetooth
+f0940 md battery 30 bluetooth
+f0941 md battery 40 bluetooth
+f0942 md battery 50 bluetooth
+f0943 md battery 60 bluetooth
+f0944 md battery 70 bluetooth
+f0945 md battery 80 bluetooth
+f0946 md battery 90 bluetooth
+f0947 md battery alert bluetooth
+f0948 md battery bluetooth
+f0949 md battery bluetooth variant
+f094a md battery unknown bluetooth
+f094b md dharmachakra
+f094c md calendar search
+f094d md cellphone remove
+f094e md cellphone key
+f094f md cellphone lock
+f0950 md cellphone off
+f0951 md cellphone cog
+f0952 md cellphone sound
+f0953 md cross
+f0954 md clock
+f0955 md clock alert
+f0956 md cloud search
+f0957 md cloud search outline
+f0958 md cordova
+f0959 md cryengine
+f095a md cupcake
+f095b md sine wave
+f095c md current dc
+f095d md database import
+f095e md database export
+f095f md desk lamp
+f0960 md disc player
+f0961 md email search
+f0962 md email search outline
+f0963 md exponent
+f0964 md exponent box
+f0965 md file download
+f0966 md file download outline
+f0967 md firebase
+f0968 md folder search
+f0969 md folder search outline
+f096a md format list checkbox
+f096b md fountain
+f096c md google fit
+f096d md greater than
+f096e md greater than or equal
+f096f md hard hat
+f0970 md headphones bluetooth
+f0971 md heart circle
+f0972 md heart circle outline
+f0973 md om
+f0974 md home minus
+f0975 md home plus
+f0976 md image outline
+f0977 md image search
+f0978 md image search outline
+f0979 md star crescent
+f097a md star david
+f097b md keyboard outline
+f097c md less than
+f097d md less than or equal
+f097e md light switch
+f097f md lock clock
+f0980 md magnify close
+f0981 md map minus
+f0982 md map outline
+f0983 md map plus
+f0984 md map search
+f0985 md map search outline
+f0986 md material design
+f0987 md medal
+f0988 md microsoft dynamics 365
+f0989 md monitor cellphone
+f098a md monitor cellphone star
+f098b md mouse bluetooth
+f098c md muffin
+f098d md not equal
+f098e md not equal variant
+f098f md order bool ascending variant
+f0990 md order bool descending variant
+f0991 md office building
+f0992 md plus minus
+f0993 md plus minus box
+f0994 md podcast
+f0995 md progress check
+f0996 md progress clock
+f0997 md progress download
+f0998 md progress upload
+f0999 md qi
+f099a md record player
+f099b md restore
+f099c md shield off outline
+f099d md shield lock
+f099e md shield off
+f099f md set top box
+f09a0 md shower
+f09a1 md shower head
+f09a2 md speaker bluetooth
+f09a3 md square root box
+f09a4 md star circle outline
+f09a5 md star face
+f09a6 md table merge cells
+f09a7 md tablet cellphone
+f09a8 md text
+f09a9 md text short
+f09aa md text long
+f09ab md toilet
+f09ac md toolbox
+f09ad md toolbox outline
+f09ae md tournament
+f09af md two factor authentication
+f09b0 md umbrella closed
+f09b1 md unreal
+f09b2 md video minus
+f09b3 md video plus
+f09b4 md volleyball
+f09b5 md weight pound
+f09b6 md whistle
+f09b7 md arrow bottom left bold outline
+f09b8 md arrow bottom left thick
+f09b9 md arrow bottom right bold outline
+f09ba md arrow bottom right thick
+f09bb md arrow decision
+f09bc md arrow decision auto
+f09bd md arrow decision auto outline
+f09be md arrow decision outline
+f09bf md arrow down bold outline
+f09c0 md arrow left bold outline
+f09c1 md arrow left right bold outline
+f09c2 md arrow right bold outline
+f09c3 md arrow top left bold outline
+f09c4 md arrow top left thick
+f09c5 md arrow top right bold outline
+f09c6 md arrow top right thick
+f09c7 md arrow up bold outline
+f09c8 md arrow up down bold outline
+f09c9 md ballot
+f09ca md ballot outline
+f09cb md betamax
+f09cc md bookmark minus
+f09cd md bookmark minus outline
+f09ce md bookmark off
+f09cf md bookmark off outline
+f09d0 md braille
+f09d1 md brain
+f09d2 md calendar heart
+f09d3 md calendar star
+f09d4 md cassette
+f09d5 md cellphone arrow down
+f09d6 md chevron down box
+f09d7 md chevron down box outline
+f09d8 md chevron left box
+f09d9 md chevron left box outline
+f09da md chevron right box
+f09db md chevron right box outline
+f09dc md chevron up box
+f09dd md chevron up box outline
+f09de md circle medium
+f09df md circle small
+f09e0 md cloud alert
+f09e1 md comment arrow left
+f09e2 md comment arrow left outline
+f09e3 md comment arrow right
+f09e4 md comment arrow right outline
+f09e5 md comment plus
+f09e6 md currency php
+f09e7 md delete outline
+f09e8 md desktop mac dashboard
+f09e9 md download multiple
+f09ea md eight track
+f09eb md email plus
+f09ec md email plus outline
+f09ed md text box outline
+f09ee md file document outline
+f09ef md floppy variant
+f09f0 md flower outline
+f09f1 md flower tulip
+f09f2 md flower tulip outline
+f09f3 md format font size decrease
+f09f4 md format font size increase
+f09f5 md ghost off
+f09f6 md google lens
+f09f7 md google spreadsheet
+f09f8 md image move
+f09f9 md keyboard settings
+f09fa md keyboard settings outline
+f09fb md knife
+f09fc md knife military
+f09fd md layers off outline
+f09fe md layers outline
+f09ff md lighthouse
+f0a00 md lighthouse on
+f0a01 md map legend
+f0a02 md menu left outline
+f0a03 md menu right outline
+f0a04 md message alert outline
+f0a05 md mini sd
+f0a06 md minidisc
+f0a07 md monitor dashboard
+f0a08 md pirate
+f0a09 md pokemon go
+f0a0a md powershell
+f0a0b md printer wireless
+f0a0c md quality low
+f0a0d md quality medium
+f0a0e md reflect horizontal
+f0a0f md reflect vertical
+f0a10 md rhombus medium
+f0a11 md rhombus split
+f0a12 md shield account outline
+f0a13 md square medium
+f0a14 md square medium outline
+f0a15 md square small
+f0a16 md subtitles
+f0a17 md subtitles outline
+f0a18 md table border
+f0a19 md toggle switch off outline
+f0a1a md toggle switch outline
+f0a1b md vhs
+f0a1c md video vintage
+f0a1d md view dashboard outline
+f0a1e md microsoft visual studio code
+f0a1f md vote
+f0a20 md vote outline
+f0a21 md microsoft windows classic
+f0a22 md microsoft xbox controller battery charging
+f0a23 md zip disk
+f0a24 md aspect ratio
+f0a25 md babel
+f0a26 md balloon
+f0a27 md bank transfer
+f0a28 md bank transfer in
+f0a29 md bank transfer out
+f0a2a md briefcase minus
+f0a2b md briefcase plus
+f0a2c md briefcase remove
+f0a2d md briefcase search
+f0a2e md bug check
+f0a2f md bug check outline
+f0a30 md bug outline
+f0a31 md calendar alert
+f0a32 md calendar multiselect
+f0a33 md calendar week
+f0a34 md calendar week begin
+f0a35 md cellphone screenshot
+f0a36 md city variant
+f0a37 md city variant outline
+f0a38 md clipboard text outline
+f0a39 md cloud question
+f0a3a md comment eye
+f0a3b md comment eye outline
+f0a3c md comment search
+f0a3d md comment search outline
+f0a3e md contain
+f0a3f md contain end
+f0a40 md contain start
+f0a41 md dlna
+f0a42 md doctor
+f0a43 md dog
+f0a44 md dog side
+f0a45 md ear hearing off
+f0a46 md engine off
+f0a47 md engine off outline
+f0a48 md exit run
+f0a49 md feature search
+f0a4a md feature search outline
+f0a4b md file alert
+f0a4c md file alert outline
+f0a4d md file upload
+f0a4e md file upload outline
+f0a4f md hand front right
+f0a50 md hand okay
+f0a51 md hand peace
+f0a52 md hand peace variant
+f0a53 md hand pointing down
+f0a54 md hand pointing left
+f0a55 md hand pointing up
+f0a56 md heart multiple
+f0a57 md heart multiple outline
+f0a58 md horseshoe
+f0a59 md human female boy
+f0a5a md human female female
+f0a5b md human female girl
+f0a5c md human male boy
+f0a5d md human male girl
+f0a5e md human male male
+f0a5f md ip
+f0a60 md ip network
+f0a61 md litecoin
+f0a62 md magnify minus cursor
+f0a63 md magnify plus cursor
+f0a64 md menu swap
+f0a65 md menu swap outline
+f0a66 md puzzle outline
+f0a67 md registered trademark
+f0a68 md resize
+f0a69 md router wireless settings
+f0a6a md safe
+f0a6b md scissors cutting
+f0a6c md select drag
+f0a6d md selection drag
+f0a6e md settings helper
+f0a6f md signal 5g
+f0a70 md silverware fork knife
+f0a71 md smog
+f0a72 md solar power
+f0a73 md star box
+f0a74 md star box outline
+f0a75 md table plus
+f0a76 md table remove
+f0a77 md target variant
+f0a78 md trademark
+f0a79 md trash can
+f0a7a md trash can outline
+f0a7b md tshirt crew
+f0a7c md tshirt v
+f0a7d md zodiac aquarius
+f0a7e md zodiac aries
+f0a7f md zodiac cancer
+f0a80 md zodiac capricorn
+f0a81 md zodiac gemini
+f0a82 md zodiac leo
+f0a83 md zodiac libra
+f0a84 md zodiac pisces
+f0a85 md zodiac sagittarius
+f0a86 md zodiac scorpio
+f0a87 md zodiac taurus
+f0a88 md zodiac virgo
+f0a89 md account child
+f0a8a md account child circle
+f0a8b md account supervisor
+f0a8c md account supervisor circle
+f0a8d md ampersand
+f0a8e md web off
+f0a8f md animation outline
+f0a90 md animation play outline
+f0a91 md bell off outline
+f0a92 md bell plus outline
+f0a93 md bell sleep outline
+f0a94 md book minus multiple
+f0a95 md book plus multiple
+f0a96 md book remove multiple
+f0a97 md book remove
+f0a98 md briefcase edit
+f0a99 md bus alert
+f0a9a md calculator variant
+f0a9b md caps lock
+f0a9c md cash refund
+f0a9d md checkbook
+f0a9e md circle slice 1
+f0a9f md circle slice 2
+f0aa0 md circle slice 3
+f0aa1 md circle slice 4
+f0aa2 md circle slice 5
+f0aa3 md circle slice 6
+f0aa4 md circle slice 7
+f0aa5 md circle slice 8
+f0aa6 md collapse all
+f0aa7 md collapse all outline
+f0aa8 md credit card refund outline
+f0aa9 md database check
+f0aaa md database lock
+f0aab md desktop tower monitor
+f0aac md dishwasher
+f0aad md dog service
+f0aae md dot net
+f0aaf md egg
+f0ab0 md egg easter
+f0ab1 md email check
+f0ab2 md email check outline
+f0ab3 md et
+f0ab4 md expand all
+f0ab5 md expand all outline
+f0ab6 md file cabinet
+f0ab7 md text box multiple
+f0ab8 md text box multiple outline
+f0ab9 md file move
+f0aba md folder clock
+f0abb md folder clock outline
+f0abc md format annotation minus
+f0abd md gesture pinch
+f0abe md gesture spread
+f0abf md gesture swipe horizontal
+f0ac0 md gesture swipe vertical
+f0ac1 md hail
+f0ac2 md helicopter
+f0ac3 md hexagon slice 1
+f0ac4 md hexagon slice 2
+f0ac5 md hexagon slice 3
+f0ac6 md hexagon slice 4
+f0ac7 md hexagon slice 5
+f0ac8 md hexagon slice 6
+f0ac9 md hexagram
+f0aca md hexagram outline
+f0acb md label off
+f0acc md label off outline
+f0acd md label variant
+f0ace md label variant outline
+f0acf md language ruby on rails
+f0ad0 md laravel
+f0ad1 md mastodon
+f0ad2 md sort numeric descending variant
+f0ad3 md minus circle multiple outline
+f0ad4 md music circle outline
+f0ad5 md pinwheel
+f0ad6 md pinwheel outline
+f0ad7 md radiator disabled
+f0ad8 md radiator off
+f0ad9 md select compare
+f0ada md shield plus
+f0adb md shield plus outline
+f0adc md shield remove
+f0add md shield remove outline
+f0ade md book plus multiple outline
+f0adf md sina weibo
+f0ae0 md spray bottle
+f0ae1 md squeegee
+f0ae2 md star four points
+f0ae3 md star four points outline
+f0ae4 md star three points
+f0ae5 md star three points outline
+f0ae6 md symfony
+f0ae7 md variable
+f0ae8 md vector bezier
+f0ae9 md wiper
+f0aea md z wave
+f0aeb md zend
+f0aec md account minus outline
+f0aed md account remove outline
+f0aee md alpha a
+f0aef md alpha b
+f0af0 md alpha c
+f0af1 md alpha d
+f0af2 md alpha e
+f0af3 md alpha f
+f0af4 md alpha g
+f0af5 md alpha h
+f0af7 md alpha j
+f0af8 md alpha k
+f0afa md alpha m
+f0afb md alpha n
+f0afd md alpha p
+f0afe md alpha q
+f0aff md alpha r
+f0b00 md alpha s
+f0b01 md alpha t
+f0b02 md alpha u
+f0b04 md alpha w
+f0b06 md alpha y
+f0b07 md alpha z
+f0b08 md alpha a box
+f0b09 md alpha b box
+f0b0a md alpha c box
+f0b0b md alpha d box
+f0b0c md alpha e box
+f0b0d md alpha f box
+f0b0e md alpha g box
+f0b0f md alpha h box
+f0b10 md alpha i box
+f0b11 md alpha j box
+f0b12 md alpha k box
+f0b13 md alpha l box
+f0b14 md alpha m box
+f0b15 md alpha n box
+f0b16 md alpha o box
+f0b17 md alpha p box
+f0b18 md alpha q box
+f0b19 md alpha r box
+f0b1a md alpha s box
+f0b1b md alpha t box
+f0b1c md alpha u box
+f0b1d md alpha v box
+f0b1e md alpha w box
+f0b1f md alpha x box
+f0b20 md alpha y box
+f0b21 md alpha z box
+f0b22 md bulldozer
+f0b23 md bullhorn outline
+f0b24 md calendar export
+f0b25 md calendar import
+f0b26 md chevron down circle
+f0b27 md chevron down circle outline
+f0b28 md chevron left circle
+f0b29 md chevron left circle outline
+f0b2a md chevron right circle
+f0b2b md chevron right circle outline
+f0b2c md chevron up circle
+f0b2d md chevron up circle outline
+f0b2e md content save settings outline
+f0b2f md crystal ball
+f0b30 md ember
+f0b31 md facebook workplace
+f0b32 md file replace
+f0b33 md file replace outline
+f0b34 md format letter case
+f0b35 md format letter case lower
+f0b36 md format letter case upper
+f0b37 md language java
+f0b38 md circle multiple
+f0b39 md alpha o
+f0b3a md numeric 1
+f0b3b md numeric 2
+f0b3c md numeric 3
+f0b3d md numeric 4
+f0b3e md numeric 5
+f0b3f md numeric 6
+f0b40 md numeric 7
+f0b41 md numeric 8
+f0b42 md numeric 9
+f0b43 md origin
+f0b44 md resistor
+f0b45 md resistor nodes
+f0b46 md robot industrial
+f0b47 md shoe formal
+f0b48 md shoe heel
+f0b49 md silo
+f0b4a md box cutter off
+f0b4b md tab minus
+f0b4c md tab remove
+f0b4d md tape measure
+f0b4e md telescope
+f0b4f md yahoo
+f0b50 md account alert outline
+f0b51 md account arrow left
+f0b52 md account arrow left outline
+f0b53 md account arrow right
+f0b54 md account arrow right outline
+f0b55 md account circle outline
+f0b56 md account clock
+f0b57 md account clock outline
+f0b58 md account group outline
+f0b59 md account question
+f0b5a md account question outline
+f0b5b md artstation
+f0b5c md backspace outline
+f0b5d md barley off
+f0b5e md barn
+f0b5f md bat
+f0b60 md application settings
+f0b61 md billiards
+f0b62 md billiards rack
+f0b63 md book open outline
+f0b64 md book outline
+f0b65 md boxing glove
+f0b66 md calendar blank outline
+f0b67 md calendar outline
+f0b68 md calendar range outline
+f0b69 md camera control
+f0b6a md camera enhance outline
+f0b6b md car door
+f0b6c md car electric
+f0b6d md car key
+f0b6e md car multiple
+f0b6f md card
+f0b70 md card bulleted
+f0b71 md card bulleted off
+f0b72 md card bulleted off outline
+f0b73 md card bulleted outline
+f0b74 md card bulleted settings
+f0b75 md card bulleted settings outline
+f0b76 md card outline
+f0b77 md card text
+f0b78 md card text outline
+f0b79 md chat
+f0b7a md chat alert
+f0b7b md chat processing
+f0b7c md chef hat
+f0b7d md cloud download outline
+f0b7e md cloud upload outline
+f0b7f md coffin
+f0b80 md compass off
+f0b81 md compass off outline
+f0b82 md controller classic
+f0b83 md controller classic outline
+f0b84 md cube scan
+f0b85 md currency brl
+f0b86 md database edit
+f0b87 md deathly hallows
+f0b88 md delete circle outline
+f0b89 md delete forever outline
+f0b8a md diamond
+f0b8b md diamond outline
+f0b8c md dns outline
+f0b8d md dots horizontal circle outline
+f0b8e md dots vertical circle outline
+f0b8f md download outline
+f0b90 md drag variant
+f0b91 md eject outline
+f0b92 md email mark as unread
+f0b93 md export variant
+f0b94 md eye circle
+f0b95 md eye circle outline
+f0b96 md face man outline
+f0b97 md file find outline
+f0b98 md file remove
+f0b99 md flag minus
+f0b9a md flag plus
+f0b9b md flag remove
+f0b9c md folder account outline
+f0b9d md folder plus outline
+f0b9e md folder remove outline
+f0b9f md folder star outline
+f0ba0 md gitlab
+f0ba1 md gog
+f0ba2 md grave stone
+f0ba3 md halloween
+f0ba4 md hat fedora
+f0ba5 md help rhombus
+f0ba6 md help rhombus outline
+f0ba7 md home variant outline
+f0ba8 md inbox multiple outline
+f0ba9 md library shelves
+f0baa md mapbox
+f0bab md menu open
+f0bac md molecule
+f0bad md one up
+f0bae md open source initiative
+f0baf md pac man
+f0bb0 md page next
+f0bb1 md page next outline
+f0bb2 md page previous
+f0bb3 md page previous outline
+f0bb4 md pan
+f0bb5 md pan bottom left
+f0bb6 md pan bottom right
+f0bb7 md pan down
+f0bb8 md pan horizontal
+f0bb9 md pan left
+f0bba md pan right
+f0bbb md pan top left
+f0bbc md pan top right
+f0bbd md pan up
+f0bbe md pan vertical
+f0bbf md pumpkin
+f0bc0 md rollupjs
+f0bc1 md script
+f0bc2 md script text
+f0bc3 md script text outline
+f0bc4 md shield key
+f0bc5 md shield key outline
+f0bc6 md skull crossbones
+f0bc7 md skull crossbones outline
+f0bc8 md skull outline
+f0bc9 md space invaders
+f0bca md spider web
+f0bcb md view split horizontal
+f0bcc md view split vertical
+f0bcd md swap horizontal bold
+f0bce md swap vertical bold
+f0bcf md tag heart outline
+f0bd0 md target account
+f0bd1 md timeline
+f0bd2 md timeline outline
+f0bd3 md timeline text
+f0bd4 md timeline text outline
+f0bd5 md tooltip image outline
+f0bd6 md tooltip plus
+f0bd7 md tooltip text outline
+f0bd8 md train car
+f0bd9 md triforce
+f0bda md ubisoft
+f0bdb md video off outline
+f0bdc md video outline
+f0bdd md wallet outline
+f0bde md waze
+f0bdf md wrap disabled
+f0be0 md wrench outline
+f0be1 md access point network off
+f0be2 md account check outline
+f0be3 md account heart outline
+f0be4 md account key outline
+f0be5 md account multiple minus outline
+f0be6 md account network outline
+f0be7 md account off outline
+f0be8 md account star outline
+f0be9 md airbag
+f0bea md alarm light outline
+f0beb md alpha a box outline
+f0bec md alpha a circle
+f0bed md alpha a circle outline
+f0bee md alpha b box outline
+f0bef md alpha b circle
+f0bf0 md alpha b circle outline
+f0bf1 md alpha c box outline
+f0bf2 md alpha c circle
+f0bf3 md alpha c circle outline
+f0bf4 md alpha d box outline
+f0bf5 md alpha d circle
+f0bf6 md alpha d circle outline
+f0bf7 md alpha e box outline
+f0bf8 md alpha e circle
+f0bf9 md alpha e circle outline
+f0bfa md alpha f box outline
+f0bfb md alpha f circle
+f0bfc md alpha f circle outline
+f0bfd md alpha g box outline
+f0bfe md alpha g circle
+f0bff md alpha g circle outline
+f0c00 md alpha h box outline
+f0c01 md alpha h circle
+f0c02 md alpha h circle outline
+f0c03 md alpha i box outline
+f0c04 md alpha i circle
+f0c05 md alpha i circle outline
+f0c06 md alpha j box outline
+f0c07 md alpha j circle
+f0c08 md alpha j circle outline
+f0c09 md alpha k box outline
+f0c0a md alpha k circle
+f0c0b md alpha k circle outline
+f0c0c md alpha l box outline
+f0c0d md alpha l circle
+f0c0e md alpha l circle outline
+f0c0f md alpha m box outline
+f0c10 md alpha m circle
+f0c11 md alpha m circle outline
+f0c12 md alpha n box outline
+f0c13 md alpha n circle
+f0c14 md alpha n circle outline
+f0c15 md alpha o box outline
+f0c18 md alpha p box outline
+f0c19 md alpha p circle
+f0c1a md alpha p circle outline
+f0c1b md alpha q box outline
+f0c1c md alpha q circle
+f0c1d md alpha q circle outline
+f0c1e md alpha r box outline
+f0c1f md alpha r circle
+f0c20 md alpha r circle outline
+f0c21 md alpha s box outline
+f0c22 md alpha s circle
+f0c23 md alpha s circle outline
+f0c24 md alpha t box outline
+f0c25 md alpha t circle
+f0c26 md alpha t circle outline
+f0c27 md alpha u box outline
+f0c28 md alpha u circle
+f0c29 md alpha u circle outline
+f0c2a md alpha v box outline
+f0c2b md alpha v circle
+f0c2c md alpha v circle outline
+f0c2d md alpha w box outline
+f0c2e md alpha w circle
+f0c2f md alpha w circle outline
+f0c30 md alpha x box outline
+f0c31 md alpha x circle
+f0c32 md alpha x circle outline
+f0c33 md alpha y box outline
+f0c34 md alpha y circle
+f0c35 md alpha y circle outline
+f0c36 md alpha z box outline
+f0c37 md alpha z circle
+f0c38 md alpha z circle outline
+f0c39 md ballot recount
+f0c3a md ballot recount outline
+f0c3b md basketball hoop
+f0c3c md basketball hoop outline
+f0c3d md briefcase download outline
+f0c3e md briefcase edit outline
+f0c3f md briefcase minus outline
+f0c40 md briefcase plus outline
+f0c41 md briefcase remove outline
+f0c42 md briefcase search outline
+f0c43 md briefcase upload outline
+f0c44 md calendar check outline
+f0c45 md calendar remove outline
+f0c46 md calendar text outline
+f0c47 md car brake abs
+f0c48 md car brake alert
+f0c49 md car esp
+f0c4a md car light dimmed
+f0c4b md car light fog
+f0c4c md car light high
+f0c4d md car tire alert
+f0c4e md cart arrow right
+f0c4f md charity
+f0c50 md chart bell curve
+f0c51 md checkbox multiple outline
+f0c52 md checkbox outline
+f0c53 md check network
+f0c54 md check network outline
+f0c55 md clipboard account outline
+f0c56 md clipboard arrow down outline
+f0c57 md clipboard arrow up
+f0c58 md clipboard arrow up outline
+f0c59 md clipboard play
+f0c5a md clipboard play outline
+f0c5b md clipboard text play
+f0c5c md clipboard text play outline
+f0c5d md close box multiple
+f0c5e md close box multiple outline
+f0c5f md close network outline
+f0c60 md console network outline
+f0c61 md currency ils
+f0c62 md delete sweep outline
+f0c63 md diameter
+f0c64 md diameter outline
+f0c65 md diameter variant
+f0c66 md download network outline
+f0c67 md dump truck
+f0c68 md emoticon
+f0c69 md emoticon angry
+f0c6a md emoticon angry outline
+f0c6b md emoticon cool
+f0c6c md emoticon cry
+f0c6d md emoticon cry outline
+f0c6e md emoticon dead
+f0c6f md emoticon devil
+f0c70 md emoticon excited
+f0c71 md emoticon happy
+f0c72 md emoticon kiss
+f0c73 md emoticon kiss outline
+f0c74 md emoticon neutral
+f0c75 md emoticon poop outline
+f0c76 md emoticon sad
+f0c77 md emoticon tongue outline
+f0c78 md emoticon wink
+f0c79 md emoticon wink outline
+f0c7a md eslint
+f0c7b md face recognition
+f0c7c md file search
+f0c7d md file search outline
+f0c7e md file table
+f0c7f md file table outline
+f0c80 md folder key network outline
+f0c81 md folder network outline
+f0c82 md folder text
+f0c83 md folder text outline
+f0c84 md food apple outline
+f0c85 md fuse
+f0c86 md fuse blade
+f0c87 md google ads
+f0c88 md google street view
+f0c89 md hazard lights
+f0c8a md help network outline
+f0c8b md application brackets
+f0c8c md application brackets outline
+f0c8d md image size select actual
+f0c8e md image size select large
+f0c8f md image size select small
+f0c90 md ip network outline
+f0c91 md ipod
+f0c92 md language haskell
+f0c93 md leaf maple
+f0c94 md link plus
+f0c95 md map marker check
+f0c96 md math cos
+f0c97 md math sin
+f0c98 md math tan
+f0c99 md microwave
+f0c9a md minus network outline
+f0c9b md network off
+f0c9c md network off outline
+f0c9d md network outline
+f0c9e md alpha o circle
+f0c9f md alpha o circle outline
+f0ca0 md numeric 1 circle
+f0ca1 md numeric 1 circle outline
+f0ca2 md numeric 2 circle
+f0ca3 md numeric 2 circle outline
+f0ca4 md numeric 3 circle
+f0ca5 md numeric 3 circle outline
+f0ca6 md numeric 4 circle
+f0ca7 md numeric 4 circle outline
+f0ca8 md numeric 5 circle
+f0ca9 md numeric 5 circle outline
+f0caa md numeric 6 circle
+f0cab md numeric 6 circle outline
+f0cac md numeric 7 circle
+f0cad md numeric 7 circle outline
+f0cae md numeric 8 circle
+f0caf md numeric 8 circle outline
+f0cb0 md numeric 9 circle
+f0cb1 md numeric 9 circle outline
+f0cb2 md numeric 9 plus circle
+f0cb3 md numeric 9 plus circle outline
+f0cb4 md parachute
+f0cb5 md parachute outline
+f0cb6 md pencil outline
+f0cb7 md play network outline
+f0cb8 md playlist music
+f0cb9 md playlist music outline
+f0cba md plus network outline
+f0cbb md postage stamp
+f0cbc md progress alert
+f0cbd md progress wrench
+f0cbe md radio am
+f0cbf md radio fm
+f0cc0 md radius
+f0cc1 md radius outline
+f0cc2 md ruler square
+f0cc3 md seat
+f0cc4 md seat outline
+f0cc5 md seatbelt
+f0cc6 md sheep
+f0cc7 md shield airplane outline
+f0cc8 md shield check outline
+f0cc9 md shield cross
+f0cca md shield cross outline
+f0ccb md shield home outline
+f0ccc md shield lock outline
+f0ccd md sort variant lock
+f0cce md sort variant lock open
+f0ccf md source repository
+f0cd0 md source repository multiple
+f0cd1 md spa
+f0cd2 md spa outline
+f0cd3 md toaster oven
+f0cd4 md truck check
+f0cd5 md turnstile
+f0cd6 md turnstile outline
+f0cd7 md turtle
+f0cd8 md upload network outline
+f0cd9 md vibrate off
+f0cda md watch vibrate off
+f0cdb md arrow down circle
+f0cdc md arrow down circle outline
+f0cdd md arrow left circle
+f0cde md arrow left circle outline
+f0cdf md arrow right circle
+f0ce0 md arrow right circle outline
+f0ce1 md arrow up circle
+f0ce2 md arrow up circle outline
+f0ce3 md account tie
+f0ce4 md alert box outline
+f0ce5 md alert decagram outline
+f0ce6 md alert octagon outline
+f0ce7 md alert octagram outline
+f0ce8 md ammunition
+f0ce9 md account music outline
+f0cea md beaker
+f0ceb md blender
+f0cec md blood bag
+f0ced md cross bolnisi
+f0cee md bread slice
+f0cef md bread slice outline
+f0cf0 md briefcase account
+f0cf1 md briefcase account outline
+f0cf2 md brightness percent
+f0cf3 md bullet
+f0cf4 md cash register
+f0cf5 md cross celtic
+f0cf6 md cross outline
+f0cf7 md clipboard alert outline
+f0cf8 md clipboard arrow left outline
+f0cf9 md clipboard arrow right
+f0cfa md clipboard arrow right outline
+f0cfb md content save edit
+f0cfc md content save edit outline
+f0cfd md cursor default click
+f0cfe md cursor default click outline
+f0cff md database sync
+f0d00 md database remove
+f0d01 md database settings
+f0d02 md drama masks
+f0d03 md email box
+f0d04 md eye check
+f0d05 md eye check outline
+f0d06 md fast forward 30
+f0d07 md order alphabetical descending
+f0d08 md flower poppy
+f0d09 md folder pound
+f0d0a md folder pound outline
+f0d0b md folder sync
+f0d0c md folder sync outline
+f0d0d md format list numbered rtl
+f0d0e md format text wrapping clip
+f0d0f md format text wrapping overflow
+f0d10 md format text wrapping wrap
+f0d11 md format textbox
+f0d12 md fountain pen
+f0d13 md fountain pen tip
+f0d14 md heart broken outline
+f0d15 md home city
+f0d16 md home city outline
+f0d17 md hubspot
+f0d18 md filmstrip box multiple
+f0d19 md play box multiple
+f0d1a md link box
+f0d1b md link box outline
+f0d1c md link box variant
+f0d1d md link box variant outline
+f0d1e md map clock
+f0d1f md map clock outline
+f0d20 md map marker path
+f0d21 md mother nurse
+f0d22 md microsoft outlook
+f0d23 md perspective less
+f0d24 md perspective more
+f0d25 md podium
+f0d26 md podium bronze
+f0d27 md podium gold
+f0d28 md podium silver
+f0d29 md quora
+f0d2a md rewind 10
+f0d2b md roller skate
+f0d2c md rollerblade
+f0d2d md language ruby
+f0d2e md sack
+f0d2f md sack percent
+f0d30 md safety goggles
+f0d31 md select color
+f0d32 md selection ellipse
+f0d33 md shield link variant
+f0d34 md shield link variant outline
+f0d35 md skate
+f0d36 md skew less
+f0d37 md skew more
+f0d38 md speaker multiple
+f0d39 md stamper
+f0d3a md tank
+f0d3b md tortoise
+f0d3c md transit connection
+f0d3d md transit connection variant
+f0d3e md transmission tower
+f0d3f md weight gram
+f0d40 md youtube subscription
+f0d41 md zigbee
+f0d42 md email alert outline
+f0d43 md air filter
+f0d44 md air purifier
+f0d45 md android messages
+f0d46 md apps box
+f0d47 md atm
+f0d48 md axis
+f0d49 md axis arrow
+f0d4a md axis arrow lock
+f0d4b md axis lock
+f0d4c md axis x arrow
+f0d4d md axis x arrow lock
+f0d4e md axis x rotate clockwise
+f0d4f md axis x rotate counterclockwise
+f0d50 md axis x y arrow lock
+f0d51 md axis y arrow
+f0d52 md axis y arrow lock
+f0d53 md axis y rotate clockwise
+f0d54 md axis y rotate counterclockwise
+f0d55 md axis z arrow
+f0d56 md axis z arrow lock
+f0d57 md axis z rotate clockwise
+f0d58 md axis z rotate counterclockwise
+f0d59 md bell alert
+f0d5a md bell circle
+f0d5b md bell circle outline
+f0d5c md calendar minus
+f0d5d md camera outline
+f0d5e md car brake hold
+f0d5f md car brake parking
+f0d60 md car cruise control
+f0d61 md car defrost front
+f0d62 md car defrost rear
+f0d63 md car parking lights
+f0d64 md car traction control
+f0d65 md bag carry on check
+f0d66 md cart arrow down
+f0d67 md cart arrow up
+f0d68 md cart minus
+f0d69 md cart remove
+f0d6a md contactless payment
+f0d6b md creative commons
+f0d6c md credit card wireless outline
+f0d6d md cricket
+f0d6e md dev to
+f0d6f md domain off
+f0d70 md face agent
+f0d71 md fast forward 10
+f0d72 md flare
+f0d73 md format text rotation down
+f0d74 md format text rotation none
+f0d75 md forwardburger
+f0d76 md gesture swipe
+f0d77 md gesture tap hold
+f0d78 md file gif box
+f0d79 md go kart
+f0d7a md go kart track
+f0d7b md goodreads
+f0d7c md grain
+f0d7d md hdr
+f0d7e md hdr off
+f0d7f md hiking
+f0d80 md home floor 1
+f0d81 md home floor 2
+f0d82 md home floor 3
+f0d83 md home floor a
+f0d84 md home floor b
+f0d85 md home floor g
+f0d86 md home floor l
+f0d87 md kabaddi
+f0d88 md mailbox open
+f0d89 md mailbox open outline
+f0d8a md mailbox open up
+f0d8b md mailbox open up outline
+f0d8c md mailbox outline
+f0d8d md mailbox up
+f0d8e md mailbox up outline
+f0d8f md mixed martial arts
+f0d90 md monitor off
+f0d91 md motion sensor
+f0d92 md point of sale
+f0d93 md racing helmet
+f0d94 md racquetball
+f0d95 md restart off
+f0d96 md rewind 30
+f0d97 md room service outline
+f0d98 md rotate orbit
+f0d99 md rugby
+f0d9a md shield search
+f0d9b md solar panel
+f0d9c md solar panel large
+f0d9d md subway alert variant
+f0d9e md tea
+f0d9f md tea outline
+f0da0 md tennis
+f0da1 md transfer down
+f0da2 md transfer left
+f0da3 md transfer up
+f0da4 md trophy broken
+f0da5 md wind turbine
+f0da6 md wiper wash
+f0da7 md badge account
+f0da8 md badge account alert
+f0da9 md badge account alert outline
+f0daa md badge account outline
+f0dab md card account details outline
+f0dac md air horn
+f0dad md application export
+f0dae md application import
+f0daf md bandage
+f0db0 md bank minus
+f0db1 md bank plus
+f0db2 md bank remove
+f0db3 md bolt
+f0db4 md bugle
+f0db5 md cactus
+f0db6 md camera wireless
+f0db7 md camera wireless outline
+f0db8 md cash marker
+f0db9 md chevron triple down
+f0dba md chevron triple left
+f0dbb md chevron triple right
+f0dbc md chevron triple up
+f0dbd md closed caption outline
+f0dbe md credit card marker outline
+f0dbf md diving flippers
+f0dc0 md diving helmet
+f0dc1 md diving scuba
+f0dc2 md diving scuba flag
+f0dc3 md diving scuba tank
+f0dc4 md diving scuba tank multiple
+f0dc5 md diving snorkel
+f0dc6 md file cancel
+f0dc7 md file cancel outline
+f0dc8 md file document edit
+f0dc9 md file document edit outline
+f0dca md file eye
+f0dcb md file eye outline
+f0dcc md folder alert
+f0dcd md folder alert outline
+f0dce md folder edit outline
+f0dcf md folder open outline
+f0dd0 md format list bulleted square
+f0dd1 md gantry crane
+f0dd2 md home floor 0
+f0dd3 md home floor negative 1
+f0dd4 md home group
+f0dd5 md jabber
+f0dd6 md key outline
+f0dd7 md leak
+f0dd8 md leak off
+f0dd9 md marker cancel
+f0dda md mine
+f0ddb md monitor lock
+f0ddc md monitor star
+f0ddd md movie outline
+f0dde md music note plus
+f0ddf md nail
+f0de0 md ocarina
+f0de1 md passport biometric
+f0de2 md pen lock
+f0de3 md pen minus
+f0de4 md pen off
+f0de5 md pen plus
+f0de6 md pen remove
+f0de7 md pencil lock outline
+f0de8 md pencil minus
+f0de9 md pencil minus outline
+f0dea md pencil off outline
+f0deb md pencil plus
+f0dec md pencil plus outline
+f0ded md pencil remove
+f0dee md pencil remove outline
+f0def md phone off
+f0df0 md phone outline
+f0df1 md pi hole
+f0df2 md playlist star
+f0df3 md screw flat top
+f0df4 md screw lag
+f0df5 md screw machine flat top
+f0df6 md screw machine round top
+f0df7 md screw round top
+f0df8 md send circle
+f0df9 md send circle outline
+f0dfa md shoe print
+f0dfb md signature
+f0dfc md signature freehand
+f0dfd md signature image
+f0dfe md signature text
+f0dff md slope downhill
+f0e00 md slope uphill
+f0e01 md thermometer alert
+f0e02 md thermometer chevron down
+f0e03 md thermometer chevron up
+f0e04 md thermometer minus
+f0e05 md thermometer plus
+f0e06 md translate off
+f0e07 md upload outline
+f0e08 md volume variant off
+f0e09 md wallpaper
+f0e0a md water outline
+f0e0b md wifi star
+f0e0c md palette outline
+f0e0d md badge account horizontal
+f0e0e md badge account horizontal outline
+f0e0f md aws
+f0e10 md bag personal
+f0e11 md bag personal off
+f0e12 md bag personal off outline
+f0e13 md bag personal outline
+f0e14 md biathlon
+f0e15 md bookmark multiple
+f0e16 md bookmark multiple outline
+f0e17 md calendar month
+f0e18 md calendar month outline
+f0e19 md camera retake
+f0e1a md camera retake outline
+f0e1b md car back
+f0e1c md car off
+f0e1d md cast education
+f0e1e md check bold
+f0e1f md check underline
+f0e20 md check underline circle
+f0e21 md check underline circle outline
+f0e22 md circular saw
+f0e23 md comma
+f0e24 md comma box outline
+f0e25 md comma circle
+f0e26 md comma circle outline
+f0e27 md content save move
+f0e28 md content save move outline
+f0e29 md file check outline
+f0e2a md file music outline
+f0e2b md comma box
+f0e2c md file video outline
+f0e2d md file png box
+f0e2e md fireplace
+f0e2f md fireplace off
+f0e30 md firework
+f0e31 md format color highlight
+f0e32 md format text variant
+f0e33 md gamepad circle
+f0e34 md gamepad circle down
+f0e35 md gamepad circle left
+f0e36 md gamepad circle outline
+f0e37 md gamepad circle right
+f0e38 md gamepad circle up
+f0e39 md gamepad down
+f0e3a md gamepad left
+f0e3b md gamepad right
+f0e3c md gamepad round
+f0e3d md gamepad round down
+f0e3e md gamepad round left
+f0e3f md gamepad round outline
+f0e40 md gamepad round right
+f0e41 md gamepad round up
+f0e42 md gamepad up
+f0e43 md gatsby
+f0e44 md gift
+f0e45 md grill
+f0e46 md hand back left
+f0e47 md hand back right
+f0e48 md hand saw
+f0e49 md image frame
+f0e4a md invert colors off
+f0e4b md keyboard off outline
+f0e4c md layers minus
+f0e4d md layers plus
+f0e4e md layers remove
+f0e4f md lightbulb off
+f0e50 md lightbulb off outline
+f0e51 md monitor screenshot
+f0e52 md ice cream off
+f0e53 md nfc search variant
+f0e54 md nfc variant off
+f0e55 md notebook multiple
+f0e56 md hoop house
+f0e57 md picture in picture bottom right
+f0e58 md picture in picture bottom right outline
+f0e59 md picture in picture top right
+f0e5a md picture in picture top right outline
+f0e5b md printer 3d nozzle
+f0e5c md printer 3d nozzle outline
+f0e5d md printer off
+f0e5e md rectangle
+f0e5f md rectangle outline
+f0e60 md rivet
+f0e61 md saw blade
+f0e62 md seed
+f0e63 md seed outline
+f0e64 md signal distance variant
+f0e65 md spade
+f0e66 md sprout
+f0e67 md sprout outline
+f0e68 md table tennis
+f0e69 md tree outline
+f0e6a md view comfy
+f0e6b md view compact
+f0e6c md view compact outline
+f0e6d md vuetify
+f0e6e md weather cloudy arrow right
+f0e6f md microsoft xbox controller menu
+f0e70 md microsoft xbox controller view
+f0e71 md alarm note
+f0e72 md alarm note off
+f0e73 md arrow left right
+f0e74 md arrow left right bold
+f0e75 md arrow top left bottom right
+f0e76 md arrow top left bottom right bold
+f0e77 md arrow top right bottom left
+f0e78 md arrow top right bottom left bold
+f0e79 md arrow up down
+f0e7a md arrow up down bold
+f0e7b md atom variant
+f0e7c md baby face
+f0e7d md baby face outline
+f0e7e md backspace reverse
+f0e7f md backspace reverse outline
+f0e80 md bank outline
+f0e81 md bell alert outline
+f0e82 md book play
+f0e83 md book play outline
+f0e84 md book search
+f0e85 md book search outline
+f0e86 md boom gate
+f0e87 md boom gate alert
+f0e88 md boom gate alert outline
+f0e89 md boom gate arrow down
+f0e8a md boom gate arrow down outline
+f0e8b md boom gate outline
+f0e8c md boom gate arrow up
+f0e8d md boom gate arrow up outline
+f0e8e md calendar sync
+f0e8f md calendar sync outline
+f0e90 md cellphone nfc
+f0e91 md chart areaspline variant
+f0e92 md chart scatter plot
+f0e93 md chart timeline variant
+f0e94 md chart tree
+f0e95 md circle double
+f0e96 md circle expand
+f0e97 md clock digital
+f0e98 md card account mail outline
+f0e99 md card account phone
+f0e9a md card account phone outline
+f0e9b md account cowboy hat
+f0e9c md currency rial
+f0e9d md delete empty outline
+f0e9e md dolly
+f0e9f md electric switch
+f0ea0 md ellipse
+f0ea1 md ellipse outline
+f0ea2 md equalizer
+f0ea3 md equalizer outline
+f0ea4 md ferris wheel
+f0ea5 md file delimited outline
+f0ea6 md text box check
+f0ea7 md text box check outline
+f0ea8 md text box minus
+f0ea9 md text box minus outline
+f0eaa md text box plus
+f0eab md text box plus outline
+f0eac md text box remove
+f0ead md text box remove outline
+f0eae md text box search
+f0eaf md text box search outline
+f0eb0 md file image outline
+f0eb1 md fingerprint off
+f0eb2 md format list bulleted triangle
+f0eb3 md format overline
+f0eb4 md frequently asked questions
+f0eb5 md gamepad square
+f0eb6 md gamepad square outline
+f0eb7 md gamepad variant outline
+f0eb8 md gas station outline
+f0eb9 md google podcast
+f0eba md home analytics
+f0ebb md mail
+f0ebc md map check
+f0ebd md map check outline
+f0ebe md ruler square compass
+f0ebf md notebook outline
+f0ec0 md penguin
+f0ec1 md radioactive off
+f0ec2 md record circle
+f0ec3 md record circle outline
+f0ec4 md remote off
+f0ec5 md remote tv
+f0ec6 md remote tv off
+f0ec7 md rotate 3d
+f0ec8 md sail boat
+f0ec9 md scatter plot
+f0eca md scatter plot outline
+f0ecb md segment
+f0ecc md shield alert
+f0ecd md shield alert outline
+f0ece md tablet dashboard
+f0ecf md television play
+f0ed0 md unicode
+f0ed1 md video 3d variant
+f0ed2 md video wireless
+f0ed3 md video wireless outline
+f0ed4 md account voice off
+f0ed5 md bacteria
+f0ed6 md bacteria outline
+f0ed7 md calendar account
+f0ed8 md calendar account outline
+f0ed9 md calendar weekend
+f0eda md calendar weekend outline
+f0edb md camera plus
+f0edc md camera plus outline
+f0edd md campfire
+f0ede md chat outline
+f0edf md cpu 32 bit
+f0ee0 md cpu 64 bit
+f0ee1 md credit card clock
+f0ee2 md credit card clock outline
+f0ee3 md email edit
+f0ee4 md email edit outline
+f0ee5 md email minus
+f0ee6 md email minus outline
+f0ee7 md email multiple
+f0ee8 md email multiple outline
+f0ee9 md email open multiple
+f0eea md email open multiple outline
+f0eeb md file cad
+f0eec md file cad box
+f0eed md file plus outline
+f0eee md filter minus
+f0eef md filter minus outline
+f0ef0 md filter plus
+f0ef1 md filter plus outline
+f0ef2 md fire extinguisher
+f0ef3 md fishbowl
+f0ef4 md fishbowl outline
+f0ef5 md fit to page
+f0ef6 md fit to page outline
+f0ef7 md flash alert
+f0ef8 md flash alert outline
+f0ef9 md heart flash
+f0efa md home flood
+f0efb md human male height
+f0efc md human male height variant
+f0efd md ice pop
+f0efe md identifier
+f0eff md image filter center focus strong
+f0f00 md image filter center focus strong outline
+f0f01 md jellyfish
+f0f02 md jellyfish outline
+f0f03 md lasso
+f0f04 md music box multiple outline
+f0f05 md map marker alert
+f0f06 md map marker alert outline
+f0f07 md map marker question
+f0f08 md map marker question outline
+f0f09 md map marker remove
+f0f0a md map marker remove variant
+f0f0b md necklace
+f0f0c md newspaper minus
+f0f0d md newspaper plus
+f0f0e md numeric 0 box multiple
+f0f0f md numeric 1 box multiple
+f0f10 md numeric 2 box multiple
+f0f11 md numeric 3 box multiple
+f0f12 md numeric 4 box multiple
+f0f13 md numeric 5 box multiple
+f0f14 md numeric 6 box multiple
+f0f15 md numeric 7 box multiple
+f0f16 md numeric 8 box multiple
+f0f17 md numeric 9 box multiple
+f0f18 md numeric 9 plus box multiple
+f0f19 md oil lamp
+f0f1a md phone alert
+f0f1b md play outline
+f0f1c md purse
+f0f1d md purse outline
+f0f1e md railroad light
+f0f1f md reply all outline
+f0f20 md reply outline
+f0f21 md rss off
+f0f22 md selection ellipse arrow inside
+f0f23 md share off
+f0f24 md share off outline
+f0f25 md skip backward outline
+f0f26 md skip forward outline
+f0f27 md skip next outline
+f0f28 md skip previous outline
+f0f29 md snowflake alert
+f0f2a md snowflake variant
+f0f2b md stretch to page
+f0f2c md stretch to page outline
+f0f2d md typewriter
+f0f2e md wave
+f0f2f md weather cloudy alert
+f0f30 md weather hazy
+f0f31 md weather night partly cloudy
+f0f32 md weather partly lightning
+f0f33 md weather partly rainy
+f0f34 md weather partly snowy
+f0f35 md weather partly snowy rainy
+f0f36 md weather snowy heavy
+f0f37 md weather sunny alert
+f0f38 md weather tornado
+f0f39 md baby bottle
+f0f3a md baby bottle outline
+f0f3b md bag carry on
+f0f3c md bag carry on off
+f0f3d md bag checked
+f0f3e md baguette
+f0f3f md bus multiple
+f0f40 md car shift pattern
+f0f41 md cellphone information
+f0f42 md content save alert
+f0f43 md content save alert outline
+f0f44 md content save all outline
+f0f45 md crosshairs off
+f0f46 md cupboard
+f0f47 md cupboard outline
+f0f48 md chair rolling
+f0f49 md draw
+f0f4a md dresser
+f0f4b md dresser outline
+f0f4c md emoticon frown
+f0f4d md emoticon frown outline
+f0f4e md focus auto
+f0f4f md focus field
+f0f50 md focus field horizontal
+f0f51 md focus field vertical
+f0f52 md foot print
+f0f53 md handball
+f0f54 md home thermometer
+f0f55 md home thermometer outline
+f0f56 md kettle outline
+f0f57 md latitude
+f0f58 md layers triple
+f0f59 md layers triple outline
+f0f5a md longitude
+f0f5b md language markdown outline
+f0f5c md merge
+f0f5d md middleware
+f0f5e md middleware outline
+f0f5f md monitor speaker
+f0f60 md monitor speaker off
+f0f61 md moon first quarter
+f0f62 md moon full
+f0f63 md moon last quarter
+f0f64 md moon new
+f0f65 md moon waning crescent
+f0f66 md moon waning gibbous
+f0f67 md moon waxing crescent
+f0f68 md moon waxing gibbous
+f0f69 md music accidental double flat
+f0f6a md music accidental double sharp
+f0f6b md music accidental flat
+f0f6c md music accidental natural
+f0f6d md music accidental sharp
+f0f6e md music clef alto
+f0f6f md music clef bass
+f0f70 md music clef treble
+f0f71 md music note eighth dotted
+f0f72 md music note half dotted
+f0f73 md music note off outline
+f0f74 md music note outline
+f0f75 md music note quarter dotted
+f0f76 md music note sixteenth dotted
+f0f77 md music note whole dotted
+f0f78 md music rest eighth
+f0f79 md music rest half
+f0f7a md music rest quarter
+f0f7b md music rest sixteenth
+f0f7c md music rest whole
+f0f7d md numeric 10 box
+f0f7e md numeric 10 box outline
+f0f7f md page layout header footer
+f0f80 md patio heater
+f0f81 md warehouse
+f0f82 md select group
+f0f83 md shield car
+f0f84 md shopping search
+f0f85 md speedometer medium
+f0f86 md speedometer slow
+f0f87 md table large plus
+f0f88 md table large remove
+f0f89 md television pause
+f0f8a md television stop
+f0f8b md transit detour
+f0f8c md video input scart
+f0f8d md view grid plus
+f0f8e md wallet plus
+f0f8f md wallet plus outline
+f0f90 md wardrobe
+f0f91 md wardrobe outline
+f0f92 md water boiler
+f0f93 md water pump off
+f0f94 md web box
+f0f95 md timeline alert
+f0f96 md timeline plus
+f0f97 md timeline plus outline
+f0f98 md timeline alert outline
+f0f99 md timeline help
+f0f9a md timeline help outline
+f0f9b md home export outline
+f0f9c md home import outline
+f0f9d md account filter outline
+f0f9e md approximately equal
+f0f9f md approximately equal box
+f0fa0 md baby carriage off
+f0fa1 md bee
+f0fa2 md bee flower
+f0fa3 md car child seat
+f0fa4 md car seat
+f0fa5 md car seat cooler
+f0fa6 md car seat heater
+f0fa7 md chart bell curve cumulative
+f0fa8 md clock check
+f0fa9 md clock check outline
+f0faa md coffee off
+f0fab md coffee off outline
+f0fac md credit card minus
+f0fad md credit card minus outline
+f0fae md credit card remove
+f0faf md credit card remove outline
+f0fb0 md devices
+f0fb1 md email newsletter
+f0fb2 md expansion card variant
+f0fb3 md power socket ch
+f0fb4 md file swap
+f0fb5 md file swap outline
+f0fb6 md folder swap
+f0fb7 md folder swap outline
+f0fb8 md format letter ends with
+f0fb9 md format letter matches
+f0fba md format letter starts with
+f0fbb md format text rotation angle down
+f0fbc md format text rotation angle up
+f0fbd md format text rotation down vertical
+f0fbe md format text rotation up
+f0fbf md format text rotation vertical
+f0fc0 md id card
+f0fc1 md image auto adjust
+f0fc2 md key wireless
+f0fc3 md license
+f0fc4 md location enter
+f0fc5 md location exit
+f0fc6 md lock open variant
+f0fc7 md lock open variant outline
+f0fc8 md math integral
+f0fc9 md math integral box
+f0fca md math norm
+f0fcb md math norm box
+f0fcc md message lock
+f0fcd md message text lock
+f0fce md movie open
+f0fcf md movie open outline
+f0fd0 md bed queen
+f0fd1 md bed king outline
+f0fd2 md bed king
+f0fd3 md bed double outline
+f0fd4 md bed double
+f0fd5 md microsoft azure devops
+f0fd6 md arm flex outline
+f0fd7 md arm flex
+f0fd8 md protocol
+f0fd9 md seal variant
+f0fda md select place
+f0fdb md bed queen outline
+f0fdc md sign direction plus
+f0fdd md sign direction remove
+f0fde md silverware clean
+f0fdf md slash forward
+f0fe0 md slash forward box
+f0fe1 md swap horizontal circle
+f0fe2 md swap horizontal circle outline
+f0fe3 md swap vertical circle
+f0fe4 md swap vertical circle outline
+f0fe5 md tanker truck
+f0fe6 md texture box
+f0fe7 md tram side
+f0fe8 md vector link
+f0fe9 md numeric 10
+f0fea md numeric 10 box multiple
+f0feb md numeric 10 box multiple outline
+f0fec md numeric 10 circle
+f0fed md numeric 10 circle outline
+f0fee md numeric 9 plus
+f0fef md credit card
+f0ff0 md credit card multiple
+f0ff1 md credit card off
+f0ff2 md credit card plus
+f0ff3 md credit card refund
+f0ff4 md credit card scan
+f0ff5 md credit card settings
+f0ff6 md hospital
+f0ff7 md hospital box outline
+f0ff8 md oil temperature
+f0ff9 md stadium
+f0ffa md zip box outline
+f0ffb md account edit outline
+f0ffc md peanut
+f0ffd md peanut off
+f0ffe md peanut outline
+f0fff md peanut off outline
+f1000 md sign direction minus
+f1001 md newspaper variant
+f1002 md newspaper variant multiple
+f1003 md newspaper variant multiple outline
+f1004 md newspaper variant outline
+f1005 md overscan
+f1006 md pig variant
+f1007 md piggy bank
+f1008 md post
+f1009 md post outline
+f100a md account box multiple outline
+f100b md airballoon outline
+f100c md alphabetical off
+f100d md alphabetical variant
+f100e md alphabetical variant off
+f100f md apache kafka
+f1010 md billboard
+f1011 md blinds open
+f1012 md bus stop
+f1013 md bus stop covered
+f1014 md bus stop uncovered
+f1015 md car 2 plus
+f1016 md car 3 plus
+f1017 md car brake retarder
+f1018 md car clutch
+f1019 md car coolant level
+f101a md car turbocharger
+f101b md car windshield
+f101c md car windshield outline
+f101d md cards diamond outline
+f101e md cast audio
+f101f md cellphone play
+f1020 md coach lamp
+f1021 md comment quote
+f1022 md comment quote outline
+f1023 md domino mask
+f1024 md electron framework
+f1025 md excavator
+f1026 md eye minus
+f1027 md eye minus outline
+f1028 md file account outline
+f1029 md file chart outline
+f102a md file cloud outline
+f102b md file code outline
+f102c md file excel box outline
+f102d md file excel outline
+f102e md file export outline
+f102f md file import outline
+f1030 md file lock outline
+f1031 md file move outline
+f1032 md file multiple outline
+f1033 md file percent outline
+f1034 md file powerpoint box outline
+f1035 md file powerpoint outline
+f1036 md file question outline
+f1037 md file remove outline
+f1038 md file restore outline
+f1039 md file send outline
+f103a md file star
+f103b md file star outline
+f103c md file undo outline
+f103d md file word box outline
+f103e md file word outline
+f103f md filter variant remove
+f1040 md floor lamp dual
+f1041 md floor lamp torchiere variant
+f1042 md fruit cherries
+f1043 md fruit citrus
+f1044 md fruit grapes
+f1045 md fruit grapes outline
+f1046 md fruit pineapple
+f1047 md fruit watermelon
+f1048 md google my business
+f1049 md graph
+f104a md graph outline
+f104b md harddisk plus
+f104c md harddisk remove
+f104d md home circle outline
+f104e md instrument triangle
+f104f md island
+f1050 md keyboard space
+f1051 md led strip variant
+f1052 md numeric negative 1
+f1053 md oil level
+f1054 md outdoor lamp
+f1055 md palm tree
+f1056 md party popper
+f1057 md printer pos
+f1058 md robber
+f1059 md routes clock
+f105a md scale off
+f105b md cog transfer
+f105c md cog transfer outline
+f105d md shield sun
+f105e md shield sun outline
+f105f md sprinkler
+f1060 md sprinkler variant
+f1061 md table chair
+f1062 md terraform
+f1063 md toaster
+f1064 md tools
+f1065 md transfer
+f1066 md valve
+f1067 md valve closed
+f1068 md valve open
+f1069 md video check
+f106a md video check outline
+f106b md water well
+f106c md water well outline
+f106d md bed single
+f106e md bed single outline
+f106f md book information variant
+f1070 md bottle soda
+f1071 md bottle soda classic
+f1072 md bottle soda outline
+f1073 md calendar blank multiple
+f1074 md card search
+f1075 md card search outline
+f1076 md face woman profile
+f1077 md face woman
+f1078 md face woman outline
+f1079 md file settings
+f107a md file settings outline
+f107b md file cog
+f107c md file cog outline
+f107d md folder settings
+f107e md folder settings outline
+f107f md folder cog
+f1080 md folder cog outline
+f1081 md furigana horizontal
+f1082 md furigana vertical
+f1083 md golf tee
+f1084 md lungs
+f1085 md math log
+f1086 md moped
+f1087 md router network
+f1088 md alpha i
+f1089 md roman numeral 2
+f108a md roman numeral 3
+f108b md roman numeral 4
+f108c md alpha v
+f108d md roman numeral 6
+f108e md roman numeral 7
+f108f md roman numeral 8
+f1090 md roman numeral 9
+f1091 md alpha x
+f1092 md soldering iron
+f1093 md stomach
+f1094 md table eye
+f1095 md form textarea
+f1096 md trumpet
+f1097 md account cash
+f1098 md account cash outline
+f1099 md air humidifier
+f109a md ansible
+f109b md api
+f109c md bicycle
+f109d md car door lock
+f109e md coat rack
+f109f md coffee maker
+f10a0 md web minus
+f10a1 md decimal
+f10a2 md decimal comma
+f10a3 md decimal comma decrease
+f10a4 md decimal comma increase
+f10a5 md delete alert
+f10a6 md delete alert outline
+f10a7 md delete off
+f10a8 md delete off outline
+f10a9 md dock bottom
+f10aa md dock left
+f10ab md dock right
+f10ac md dock window
+f10ad md domain plus
+f10ae md domain remove
+f10af md door closed lock
+f10b0 md download off
+f10b1 md download off outline
+f10b2 md flag minus outline
+f10b3 md flag plus outline
+f10b4 md flag remove outline
+f10b5 md folder home
+f10b6 md folder home outline
+f10b7 md folder information
+f10b8 md folder information outline
+f10b9 md iv bag
+f10ba md link lock
+f10bb md message plus outline
+f10bc md phone cancel
+f10bd md smart card
+f10be md smart card outline
+f10bf md smart card reader
+f10c0 md smart card reader outline
+f10c1 md storefront outline
+f10c2 md thermometer high
+f10c3 md thermometer low
+f10c4 md ufo
+f10c5 md ufo outline
+f10c6 md upload off
+f10c7 md upload off outline
+f10c8 md account child outline
+f10c9 md account settings outline
+f10ca md account tie outline
+f10cb md alien outline
+f10cc md battery alert variant
+f10cd md battery alert variant outline
+f10ce md beehive outline
+f10cf md boomerang
+f10d0 md briefcase clock
+f10d1 md briefcase clock outline
+f10d2 md cellphone message off
+f10d3 md circle off outline
+f10d4 md clipboard list
+f10d5 md clipboard list outline
+f10d6 md code braces box
+f10d7 md code parentheses box
+f10d8 md consolidate
+f10d9 md electric switch closed
+f10da md email receive
+f10db md email receive outline
+f10dc md email send
+f10dd md email send outline
+f10de md emoticon confused
+f10df md emoticon confused outline
+f10e0 md epsilon
+f10e1 md file table box
+f10e2 md file table box multiple
+f10e3 md file table box multiple outline
+f10e4 md file table box outline
+f10e5 md filter menu
+f10e6 md filter menu outline
+f10e7 md flip horizontal
+f10e8 md flip vertical
+f10e9 md folder download outline
+f10ea md folder heart
+f10eb md folder heart outline
+f10ec md folder key outline
+f10ed md folder upload outline
+f10ee md gamma
+f10ef md hair dryer
+f10f0 md hair dryer outline
+f10f1 md hand heart
+f10f2 md hexagon multiple outline
+f10f3 md horizontal rotate clockwise
+f10f4 md horizontal rotate counterclockwise
+f10f5 md application array
+f10f6 md application array outline
+f10f7 md application braces
+f10f8 md application braces outline
+f10f9 md application parentheses
+f10fa md application parentheses outline
+f10fb md application variable
+f10fc md application variable outline
+f10fd md khanda
+f10fe md kubernetes
+f10ff md link variant minus
+f1100 md link variant plus
+f1101 md link variant remove
+f1102 md map marker down
+f1103 md map marker up
+f1104 md monitor shimmer
+f1105 md nix
+f1106 md nuxt
+f1107 md power socket de
+f1108 md power socket fr
+f1109 md power socket jp
+f110a md progress close
+f110b md reload alert
+f110c md restart alert
+f110d md restore alert
+f110e md shaker
+f110f md shaker outline
+f1110 md television shimmer
+f1111 md variable box
+f1112 md filter variant minus
+f1113 md filter variant plus
+f1114 md slot machine
+f1115 md slot machine outline
+f1116 md glass mug variant
+f1117 md clipboard flow outline
+f1118 md sign real estate
+f1119 md antenna
+f111a md centos
+f111b md redhat
+f111c md window shutter
+f111d md window shutter alert
+f111e md window shutter open
+f111f md bike fast
+f1120 md volume source
+f1121 md volume vibrate
+f1122 md movie edit
+f1123 md movie edit outline
+f1124 md movie filter
+f1125 md movie filter outline
+f1126 md diabetes
+f1127 md cursor default gesture
+f1128 md cursor default gesture outline
+f1129 md toothbrush
+f112a md toothbrush paste
+f112b md home roof
+f112c md toothbrush electric
+f112d md account supervisor outline
+f112e md bottle tonic
+f112f md bottle tonic outline
+f1130 md bottle tonic plus
+f1131 md bottle tonic plus outline
+f1132 md bottle tonic skull
+f1133 md bottle tonic skull outline
+f1134 md calendar arrow left
+f1135 md calendar arrow right
+f1136 md crosshairs question
+f1137 md fire hydrant
+f1138 md fire hydrant alert
+f1139 md fire hydrant off
+f113a md ocr
+f113b md shield star
+f113c md shield star outline
+f113d md text recognition
+f113e md handcuffs
+f113f md gender male female variant
+f1140 md gender non binary
+f1141 md minus box multiple
+f1142 md minus box multiple outline
+f1143 md plus box multiple outline
+f1144 md pencil box multiple
+f1145 md pencil box multiple outline
+f1146 md printer check
+f1147 md sort variant remove
+f1148 md sort alphabetical ascending variant
+f1149 md sort alphabetical descending variant
+f114a md dice 1 outline
+f114b md dice 2 outline
+f114c md dice 3 outline
+f114d md dice 4 outline
+f114e md dice 5 outline
+f114f md dice 6 outline
+f1150 md dice d4
+f1151 md dice d6
+f1152 md dice d8
+f1153 md dice d10
+f1154 md dice d12
+f1155 md dice d20
+f1156 md dice multiple outline
+f1157 md paper roll
+f1158 md paper roll outline
+f1159 md home edit
+f115a md home edit outline
+f115b md arrow horizontal lock
+f115c md arrow vertical lock
+f115d md weight lifter
+f115e md account lock
+f115f md account lock outline
+f1160 md pasta
+f1161 md send check
+f1162 md send check outline
+f1163 md send clock
+f1164 md send clock outline
+f1165 md send outline
+f1166 md send lock outline
+f1167 md police badge
+f1168 md police badge outline
+f1169 md gate arrow right
+f116a md gate open
+f116b md bell badge
+f116c md message image outline
+f116d md message lock outline
+f116e md message minus
+f116f md message minus outline
+f1170 md message processing outline
+f1171 md message settings outline
+f1172 md message cog outline
+f1173 md message text clock
+f1174 md message text clock outline
+f1175 md message text lock outline
+f1176 md checkbox blank badge
+f1177 md file link
+f1178 md file link outline
+f1179 md file phone
+f117a md file phone outline
+f117b md meditation
+f117c md yoga
+f117d md leek
+f117e md noodles
+f117f md pound box outline
+f1180 md school outline
+f1181 md basket outline
+f1182 md phone in talk outline
+f1183 md bash
+f1184 md file key
+f1185 md file key outline
+f1186 md file certificate
+f1187 md file certificate outline
+f1188 md certificate outline
+f1189 md cigar
+f118a md grill outline
+f118b md qrcode plus
+f118c md qrcode minus
+f118d md qrcode remove
+f118e md phone alert outline
+f118f md phone bluetooth outline
+f1190 md phone cancel outline
+f1191 md phone forward outline
+f1192 md phone hangup outline
+f1193 md phone incoming outline
+f1194 md phone lock outline
+f1195 md phone log outline
+f1196 md phone message
+f1197 md phone message outline
+f1198 md phone minus outline
+f1199 md phone outgoing outline
+f119a md phone paused outline
+f119b md phone plus outline
+f119c md phone return outline
+f119d md phone settings outline
+f119e md key star
+f119f md key link
+f11a0 md shield edit
+f11a1 md shield edit outline
+f11a2 md shield sync
+f11a3 md shield sync outline
+f11a4 md golf cart
+f11a5 md phone missed outline
+f11a6 md phone off outline
+f11a7 md format quote open outline
+f11a8 md format quote close outline
+f11a9 md phone check
+f11aa md phone check outline
+f11ab md phone ring
+f11ac md phone ring outline
+f11ad md share circle
+f11ae md reply circle
+f11af md fridge off
+f11b0 md fridge off outline
+f11b1 md fridge alert
+f11b2 md fridge alert outline
+f11b3 md water boiler alert
+f11b4 md water boiler off
+f11b5 md amplifier off
+f11b6 md audio video off
+f11b7 md toaster off
+f11b8 md dishwasher alert
+f11b9 md dishwasher off
+f11ba md tumble dryer alert
+f11bb md tumble dryer off
+f11bc md washing machine alert
+f11bd md washing machine off
+f11be md car info
+f11bf md comment edit
+f11c0 md printer 3d nozzle alert
+f11c1 md printer 3d nozzle alert outline
+f11c2 md align horizontal left
+f11c3 md align horizontal center
+f11c4 md align horizontal right
+f11c5 md align vertical bottom
+f11c6 md align vertical center
+f11c7 md align vertical top
+f11c8 md distribute horizontal left
+f11c9 md distribute horizontal center
+f11ca md distribute horizontal right
+f11cb md distribute vertical bottom
+f11cc md distribute vertical center
+f11cd md distribute vertical top
+f11ce md alert rhombus
+f11cf md alert rhombus outline
+f11d0 md crown outline
+f11d1 md image off outline
+f11d2 md movie search
+f11d3 md movie search outline
+f11d4 md rv truck
+f11d5 md shopping outline
+f11d6 md strategy
+f11d7 md note text outline
+f11d8 md view agenda outline
+f11d9 md view grid outline
+f11da md view grid plus outline
+f11db md window closed variant
+f11dc md window open variant
+f11dd md cog clockwise
+f11de md cog counterclockwise
+f11df md chart sankey
+f11e0 md chart sankey variant
+f11e1 md vanity light
+f11e2 md router
+f11e3 md image edit
+f11e4 md image edit outline
+f11e5 md bell check
+f11e6 md bell check outline
+f11e7 md file edit
+f11e8 md file edit outline
+f11e9 md human scooter
+f11ea md spider
+f11eb md spider thread
+f11ec md plus thick
+f11ed md alert circle check
+f11ee md alert circle check outline
+f11ef md state machine
+f11f0 md usb port
+f11f1 md cloud lock
+f11f2 md cloud lock outline
+f11f3 md robot mower outline
+f11f4 md share all
+f11f5 md share all outline
+f11f6 md google cloud
+f11f7 md robot mower
+f11f8 md fast forward 5
+f11f9 md rewind 5
+f11fa md shape oval plus
+f11fb md timeline clock
+f11fc md timeline clock outline
+f11fd md mirror
+f11fe md account multiple check outline
+f11ff md card plus
+f1200 md card plus outline
+f1201 md checkerboard plus
+f1202 md checkerboard minus
+f1203 md checkerboard remove
+f1204 md select search
+f1205 md selection search
+f1206 md layers search
+f1207 md layers search outline
+f1208 md lightbulb cfl
+f1209 md lightbulb cfl off
+f120a md account multiple remove
+f120b md account multiple remove outline
+f120c md magnify remove cursor
+f120d md magnify remove outline
+f120e md archive outline
+f120f md battery heart
+f1210 md battery heart outline
+f1211 md battery heart variant
+f1212 md bus marker
+f1213 md chart multiple
+f1214 md emoticon lol
+f1215 md emoticon lol outline
+f1216 md file sync
+f1217 md file sync outline
+f1218 md handshake
+f1219 md language kotlin
+f121a md language fortran
+f121b md offer
+f121c md radio off
+f121d md table headers eye
+f121e md table headers eye off
+f121f md tag minus outline
+f1220 md tag off
+f1221 md tag off outline
+f1222 md tag plus outline
+f1223 md tag remove outline
+f1224 md tag text
+f1225 md vector polyline edit
+f1226 md vector polyline minus
+f1227 md vector polyline plus
+f1228 md vector polyline remove
+f1229 md beaker alert
+f122a md beaker alert outline
+f122b md beaker check
+f122c md beaker check outline
+f122d md beaker minus
+f122e md beaker minus outline
+f122f md beaker plus
+f1230 md beaker plus outline
+f1231 md beaker question
+f1232 md beaker question outline
+f1233 md beaker remove
+f1234 md beaker remove outline
+f1235 md bicycle basket
+f1236 md barcode off
+f1237 md digital ocean
+f1238 md exclamation thick
+f1239 md desk
+f123a md flask empty minus
+f123b md flask empty minus outline
+f123c md flask empty plus
+f123d md flask empty plus outline
+f123e md flask empty remove
+f123f md flask empty remove outline
+f1240 md flask minus
+f1241 md flask minus outline
+f1242 md flask plus
+f1243 md flask plus outline
+f1244 md flask remove
+f1245 md flask remove outline
+f1246 md folder move outline
+f1247 md home remove
+f1248 md webrtc
+f1249 md seat passenger
+f124a md web clock
+f124b md flask round bottom
+f124c md flask round bottom empty
+f124d md flask round bottom empty outline
+f124e md flask round bottom outline
+f124f md gold
+f1250 md message star outline
+f1251 md home lightbulb
+f1252 md home lightbulb outline
+f1253 md lightbulb group
+f1254 md lightbulb group outline
+f1255 md lightbulb multiple
+f1256 md lightbulb multiple outline
+f1257 md api off
+f1258 md allergy
+f1259 md archive arrow down
+f125a md archive arrow down outline
+f125b md archive arrow up
+f125c md archive arrow up outline
+f125d md battery off
+f125e md battery off outline
+f125f md bookshelf
+f1260 md cash minus
+f1261 md cash plus
+f1262 md cash remove
+f1263 md clipboard check multiple
+f1264 md clipboard check multiple outline
+f1265 md clipboard file
+f1266 md clipboard file outline
+f1267 md clipboard multiple
+f1268 md clipboard multiple outline
+f1269 md clipboard play multiple
+f126a md clipboard play multiple outline
+f126b md clipboard text multiple
+f126c md clipboard text multiple outline
+f126d md folder marker
+f126e md folder marker outline
+f126f md format list text
+f1270 md inbox arrow down outline
+f1271 md inbox arrow up outline
+f1272 md inbox full
+f1273 md inbox full outline
+f1274 md inbox outline
+f1275 md lightbulb cfl spiral
+f1276 md magnify scan
+f1277 md map marker multiple outline
+f1278 md percent outline
+f1279 md phone classic off
+f127a md play box
+f127b md account eye outline
+f127c md safe square
+f127d md safe square outline
+f127e md scoreboard
+f127f md scoreboard outline
+f1280 md select marker
+f1281 md select multiple
+f1282 md select multiple marker
+f1283 md selection marker
+f1284 md selection multiple marker
+f1285 md selection multiple
+f1286 md star box multiple
+f1287 md star box multiple outline
+f1288 md toy brick
+f1289 md toy brick marker
+f128a md toy brick marker outline
+f128b md toy brick minus
+f128c md toy brick minus outline
+f128d md toy brick outline
+f128e md toy brick plus
+f128f md toy brick plus outline
+f1290 md toy brick remove
+f1291 md toy brick remove outline
+f1292 md toy brick search
+f1293 md toy brick search outline
+f1294 md tray
+f1295 md tray alert
+f1296 md tray full
+f1297 md tray minus
+f1298 md tray plus
+f1299 md tray remove
+f129a md truck check outline
+f129b md truck delivery outline
+f129c md truck fast outline
+f129d md truck outline
+f129e md usb flash drive
+f129f md usb flash drive outline
+f12a0 md water polo
+f12a1 md battery low
+f12a2 md battery medium
+f12a3 md battery high
+f12a4 md battery charging low
+f12a5 md battery charging medium
+f12a6 md battery charging high
+f12a7 md hexadecimal
+f12a8 md gesture tap button
+f12a9 md gesture tap box
+f12aa md lan check
+f12ab md keyboard f1
+f12ac md keyboard f2
+f12ad md keyboard f3
+f12ae md keyboard f4
+f12af md keyboard f5
+f12b0 md keyboard f6
+f12b1 md keyboard f7
+f12b2 md keyboard f8
+f12b3 md keyboard f9
+f12b4 md keyboard f10
+f12b5 md keyboard f11
+f12b6 md keyboard f12
+f12b7 md keyboard esc
+f12b8 md toslink
+f12b9 md cheese
+f12ba md string lights
+f12bb md string lights off
+f12bc md whistle outline
+f12bd md stairs up
+f12be md stairs down
+f12bf md escalator up
+f12c0 md escalator down
+f12c1 md elevator up
+f12c2 md elevator down
+f12c3 md lightbulb cfl spiral off
+f12c4 md comment edit outline
+f12c5 md tooltip edit outline
+f12c6 md monitor edit
+f12c7 md email sync
+f12c8 md email sync outline
+f12c9 md chat alert outline
+f12ca md chat processing outline
+f12cb md snowflake melt
+f12cc md cloud check outline
+f12cd md lightbulb group off
+f12ce md lightbulb group off outline
+f12cf md lightbulb multiple off
+f12d0 md lightbulb multiple off outline
+f12d1 md chat sleep
+f12d2 md chat sleep outline
+f12d3 md garage variant
+f12d4 md garage open variant
+f12d5 md garage alert variant
+f12d6 md cloud sync outline
+f12d7 md globe light
+f12d8 md cellphone nfc off
+f12d9 md leaf off
+f12da md leaf maple off
+f12db md map marker left
+f12dc md map marker right
+f12dd md map marker left outline
+f12de md map marker right outline
+f12df md account cancel
+f12e0 md account cancel outline
+f12e1 md file clock
+f12e2 md file clock outline
+f12e3 md folder table
+f12e4 md folder table outline
+f12e5 md hydro power
+f12e6 md doorbell
+f12e7 md bulma
+f12e8 md iobroker
+f12e9 md oci
+f12ea md label percent
+f12eb md label percent outline
+f12ec md checkbox blank off
+f12ed md checkbox blank off outline
+f12ee md square off
+f12ef md square off outline
+f12f0 md drag horizontal variant
+f12f1 md drag vertical variant
+f12f2 md message arrow left
+f12f3 md message arrow left outline
+f12f4 md message arrow right
+f12f5 md message arrow right outline
+f12f6 md database marker
+f12f7 md tag multiple outline
+f12f8 md map marker plus outline
+f12f9 md map marker minus outline
+f12fa md map marker remove outline
+f12fb md map marker check outline
+f12fc md map marker radius outline
+f12fd md map marker off outline
+f12fe md molecule co
+f12ff md jump rope
+f1300 md kettlebell
+f1301 md account convert outline
+f1302 md bunk bed
+f1303 md fleur de lis
+f1304 md ski
+f1305 md ski cross country
+f1306 md ski water
+f1307 md snowboard
+f1308 md account tie voice
+f1309 md account tie voice outline
+f130a md account tie voice off
+f130b md account tie voice off outline
+f130c md beer outline
+f130d md glass pint outline
+f130e md coffee to go outline
+f130f md cup outline
+f1310 md bottle wine outline
+f1311 md earth arrow right
+f1312 md key arrow right
+f1313 md format color marker cancel
+f1314 md mother heart
+f1315 md currency eur off
+f1316 md semantic web
+f1317 md kettle alert
+f1318 md kettle alert outline
+f1319 md kettle steam
+f131a md kettle steam outline
+f131b md kettle off
+f131c md kettle off outline
+f131d md simple icons
+f131e md briefcase check outline
+f131f md clipboard plus outline
+f1320 md download lock
+f1321 md download lock outline
+f1322 md hammer screwdriver
+f1323 md hammer wrench
+f1324 md hydraulic oil level
+f1325 md hydraulic oil temperature
+f1326 md medal outline
+f1327 md rodent
+f1328 md abjad arabic
+f1329 md abjad hebrew
+f132a md abugida devanagari
+f132b md abugida thai
+f132c md alphabet aurebesh
+f132d md alphabet cyrillic
+f132e md alphabet greek
+f132f md alphabet latin
+f1330 md alphabet piqad
+f1331 md ideogram cjk
+f1332 md ideogram cjk variant
+f1333 md syllabary hangul
+f1334 md syllabary hiragana
+f1335 md syllabary katakana
+f1336 md syllabary katakana halfwidth
+f1337 md alphabet tengwar
+f1338 md head alert
+f1339 md head alert outline
+f133a md head check
+f133b md head check outline
+f133c md head cog
+f133d md head cog outline
+f133e md head dots horizontal
+f133f md head dots horizontal outline
+f1340 md head flash
+f1341 md head flash outline
+f1342 md head heart
+f1343 md head heart outline
+f1344 md head lightbulb
+f1345 md head lightbulb outline
+f1346 md head minus
+f1347 md head minus outline
+f1348 md head plus
+f1349 md head plus outline
+f134a md head question
+f134b md head question outline
+f134c md head remove
+f134d md head remove outline
+f134e md head snowflake
+f134f md head snowflake outline
+f1350 md head sync
+f1351 md head sync outline
+f1352 md hvac
+f1353 md pencil ruler
+f1354 md pipe wrench
+f1355 md widgets outline
+f1356 md television ambient light
+f1357 md propane tank
+f1358 md propane tank outline
+f1359 md folder music
+f135a md folder music outline
+f135b md klingon
+f135c md palette swatch outline
+f135d md form textbox lock
+f135e md head
+f135f md head outline
+f1360 md shield half
+f1361 md store outline
+f1362 md google downasaur
+f1363 md bottle soda classic outline
+f1364 md sticker
+f1365 md sticker alert
+f1366 md sticker alert outline
+f1367 md sticker check
+f1368 md sticker check outline
+f1369 md sticker minus
+f136a md sticker minus outline
+f136b md sticker outline
+f136c md sticker plus
+f136d md sticker plus outline
+f136e md sticker remove
+f136f md sticker remove outline
+f1370 md account cog
+f1371 md account cog outline
+f1372 md account details outline
+f1373 md upload lock
+f1374 md upload lock outline
+f1375 md label multiple
+f1376 md label multiple outline
+f1377 md refresh circle
+f1378 md sync circle
+f1379 md bookmark music outline
+f137a md bookmark remove outline
+f137b md bookmark check outline
+f137c md traffic cone
+f137d md cup off outline
+f137e md auto download
+f137f md shuriken
+f1380 md chart ppf
+f1381 md elevator passenger
+f1382 md compass rose
+f1383 md space station
+f1384 md order bool descending
+f1385 md sort bool ascending
+f1386 md sort bool ascending variant
+f1387 md sort bool descending
+f1388 md sort bool descending variant
+f1389 md sort numeric ascending
+f138a md sort numeric descending
+f138b md human baby changing table
+f138c md human male child
+f138d md human wheelchair
+f138e md microsoft access
+f138f md microsoft excel
+f1390 md microsoft powerpoint
+f1391 md microsoft sharepoint
+f1392 md microsoft word
+f1393 md nintendo game boy
+f1394 md cable data
+f1395 md circle half
+f1396 md circle half full
+f1397 md cellphone charging
+f1398 md close thick
+f1399 md escalator box
+f139a md lock check
+f139b md lock open alert
+f139c md lock open check
+f139d md recycle variant
+f139e md stairs box
+f139f md hand water
+f13a0 md table refresh
+f13a1 md table sync
+f13a2 md size xxs
+f13a3 md size xs
+f13a4 md size s
+f13a5 md size m
+f13a6 md alpha l
+f13a7 md size xl
+f13a8 md size xxl
+f13a9 md size xxxl
+f13aa md ticket confirmation outline
+f13ab md timer
+f13ac md timer off
+f13ad md book account
+f13ae md book account outline
+f13af md rocket outline
+f13b0 md home search
+f13b1 md home search outline
+f13b2 md car arrow left
+f13b3 md car arrow right
+f13b4 md monitor eye
+f13b5 md lipstick
+f13b6 md virus
+f13b7 md virus outline
+f13b8 md text search
+f13b9 md table account
+f13ba md table alert
+f13bb md table arrow down
+f13bc md table arrow left
+f13bd md table arrow right
+f13be md table arrow up
+f13bf md table cancel
+f13c0 md table check
+f13c1 md table clock
+f13c2 md table cog
+f13c3 md table eye off
+f13c4 md table heart
+f13c5 md table key
+f13c6 md table lock
+f13c7 md table minus
+f13c8 md table multiple
+f13c9 md table network
+f13ca md table off
+f13cb md table star
+f13cc md car cog
+f13cd md car settings
+f13ce md cog off
+f13cf md cog off outline
+f13d0 md credit card check
+f13d1 md credit card check outline
+f13d2 md file tree outline
+f13d3 md folder star multiple
+f13d4 md folder star multiple outline
+f13d5 md home minus outline
+f13d6 md home plus outline
+f13d7 md home remove outline
+f13d8 md scan helper
+f13d9 md video 3d off
+f13da md shield bug
+f13db md shield bug outline
+f13dc md eyedropper plus
+f13dd md eyedropper minus
+f13de md eyedropper remove
+f13df md eyedropper off
+f13e0 md baby buggy
+f13e1 md umbrella closed variant
+f13e2 md umbrella closed outline
+f13e3 md email off
+f13e4 md email off outline
+f13e5 md food variant off
+f13e6 md play box multiple outline
+f13e7 md bell cancel
+f13e8 md bell cancel outline
+f13e9 md bell minus
+f13ea md bell minus outline
+f13eb md bell remove
+f13ec md bell remove outline
+f13ed md beehive off outline
+f13ee md cheese off
+f13ef md corn off
+f13f0 md egg off
+f13f1 md egg off outline
+f13f2 md egg outline
+f13f3 md fish off
+f13f4 md flask empty off
+f13f5 md flask empty off outline
+f13f6 md flask off
+f13f7 md flask off outline
+f13f8 md fruit cherries off
+f13f9 md fruit citrus off
+f13fa md mushroom off
+f13fb md mushroom off outline
+f13fc md soy sauce off
+f13fd md seed off
+f13fe md seed off outline
+f13ff md tailwind
+f1400 md form dropdown
+f1401 md form select
+f1402 md pump
+f1403 md earth plus
+f1404 md earth minus
+f1405 md earth remove
+f1406 md earth box plus
+f1407 md earth box minus
+f1408 md earth box remove
+f1409 md gas station off
+f140a md gas station off outline
+f140b md lightning bolt
+f140c md lightning bolt outline
+f140d md smoking pipe
+f140e md axis arrow info
+f140f md chat plus
+f1410 md chat minus
+f1411 md chat remove
+f1412 md chat plus outline
+f1413 md chat minus outline
+f1414 md chat remove outline
+f1415 md bucket
+f1416 md bucket outline
+f1417 md pail
+f1418 md image remove
+f1419 md image minus
+f141a md pine tree fire
+f141b md cigar off
+f141c md cube off
+f141d md cube off outline
+f141e md dome light
+f141f md food drumstick
+f1420 md food drumstick outline
+f1421 md incognito circle
+f1422 md incognito circle off
+f1423 md microwave off
+f1424 md power plug off outline
+f1425 md power plug outline
+f1426 md puzzle check
+f1427 md puzzle check outline
+f1428 md smoking pipe off
+f1429 md spoon sugar
+f142a md table split cell
+f142b md ticket percent outline
+f142c md fuse off
+f142d md fuse alert
+f142e md heart plus
+f142f md heart minus
+f1430 md heart remove
+f1431 md heart plus outline
+f1432 md heart minus outline
+f1433 md heart remove outline
+f1434 md heart off outline
+f1435 md motion sensor off
+f1436 md pail plus
+f1437 md pail minus
+f1438 md pail remove
+f1439 md pail off
+f143a md pail outline
+f143b md pail plus outline
+f143c md pail minus outline
+f143d md pail remove outline
+f143e md pail off outline
+f143f md clock time one
+f1440 md clock time two
+f1441 md clock time three
+f1442 md clock time four
+f1443 md clock time five
+f1444 md clock time six
+f1445 md clock time seven
+f1446 md clock time eight
+f1447 md clock time nine
+f1448 md clock time ten
+f1449 md clock time eleven
+f144a md clock time twelve
+f144b md clock time one outline
+f144c md clock time two outline
+f144d md clock time three outline
+f144e md clock time four outline
+f144f md clock time five outline
+f1450 md clock time six outline
+f1451 md clock time seven outline
+f1452 md clock time eight outline
+f1453 md clock time nine outline
+f1454 md clock time ten outline
+f1455 md clock time eleven outline
+f1456 md clock time twelve outline
+f1457 md printer search
+f1458 md printer eye
+f1459 md minus circle off
+f145a md minus circle off outline
+f145b md content save cog
+f145c md content save cog outline
+f145d md set square
+f145e md cog refresh
+f145f md cog refresh outline
+f1460 md cog sync
+f1461 md cog sync outline
+f1462 md download box
+f1463 md download box outline
+f1464 md download circle
+f1465 md download circle outline
+f1466 md air humidifier off
+f1467 md chili off
+f1468 md food drumstick off
+f1469 md food drumstick off outline
+f146a md food steak
+f146b md food steak off
+f146c md fan alert
+f146d md fan chevron down
+f146e md fan chevron up
+f146f md fan plus
+f1470 md fan minus
+f1471 md fan remove
+f1472 md fan speed 1
+f1473 md fan speed 2
+f1474 md fan speed 3
+f1475 md rug
+f1476 md lingerie
+f1477 md wizard hat
+f1478 md hours 24
+f1479 md cosine wave
+f147a md sawtooth wave
+f147b md square wave
+f147c md triangle wave
+f147d md waveform
+f147e md folder multiple plus
+f147f md folder multiple plus outline
+f1480 md current ac
+f1481 md watering can
+f1482 md watering can outline
+f1483 md monitor share
+f1484 md laser pointer
+f1485 md view array outline
+f1486 md view carousel outline
+f1487 md view column outline
+f1488 md view comfy outline
+f1489 md view dashboard variant outline
+f148a md view day outline
+f148b md view list outline
+f148c md view module outline
+f148d md view parallel outline
+f148e md view quilt outline
+f148f md view sequential outline
+f1490 md view stream outline
+f1491 md view week outline
+f1492 md compare horizontal
+f1493 md compare vertical
+f1494 md briefcase variant
+f1495 md briefcase variant outline
+f1496 md relation many to many
+f1497 md relation many to one
+f1498 md relation many to one or many
+f1499 md relation many to only one
+f149a md relation many to zero or many
+f149b md relation many to zero or one
+f149c md relation one or many to many
+f149d md relation one or many to one
+f149e md relation one or many to one or many
+f149f md relation one or many to only one
+f14a0 md relation one or many to zero or many
+f14a1 md relation one or many to zero or one
+f14a2 md relation one to many
+f14a3 md relation one to one
+f14a4 md relation one to one or many
+f14a5 md relation one to only one
+f14a6 md relation one to zero or many
+f14a7 md relation one to zero or one
+f14a8 md relation only one to many
+f14a9 md relation only one to one
+f14aa md relation only one to one or many
+f14ab md relation only one to only one
+f14ac md relation only one to zero or many
+f14ad md relation only one to zero or one
+f14ae md relation zero or many to many
+f14af md relation zero or many to one
+f14b0 md relation zero or many to one or many
+f14b1 md relation zero or many to only one
+f14b2 md relation zero or many to zero or many
+f14b3 md relation zero or many to zero or one
+f14b4 md relation zero or one to many
+f14b5 md relation zero or one to one
+f14b6 md relation zero or one to one or many
+f14b7 md relation zero or one to only one
+f14b8 md relation zero or one to zero or many
+f14b9 md relation zero or one to zero or one
+f14ba md alert plus
+f14bb md alert minus
+f14bc md alert remove
+f14bd md alert plus outline
+f14be md alert minus outline
+f14bf md alert remove outline
+f14c0 md carabiner
+f14c1 md fencing
+f14c2 md skateboard
+f14c3 md polo
+f14c4 md tractor variant
+f14c5 md radiology box
+f14c6 md radiology box outline
+f14c7 md skull scan
+f14c8 md skull scan outline
+f14c9 md plus minus variant
+f14ca md source branch plus
+f14cb md source branch minus
+f14cc md source branch remove
+f14cd md source branch refresh
+f14ce md source branch sync
+f14cf md source branch check
+f14d0 md puzzle plus
+f14d1 md puzzle minus
+f14d2 md puzzle remove
+f14d3 md puzzle edit
+f14d4 md puzzle heart
+f14d5 md puzzle star
+f14d6 md puzzle plus outline
+f14d7 md puzzle minus outline
+f14d8 md puzzle remove outline
+f14d9 md puzzle edit outline
+f14da md puzzle heart outline
+f14db md puzzle star outline
+f14dc md rhombus medium outline
+f14dd md rhombus split outline
+f14de md rocket launch
+f14df md rocket launch outline
+f14e0 md set merge
+f14e1 md set split
+f14e2 md beekeeper
+f14e3 md snowflake off
+f14e4 md weather sunny off
+f14e5 md clipboard edit
+f14e6 md clipboard edit outline
+f14e7 md notebook edit
+f14e8 md human edit
+f14e9 md notebook edit outline
+f14ea md cash lock
+f14eb md cash lock open
+f14ec md account supervisor circle outline
+f14ed md car outline
+f14ee md cash check
+f14ef md filter off
+f14f0 md filter off outline
+f14f1 md spirit level
+f14f2 md wheel barrow
+f14f3 md book check
+f14f4 md book check outline
+f14f5 md notebook check
+f14f6 md notebook check outline
+f14f7 md book open variant
+f14f8 md sign pole
+f14f9 md shore
+f14fa md shape square rounded plus
+f14fb md square rounded
+f14fc md square rounded outline
+f14fd md archive alert
+f14fe md archive alert outline
+f14ff md power socket it
+f1500 md square circle
+f1501 md symbol
+f1502 md water alert
+f1503 md water alert outline
+f1504 md water check
+f1505 md water check outline
+f1506 md water minus
+f1507 md water minus outline
+f1508 md water off outline
+f1509 md water percent alert
+f150a md water plus
+f150b md water plus outline
+f150c md water remove
+f150d md water remove outline
+f150e md snake
+f150f md format text variant outline
+f1510 md grass
+f1511 md access point off
+f1512 md currency mnt
+f1513 md dock top
+f1514 md share variant outline
+f1515 md transit skip
+f1516 md yurt
+f1517 md file document multiple
+f1518 md file document multiple outline
+f1519 md ev plug ccs1
+f151a md ev plug ccs2
+f151b md ev plug chademo
+f151c md ev plug tesla
+f151d md ev plug type1
+f151e md ev plug type2
+f151f md office building outline
+f1520 md office building marker
+f1521 md office building marker outline
+f1522 md progress question
+f1523 md basket minus
+f1524 md basket minus outline
+f1525 md basket off
+f1526 md basket off outline
+f1527 md basket plus
+f1528 md basket plus outline
+f1529 md basket remove
+f152a md basket remove outline
+f152b md account reactivate
+f152c md account reactivate outline
+f152d md car lifted pickup
+f152e md video high definition
+f152f md phone remove
+f1530 md phone remove outline
+f1531 md thermometer off
+f1532 md timeline check
+f1533 md timeline check outline
+f1534 md timeline minus
+f1535 md timeline minus outline
+f1536 md timeline remove
+f1537 md timeline remove outline
+f1538 md access point check
+f1539 md access point minus
+f153a md access point plus
+f153b md access point remove
+f153c md data matrix
+f153d md data matrix edit
+f153e md data matrix minus
+f153f md data matrix plus
+f1540 md data matrix remove
+f1541 md data matrix scan
+f1542 md tune variant
+f1543 md tune vertical variant
+f1544 md rake
+f1545 md shimmer
+f1546 md transit connection horizontal
+f1547 md sort calendar ascending
+f1548 md sort calendar descending
+f1549 md sort clock ascending
+f154a md sort clock ascending outline
+f154b md sort clock descending
+f154c md sort clock descending outline
+f154d md chart box
+f154e md chart box outline
+f154f md chart box plus outline
+f1550 md mouse move down
+f1551 md mouse move up
+f1552 md mouse move vertical
+f1553 md pitchfork
+f1554 md vanish quarter
+f1555 md application settings outline
+f1556 md delete clock
+f1557 md delete clock outline
+f1558 md kangaroo
+f1559 md phone dial
+f155a md phone dial outline
+f155b md star off outline
+f155c md tooltip check
+f155d md tooltip check outline
+f155e md tooltip minus
+f155f md tooltip minus outline
+f1560 md tooltip remove
+f1561 md tooltip remove outline
+f1562 md pretzel
+f1563 md star plus
+f1564 md star minus
+f1565 md star remove
+f1566 md star check
+f1567 md star plus outline
+f1568 md star minus outline
+f1569 md star remove outline
+f156a md star check outline
+f156b md eiffel tower
+f156c md submarine
+f156d md sofa outline
+f156e md sofa single
+f156f md sofa single outline
+f1570 md text account
+f1571 md human queue
+f1572 md food halal
+f1573 md food kosher
+f1574 md key chain
+f1575 md key chain variant
+f1576 md lamps
+f1577 md application cog outline
+f1578 md dance pole
+f1579 md social distance 2 meters
+f157a md social distance 6 feet
+f157b md calendar cursor
+f157c md emoticon sick
+f157d md emoticon sick outline
+f157e md hand heart outline
+f157f md hand wash
+f1580 md hand wash outline
+f1581 md human cane
+f1582 md lotion
+f1583 md lotion outline
+f1584 md lotion plus
+f1585 md lotion plus outline
+f1586 md face mask
+f1587 md face mask outline
+f1588 md reiterate
+f1589 md butterfly
+f158a md butterfly outline
+f158b md bag suitcase
+f158c md bag suitcase outline
+f158d md bag suitcase off
+f158e md bag suitcase off outline
+f158f md motion play
+f1590 md motion pause
+f1591 md motion play outline
+f1592 md motion pause outline
+f1593 md arrow top left thin circle outline
+f1594 md arrow top right thin circle outline
+f1595 md arrow bottom right thin circle outline
+f1596 md arrow bottom left thin circle outline
+f1597 md arrow up thin circle outline
+f1598 md arrow right thin circle outline
+f1599 md arrow down thin circle outline
+f159a md arrow left thin circle outline
+f159b md human capacity decrease
+f159c md human capacity increase
+f159d md human greeting proximity
+f159e md hvac off
+f159f md inbox remove
+f15a0 md inbox remove outline
+f15a1 md handshake outline
+f15a2 md ladder
+f15a3 md router wireless off
+f15a4 md seesaw
+f15a5 md slide
+f15a6 md calculator variant outline
+f15a7 md shield account variant
+f15a8 md shield account variant outline
+f15a9 md message flash
+f15aa md message flash outline
+f15ab md list status
+f15ac md message bookmark
+f15ad md message bookmark outline
+f15ae md comment bookmark
+f15af md comment bookmark outline
+f15b0 md comment flash
+f15b1 md comment flash outline
+f15b2 md motion
+f15b3 md motion outline
+f15b4 md bicycle electric
+f15b5 md car electric outline
+f15b6 md chart timeline variant shimmer
+f15b7 md moped electric
+f15b8 md moped electric outline
+f15b9 md moped outline
+f15ba md motorbike electric
+f15bb md rickshaw
+f15bc md rickshaw electric
+f15bd md scooter
+f15be md scooter electric
+f15bf md horse
+f15c0 md horse human
+f15c1 md horse variant
+f15c2 md unicorn
+f15c3 md unicorn variant
+f15c4 md alarm panel
+f15c5 md alarm panel outline
+f15c6 md bird
+f15c7 md shoe cleat
+f15c8 md shoe sneaker
+f15c9 md human female dance
+f15ca md shoe ballet
+f15cb md numeric positive 1
+f15cc md face man shimmer
+f15cd md face man shimmer outline
+f15ce md face woman shimmer
+f15cf md face woman shimmer outline
+f15d0 md home alert outline
+f15d1 md lock alert outline
+f15d2 md lock open alert outline
+f15d3 md sim alert outline
+f15d4 md sim off outline
+f15d5 md sim outline
+f15d6 md book open page variant outline
+f15d7 md fire alert
+f15d8 md ray start vertex end
+f15d9 md camera flip
+f15da md camera flip outline
+f15db md orbit variant
+f15dc md circle box
+f15dd md circle box outline
+f15de md mustache
+f15df md comment minus
+f15e0 md comment minus outline
+f15e1 md comment off
+f15e2 md comment off outline
+f15e3 md eye remove
+f15e4 md eye remove outline
+f15e5 md unicycle
+f15e6 md glass cocktail off
+f15e7 md glass mug off
+f15e8 md glass mug variant off
+f15e9 md bicycle penny farthing
+f15ea md cart check
+f15eb md cart variant
+f15ec md baseball diamond
+f15ed md baseball diamond outline
+f15ee md fridge industrial
+f15ef md fridge industrial alert
+f15f0 md fridge industrial alert outline
+f15f1 md fridge industrial off
+f15f2 md fridge industrial off outline
+f15f3 md fridge industrial outline
+f15f4 md fridge variant
+f15f5 md fridge variant alert
+f15f6 md fridge variant alert outline
+f15f7 md fridge variant off
+f15f8 md fridge variant off outline
+f15f9 md fridge variant outline
+f15fa md windsock
+f15fb md dance ballroom
+f15fc md dots grid
+f15fd md dots square
+f15fe md dots triangle
+f15ff md dots hexagon
+f1600 md card minus
+f1601 md card minus outline
+f1602 md card off
+f1603 md card off outline
+f1604 md card remove
+f1605 md card remove outline
+f1606 md torch
+f1607 md navigation outline
+f1608 md map marker star
+f1609 md map marker star outline
+f160a md manjaro
+f160b md fast forward 60
+f160c md rewind 60
+f160d md image text
+f160e md family tree
+f160f md car emergency
+f1610 md notebook minus
+f1611 md notebook minus outline
+f1612 md notebook plus
+f1613 md notebook plus outline
+f1614 md notebook remove
+f1615 md notebook remove outline
+f1616 md connection
+f1617 md language rust
+f1618 md clipboard minus
+f1619 md clipboard minus outline
+f161a md clipboard off
+f161b md clipboard off outline
+f161c md clipboard remove
+f161d md clipboard remove outline
+f161e md clipboard search
+f161f md clipboard search outline
+f1620 md clipboard text off
+f1621 md clipboard text off outline
+f1622 md clipboard text search
+f1623 md clipboard text search outline
+f1624 md database alert outline
+f1625 md database arrow down outline
+f1626 md database arrow left outline
+f1627 md database arrow right outline
+f1628 md database arrow up outline
+f1629 md database check outline
+f162a md database clock outline
+f162b md database edit outline
+f162c md database export outline
+f162d md database import outline
+f162e md database lock outline
+f162f md database marker outline
+f1630 md database minus outline
+f1631 md database off outline
+f1632 md database outline
+f1633 md database plus outline
+f1634 md database refresh outline
+f1635 md database remove outline
+f1636 md database search outline
+f1637 md database settings outline
+f1638 md database sync outline
+f1639 md minus thick
+f163a md database alert
+f163b md database arrow down
+f163c md database arrow left
+f163d md database arrow right
+f163e md database arrow up
+f163f md database clock
+f1640 md database off
+f1641 md calendar lock
+f1642 md calendar lock outline
+f1643 md content save off
+f1644 md content save off outline
+f1645 md credit card refresh
+f1646 md credit card refresh outline
+f1647 md credit card search
+f1648 md credit card search outline
+f1649 md credit card sync
+f164a md credit card sync outline
+f164b md database cog
+f164c md database cog outline
+f164d md message off
+f164e md message off outline
+f164f md note minus
+f1650 md note minus outline
+f1651 md note remove
+f1652 md note remove outline
+f1653 md note search
+f1654 md note search outline
+f1655 md bank check
+f1656 md bank off
+f1657 md bank off outline
+f1658 md briefcase off
+f1659 md briefcase off outline
+f165a md briefcase variant off
+f165b md briefcase variant off outline
+f165c md ghost off outline
+f165d md ghost outline
+f165e md store minus
+f165f md store plus
+f1660 md store remove
+f1661 md email remove
+f1662 md email remove outline
+f1663 md heart cog
+f1664 md heart cog outline
+f1665 md heart settings
+f1666 md heart settings outline
+f1667 md pentagram
+f1668 md star cog
+f1669 md star cog outline
+f166a md star settings
+f166b md star settings outline
+f166c md calendar end
+f166d md calendar start
+f166e md cannabis off
+f166f md mower
+f1670 md mower bag
+f1671 md lock off
+f1672 md lock off outline
+f1673 md shark fin
+f1674 md shark fin outline
+f1675 md paw outline
+f1676 md paw off outline
+f1677 md snail
+f1678 md pig variant outline
+f1679 md piggy bank outline
+f167a md robot outline
+f167b md robot off outline
+f167c md book alert
+f167d md book alert outline
+f167e md book arrow down
+f167f md book arrow down outline
+f1680 md book arrow left
+f1681 md book arrow left outline
+f1682 md book arrow right
+f1683 md book arrow right outline
+f1684 md book arrow up
+f1685 md book arrow up outline
+f1686 md book cancel
+f1687 md book cancel outline
+f1688 md book clock
+f1689 md book clock outline
+f168a md book cog
+f168b md book cog outline
+f168c md book edit
+f168d md book edit outline
+f168e md book lock open outline
+f168f md book lock outline
+f1690 md book marker
+f1691 md book marker outline
+f1692 md book minus outline
+f1693 md book music outline
+f1694 md book off
+f1695 md book off outline
+f1696 md book plus outline
+f1697 md book refresh
+f1698 md book refresh outline
+f1699 md book remove outline
+f169a md book settings
+f169b md book settings outline
+f169c md book sync
+f169d md robot angry
+f169e md robot angry outline
+f169f md robot confused
+f16a0 md robot confused outline
+f16a1 md robot dead
+f16a2 md robot dead outline
+f16a3 md robot excited
+f16a4 md robot excited outline
+f16a5 md robot love
+f16a6 md robot love outline
+f16a7 md robot off
+f16a8 md lock check outline
+f16a9 md lock minus
+f16aa md lock minus outline
+f16ab md lock open check outline
+f16ac md lock open minus
+f16ad md lock open minus outline
+f16ae md lock open plus
+f16af md lock open plus outline
+f16b0 md lock open remove
+f16b1 md lock open remove outline
+f16b2 md lock plus outline
+f16b3 md lock remove
+f16b4 md lock remove outline
+f16b5 md wifi alert
+f16b6 md wifi arrow down
+f16b7 md wifi arrow left
+f16b8 md wifi arrow left right
+f16b9 md wifi arrow right
+f16ba md wifi arrow up
+f16bb md wifi arrow up down
+f16bc md wifi cancel
+f16bd md wifi check
+f16be md wifi cog
+f16bf md wifi lock
+f16c0 md wifi lock open
+f16c1 md wifi marker
+f16c2 md wifi minus
+f16c3 md wifi plus
+f16c4 md wifi refresh
+f16c5 md wifi remove
+f16c6 md wifi settings
+f16c7 md wifi sync
+f16c8 md book sync outline
+f16c9 md book education
+f16ca md book education outline
+f16cb md wifi strength 1 lock open
+f16cc md wifi strength 2 lock open
+f16cd md wifi strength 3 lock open
+f16ce md wifi strength 4 lock open
+f16cf md wifi strength lock open outline
+f16d0 md cookie alert
+f16d1 md cookie alert outline
+f16d2 md cookie check
+f16d3 md cookie check outline
+f16d4 md cookie cog
+f16d5 md cookie cog outline
+f16d6 md cookie plus
+f16d7 md cookie plus outline
+f16d8 md cookie remove
+f16d9 md cookie remove outline
+f16da md cookie minus
+f16db md cookie minus outline
+f16dc md cookie settings
+f16dd md cookie settings outline
+f16de md cookie outline
+f16df md tape drive
+f16e0 md abacus
+f16e1 md calendar clock outline
+f16e2 md clipboard clock
+f16e3 md clipboard clock outline
+f16e4 md cookie clock
+f16e5 md cookie clock outline
+f16e6 md cookie edit
+f16e7 md cookie edit outline
+f16e8 md cookie lock
+f16e9 md cookie lock outline
+f16ea md cookie off
+f16eb md cookie off outline
+f16ec md cookie refresh
+f16ed md cookie refresh outline
+f16ee md dog side off
+f16ef md gift off
+f16f0 md gift off outline
+f16f1 md gift open
+f16f2 md gift open outline
+f16f3 md movie check
+f16f4 md movie check outline
+f16f5 md movie cog
+f16f6 md movie cog outline
+f16f7 md movie minus
+f16f8 md movie minus outline
+f16f9 md movie off
+f16fa md movie off outline
+f16fb md movie open check
+f16fc md movie open check outline
+f16fd md movie open cog
+f16fe md movie open cog outline
+f16ff md movie open edit
+f1700 md movie open edit outline
+f1701 md movie open minus
+f1702 md movie open minus outline
+f1703 md movie open off
+f1704 md movie open off outline
+f1705 md movie open play
+f1706 md movie open play outline
+f1707 md movie open plus
+f1708 md movie open plus outline
+f1709 md movie open remove
+f170a md movie open remove outline
+f170b md movie open settings
+f170c md movie open settings outline
+f170d md movie open star
+f170e md movie open star outline
+f170f md movie play
+f1710 md movie play outline
+f1711 md movie plus
+f1712 md movie plus outline
+f1713 md movie remove
+f1714 md movie remove outline
+f1715 md movie settings
+f1716 md movie settings outline
+f1717 md movie star
+f1718 md movie star outline
+f1719 md robot happy
+f171a md robot happy outline
+f171b md turkey
+f171c md food turkey
+f171d md fan auto
+f171e md alarm light off
+f171f md alarm light off outline
+f1720 md broadcast
+f1721 md broadcast off
+f1722 md fire off
+f1723 md firework off
+f1724 md projector screen outline
+f1725 md script text key
+f1726 md script text key outline
+f1727 md script text play
+f1728 md script text play outline
+f1729 md surround sound 2 1
+f172a md surround sound 5 1 2
+f172b md tag arrow down
+f172c md tag arrow down outline
+f172d md tag arrow left
+f172e md tag arrow left outline
+f172f md tag arrow right
+f1730 md tag arrow right outline
+f1731 md tag arrow up
+f1732 md tag arrow up outline
+f1733 md train car passenger
+f1734 md train car passenger door
+f1735 md train car passenger door open
+f1736 md train car passenger variant
+f1737 md webcam off
+f1738 md chat question
+f1739 md chat question outline
+f173a md message question
+f173b md message question outline
+f173c md kettle pour over
+f173d md message reply outline
+f173e md message reply text outline
+f173f md koala
+f1740 md check decagram outline
+f1741 md star shooting
+f1742 md star shooting outline
+f1743 md table picnic
+f1744 md kitesurfing
+f1745 md paragliding
+f1746 md surfing
+f1747 md floor lamp torchiere
+f1748 md mortar pestle
+f1749 md cast audio variant
+f174a md gradient horizontal
+f174b md archive cancel
+f174c md archive cancel outline
+f174d md archive check
+f174e md archive check outline
+f174f md archive clock
+f1750 md archive clock outline
+f1751 md archive cog
+f1752 md archive cog outline
+f1753 md archive edit
+f1754 md archive edit outline
+f1755 md archive eye
+f1756 md archive eye outline
+f1757 md archive lock
+f1758 md archive lock open
+f1759 md archive lock open outline
+f175a md archive lock outline
+f175b md archive marker
+f175c md archive marker outline
+f175d md archive minus
+f175e md archive minus outline
+f175f md archive music
+f1760 md archive music outline
+f1761 md archive off
+f1762 md archive off outline
+f1763 md archive plus
+f1764 md archive plus outline
+f1765 md archive refresh
+f1766 md archive refresh outline
+f1767 md archive remove
+f1768 md archive remove outline
+f1769 md archive search
+f176a md archive search outline
+f176b md archive settings
+f176c md archive settings outline
+f176d md archive star
+f176e md archive star outline
+f176f md archive sync
+f1770 md archive sync outline
+f1771 md brush off
+f1772 md file image marker
+f1773 md file image marker outline
+f1774 md file marker
+f1775 md file marker outline
+f1776 md hamburger check
+f1777 md hamburger minus
+f1778 md hamburger off
+f1779 md hamburger plus
+f177a md hamburger remove
+f177b md image marker
+f177c md image marker outline
+f177d md note alert
+f177e md note alert outline
+f177f md note check
+f1780 md note check outline
+f1781 md note edit
+f1782 md note edit outline
+f1783 md note off
+f1784 md note off outline
+f1785 md printer off outline
+f1786 md printer outline
+f1787 md progress pencil
+f1788 md progress star
+f1789 md sausage off
+f178a md folder eye
+f178b md folder eye outline
+f178c md information off
+f178d md information off outline
+f178e md sticker text
+f178f md sticker text outline
+f1790 md web cancel
+f1791 md web refresh
+f1792 md web sync
+f1793 md chandelier
+f1794 md home switch
+f1795 md home switch outline
+f1796 md sun snowflake
+f1797 md ceiling fan
+f1798 md ceiling fan light
+f1799 md smoke
+f179a md fence
+f179b md light recessed
+f179c md battery lock
+f179d md battery lock open
+f179e md folder hidden
+f179f md mirror rectangle
+f17a0 md mirror variant
+f17a1 md arrow down left
+f17a2 md arrow down left bold
+f17a3 md arrow down right
+f17a4 md arrow down right bold
+f17a5 md arrow left bottom
+f17a6 md arrow left bottom bold
+f17a7 md arrow left top
+f17a8 md arrow left top bold
+f17a9 md arrow right bottom
+f17aa md arrow right bottom bold
+f17ab md arrow right top
+f17ac md arrow right top bold
+f17ad md arrow u down left
+f17ae md arrow u down left bold
+f17af md arrow u down right
+f17b0 md arrow u down right bold
+f17b1 md arrow u left bottom
+f17b2 md arrow u left bottom bold
+f17b3 md arrow u left top
+f17b4 md arrow u left top bold
+f17b5 md arrow u right bottom
+f17b6 md arrow u right bottom bold
+f17b7 md arrow u right top
+f17b8 md arrow u right top bold
+f17b9 md arrow u up left
+f17ba md arrow u up left bold
+f17bb md arrow u up right
+f17bc md arrow u up right bold
+f17bd md arrow up left
+f17be md arrow up left bold
+f17bf md arrow up right
+f17c0 md arrow up right bold
+f17c1 md select remove
+f17c2 md selection ellipse remove
+f17c3 md selection remove
+f17c4 md human greeting
+f17c5 md ph
+f17c6 md water sync
+f17c7 md ceiling light outline
+f17c8 md floor lamp outline
+f17c9 md wall sconce flat outline
+f17ca md wall sconce flat variant outline
+f17cb md wall sconce outline
+f17cc md wall sconce round outline
+f17cd md wall sconce round variant outline
+f17ce md floor lamp dual outline
+f17cf md floor lamp torchiere variant outline
+f17d0 md lamp outline
+f17d1 md lamps outline
+f17d2 md candelabra
+f17d3 md candelabra fire
+f17d4 md menorah
+f17d5 md menorah fire
+f17d6 md floor lamp torchiere outline
+f17d7 md credit card edit
+f17d8 md credit card edit outline
+f17d9 md briefcase eye
+f17da md briefcase eye outline
+f17db md soundbar
+f17dc md crown circle
+f17dd md crown circle outline
+f17de md battery arrow down
+f17df md battery arrow down outline
+f17e0 md battery arrow up
+f17e1 md battery arrow up outline
+f17e2 md battery check
+f17e3 md battery check outline
+f17e4 md battery minus
+f17e5 md battery minus outline
+f17e6 md battery plus
+f17e7 md battery plus outline
+f17e8 md battery remove
+f17e9 md battery remove outline
+f17ea md chili alert
+f17eb md chili alert outline
+f17ec md chili hot outline
+f17ed md chili medium outline
+f17ee md chili mild outline
+f17ef md chili off outline
+f17f0 md cake variant outline
+f17f1 md card multiple
+f17f2 md card multiple outline
+f17f3 md account cowboy hat outline
+f17f4 md lightbulb spot
+f17f5 md lightbulb spot off
+f17f6 md fence electric
+f17f7 md gate arrow left
+f17f8 md gate alert
+f17f9 md boom gate up
+f17fa md boom gate up outline
+f17fb md garage lock
+f17fc md garage variant lock
+f17fd md cellphone check
+f17fe md sun wireless
+f17ff md sun wireless outline
+f1800 md lightbulb auto
+f1801 md lightbulb auto outline
+f1802 md lightbulb variant
+f1803 md lightbulb variant outline
+f1804 md lightbulb fluorescent tube
+f1805 md lightbulb fluorescent tube outline
+f1806 md water circle
+f1807 md fire circle
+f1808 md smoke detector outline
+f1809 md smoke detector off
+f180a md smoke detector off outline
+f180b md smoke detector variant
+f180c md smoke detector variant off
+f180d md projector screen off
+f180e md projector screen off outline
+f180f md projector screen variant
+f1810 md projector screen variant off
+f1811 md projector screen variant off outline
+f1812 md projector screen variant outline
+f1813 md brush variant
+f1814 md car wrench
+f1815 md account injury
+f1816 md account injury outline
+f1817 md balcony
+f1818 md bathtub
+f1819 md bathtub outline
+f181a md blender outline
+f181b md coffee maker outline
+f181c md countertop
+f181d md countertop outline
+f181e md door sliding
+f181f md door sliding lock
+f1820 md door sliding open
+f1821 md hand wave
+f1822 md hand wave outline
+f1823 md human male female child
+f1824 md iron
+f1825 md iron outline
+f1826 md liquid spot
+f1827 md mosque
+f1828 md shield moon
+f1829 md shield moon outline
+f182a md traffic light outline
+f182b md hand front left
+f182c md hand back left outline
+f182d md hand back right outline
+f182e md hand front left outline
+f182f md hand front right outline
+f1830 md hand back left off
+f1831 md hand back right off
+f1832 md hand back left off outline
+f1833 md hand back right off outline
+f1834 md battery sync
+f1835 md battery sync outline
+f1836 md food takeout box
+f1837 md food takeout box outline
+f1838 md iron board
+f1839 md police station
+f183a md cellphone marker
+f183b md tooltip cellphone
+f183c md table pivot
+f183d md tunnel
+f183e md tunnel outline
+f183f md arrow projectile multiple
+f1840 md arrow projectile
+f1841 md bow arrow
+f1842 md axe battle
+f1843 md mace
+f1844 md magic staff
+f1845 md spear
+f1846 md curtains
+f1847 md curtains closed
+f1848 md human non binary
+f1849 md waterfall
+f184a md egg fried
+f184b md food hot dog
+f184c md induction
+f184d md pipe valve
+f184e md shipping pallet
+f184f md earbuds
+f1850 md earbuds off
+f1851 md earbuds off outline
+f1852 md earbuds outline
+f1853 md circle opacity
+f1854 md square opacity
+f1855 md water opacity
+f1856 md vector polygon variant
+f1857 md vector square close
+f1858 md vector square open
+f1859 md waves arrow left
+f185a md waves arrow right
+f185b md waves arrow up
+f185c md cash fast
+f185d md radioactive circle
+f185e md radioactive circle outline
+f185f md cctv off
+f1860 md format list group
+f1861 md clock plus
+f1862 md clock plus outline
+f1863 md clock minus
+f1864 md clock minus outline
+f1865 md clock remove
+f1866 md clock remove outline
+f1867 md account arrow up
+f1868 md account arrow down
+f1869 md account arrow down outline
+f186a md account arrow up outline
+f186b md audio input rca
+f186c md audio input stereo minijack
+f186d md audio input xlr
+f186e md horse variant fast
+f186f md email fast
+f1870 md email fast outline
+f1871 md camera document
+f1872 md camera document off
+f1873 md glass fragile
+f1874 md magnify expand
+f1875 md town hall
+f1876 md monitor small
+f1877 md diversify
+f1878 md car wireless
+f1879 md car select
+f187a md airplane alert
+f187b md airplane check
+f187c md airplane clock
+f187d md airplane cog
+f187e md airplane edit
+f187f md airplane marker
+f1880 md airplane minus
+f1881 md airplane plus
+f1882 md airplane remove
+f1883 md airplane search
+f1884 md airplane settings
+f1885 md flower pollen
+f1886 md flower pollen outline
+f1887 md hammer sickle
+f1888 md view gallery
+f1889 md view gallery outline
+f188a md umbrella beach
+f188b md umbrella beach outline
+f188c md cabin a frame
+f188d md all inclusive box
+f188e md all inclusive box outline
+f188f md hand coin
+f1890 md hand coin outline
+f1891 md truck flatbed
+f1892 md layers edit
+f1893 md multicast
+f1894 md hydrogen station
+f1895 md thermometer bluetooth
+f1896 md tire
+f1897 md forest
+f1898 md account tie hat
+f1899 md account tie hat outline
+f189a md account wrench
+f189b md account wrench outline
+f189c md bicycle cargo
+f189d md calendar collapse horizontal
+f189e md calendar expand horizontal
+f189f md cards club outline
+f18a0 md heart outline
+f18a1 md cards playing
+f18a2 md cards playing club
+f18a3 md cards playing club multiple
+f18a4 md cards playing club multiple outline
+f18a5 md cards playing club outline
+f18a6 md cards playing diamond
+f18a7 md cards playing diamond multiple
+f18a8 md cards playing diamond multiple outline
+f18a9 md cards playing diamond outline
+f18aa md cards playing heart
+f18ab md cards playing heart multiple
+f18ac md cards playing heart multiple outline
+f18ad md cards playing heart outline
+f18ae md cards playing spade
+f18af md cards playing spade multiple
+f18b0 md cards playing spade multiple outline
+f18b1 md cards playing spade outline
+f18b2 md cards spade outline
+f18b3 md compare remove
+f18b4 md dolphin
+f18b5 md fuel cell
+f18b6 md hand extended
+f18b7 md hand extended outline
+f18b8 md printer 3d nozzle heat
+f18b9 md printer 3d nozzle heat outline
+f18ba md shark
+f18bb md shark off
+f18bc md shield crown
+f18bd md shield crown outline
+f18be md shield sword
+f18bf md shield sword outline
+f18c0 md sickle
+f18c1 md store alert
+f18c2 md store alert outline
+f18c3 md store check
+f18c4 md store check outline
+f18c5 md store clock
+f18c6 md store clock outline
+f18c7 md store cog
+f18c8 md store cog outline
+f18c9 md store edit
+f18ca md store edit outline
+f18cb md store marker
+f18cc md store marker outline
+f18cd md store minus outline
+f18ce md store off
+f18cf md store off outline
+f18d0 md store plus outline
+f18d1 md store remove outline
+f18d2 md store search
+f18d3 md store search outline
+f18d4 md store settings
+f18d5 md store settings outline
+f18d6 md sun thermometer
+f18d7 md sun thermometer outline
+f18d8 md truck cargo container
+f18d9 md vector square edit
+f18da md vector square minus
+f18db md vector square plus
+f18dc md vector square remove
+f18dd md ceiling light multiple
+f18de md ceiling light multiple outline
+f18df md wiper wash alert
+f18e0 md cart heart
+f18e1 md virus off
+f18e2 md virus off outline
+f18e3 md map marker account
+f18e4 md map marker account outline
+f18e5 md basket check
+f18e6 md basket check outline
+f18e7 md credit card lock
+f18e8 md credit card lock outline
+f18e9 md format underline wavy
+f18ea md content save check
+f18eb md content save check outline
+f18ec md filter check
+f18ed md filter check outline
+f18ee md flag off
+f18ef md flag off outline
+f18f0 md near me
+f18f1 md navigation variant outline
+f18f2 md refresh auto
+f18f3 md tilde off
+f18f4 md fit to screen
+f18f5 md fit to screen outline
+f18f6 md weather cloudy clock
+f18f7 md smart card off
+f18f8 md smart card off outline
+f18f9 md clipboard text clock
+f18fa md clipboard text clock outline
+f18fb md teddy bear
+f18fc md cow off
+f18fd md eye arrow left
+f18fe md eye arrow left outline
+f18ff md eye arrow right
+f1900 md eye arrow right outline
+f1901 md home battery
+f1902 md home battery outline
+f1903 md home lightning bolt
+f1904 md home lightning bolt outline
+f1905 md leaf circle
+f1906 md leaf circle outline
+f1907 md tag search
+f1908 md tag search outline
+f1909 md car brake fluid level
+f190a md car brake low pressure
+f190b md car brake temperature
+f190c md car brake worn linings
+f190d md car light alert
+f190e md car speed limiter
+f190f md credit card chip
+f1910 md credit card chip outline
+f1911 md credit card fast
+f1912 md credit card fast outline
+f1913 md integrated circuit chip
+f1914 md thumbs up down outline
+f1915 md food off outline
+f1916 md food outline
+f1917 md format page split
+f1918 md chart waterfall
+f1919 md gamepad outline
+f191a md network strength 4 cog
+f191b md account sync
+f191c md account sync outline
+f191d md bus electric
+f191e md liquor
+f191f md database eye
+f1920 md database eye off
+f1921 md database eye off outline
+f1922 md database eye outline
+f1923 md timer settings
+f1924 md timer settings outline
+f1925 md timer cog
+f1926 md timer cog outline
+f1927 md checkbox marked circle plus outline
+f1928 md panorama horizontal
+f1929 md panorama vertical
+f192a md advertisements
+f192b md advertisements off
+f192c md transmission tower export
+f192d md transmission tower import
+f192e md smoke detector alert
+f192f md smoke detector alert outline
+f1930 md smoke detector variant alert
+f1931 md coffee maker check
+f1932 md coffee maker check outline
+f1933 md cog pause
+f1934 md cog pause outline
+f1935 md cog play
+f1936 md cog play outline
+f1937 md cog stop
+f1938 md cog stop outline
+f1939 md copyleft
+f193a md fast forward 15
+f193b md file image minus
+f193c md file image minus outline
+f193d md file image plus
+f193e md file image plus outline
+f193f md file image remove
+f1940 md file image remove outline
+f1941 md message badge
+f1942 md message badge outline
+f1943 md newspaper check
+f1944 md newspaper remove
+f1945 md publish off
+f1946 md rewind 15
+f1947 md view dashboard edit
+f1948 md view dashboard edit outline
+f1949 md office building cog
+f194a md office building cog outline
+f194b md hand clap
+f194c md cone
+f194d md cone off
+f194e md cylinder
+f194f md cylinder off
+f1950 md octahedron
+f1951 md octahedron off
+f1952 md pyramid
+f1953 md pyramid off
+f1954 md sphere
+f1955 md sphere off
+f1956 md format letter spacing
+f1957 md french fries
+f1958 md scent
+f1959 md scent off
+f195a md palette swatch variant
+f195b md email seal
+f195c md email seal outline
+f195d md stool
+f195e md stool outline
+f195f md panorama wide angle
+f1960 md account lock open
+f1961 md account lock open outline
+f1962 md align horizontal distribute
+f1963 md align vertical distribute
+f1964 md arrow bottom left bold box
+f1965 md arrow bottom left bold box outline
+f1966 md arrow bottom right bold box
+f1967 md arrow bottom right bold box outline
+f1968 md arrow top left bold box
+f1969 md arrow top left bold box outline
+f196a md arrow top right bold box
+f196b md arrow top right bold box outline
+f196c md bookmark box multiple
+f196d md bookmark box multiple outline
+f196e md bullhorn variant
+f196f md bullhorn variant outline
+f1970 md candy
+f1971 md candy off
+f1972 md candy off outline
+f1973 md candy outline
+f1974 md car clock
+f1975 md crowd
+f1976 md currency rupee
+f1977 md diving
+f1978 md dots circle
+f1979 md elevator passenger off
+f197a md elevator passenger off outline
+f197b md elevator passenger outline
+f197c md eye refresh
+f197d md eye refresh outline
+f197e md folder check
+f197f md folder check outline
+f1980 md human dolly
+f1981 md human white cane
+f1982 md ip outline
+f1983 md key alert
+f1984 md key alert outline
+f1985 md kite
+f1986 md kite outline
+f1987 md light flood down
+f1988 md light flood up
+f1989 md microphone question
+f198a md microphone question outline
+f198b md cradle
+f198c md panorama outline
+f198d md panorama sphere
+f198e md panorama sphere outline
+f198f md panorama variant
+f1990 md panorama variant outline
+f1991 md cradle outline
+f1992 md fraction one half
+f1993 md phone refresh
+f1994 md phone refresh outline
+f1995 md phone sync
+f1996 md phone sync outline
+f1997 md razor double edge
+f1998 md razor single edge
+f1999 md rotate 360
+f199a md shield lock open
+f199b md shield lock open outline
+f199c md sitemap outline
+f199d md sprinkler fire
+f199e md tab search
+f199f md timer sand complete
+f19a0 md timer sand paused
+f19a1 md vacuum
+f19a2 md vacuum outline
+f19a3 md wrench clock
+f19a4 md pliers
+f19a5 md sun compass
+f19a6 md truck snowflake
+f19a7 md camera marker
+f19a8 md camera marker outline
+f19a9 md video marker
+f19aa md video marker outline
+f19ab md wind turbine alert
+f19ac md wind turbine check
+f19ad md truck plus
+f19ae md truck minus
+f19af md truck remove
+f19b0 md arrow right thin
+f19b1 md arrow left thin
+f19b2 md arrow up thin
+f19b3 md arrow down thin
+f19b4 md arrow top right thin
+f19b5 md arrow top left thin
+f19b6 md arrow bottom left thin
+f19b7 md arrow bottom right thin
+f19b8 md scale unbalanced
+f19b9 md draw pen
+f19ba md clock edit
+f19bb md clock edit outline
+f19bc md truck plus outline
+f19bd md truck minus outline
+f19be md truck remove outline
+f19bf md camera off outline
+f19c0 md home group plus
+f19c1 md home group minus
+f19c2 md home group remove
+f19c3 md file sign
+f19c4 md attachment lock
+f19c5 md cellphone arrow down variant
+f19c6 md file chart check
+f19c7 md file chart check outline
+f19c8 md file lock open
+f19c9 md file lock open outline
+f19ca md folder question
+f19cb md folder question outline
+f19cc md message fast
+f19cd md message fast outline
+f19ce md message text fast
+f19cf md message text fast outline
+f19d0 md monitor arrow down
+f19d1 md monitor arrow down variant
+f19d2 md needle off
+f19d3 md numeric off
+f19d4 md package variant closed minus
+f19d5 md package variant closed plus
+f19d6 md package variant closed remove
+f19d7 md package variant minus
+f19d8 md package variant plus
+f19d9 md package variant remove
+f19da md paperclip lock
+f19db md phone clock
+f19dc md receipt outline
+f19dd md transmission tower off
+f19de md truck alert
+f19df md truck alert outline
+f19e0 md bone off
+f19e1 md lightbulb alert
+f19e2 md lightbulb alert outline
+f19e3 md lightbulb question
+f19e4 md lightbulb question outline
+f19e5 md battery clock
+f19e6 md battery clock outline
+f19e7 md autorenew off
+f19e8 md folder arrow down
+f19e9 md folder arrow down outline
+f19ea md folder arrow left
+f19eb md folder arrow left outline
+f19ec md folder arrow left right
+f19ed md folder arrow left right outline
+f19ee md folder arrow right
+f19ef md folder arrow right outline
+f19f0 md folder arrow up
+f19f1 md folder arrow up down
+f19f2 md folder arrow up down outline
+f19f3 md folder arrow up outline
+f19f4 md folder cancel
+f19f5 md folder cancel outline
+f19f6 md folder file
+f19f7 md folder file outline
+f19f8 md folder off
+f19f9 md folder off outline
+f19fa md folder play
+f19fb md folder play outline
+f19fc md folder wrench
+f19fd md folder wrench outline
+f19fe md image refresh
+f19ff md image refresh outline
+f1a00 md image sync
+f1a01 md image sync outline
+f1a02 md percent box
+f1a03 md percent box outline
+f1a04 md percent circle
+f1a05 md percent circle outline
+f1a06 md sale outline
+f1a07 md square rounded badge
+f1a08 md square rounded badge outline
+f1a09 md triangle small down
+f1a0a md triangle small up
+f1a0b md notebook heart
+f1a0c md notebook heart outline
+f1a0d md brush outline
+f1a0e md fruit pear
+f1a0f md raw
+f1a10 md raw off
+f1a11 md wall fire
+f1a12 md home clock
+f1a13 md home clock outline
+f1a14 md camera lock
+f1a15 md camera lock outline
+f1a16 md play box lock
+f1a17 md play box lock open
+f1a18 md play box lock open outline
+f1a19 md play box lock outline
+f1a1a md robot industrial outline
+f1a1b md gas burner
+f1a1c md video 2d
+f1a1d md book heart
+f1a1e md book heart outline
+f1a1f md account hard hat outline
+f1a20 md account school
+f1a21 md account school outline
+f1a22 md library outline
+f1a23 md projector off
+f1a24 md light switch off
+f1a25 md toggle switch variant
+f1a26 md toggle switch variant off
+f1a27 md asterisk circle outline
+f1a28 md barrel outline
+f1a29 md bell cog
+f1a2a md bell cog outline
+f1a2b md blinds horizontal
+f1a2c md blinds horizontal closed
+f1a2d md blinds vertical
+f1a2e md blinds vertical closed
+f1a2f md bulkhead light
+f1a30 md calendar today outline
+f1a31 md calendar week begin outline
+f1a32 md calendar week end
+f1a33 md calendar week end outline
+f1a34 md calendar week outline
+f1a35 md cloud percent
+f1a36 md cloud percent outline
+f1a37 md coach lamp variant
+f1a38 md compost
+f1a39 md currency fra
+f1a3a md fan clock
+f1a3b md file rotate left
+f1a3c md file rotate left outline
+f1a3d md file rotate right
+f1a3e md file rotate right outline
+f1a3f md filter multiple
+f1a40 md filter multiple outline
+f1a41 md gymnastics
+f1a42 md hand clap off
+f1a43 md heat pump
+f1a44 md heat pump outline
+f1a45 md heat wave
+f1a46 md home off
+f1a47 md home off outline
+f1a48 md landslide
+f1a49 md landslide outline
+f1a4a md laptop account
+f1a4b md led strip variant off
+f1a4c md lightbulb night
+f1a4d md lightbulb night outline
+f1a4e md lightbulb on 10
+f1a4f md lightbulb on 20
+f1a50 md lightbulb on 30
+f1a51 md lightbulb on 40
+f1a52 md lightbulb on 50
+f1a53 md lightbulb on 60
+f1a54 md lightbulb on 70
+f1a55 md lightbulb on 80
+f1a56 md lightbulb on 90
+f1a57 md meter electric
+f1a58 md meter electric outline
+f1a59 md meter gas
+f1a5a md meter gas outline
+f1a5b md monitor account
+f1a5c md pill off
+f1a5d md plus lock
+f1a5e md plus lock open
+f1a5f md pool thermometer
+f1a60 md post lamp
+f1a61 md rabbit variant
+f1a62 md rabbit variant outline
+f1a63 md receipt text check
+f1a64 md receipt text check outline
+f1a65 md receipt text minus
+f1a66 md receipt text minus outline
+f1a67 md receipt text plus
+f1a68 md receipt text plus outline
+f1a69 md receipt text remove
+f1a6a md receipt text remove outline
+f1a6b md roller shade
+f1a6c md roller shade closed
+f1a6d md seed plus
+f1a6e md seed plus outline
+f1a6f md shopping search outline
+f1a70 md snowflake check
+f1a71 md snowflake thermometer
+f1a72 md snowshoeing
+f1a73 md solar power variant
+f1a74 md solar power variant outline
+f1a75 md storage tank
+f1a76 md storage tank outline
+f1a77 md sun clock
+f1a78 md sun clock outline
+f1a79 md sun snowflake variant
+f1a7a md tag check
+f1a7b md tag check outline
+f1a7c md text box edit
+f1a7d md text box edit outline
+f1a7e md text search variant
+f1a7f md thermometer check
+f1a80 md thermometer water
+f1a81 md tsunami
+f1a82 md turbine
+f1a83 md volcano
+f1a84 md volcano outline
+f1a85 md water thermometer
+f1a86 md water thermometer outline
+f1a87 md wheelchair
+f1a88 md wind power
+f1a89 md wind power outline
+f1a8a md window shutter cog
+f1a8b md window shutter settings
+f1a8c md account tie woman
+f1a8d md briefcase arrow left right
+f1a8e md briefcase arrow left right outline
+f1a8f md briefcase arrow up down
+f1a90 md briefcase arrow up down outline
+f1a91 md cash clock
+f1a92 md cash sync
+f1a93 md file arrow left right
+f1a94 md file arrow left right outline
+f1a95 md file arrow up down
+f1a96 md file arrow up down outline
+f1a97 md file document alert
+f1a98 md file document alert outline
+f1a99 md file document check
+f1a9a md file document check outline
+f1a9b md file document minus
+f1a9c md file document minus outline
+f1a9d md file document plus
+f1a9e md file document plus outline
+f1a9f md file document remove
+f1aa0 md file document remove outline
+f1aa1 md file minus
+f1aa2 md file minus outline
+f1aa3 md filter cog
+f1aa4 md filter cog outline
+f1aa5 md filter settings
+f1aa6 md filter settings outline
+f1aa7 md folder lock open outline
+f1aa8 md folder lock outline
+f1aa9 md forum minus
+f1aaa md forum minus outline
+f1aab md forum plus
+f1aac md forum plus outline
+f1aad md forum remove
+f1aae md forum remove outline
+f1aaf md heating coil
+f1ab0 md image lock
+f1ab1 md image lock outline
+f1ab2 md land fields
+f1ab3 md land plots
+f1ab4 md land plots circle
+f1ab5 md land plots circle variant
+f1ab6 md land rows horizontal
+f1ab7 md land rows vertical
+f1ab8 md medical cotton swab
+f1ab9 md rolodex
+f1aba md rolodex outline
+f1abb md sort variant off
+f1abc md tally mark 1
+f1abd md tally mark 2
+f1abe md tally mark 3
+f1abf md tally mark 4
+f1ac0 md tally mark 5
+f1ac1 md attachment check
+f1ac2 md attachment minus
+f1ac3 md attachment off
+f1ac4 md attachment plus
+f1ac5 md attachment remove
+f1ac6 md paperclip check
+f1ac7 md paperclip minus
+f1ac8 md paperclip off
+f1ac9 md paperclip plus
+f1aca md paperclip remove
+f1acb md network pos
+f1acc md timer alert
+f1acd md timer alert outline
+f1ace md timer cancel
+f1acf md timer cancel outline
+f1ad0 md timer check
+f1ad1 md timer check outline
+f1ad2 md timer edit
+f1ad3 md timer edit outline
+f1ad4 md timer lock
+f1ad5 md timer lock open
+f1ad6 md timer lock open outline
+f1ad7 md timer lock outline
+f1ad8 md timer marker
+f1ad9 md timer marker outline
+f1ada md timer minus
+f1adb md timer minus outline
+f1adc md timer music
+f1add md timer music outline
+f1ade md timer pause
+f1adf md timer pause outline
+f1ae0 md timer play
+f1ae1 md timer play outline
+f1ae2 md timer plus
+f1ae3 md timer plus outline
+f1ae4 md timer refresh
+f1ae5 md timer refresh outline
+f1ae6 md timer remove
+f1ae7 md timer remove outline
+f1ae8 md timer star
+f1ae9 md timer star outline
+f1aea md timer stop
+f1aeb md timer stop outline
+f1aec md timer sync
+f1aed md timer sync outline
+f1aee md ear hearing loop
+f1aef md sail boat sink
+f1af0 md lecturn
 f500 mdi vector square
 f501 mdi access point
 f502 mdi access point network
@@ -3838,7 +10721,6 @@ e009 pom internal interruption
 e00a pom external interruption
 e600 seti stylus
 e601 seti project
-e602 seti play arrow
 e603 seti sass
 e604 seti rails
 e605 seti ruby
@@ -3854,12 +10736,10 @@ e60e seti html
 e60f seti mustache
 e610 seti gulp
 e611 seti grunt
-e612 seti text
 e613 seti folder
 e614 seti css
 e615 seti config
 e616 seti npm
-e617 seti home
 e618 seti ejs
 e619 seti xml
 e61a seti bower
@@ -3873,6 +10753,124 @@ e624 seti julia
 e625 seti react
 e627 seti go
 e628 seti typescript
+e635 seti apple
+e636 seti argdown
+e637 seti asm
+e638 seti audio
+e639 seti babel
+e63a seti bazel
+e63b seti bicep
+e63c seti bsl
+e63d seti cake php
+e63e seti cake
+e63f seti checkbox
+e640 seti checkbox unchecked
+e641 seti clock time cop
+e642 seti clojure
+e643 seti code climate
+e644 seti code search
+e645 seti coldfusion
+e646 seti cpp
+e647 seti crystal embedded
+e648 seti c sharp
+e649 seti c
+e64a seti csv
+e64b seti cu
+e64c seti dart
+e64d seti db
+e64e seti default
+e64f seti deprecation cop
+e650 seti docker
+e651 seti d
+e652 seti editorconfig
+e653 seti elixir script
+e654 seti error
+e655 seti eslint
+e656 seti ethereum
+e657 seti firebase
+e658 seti firefox
+e659 seti font
+e65a seti f sharp
+e65b seti github
+e65c seti gitlab
+e65d seti git
+e65e seti go2
+e65f seti godot
+e660 seti gradle
+e661 seti grails
+e662 seti graphql
+e663 seti hacklang
+e664 seti haml
+e665 seti happenings
+e666 seti haxe
+e667 seti hex
+e668 seti ignored
+e669 seti illustrator
+e66a seti info
+e66b seti ionic
+e66c seti jade
+e66d seti java
+e66e seti jenkins
+e66f seti jinja
+e670 seti liquid
+e671 seti livescript
+e672 seti lock
+e673 seti makefile
+e674 seti maven
+e675 seti mdo
+e676 seti new file
+e677 seti nim
+e678 seti notebook
+e679 seti nunjucks
+e67a seti ocaml
+e67b seti odata
+e67c seti pddl
+e67d seti pdf
+e67e seti perl
+e67f seti photoshop
+e680 seti pipeline
+e681 seti plan
+e682 seti platformio
+e683 seti powershell
+e684 seti prisma
+e685 seti prolog
+e686 seti pug
+e687 seti reasonml
+e688 seti rescript
+e689 seti rollup
+e68a seti r
+e68b seti rust
+e68c seti salesforce
+e68d seti sbt
+e68e seti scala
+e68f seti search
+e690 seti settings
+e691 seti shell
+e692 seti slim
+e693 seti smarty
+e694 seti spring
+e695 seti stylelint
+e696 seti sublime
+e697 seti svelte
+e698 seti svg
+e699 seti swift
+e69a seti terraform
+e69b seti tex
+e69c seti todo
+e69d seti tsconfig
+e69e seti vala
+e69f seti video
+e6a0 seti vue
+e6a1 seti wasm
+e6a2 seti wat
+e6a3 seti webpack
+e6a4 seti wgt
+e6a5 seti word
+e6a6 seti xls
+e6a7 seti yarn
+e6a8 seti yml
+e6a9 seti zig
+e6aa seti zip
 e300 weather day cloudy gusts
 e301 weather day cloudy windy
 e302 weather day cloudy

--- a/tools/unicode_names/names.txt
+++ b/tools/unicode_names/names.txt
@@ -1,4 +1,4 @@
-37997 17455
+44995 18283
 0 null
 1 start of heading
 2 start of text
@@ -15724,7 +15724,7 @@
 58895 mustache
 58896 gulp
 58897 grunt
-58898 text
+58898 default text
 58899 folder
 58900 css
 58901 config
@@ -15759,6 +15759,124 @@
 58930 emacs
 58931 orgmode
 58932 kotlin
+58933 apple
+58934 argdown
+58935 asm
+58936 audio
+58937 babel
+58938 bazel
+58939 bicep
+58940 bsl
+58941 cake php
+58942 cake
+58943 checkbox
+58944 checkbox unchecked
+58945 clock time cop
+58946 clojure
+58947 code climate
+58948 code search
+58949 coldfusion
+58950 cpp
+58951 crystal embedded
+58952 c sharp
+58953 c
+58954 csv
+58955 cu
+58956 dart
+58957 db
+58958 default
+58959 deprecation cop
+58960 docker
+58961 d
+58962 editorconfig
+58963 elixir script
+58964 error
+58965 eslint
+58966 ethereum
+58967 firebase
+58968 firefox
+58969 font
+58970 f sharp
+58971 github
+58972 gitlab
+58973 git
+58974 go2
+58975 godot
+58976 gradle
+58977 grails
+58978 graphql
+58979 hacklang
+58980 haml
+58981 happenings
+58982 haxe
+58983 hex
+58984 ignored
+58985 illustrator
+58986 info
+58987 ionic
+58988 jade
+58989 java
+58990 jenkins
+58991 jinja
+58992 liquid
+58993 livescript
+58994 lock
+58995 makefile
+58996 maven
+58997 mdo
+58998 new file
+58999 nim
+59000 notebook
+59001 nunjucks
+59002 ocaml
+59003 odata
+59004 pddl
+59005 pdf
+59006 perl
+59007 photoshop
+59008 pipeline
+59009 plan
+59010 platformio
+59011 powershell
+59012 prisma
+59013 prolog
+59014 pug
+59015 reasonml
+59016 rescript
+59017 rollup
+59018 r
+59019 rust
+59020 salesforce
+59021 sbt
+59022 scala
+59023 search
+59024 settings
+59025 shell
+59026 slim
+59027 smarty
+59028 spring
+59029 stylelint
+59030 sublime
+59031 svelte
+59032 svg
+59033 swift
+59034 terraform
+59035 tex
+59036 todo
+59037 tsconfig
+59038 vala
+59039 video
+59040 vue
+59041 wasm
+59042 wat
+59043 webpack
+59044 wgt
+59045 word
+59046 xls
+59047 yarn
+59048 yml
+59049 zig
+59050 zip
 59136 bing small
 59137 css tricks
 59138 git
@@ -37993,6 +38111,6886 @@
 917998 variation selector-255
 917999 variation selector-256
 983040 <plane 15 private use, first>
+983041 vector square
+983042 access point network
+983043 access point
+983044 account
+983045 account alert
+983046 account box
+983047 account box outline
+983048 account check
+983049 account circle
+983050 account convert
+983051 account key
+983052 tooltip account
+983053 account minus
+983054 account multiple
+983055 account multiple outline
+983056 account multiple plus
+983057 account network
+983058 account off
+983059 account outline
+983060 account plus
+983061 account remove
+983062 account search
+983063 account star
+983064 orbit
+983065 account switch
+983066 adjust
+983067 air conditioner
+983068 airballoon
+983069 airplane
+983070 airplane off
+983071 cast variant
+983072 alarm
+983073 alarm check
+983074 alarm multiple
+983075 alarm off
+983076 alarm plus
+983077 album
+983078 alert
+983079 alert box
+983080 alert circle
+983081 alert octagon
+983082 alert outline
+983083 alpha
+983084 alphabetical
+983085 greenhouse
+983086 rollerblade off
+983087 ambulance
+983088 amplifier
+983089 anchor
+983090 android
+983091 web plus
+983092 android studio
+983093 apple
+983094 apple finder
+983095 apple ios
+983096 apple icloud
+983097 apple safari
+983098 font awesome
+983099 apps
+983100 archive
+983101 arrange bring forward
+983102 arrange bring to front
+983103 arrange send backward
+983104 arrange send to back
+983105 arrow all
+983106 arrow bottom left
+983107 arrow bottom right
+983108 arrow collapse all
+983109 arrow down
+983110 arrow down thick
+983111 arrow down bold circle
+983112 arrow down bold circle outline
+983113 arrow down bold hexagon outline
+983114 arrow down drop circle
+983115 arrow down drop circle outline
+983116 arrow expand all
+983117 arrow left
+983118 arrow left thick
+983119 arrow left bold circle
+983120 arrow left bold circle outline
+983121 arrow left bold hexagon outline
+983122 arrow left drop circle
+983123 arrow left drop circle outline
+983124 arrow right
+983125 arrow right thick
+983126 arrow right bold circle
+983127 arrow right bold circle outline
+983128 arrow right bold hexagon outline
+983129 arrow right drop circle
+983130 arrow right drop circle outline
+983131 arrow top left
+983132 arrow top right
+983133 arrow up
+983134 arrow up thick
+983135 arrow up bold circle
+983136 arrow up bold circle outline
+983137 arrow up bold hexagon outline
+983138 arrow up drop circle
+983139 arrow up drop circle outline
+983140 assistant
+983141 at
+983142 attachment
+983143 book music
+983144 auto fix
+983145 auto upload
+983146 autorenew
+983147 av timer
+983148 baby
+983149 backburger
+983150 backspace
+983151 backup restore
+983152 bank
+983153 barcode
+983154 barcode scan
+983155 barley
+983156 barrel
+983157 incognito off
+983158 basket
+983159 basket fill
+983160 basket unfill
+983161 battery
+983162 battery 10
+983163 battery 20
+983164 battery 30
+983165 battery 40
+983166 battery 50
+983167 battery 60
+983168 battery 70
+983169 battery 80
+983170 battery 90
+983171 battery alert
+983172 battery charging
+983173 battery charging 100
+983174 battery charging 20
+983175 battery charging 30
+983176 battery charging 40
+983177 battery charging 60
+983178 battery charging 80
+983179 battery charging 90
+983180 battery minus variant
+983181 battery negative
+983182 battery outline
+983183 battery plus variant
+983184 battery positive
+983185 battery unknown
+983186 beach
+983187 flask
+983188 flask empty
+983189 flask empty outline
+983190 flask outline
+983191 bunk bed outline
+983192 beer
+983193 bed outline
+983194 bell
+983195 bell off
+983196 bell outline
+983197 bell plus
+983198 bell ring
+983199 bell ring outline
+983200 bell sleep
+983201 beta
+983202 book cross
+983203 bike
+983204 microsoft bing
+983205 binoculars
+983206 bio
+983207 biohazard
+983208 bitbucket
+983209 black mesa
+983210 shield refresh
+983211 blender software
+983212 blinds
+983213 block helper
+983214 application edit
+983215 bluetooth
+983216 bluetooth audio
+983217 bluetooth connect
+983218 bluetooth off
+983219 bluetooth settings
+983220 bluetooth transfer
+983221 blur
+983222 blur linear
+983223 blur off
+983224 blur radial
+983225 bone
+983226 book
+983227 book multiple
+983228 book variant multiple
+983229 book open
+983230 book open blank variant
+983231 book variant
+983232 bookmark
+983233 bookmark check
+983234 bookmark music
+983235 bookmark outline
+983236 bookmark plus outline
+983237 bookmark plus
+983238 bookmark remove
+983239 border all
+983240 border bottom
+983241 border color
+983242 border horizontal
+983243 border inside
+983244 border left
+983245 border none
+983246 border outside
+983247 border right
+983248 border style
+983249 border top
+983250 border vertical
+983251 bowling
+983252 box
+983253 box cutter
+983254 briefcase
+983255 briefcase check
+983256 briefcase download
+983257 briefcase upload
+983258 brightness 1
+983259 brightness 2
+983260 brightness 3
+983261 brightness 4
+983262 brightness 5
+983263 brightness 6
+983264 brightness 7
+983265 brightness auto
+983266 broom
+983267 brush
+983268 bug
+983269 bulletin board
+983270 bullhorn
+983271 bus
+983272 cached
+983273 cake
+983274 cake layered
+983275 cake variant
+983276 calculator
+983277 calendar
+983278 calendar blank
+983279 calendar check
+983280 calendar clock
+983281 calendar multiple
+983282 calendar multiple check
+983283 calendar plus
+983284 calendar remove
+983285 calendar text
+983286 calendar today
+983287 call made
+983288 call merge
+983289 call missed
+983290 call received
+983291 call split
+983292 camcorder
+983293 video box
+983294 video box off
+983295 camcorder off
+983296 camera
+983297 camera enhance
+983298 camera front
+983299 camera front variant
+983300 camera iris
+983301 camera party mode
+983302 camera rear
+983303 camera rear variant
+983304 camera switch
+983305 camera timer
+983306 candycane
+983307 car
+983308 car battery
+983309 car connected
+983310 car wash
+983311 carrot
+983312 cart
+983313 cart outline
+983314 cart plus
+983315 case sensitive alt
+983316 cash
+983317 cash 100
+983318 cash multiple
+983319 checkbox blank badge outline
+983320 cast
+983321 cast connected
+983322 castle
+983323 cat
+983324 cellphone
+983325 tray arrow up
+983326 cellphone basic
+983327 cellphone dock
+983328 tray arrow down
+983329 cellphone link
+983330 cellphone link off
+983331 cellphone settings
+983332 certificate
+983333 chair school
+983334 chart arc
+983335 chart areaspline
+983336 chart bar
+983337 chart histogram
+983338 chart line
+983339 chart pie
+983340 check
+983341 check all
+983342 checkbox blank
+983345 checkbox blank outline
+983346 checkbox marked
+983347 checkbox marked circle
+983348 checkbox marked circle outline
+983349 checkbox marked outline
+983350 checkbox multiple blank
+983351 checkbox multiple blank outline
+983352 checkbox multiple marked
+983353 checkbox multiple marked outline
+983354 checkerboard
+983355 chemical weapon
+983356 chevron double down
+983357 chevron double left
+983358 chevron double right
+983359 chevron double up
+983360 chevron down
+983361 chevron left
+983362 chevron right
+983363 chevron up
+983364 church
+983365 roller skate off
+983366 city
+983367 clipboard
+983368 clipboard account
+983369 clipboard alert
+983370 clipboard arrow down
+983371 clipboard arrow left
+983372 clipboard outline
+983373 clipboard text
+983374 clipboard check
+983375 clippy
+983376 clock outline
+983377 clock end
+983378 clock fast
+983379 clock in
+983380 clock out
+983381 clock start
+983382 close
+983383 close box
+983384 close box outline
+983385 close circle
+983386 close circle outline
+983387 close network
+983388 close octagon
+983389 close octagon outline
+983390 closed caption
+983391 cloud
+983392 cloud check
+983393 cloud circle
+983394 cloud download
+983395 cloud outline
+983396 cloud off outline
+983397 cloud print
+983398 cloud print outline
+983399 cloud upload
+983400 code array
+983401 code braces
+983402 code brackets
+983403 code equal
+983404 code greater than
+983405 code greater than or equal
+983406 code less than
+983407 code less than or equal
+983408 code not equal
+983409 code not equal variant
+983410 code parentheses
+983411 code string
+983412 code tags
+983413 codepen
+983414 coffee
+983415 coffee to go
+983416 bell badge outline
+983417 color helper
+983418 comment
+983419 comment account
+983420 comment account outline
+983421 comment alert
+983422 comment alert outline
+983423 comment check
+983424 comment check outline
+983425 comment multiple outline
+983426 comment outline
+983427 comment plus outline
+983428 comment processing
+983429 comment processing outline
+983430 comment question outline
+983431 comment remove outline
+983432 comment text
+983433 comment text outline
+983434 compare
+983435 compass
+983436 compass outline
+983437 console
+983438 card account mail
+983439 content copy
+983440 content cut
+983441 content duplicate
+983442 content paste
+983443 content save
+983444 content save all
+983445 contrast
+983446 contrast box
+983447 contrast circle
+983448 cookie
+983449 counter
+983450 cow
+983451 credit card outline
+983452 credit card multiple outline
+983453 credit card scan outline
+983454 crop
+983455 crop free
+983456 crop landscape
+983457 crop portrait
+983458 crop square
+983459 crosshairs
+983460 crosshairs gps
+983461 crown
+983462 cube
+983463 cube outline
+983464 cube send
+983465 cube unfolded
+983466 cup
+983467 cup water
+983468 currency btc
+983469 currency eur
+983470 currency gbp
+983471 currency inr
+983472 currency ngn
+983473 currency rub
+983474 currency try
+983475 delete variant
+983476 delete
+983477 decimal increase
+983478 decimal decrease
+983479 debug step over
+983480 debug step out
+983481 debug step into
+983482 database plus
+983483 database minus
+983484 database
+983485 cursor pointer
+983486 cursor move
+983487 cursor default outline
+983488 cursor default
+983489 currency usd
+983490 delta
+983491 deskphone
+983492 desktop mac
+983493 desktop tower
+983494 details
+983495 deviantart
+983496 diamond stone
+983497 ab testing
+983498 dice 1
+983499 dice 2
+983500 dice 3
+983501 dice 4
+983502 dice 5
+983503 dice 6
+983504 directions
+983505 disc alert
+983506 disqus
+983507 video plus outline
+983508 division
+983509 division box
+983510 dns
+983511 domain
+983512 dots horizontal
+983513 dots vertical
+983514 download
+983515 drag
+983516 drag horizontal
+983517 drag vertical
+983518 drawing
+983519 drawing box
+983520 shield refresh outline
+983521 calendar refresh
+983522 drone
+983523 dropbox
+983524 drupal
+983525 duck
+983526 dumbbell
+983527 earth
+983528 earth off
+983529 microsoft edge
+983530 eject
+983531 elevation decline
+983532 elevation rise
+983533 elevator
+983534 email
+983535 email open
+983536 email outline
+983537 email lock
+983538 emoticon outline
+983539 emoticon cool outline
+983540 emoticon devil outline
+983541 emoticon happy outline
+983542 emoticon neutral outline
+983543 emoticon poop
+983544 emoticon sad outline
+983545 emoticon tongue
+983546 engine
+983547 engine outline
+983548 equal
+983549 equal box
+983550 eraser
+983551 escalator
+983552 ethernet
+983553 ethernet cable
+983554 ethernet cable off
+983555 calendar refresh outline
+983556 evernote
+983557 exclamation
+983559 export
+983560 eye
+983561 eye off
+983562 eyedropper
+983563 eyedropper variant
+983564 facebook
+983565 order alphabetical ascending
+983566 facebook messenger
+983567 factory
+983568 fan
+983569 fast forward
+983570 fax
+983571 ferry
+983572 file
+983573 file chart
+983574 file check
+983575 file cloud
+983576 file delimited
+983577 file document
+983578 text box
+983579 file excel
+983580 file excel box
+983581 file export
+983582 file find
+983583 file image
+983584 file import
+983585 file lock
+983586 file multiple
+983587 file music
+983588 file outline
+983589 file jpg box
+983590 file pdf box
+983591 file powerpoint
+983592 file powerpoint box
+983593 file presentation box
+983594 file send
+983595 file video
+983596 file word
+983597 file word box
+983598 file code
+983599 film
+983600 filmstrip
+983601 filmstrip off
+983602 filter
+983603 filter outline
+983604 filter remove
+983605 filter remove outline
+983606 filter variant
+983607 fingerprint
+983608 fire
+983609 firefox
+983610 fish
+983611 flag
+983612 flag checkered
+983613 flag outline
+983614 flag variant outline
+983615 flag triangle
+983616 flag variant
+983617 flash
+983618 flash auto
+983619 flash off
+983620 flashlight
+983621 flashlight off
+983622 star half
+983623 flip to back
+983624 flip to front
+983625 floppy
+983626 flower
+983627 folder
+983628 folder account
+983629 folder download
+983630 folder google drive
+983631 folder image
+983632 folder lock
+983633 folder lock open
+983634 folder move
+983635 folder multiple
+983636 folder multiple image
+983637 folder multiple outline
+983638 folder outline
+983639 folder plus
+983640 folder remove
+983641 folder upload
+983642 food
+983643 food apple
+983644 food variant
+983645 football
+983646 football australian
+983647 football helmet
+983648 format align center
+983649 format align justify
+983650 format align left
+983651 format align right
+983652 format bold
+983653 format clear
+983654 format color fill
+983655 format float center
+983656 format float left
+983657 format float none
+983658 format float right
+983659 format header 1
+983660 format header 2
+983661 format header 3
+983662 format header 4
+983663 format header 5
+983664 format header 6
+983665 format header decrease
+983666 format header equal
+983667 format header increase
+983668 format header pound
+983669 format indent decrease
+983670 format indent increase
+983671 format italic
+983672 format line spacing
+983673 format list bulleted
+983674 format list bulleted type
+983675 format list numbered
+983676 format paint
+983677 format paragraph
+983678 format quote close
+983679 format size
+983680 format strikethrough
+983681 format strikethrough variant
+983682 format subscript
+983683 format superscript
+983684 format text
+983685 format textdirection l to r
+983686 format textdirection r to l
+983687 format underline
+983688 format wrap inline
+983689 format wrap square
+983690 format wrap tight
+983691 format wrap top bottom
+983692 forum
+983693 forward
+983694 bowl
+983695 fridge outline
+983696 fridge
+983697 fridge top
+983698 fridge bottom
+983699 fullscreen
+983700 fullscreen exit
+983701 function
+983702 gamepad
+983703 gamepad variant
+983704 gas station
+983705 gate
+983706 gauge
+983707 gavel
+983708 gender female
+983709 gender male
+983710 gender male female
+983711 gender transgender
+983712 ghost
+983713 gift outline
+983714 git
+983715 card account details star
+983716 github
+983717 glass flute
+983718 glass mug
+983719 glass stange
+983720 glass tulip
+983721 bowl outline
+983722 glasses
+983723 gmail
+983724 gnome
+983725 google
+983726 google cardboard
+983727 google chrome
+983728 google circles
+983729 google circles communities
+983730 google circles extended
+983731 google circles group
+983732 google controller
+983733 google controller off
+983734 google drive
+983735 google earth
+983736 google glass
+983737 google nearby
+983738 video minus outline
+983739 microsoft teams
+983740 google play
+983741 google plus
+983742 order bool ascending
+983743 google translate
+983744 google classroom
+983745 grid
+983746 grid off
+983747 group
+983748 guitar electric
+983749 guitar pick
+983750 guitar pick outline
+983751 hand pointing right
+983752 hanger
+983753 google hangouts
+983754 harddisk
+983755 headphones
+983756 headphones box
+983757 headphones settings
+983758 headset
+983759 headset dock
+983760 headset off
+983762 heart box
+983763 heart box outline
+983764 heart broken
+983766 help
+983767 help circle
+983768 hexagon
+983769 hexagon outline
+983770 history
+983771 hololens
+983772 home
+983773 home modern
+983774 home variant
+983775 hops
+983776 hospital box
+983777 hospital building
+983778 hospital marker
+983779 bed
+983780 bowl mix outline
+983781 pot
+983782 human
+983783 human child
+983784 human male female
+983785 image
+983786 image album
+983787 image area
+983788 image area close
+983789 image broken
+983790 image broken variant
+983791 image multiple outline
+983792 image filter black white
+983793 image filter center focus
+983794 image filter center focus weak
+983795 image filter drama
+983796 image filter frames
+983798 image filter none
+983799 image filter tilt shift
+983800 image filter vintage
+983801 image multiple
+983802 import
+983803 inbox arrow down
+983804 information
+983805 information outline
+983806 instagram
+983807 pot outline
+983808 microsoft internet explorer
+983809 invert colors
+983810 jeepney
+983811 jira
+983812 jsfiddle
+983813 keg
+983814 key
+983815 key change
+983816 key minus
+983817 key plus
+983818 key remove
+983819 key variant
+983820 keyboard
+983821 keyboard backspace
+983822 keyboard caps
+983823 keyboard close
+983824 keyboard off
+983825 keyboard return
+983826 keyboard tab
+983827 keyboard variant
+983828 kodi
+983829 label
+983830 label outline
+983831 lan
+983832 lan connect
+983833 lan disconnect
+983834 lan pending
+983835 language csharp
+983836 language css3
+983837 language html5
+983838 language javascript
+983839 language php
+983840 language python
+983841 contactless payment circle
+983842 laptop
+983843 magazine rifle
+983844 magazine pistol
+983845 keyboard tab reverse
+983846 pot steam outline
+983847 launch
+983848 layers
+983849 layers off
+983850 leaf
+983851 led off
+983852 led on
+983853 led outline
+983854 led variant off
+983855 led variant on
+983856 led variant outline
+983857 library
+983858 filmstrip box
+983859 music box multiple
+983860 plus box multiple
+983861 lightbulb
+983862 lightbulb outline
+983863 link
+983864 link off
+983865 link variant
+983866 link variant off
+983867 linkedin
+983868 sort reverse variant
+983869 linux
+983870 lock
+983871 lock open
+983872 lock open outline
+983873 lock outline
+983874 login
+983875 logout
+983876 looks
+983877 loupe
+983878 lumx
+983879 magnet
+983880 magnet on
+983881 magnify
+983882 magnify minus
+983883 magnify plus
+983884 plus circle multiple
+983885 map
+983886 map marker
+983887 map marker circle
+983888 map marker multiple
+983889 map marker off
+983890 map marker radius
+983891 margin
+983892 language markdown
+983893 marker check
+983894 glass cocktail
+983895 material ui
+983896 math compass
+983897 stackpath
+983898 minus circle multiple
+983899 memory
+983900 menu
+983901 menu down
+983902 menu left
+983903 menu right
+983904 menu up
+983905 message
+983906 message alert
+983907 message draw
+983908 message image
+983909 message outline
+983910 message processing
+983911 message reply
+983912 message reply text
+983913 message text
+983914 message text outline
+983915 message video
+983916 microphone
+983917 microphone off
+983918 microphone outline
+983919 microphone settings
+983920 microphone variant
+983921 microphone variant off
+983922 microsoft
+983923 minecraft
+983924 minus
+983925 minus box
+983926 minus circle
+983927 minus circle outline
+983928 minus network
+983929 monitor
+983930 monitor multiple
+983931 more
+983932 motorbike
+983933 mouse
+983934 mouse off
+983935 mouse variant
+983936 mouse variant off
+983937 movie
+983938 multiplication
+983939 multiplication box
+983940 music box
+983941 music box outline
+983942 music circle
+983944 music note
+983945 music note half
+983946 music note off
+983947 music note quarter
+983948 music note sixteenth
+983949 music note whole
+983950 nature
+983951 nature people
+983952 navigation
+983953 needle
+983954 smoke detector
+983955 thermostat
+983956 new box
+983957 newspaper
+983958 nfc
+983959 nfc tap
+983960 nfc variant
+983961 nodejs
+983962 note
+983963 note outline
+983964 note plus
+983965 note plus outline
+983966 note text
+983967 notification clear all
+983968 numeric
+983969 numeric 0 box
+983970 numeric 0 box multiple outline
+983971 numeric 0 box outline
+983972 numeric 1 box
+983973 numeric 1 box multiple outline
+983974 numeric 1 box outline
+983975 numeric 2 box
+983976 numeric 2 box multiple outline
+983977 numeric 2 box outline
+983978 numeric 3 box
+983979 numeric 3 box multiple outline
+983980 numeric 3 box outline
+983981 numeric 4 box
+983982 numeric 4 box outline
+983983 numeric 5 box multiple outline
+983984 numeric 5 box outline
+983985 numeric 5 box
+983986 numeric 4 box multiple outline
+983987 numeric 6 box
+983988 numeric 6 box multiple outline
+983989 numeric 6 box outline
+983990 numeric 7 box
+983991 numeric 7 box multiple outline
+983992 numeric 7 box outline
+983993 numeric 8 box
+983994 numeric 8 box multiple outline
+983995 numeric 8 box outline
+983996 numeric 9 box
+983997 numeric 9 box multiple outline
+983998 numeric 9 box outline
+983999 numeric 9 plus box
+984000 numeric 9 plus box multiple outline
+984001 numeric 9 plus box outline
+984002 nutrition
+984003 octagon
+984004 octagon outline
+984005 odnoklassniki
+984006 microsoft office
+984007 oil
+984008 coolant temperature
+984009 omega
+984010 microsoft onedrive
+984011 open in app
+984012 open in new
+984013 openid
+984014 opera
+984015 ornament
+984016 ornament variant
+984017 inbox arrow up
+984018 owl
+984019 package
+984020 package down
+984021 package up
+984022 package variant
+984023 package variant closed
+984024 palette
+984025 palette advanced
+984026 panda
+984027 pandora
+984028 panorama
+984029 panorama fisheye
+984030 panorama horizontal outline
+984031 panorama vertical outline
+984032 panorama wide angle outline
+984033 paper cut vertical
+984034 paperclip
+984035 parking
+984036 pause
+984037 pause circle
+984038 pause circle outline
+984039 pause octagon
+984040 pause octagon outline
+984041 paw
+984042 pen
+984043 pencil
+984044 pencil box
+984045 pencil box outline
+984046 pencil lock
+984047 pencil off
+984048 percent
+984049 mortar pestle plus
+984050 phone
+984051 phone bluetooth
+984052 phone forward
+984053 phone hangup
+984054 phone in talk
+984055 phone incoming
+984056 phone lock
+984057 phone log
+984058 phone missed
+984059 phone outgoing
+984060 phone paused
+984061 phone settings
+984062 phone voip
+984063 pi
+984064 pi box
+984065 pig
+984066 pill
+984067 pin
+984068 pin off
+984069 pine tree
+984070 pine tree box
+984071 pinterest
+984072 contactless payment circle outline
+984073 pizza
+984074 play
+984075 play box outline
+984076 play circle
+984077 play circle outline
+984078 play pause
+984079 play protected content
+984080 playlist minus
+984081 playlist play
+984082 playlist plus
+984083 playlist remove
+984084 sony playstation
+984085 plus
+984086 plus box
+984087 plus circle
+984088 plus circle multiple outline
+984089 plus circle outline
+984090 plus network
+984091 sledding
+984092 wall sconce flat variant
+984093 pokeball
+984094 polaroid
+984095 poll
+984096 account eye
+984097 polymer
+984098 popcorn
+984099 pound
+984100 pound box
+984101 power
+984102 power settings
+984103 power socket
+984104 presentation
+984105 presentation play
+984106 printer
+984107 printer 3d
+984108 printer alert
+984109 professional hexagon
+984110 projector
+984111 projector screen
+984112 pulse
+984113 puzzle
+984114 qrcode
+984115 qrcode scan
+984116 quadcopter
+984117 quality high
+984118 book multiple outline
+984119 radar
+984120 radiator
+984121 radio
+984122 radio handheld
+984123 radio tower
+984124 radioactive
+984126 radiobox marked
+984127 raspberry pi
+984128 ray end
+984129 ray end arrow
+984130 ray start
+984131 ray start arrow
+984132 ray start end
+984133 ray vertex
+984134 lastpass
+984135 read
+984136 youtube tv
+984137 receipt
+984138 record
+984139 record rec
+984140 recycle
+984141 reddit
+984142 redo
+984143 redo variant
+984144 refresh
+984145 regex
+984146 relative scale
+984147 reload
+984148 remote
+984149 rename box
+984150 repeat
+984151 repeat off
+984152 repeat once
+984153 replay
+984154 reply
+984155 reply all
+984156 reproduction
+984157 resize bottom right
+984158 responsive
+984159 rewind
+984160 ribbon
+984161 road
+984162 road variant
+984163 rocket
+984164 rotate 3d variant
+984165 rotate left
+984166 rotate left variant
+984167 rotate right
+984168 rotate right variant
+984169 router wireless
+984170 routes
+984171 rss
+984172 rss box
+984173 ruler
+984174 run fast
+984175 sale
+984176 satellite
+984177 satellite variant
+984178 scale
+984179 scale bathroom
+984180 school
+984181 screen rotation
+984182 screwdriver
+984183 script outline
+984184 screen rotation lock
+984185 sd
+984186 seal
+984187 seat flat
+984188 seat flat angled
+984189 seat individual suite
+984190 seat legroom extra
+984191 seat legroom normal
+984192 seat legroom reduced
+984193 seat recline extra
+984194 seat recline normal
+984195 security
+984196 security network
+984197 select
+984198 select all
+984199 select inverse
+984200 select off
+984201 selection
+984202 send
+984203 server
+984204 server minus
+984205 server network
+984206 server network off
+984207 server off
+984208 server plus
+984209 server remove
+984210 server security
+984211 cog
+984212 cog box
+984213 shape plus
+984214 share
+984215 share variant
+984216 shield
+984217 shield outline
+984218 shopping
+984219 shopping music
+984220 shredder
+984221 shuffle
+984222 shuffle disabled
+984223 shuffle variant
+984224 sigma
+984225 sign caution
+984226 signal
+984227 silverware
+984228 silverware fork
+984229 silverware spoon
+984230 silverware variant
+984231 sim
+984232 sim alert
+984233 sim off
+984234 sitemap
+984235 skip backward
+984236 skip forward
+984237 skip next
+984238 skip previous
+984239 skype
+984240 skype business
+984241 slack
+984242 sleep
+984243 sleep off
+984244 smoking
+984245 smoking off
+984246 snapchat
+984247 snowman
+984248 soccer
+984249 sofa
+984250 sort
+984251 sort alphabetical variant
+984252 sort ascending
+984253 sort descending
+984254 sort numeric variant
+984255 sort variant
+984256 soundcloud
+984257 source fork
+984258 source pull
+984259 speaker
+984260 speaker off
+984261 speedometer
+984262 spellcheck
+984263 spotify
+984264 spotlight
+984265 spotlight beam
+984266 book remove multiple outline
+984267 account switch outline
+984268 stack overflow
+984269 stairs
+984270 star
+984271 star circle
+984272 star half full
+984273 star off
+984274 star outline
+984275 steam
+984276 steering
+984277 step backward
+984278 step backward 2
+984279 step forward
+984280 step forward 2
+984281 stethoscope
+984282 stocking
+984283 stop
+984284 store
+984285 store 24 hour
+984286 stove
+984287 subway variant
+984288 sunglasses
+984289 swap horizontal
+984290 swap vertical
+984291 swim
+984292 switch
+984293 sword
+984294 sync
+984295 sync alert
+984296 sync off
+984297 tab
+984298 tab unselected
+984299 table
+984300 table column plus after
+984301 table column plus before
+984302 table column remove
+984303 table column width
+984304 table edit
+984305 table large
+984306 table row height
+984307 table row plus after
+984308 table row plus before
+984309 table row remove
+984310 tablet
+984311 tablet android
+984312 tangram
+984313 tag
+984314 tag faces
+984315 tag multiple
+984316 tag outline
+984317 tag text outline
+984318 target
+984319 taxi
+984320 teamviewer
+984321 skateboarding
+984322 television
+984323 television guide
+984324 temperature celsius
+984325 temperature fahrenheit
+984326 temperature kelvin
+984327 tennis ball
+984328 tent
+984329 image filter hdr
+984330 text to speech
+984331 text to speech off
+984332 texture
+984333 theater
+984334 theme light dark
+984335 thermometer
+984336 thermometer lines
+984337 thumb down
+984338 thumb down outline
+984339 thumb up
+984340 thumb up outline
+984341 thumbs up down
+984342 ticket
+984343 ticket account
+984344 ticket confirmation
+984345 tie
+984346 timelapse
+984347 timer outline
+984348 timer 10
+984349 timer 3
+984350 timer off outline
+984351 timer sand
+984352 timetable
+984353 toggle switch
+984354 toggle switch off
+984355 tooltip
+984356 tooltip edit
+984357 tooltip image
+984358 tooltip outline
+984359 tooltip plus outline
+984360 tooltip text
+984361 tooth outline
+984362 cloud refresh
+984363 traffic light
+984364 train
+984365 tram
+984366 transcribe
+984367 transcribe close
+984368 transfer right
+984369 tree
+984370 trello
+984371 trending down
+984372 trending neutral
+984373 trending up
+984374 triangle
+984375 triangle outline
+984376 trophy
+984377 trophy award
+984378 trophy outline
+984379 trophy variant
+984380 trophy variant outline
+984381 truck
+984382 truck delivery
+984383 tshirt crew outline
+984384 tshirt v outline
+984385 file refresh outline
+984386 folder refresh outline
+984387 twitch
+984388 twitter
+984389 order numeric ascending
+984390 order numeric descending
+984391 repeat variant
+984392 ubuntu
+984393 umbraco
+984394 umbrella
+984395 umbrella outline
+984396 undo
+984397 undo variant
+984398 unfold less horizontal
+984399 unfold more horizontal
+984400 ungroup
+984401 web remove
+984402 upload
+984403 usb
+984404 vector arrange above
+984405 vector arrange below
+984406 vector circle
+984407 vector circle variant
+984408 vector combine
+984409 vector curve
+984410 vector difference
+984411 vector difference ab
+984412 vector difference ba
+984413 vector intersection
+984414 vector line
+984415 vector point
+984416 vector polygon
+984417 vector polyline
+984418 vector selection
+984419 vector triangle
+984420 vector union
+984421 shield check
+984422 vibrate
+984423 video
+984424 video off
+984425 video switch
+984426 view agenda
+984427 view array
+984428 view carousel
+984429 view column
+984430 view dashboard
+984431 view day
+984432 view grid
+984433 view headline
+984434 view list
+984435 view module
+984436 view quilt
+984437 view stream
+984438 view week
+984439 vimeo
+984440 buffet
+984441 hands pray
+984442 credit card wireless off
+984443 credit card wireless off outline
+984444 vlc
+984445 voicemail
+984446 volume high
+984447 volume low
+984448 volume medium
+984449 volume off
+984450 vpn
+984451 walk
+984452 wallet
+984453 wallet giftcard
+984454 wallet membership
+984455 wallet travel
+984456 wan
+984457 watch
+984458 watch export
+984459 watch import
+984460 water
+984461 water off
+984462 water percent
+984463 water pump
+984464 weather cloudy
+984465 weather fog
+984466 weather hail
+984467 weather lightning
+984468 weather night
+984469 weather partly cloudy
+984470 weather pouring
+984471 weather rainy
+984472 weather snowy
+984473 weather sunny
+984474 weather sunset
+984475 weather sunset down
+984476 weather sunset up
+984477 weather windy
+984478 weather windy variant
+984479 web
+984480 webcam
+984481 weight
+984482 weight kilogram
+984483 whatsapp
+984484 wheelchair accessibility
+984485 white balance auto
+984486 white balance incandescent
+984487 white balance iridescent
+984488 white balance sunny
+984489 wifi
+984490 wifi off
+984491 nintendo wii
+984492 wikipedia
+984493 window close
+984494 window closed
+984495 window maximize
+984496 window minimize
+984497 window open
+984498 window restore
+984499 microsoft windows
+984500 wordpress
+984501 account hard hat
+984502 wrap
+984503 wrench
+984504 contacts outline
+984505 microsoft xbox
+984506 microsoft xbox controller
+984507 microsoft xbox controller off
+984508 table furniture
+984509 sort alphabetical ascending
+984510 firewire
+984511 sort alphabetical descending
+984512 xml
+984513 yeast
+984514 database refresh
+984515 youtube
+984516 zip box
+984517 surround sound
+984518 vector rectangle
+984519 playlist check
+984520 format line style
+984521 format line weight
+984522 translate
+984523 account voice
+984524 opacity
+984526 clock alert outline
+984527 human pregnant
+984528 sticker circle outline
+984529 scale balance
+984530 card account details
+984531 account multiple minus
+984532 airplane landing
+984533 airplane takeoff
+984534 alert circle outline
+984535 altimeter
+984536 animation
+984537 book minus
+984538 book open page variant
+984539 book plus
+984540 boombox
+984541 bullseye
+984542 comment remove
+984543 camera off
+984544 check circle
+984545 check circle outline
+984546 candle
+984547 chart bubble
+984548 credit card off outline
+984549 cup off
+984550 copyright
+984551 cursor text
+984552 delete forever
+984553 delete sweep
+984554 dice d20 outline
+984555 dice d4 outline
+984556 dice d8 outline
+984557 dice d6 outline
+984558 disc
+984559 email open outline
+984560 email variant
+984561 ev station
+984562 food fork drink
+984563 food off
+984564 format title
+984565 google maps
+984566 heart pulse
+984567 highway
+984568 home map marker
+984569 incognito
+984570 kettle
+984571 lock plus
+984572 exit to app
+984573 logout variant
+984574 music note bluetooth
+984575 music note bluetooth off
+984576 page first
+984577 page last
+984578 phone classic
+984579 priority high
+984580 priority low
+984581 qqchat
+984582 pool
+984583 rounded corner
+984584 rowing
+984585 saxophone
+984586 signal variant
+984587 stack exchange
+984588 subdirectory arrow left
+984589 subdirectory arrow right
+984590 form textbox
+984591 violin
+984592 microsoft visual studio
+984593 wechat
+984594 watermark
+984595 file hidden
+984596 application outline
+984597 arrow collapse
+984598 arrow expand
+984599 bowl mix
+984600 bridge
+984601 application edit outline
+984602 chip
+984603 content save settings
+984604 dialpad
+984605 book alphabet
+984606 format horizontal align center
+984607 format horizontal align left
+984608 format horizontal align right
+984609 format vertical align bottom
+984610 format vertical align center
+984611 format vertical align top
+984612 line scan
+984613 help circle outline
+984614 code json
+984615 lambda	lamda
+984616 matrix
+984617 meteor
+984618 close circle multiple
+984619 sigma lower
+984620 source branch
+984621 source merge
+984622 tune
+984623 webhook
+984624 account settings
+984625 account details
+984626 apple keyboard caps
+984627 apple keyboard command
+984628 apple keyboard control
+984629 apple keyboard option
+984630 apple keyboard shift
+984631 box shadow
+984632 cards
+984633 cards outline
+984634 cards playing outline
+984635 checkbox multiple blank circle
+984636 checkbox multiple blank circle outline
+984637 checkbox multiple marked circle
+984638 checkbox multiple marked circle outline
+984639 cloud sync
+984640 collage
+984641 directions fork
+984642 eraser variant
+984643 face man
+984644 face man profile
+984645 file tree
+984646 format annotation plus
+984647 gas cylinder
+984648 grease pencil
+984649 human female
+984650 human greeting variant
+984651 human handsdown
+984652 human handsup
+984653 human male
+984654 information variant
+984655 lead pencil
+984656 map marker minus
+984657 map marker plus
+984658 marker
+984659 message plus
+984660 microscope
+984661 move resize
+984662 move resize variant
+984663 paw off
+984664 phone minus
+984665 phone plus
+984666 pot steam
+984667 pot mix
+984668 serial port
+984669 shape circle plus
+984670 shape polygon plus
+984671 shape rectangle plus
+984672 shape square plus
+984673 skip next circle
+984674 skip next circle outline
+984675 skip previous circle
+984676 skip previous circle outline
+984677 spray
+984678 stop circle
+984679 stop circle outline
+984680 test tube
+984681 text shadow
+984682 tune vertical
+984683 cart off
+984684 chart gantt
+984685 chart scatter plot hexbin
+984686 chart timeline
+984687 discord
+984688 file restore
+984689 language c
+984690 language cpp
+984691 language xaml
+984692 creation
+984693 application cog
+984694 credit card plus outline
+984695 pot mix outline
+984696 bow tie
+984697 calendar range
+984698 currency usd off
+984699 flash red eye
+984700 oar
+984701 piano
+984702 weather lightning rainy
+984703 weather snowy rainy
+984704 yin yang
+984705 tower beach
+984706 tower fire
+984707 delete circle
+984708 dna
+984709 hamburger
+984710 gondola
+984711 inbox
+984712 reorder horizontal
+984713 reorder vertical
+984714 shield home
+984715 tag heart
+984716 skull
+984717 solid
+984718 alarm snooze
+984719 baby carriage
+984720 beaker outline
+984721 bomb
+984722 calendar question
+984723 camera burst
+984724 code tags check
+984725 circle multiple outline
+984726 crop rotate
+984727 developer board
+984728 piano off
+984729 skate off
+984730 message star
+984731 emoticon dead outline
+984732 emoticon excited outline
+984733 folder star
+984734 format color text
+984735 format section
+984736 gradient vertical
+984737 home outline
+984738 message bulleted
+984739 message bulleted off
+984740 nuke
+984741 power plug
+984742 power plug off
+984743 publish
+984744 credit card marker
+984745 robot
+984746 format rotate 90
+984747 scanner
+984748 subway
+984749 timer sand empty
+984750 transit transfer
+984751 unity
+984752 update
+984753 watch vibrate
+984754 angular
+984755 dolby
+984756 emby
+984757 lamp
+984758 menu down outline
+984759 menu up outline
+984760 note multiple
+984761 note multiple outline
+984762 plex
+984763 shield airplane
+984764 account edit
+984765 alert decagram
+984766 all inclusive
+984767 angularjs
+984768 arrow down box
+984769 arrow left box
+984770 arrow right box
+984771 arrow up box
+984772 asterisk
+984773 bomb off
+984774 bootstrap
+984775 cards variant
+984776 clipboard flow
+984777 close outline
+984778 coffee outline
+984779 contacts
+984780 delete empty
+984781 earth box
+984782 earth box off
+984783 email alert
+984784 eye outline
+984785 eye off outline
+984786 fast forward outline
+984787 feather
+984788 find replace
+984789 flash outline
+984790 format font
+984791 format page break
+984792 format pilcrow
+984793 garage
+984794 garage open
+984795 card account details star outline
+984796 google keep
+984797 snowmobile
+984798 heart half full
+984799 heart half
+984800 heart half outline
+984801 hexagon multiple
+984802 hook
+984803 hook off
+984804 infinity
+984805 language swift
+984806 language typescript
+984807 laptop off
+984808 lightbulb on
+984809 lightbulb on outline
+984810 lock pattern
+984811 folder zip
+984812 magnify minus outline
+984813 magnify plus outline
+984814 mailbox
+984815 medical bag
+984816 message settings
+984817 message cog
+984818 minus box outline
+984819 network
+984820 download network
+984821 help network
+984822 upload network
+984823 npm
+984824 nut
+984825 octagram
+984826 page layout body
+984827 page layout footer
+984828 page layout header
+984829 page layout sidebar left
+984830 page layout sidebar right
+984831 pencil circle
+984832 pentagon outline
+984833 pentagon
+984834 pillar
+984835 pistol
+984836 plus box outline
+984837 plus outline
+984838 prescription
+984839 printer settings
+984840 react
+984841 restart
+984842 rewind outline
+984843 rhombus
+984844 rhombus outline
+984845 robot vacuum
+984846 run
+984847 search web
+984848 shovel
+984849 shovel off
+984850 signal 2g
+984851 signal 3g
+984852 signal 4g
+984853 signal hspa
+984854 signal hspa plus
+984855 snowflake
+984856 source commit
+984857 source commit end
+984858 source commit end local
+984859 source commit local
+984860 source commit next local
+984861 source commit start
+984862 source commit start next local
+984863 speaker wireless
+984864 stadium variant
+984865 svg
+984866 tag plus
+984867 tag remove
+984868 ticket percent
+984869 tilde
+984870 treasure chest
+984871 truck trailer
+984872 view parallel
+984873 view sequential
+984874 washing machine
+984875 webpack
+984876 widgets
+984877 nintendo wiiu
+984878 arrow down bold
+984879 arrow down bold box
+984880 arrow down bold box outline
+984881 arrow left bold
+984882 arrow left bold box
+984883 arrow left bold box outline
+984884 arrow right bold
+984885 arrow right bold box
+984886 arrow right bold box outline
+984887 arrow up bold
+984888 arrow up bold box
+984889 arrow up bold box outline
+984890 cancel
+984891 file account
+984892 gesture double tap
+984893 gesture swipe down
+984894 gesture swipe left
+984895 gesture swipe right
+984896 gesture swipe up
+984897 gesture tap
+984898 gesture two double tap
+984899 gesture two tap
+984900 humble bundle
+984901 kickstarter
+984902 netflix
+984903 microsoft onenote
+984904 wall sconce round
+984905 folder refresh
+984906 vector radius
+984907 microsoft xbox controller battery alert
+984908 microsoft xbox controller battery empty
+984909 microsoft xbox controller battery full
+984910 microsoft xbox controller battery low
+984911 microsoft xbox controller battery medium
+984912 microsoft xbox controller battery unknown
+984913 clipboard plus
+984914 file plus
+984915 format align bottom
+984916 format align middle
+984917 format align top
+984918 format list checks
+984919 format quote open
+984920 grid large
+984921 heart off
+984922 music
+984923 music off
+984924 tab plus
+984925 volume plus
+984926 volume minus
+984927 volume mute
+984928 unfold less vertical
+984929 unfold more vertical
+984930 taco
+984931 square outline
+984932 square
+984933 checkbox blank circle
+984934 checkbox blank circle outline
+984935 alert octagram
+984936 atom
+984937 ceiling light
+984938 chart bar stacked
+984939 chart line stacked
+984940 decagram
+984941 decagram outline
+984942 dice multiple
+984943 dice d10 outline
+984944 folder open
+984945 guitar acoustic
+984946 loading
+984947 lock reset
+984948 ninja
+984949 octagram outline
+984950 pencil circle outline
+984951 selection off
+984952 set all
+984953 set center
+984954 set center right
+984955 set left
+984956 set left center
+984957 set left right
+984958 set none
+984959 set right
+984960 shield half full
+984961 sign direction
+984962 sign text
+984963 signal off
+984964 square root
+984965 sticker emoji
+984966 summit
+984967 sword cross
+984968 truck fast
+984969 web check
+984970 cast off
+984971 help box
+984972 timer sand full
+984973 waves
+984974 alarm bell
+984975 alarm light
+984976 video switch outline
+984977 check decagram
+984978 arrow collapse down
+984979 arrow collapse left
+984980 arrow collapse right
+984981 arrow collapse up
+984982 arrow expand down
+984983 arrow expand left
+984984 arrow expand right
+984985 arrow expand up
+984986 book lock
+984987 book lock open
+984988 bus articulated end
+984989 bus articulated front
+984990 bus double decker
+984991 bus school
+984992 bus side
+984993 camera gopro
+984994 camera metering center
+984995 camera metering matrix
+984996 camera metering partial
+984997 camera metering spot
+984998 cannabis
+984999 car convertible
+985000 car estate
+985001 car hatchback
+985002 car pickup
+985003 car side
+985004 car sports
+985005 caravan
+985006 cctv
+985007 chart donut
+985008 chart donut variant
+985009 chart line variant
+985010 chili hot
+985011 chili medium
+985012 chili mild
+985013 cloud braces
+985014 cloud tags
+985015 console line
+985016 corn
+985017 folder zip outline
+985018 currency cny
+985019 currency eth
+985020 currency jpy
+985021 currency krw
+985022 currency sign
+985023 currency twd
+985024 desktop classic
+985025 dip switch
+985026 donkey
+985027 dots horizontal circle
+985028 dots vertical circle
+985029 ear hearing
+985030 elephant
+985031 storefront
+985032 food croissant
+985033 forklift
+985034 fuel
+985035 gesture
+985036 google analytics
+985037 google assistant
+985038 headphones off
+985039 high definition
+985040 home assistant
+985041 home automation
+985042 home circle
+985043 language go
+985044 language r
+985045 lava lamp
+985046 led strip
+985047 locker
+985048 locker multiple
+985049 map marker outline
+985050 metronome
+985051 metronome tick
+985052 micro sd
+985053 facebook gaming
+985054 movie roll
+985055 mushroom
+985056 mushroom outline
+985057 nintendo switch
+985058 null
+985059 passport
+985060 molecule co2
+985061 pipe
+985062 pipe disconnected
+985063 power socket eu
+985064 power socket uk
+985065 power socket us
+985066 rice
+985067 ring
+985068 sass
+985069 send lock
+985070 soy sauce
+985071 standard definition
+985072 surround sound 2 0
+985073 surround sound 3 1
+985074 surround sound 5 1
+985075 surround sound 7 1
+985076 television classic
+985077 form textbox password
+985078 thought bubble
+985079 thought bubble outline
+985080 trackpad
+985081 ultra high definition
+985082 van passenger
+985083 van utility
+985084 vanish
+985085 video 3d
+985086 wall
+985087 xmpp
+985088 account multiple plus outline
+985089 account plus outline
+985090 credit card wireless
+985091 account music
+985092 atlassian
+985093 microsoft azure
+985094 basketball
+985095 battery charging wireless
+985096 battery charging wireless 10
+985097 battery charging wireless 20
+985098 battery charging wireless 30
+985099 battery charging wireless 40
+985100 battery charging wireless 50
+985101 battery charging wireless 60
+985102 battery charging wireless 70
+985103 battery charging wireless 80
+985104 battery charging wireless 90
+985105 battery charging wireless alert
+985106 battery charging wireless outline
+985107 bitcoin
+985108 briefcase outline
+985109 cellphone wireless
+985110 clover
+985111 comment question
+985112 content save outline
+985113 delete restore
+985114 door
+985115 door closed
+985116 door open
+985117 fan off
+985118 file percent
+985119 finance
+985120 lightning bolt circle
+985121 floor plan
+985122 forum outline
+985123 golf
+985124 google home
+985125 guy fawkes mask
+985126 home account
+985127 home heart
+985128 hot tub
+985129 hulu
+985130 ice cream
+985131 image off
+985132 karate
+985133 ladybug
+985134 notebook
+985135 phone return
+985136 poker chip
+985137 shape
+985138 shape outline
+985139 ship wheel
+985140 soccer field
+985141 table column
+985142 table of contents
+985143 table row
+985144 table settings
+985145 television box
+985146 television classic off
+985147 television off
+985148 tow truck
+985149 upload multiple
+985150 video 4k box
+985151 video input antenna
+985152 video input component
+985153 video input hdmi
+985154 video input svideo
+985155 view dashboard variant
+985156 vuejs
+985157 xamarin
+985158 human male board poll
+985159 youtube studio
+985160 youtube gaming
+985161 account group
+985162 camera switch outline
+985163 airport
+985164 arrow collapse horizontal
+985165 arrow collapse vertical
+985166 arrow expand horizontal
+985167 arrow expand vertical
+985168 augmented reality
+985169 badminton
+985170 baseball
+985171 baseball bat
+985172 bottle wine
+985173 check outline
+985174 checkbox intermediate
+985175 chess king
+985176 chess knight
+985177 chess pawn
+985178 chess queen
+985179 chess rook
+985180 chess bishop
+985181 clipboard pulse
+985182 clipboard pulse outline
+985183 comment multiple
+985184 comment text multiple
+985185 comment text multiple outline
+985186 crane
+985187 curling
+985188 currency bdt
+985189 currency kzt
+985190 database search
+985191 dice d12 outline
+985192 docker
+985193 doorbell video
+985194 ethereum
+985195 eye plus
+985196 eye plus outline
+985197 eye settings
+985198 eye settings outline
+985199 file question
+985200 folder network
+985201 function variant
+985202 garage alert
+985203 gauge empty
+985204 gauge full
+985205 gauge low
+985206 glass wine
+985207 graphql
+985208 high definition box
+985209 hockey puck
+985210 hockey sticks
+985211 home alert
+985212 image plus
+985213 jquery
+985214 lifebuoy
+985215 mixed reality
+985216 nativescript
+985217 onepassword
+985218 patreon
+985219 close circle multiple outline
+985220 peace
+985221 phone rotate landscape
+985222 phone rotate portrait
+985223 pier
+985224 pier crane
+985225 pipe leak
+985226 piston
+985227 play network
+985228 reminder
+985229 room service
+985230 salesforce
+985231 shield account
+985232 human male board
+985233 thermostat box
+985234 tractor
+985235 vector ellipse
+985236 virtual reality
+985237 watch export variant
+985238 watch import variant
+985239 watch variant
+985240 weather hurricane
+985241 account heart
+985242 alien
+985243 anvil
+985244 battery charging 10
+985245 battery charging 50
+985246 battery charging 70
+985247 battery charging outline
+985248 bed empty
+985249 border all variant
+985250 border bottom variant
+985251 border left variant
+985252 border none variant
+985253 border right variant
+985254 border top variant
+985255 calendar edit
+985256 clipboard check outline
+985257 console network
+985258 file compare
+985259 fire truck
+985260 folder key
+985261 folder key network
+985262 expansion card
+985263 kayaking
+985264 inbox multiple
+985265 language lua
+985266 lock smart
+985267 microphone minus
+985268 microphone plus
+985269 palette swatch
+985270 periodic table
+985271 pickaxe
+985272 qrcode edit
+985273 remote desktop
+985274 sausage
+985275 cog outline
+985276 signal cellular 1
+985277 signal cellular 2
+985278 signal cellular 3
+985279 signal cellular outline
+985280 ssh
+985281 swap horizontal variant
+985282 swap vertical variant
+985283 tooth
+985284 train variant
+985285 account multiple check
+985286 application
+985287 arch
+985288 axe
+985289 bullseye arrow
+985290 bus clock
+985291 camera account
+985292 camera image
+985293 car limousine
+985294 cards club
+985295 cards diamond
+985296 heart
+985297 cards spade
+985298 cellphone text
+985299 cellphone message
+985300 chart multiline
+985301 circle edit outline
+985302 cogs
+985303 credit card settings outline
+985304 death star
+985305 death star variant
+985306 debian
+985307 fedora
+985308 file undo
+985309 floor lamp
+985310 folder edit
+985311 format columns
+985312 freebsd
+985313 gate and
+985314 gate nand
+985315 gate nor
+985316 gate not
+985317 gate or
+985318 gate xnor
+985319 gate xor
+985320 gentoo
+985321 globe model
+985322 hammer
+985323 home lock
+985324 home lock open
+985325 linux mint
+985326 lock alert
+985327 lock question
+985328 map marker distance
+985329 midi
+985330 midi port
+985331 nas
+985332 network strength 1
+985333 network strength 1 alert
+985334 network strength 2
+985335 network strength 2 alert
+985336 network strength 3
+985337 network strength 3 alert
+985338 network strength 4
+985339 network strength 4 alert
+985340 network strength off
+985341 network strength off outline
+985342 network strength outline
+985343 play speed
+985344 playlist edit
+985345 power cycle
+985346 power off
+985347 power on
+985348 power sleep
+985349 power socket au
+985350 power standby
+985351 rabbit
+985352 robot vacuum variant
+985353 satellite uplink
+985354 scanner off
+985355 book minus multiple outline
+985356 square edit outline
+985357 sort numeric ascending variant
+985358 steering off
+985359 table search
+985360 tag minus
+985361 test tube empty
+985362 test tube off
+985363 ticket outline
+985364 track light
+985365 transition
+985366 transition masked
+985367 tumble dryer
+985368 file refresh
+985369 video account
+985370 video image
+985371 video stabilization
+985372 wall sconce
+985373 wall sconce flat
+985374 wall sconce round variant
+985375 wifi strength 1
+985376 wifi strength 1 alert
+985377 wifi strength 1 lock
+985378 wifi strength 2
+985379 wifi strength 2 alert
+985380 wifi strength 2 lock
+985381 wifi strength 3
+985382 wifi strength 3 alert
+985383 wifi strength 3 lock
+985384 wifi strength 4
+985385 wifi strength 4 alert
+985386 wifi strength 4 lock
+985387 wifi strength alert outline
+985388 wifi strength lock outline
+985389 wifi strength off
+985390 wifi strength off outline
+985391 wifi strength outline
+985392 pin off outline
+985393 pin outline
+985394 share outline
+985395 trackpad lock
+985396 account box multiple
+985397 account search outline
+985398 account filter
+985399 angle acute
+985400 angle obtuse
+985401 angle right
+985402 animation play
+985403 arrow split horizontal
+985404 arrow split vertical
+985405 audio video
+985406 battery 10 bluetooth
+985407 battery 20 bluetooth
+985408 battery 30 bluetooth
+985409 battery 40 bluetooth
+985410 battery 50 bluetooth
+985411 battery 60 bluetooth
+985412 battery 70 bluetooth
+985413 battery 80 bluetooth
+985414 battery 90 bluetooth
+985415 battery alert bluetooth
+985416 battery bluetooth
+985417 battery bluetooth variant
+985418 battery unknown bluetooth
+985419 dharmachakra
+985420 calendar search
+985421 cellphone remove
+985422 cellphone key
+985423 cellphone lock
+985424 cellphone off
+985425 cellphone cog
+985426 cellphone sound
+985427 cross
+985428 clock
+985429 clock alert
+985430 cloud search
+985431 cloud search outline
+985432 cordova
+985433 cryengine
+985434 cupcake
+985435 sine wave
+985436 current dc
+985437 database import
+985438 database export
+985439 desk lamp
+985440 disc player
+985441 email search
+985442 email search outline
+985443 exponent
+985444 exponent box
+985445 file download
+985446 file download outline
+985447 firebase
+985448 folder search
+985449 folder search outline
+985450 format list checkbox
+985451 fountain
+985452 google fit
+985453 greater than
+985454 greater than or equal
+985455 hard hat
+985456 headphones bluetooth
+985457 heart circle
+985458 heart circle outline
+985459 om
+985460 home minus
+985461 home plus
+985462 image outline
+985463 image search
+985464 image search outline
+985465 star crescent
+985466 star david
+985467 keyboard outline
+985468 less than
+985469 less than or equal
+985470 light switch
+985471 lock clock
+985472 magnify close
+985473 map minus
+985474 map outline
+985475 map plus
+985476 map search
+985477 map search outline
+985478 material design
+985479 medal
+985480 microsoft dynamics 365
+985481 monitor cellphone
+985482 monitor cellphone star
+985483 mouse bluetooth
+985484 muffin
+985485 not equal
+985486 not equal variant
+985487 order bool ascending variant
+985488 order bool descending variant
+985489 office building
+985490 plus minus
+985491 plus minus box
+985492 podcast
+985493 progress check
+985494 progress clock
+985495 progress download
+985496 progress upload
+985497 qi
+985498 record player
+985499 restore
+985500 shield off outline
+985501 shield lock
+985502 shield off
+985503 set top box
+985504 shower
+985505 shower head
+985506 speaker bluetooth
+985507 square root box
+985508 star circle outline
+985509 star face
+985510 table merge cells
+985511 tablet cellphone
+985512 text
+985513 text short
+985514 text long
+985515 toilet
+985516 toolbox
+985517 toolbox outline
+985518 tournament
+985519 two factor authentication
+985520 umbrella closed
+985521 unreal
+985522 video minus
+985523 video plus
+985524 volleyball
+985525 weight pound
+985526 whistle
+985527 arrow bottom left bold outline
+985528 arrow bottom left thick
+985529 arrow bottom right bold outline
+985530 arrow bottom right thick
+985531 arrow decision
+985532 arrow decision auto
+985533 arrow decision auto outline
+985534 arrow decision outline
+985535 arrow down bold outline
+985536 arrow left bold outline
+985537 arrow left right bold outline
+985538 arrow right bold outline
+985539 arrow top left bold outline
+985540 arrow top left thick
+985541 arrow top right bold outline
+985542 arrow top right thick
+985543 arrow up bold outline
+985544 arrow up down bold outline
+985545 ballot
+985546 ballot outline
+985547 betamax
+985548 bookmark minus
+985549 bookmark minus outline
+985550 bookmark off
+985551 bookmark off outline
+985552 braille
+985553 brain
+985554 calendar heart
+985555 calendar star
+985556 cassette
+985557 cellphone arrow down
+985558 chevron down box
+985559 chevron down box outline
+985560 chevron left box
+985561 chevron left box outline
+985562 chevron right box
+985563 chevron right box outline
+985564 chevron up box
+985565 chevron up box outline
+985566 circle medium
+985567 circle small
+985568 cloud alert
+985569 comment arrow left
+985570 comment arrow left outline
+985571 comment arrow right
+985572 comment arrow right outline
+985573 comment plus
+985574 currency php
+985575 delete outline
+985576 desktop mac dashboard
+985577 download multiple
+985578 eight track
+985579 email plus
+985580 email plus outline
+985581 text box outline
+985582 file document outline
+985583 floppy variant
+985584 flower outline
+985585 flower tulip
+985586 flower tulip outline
+985587 format font size decrease
+985588 format font size increase
+985589 ghost off
+985590 google lens
+985591 google spreadsheet
+985592 image move
+985593 keyboard settings
+985594 keyboard settings outline
+985595 knife
+985596 knife military
+985597 layers off outline
+985598 layers outline
+985599 lighthouse
+985600 lighthouse on
+985601 map legend
+985602 menu left outline
+985603 menu right outline
+985604 message alert outline
+985605 mini sd
+985606 minidisc
+985607 monitor dashboard
+985608 pirate
+985609 pokemon go
+985610 powershell
+985611 printer wireless
+985612 quality low
+985613 quality medium
+985614 reflect horizontal
+985615 reflect vertical
+985616 rhombus medium
+985617 rhombus split
+985618 shield account outline
+985619 square medium
+985620 square medium outline
+985621 square small
+985622 subtitles
+985623 subtitles outline
+985624 table border
+985625 toggle switch off outline
+985626 toggle switch outline
+985627 vhs
+985628 video vintage
+985629 view dashboard outline
+985630 microsoft visual studio code
+985631 vote
+985632 vote outline
+985633 microsoft windows classic
+985634 microsoft xbox controller battery charging
+985635 zip disk
+985636 aspect ratio
+985637 babel
+985638 balloon
+985639 bank transfer
+985640 bank transfer in
+985641 bank transfer out
+985642 briefcase minus
+985643 briefcase plus
+985644 briefcase remove
+985645 briefcase search
+985646 bug check
+985647 bug check outline
+985648 bug outline
+985649 calendar alert
+985650 calendar multiselect
+985651 calendar week
+985652 calendar week begin
+985653 cellphone screenshot
+985654 city variant
+985655 city variant outline
+985656 clipboard text outline
+985657 cloud question
+985658 comment eye
+985659 comment eye outline
+985660 comment search
+985661 comment search outline
+985662 contain
+985663 contain end
+985664 contain start
+985665 dlna
+985666 doctor
+985667 dog
+985668 dog side
+985669 ear hearing off
+985670 engine off
+985671 engine off outline
+985672 exit run
+985673 feature search
+985674 feature search outline
+985675 file alert
+985676 file alert outline
+985677 file upload
+985678 file upload outline
+985679 hand front right
+985680 hand okay
+985681 hand peace
+985682 hand peace variant
+985683 hand pointing down
+985684 hand pointing left
+985685 hand pointing up
+985686 heart multiple
+985687 heart multiple outline
+985688 horseshoe
+985689 human female boy
+985690 human female female
+985691 human female girl
+985692 human male boy
+985693 human male girl
+985694 human male male
+985695 ip
+985696 ip network
+985697 litecoin
+985698 magnify minus cursor
+985699 magnify plus cursor
+985700 menu swap
+985701 menu swap outline
+985702 puzzle outline
+985703 registered trademark
+985704 resize
+985705 router wireless settings
+985706 safe
+985707 scissors cutting
+985708 select drag
+985709 selection drag
+985710 settings helper
+985711 signal 5g
+985712 silverware fork knife
+985713 smog
+985714 solar power
+985715 star box
+985716 star box outline
+985717 table plus
+985718 table remove
+985719 target variant
+985720 trademark
+985721 trash can
+985722 trash can outline
+985723 tshirt crew
+985724 tshirt v
+985725 zodiac aquarius
+985726 zodiac aries
+985727 zodiac cancer
+985728 zodiac capricorn
+985729 zodiac gemini
+985730 zodiac leo
+985731 zodiac libra
+985732 zodiac pisces
+985733 zodiac sagittarius
+985734 zodiac scorpio
+985735 zodiac taurus
+985736 zodiac virgo
+985737 account child
+985738 account child circle
+985739 account supervisor
+985740 account supervisor circle
+985741 ampersand
+985742 web off
+985743 animation outline
+985744 animation play outline
+985745 bell off outline
+985746 bell plus outline
+985747 bell sleep outline
+985748 book minus multiple
+985749 book plus multiple
+985750 book remove multiple
+985751 book remove
+985752 briefcase edit
+985753 bus alert
+985754 calculator variant
+985755 caps lock
+985756 cash refund
+985757 checkbook
+985758 circle slice 1
+985759 circle slice 2
+985760 circle slice 3
+985761 circle slice 4
+985762 circle slice 5
+985763 circle slice 6
+985764 circle slice 7
+985765 circle slice 8
+985766 collapse all
+985767 collapse all outline
+985768 credit card refund outline
+985769 database check
+985770 database lock
+985771 desktop tower monitor
+985772 dishwasher
+985773 dog service
+985774 dot net
+985775 egg
+985776 egg easter
+985777 email check
+985778 email check outline
+985779 et
+985780 expand all
+985781 expand all outline
+985782 file cabinet
+985783 text box multiple
+985784 text box multiple outline
+985785 file move
+985786 folder clock
+985787 folder clock outline
+985788 format annotation minus
+985789 gesture pinch
+985790 gesture spread
+985791 gesture swipe horizontal
+985792 gesture swipe vertical
+985793 hail
+985794 helicopter
+985795 hexagon slice 1
+985796 hexagon slice 2
+985797 hexagon slice 3
+985798 hexagon slice 4
+985799 hexagon slice 5
+985800 hexagon slice 6
+985801 hexagram
+985802 hexagram outline
+985803 label off
+985804 label off outline
+985805 label variant
+985806 label variant outline
+985807 language ruby on rails
+985808 laravel
+985809 mastodon
+985810 sort numeric descending variant
+985811 minus circle multiple outline
+985812 music circle outline
+985813 pinwheel
+985814 pinwheel outline
+985815 radiator disabled
+985816 radiator off
+985817 select compare
+985818 shield plus
+985819 shield plus outline
+985820 shield remove
+985821 shield remove outline
+985822 book plus multiple outline
+985823 sina weibo
+985824 spray bottle
+985825 squeegee
+985826 star four points
+985827 star four points outline
+985828 star three points
+985829 star three points outline
+985830 symfony
+985831 variable
+985832 vector bezier
+985833 wiper
+985834 z wave
+985835 zend
+985836 account minus outline
+985837 account remove outline
+985838 alpha a
+985839 alpha b
+985840 alpha c
+985841 alpha d
+985842 alpha e
+985843 alpha f
+985844 alpha g
+985845 alpha h
+985847 alpha j
+985848 alpha k
+985850 alpha m
+985851 alpha n
+985853 alpha p
+985854 alpha q
+985855 alpha r
+985856 alpha s
+985857 alpha t
+985858 alpha u
+985860 alpha w
+985862 alpha y
+985863 alpha z
+985864 alpha a box
+985865 alpha b box
+985866 alpha c box
+985867 alpha d box
+985868 alpha e box
+985869 alpha f box
+985870 alpha g box
+985871 alpha h box
+985872 alpha i box
+985873 alpha j box
+985874 alpha k box
+985875 alpha l box
+985876 alpha m box
+985877 alpha n box
+985878 alpha o box
+985879 alpha p box
+985880 alpha q box
+985881 alpha r box
+985882 alpha s box
+985883 alpha t box
+985884 alpha u box
+985885 alpha v box
+985886 alpha w box
+985887 alpha x box
+985888 alpha y box
+985889 alpha z box
+985890 bulldozer
+985891 bullhorn outline
+985892 calendar export
+985893 calendar import
+985894 chevron down circle
+985895 chevron down circle outline
+985896 chevron left circle
+985897 chevron left circle outline
+985898 chevron right circle
+985899 chevron right circle outline
+985900 chevron up circle
+985901 chevron up circle outline
+985902 content save settings outline
+985903 crystal ball
+985904 ember
+985905 facebook workplace
+985906 file replace
+985907 file replace outline
+985908 format letter case
+985909 format letter case lower
+985910 format letter case upper
+985911 language java
+985912 circle multiple
+985913 alpha o
+985914 numeric 1
+985915 numeric 2
+985916 numeric 3
+985917 numeric 4
+985918 numeric 5
+985919 numeric 6
+985920 numeric 7
+985921 numeric 8
+985922 numeric 9
+985923 origin
+985924 resistor
+985925 resistor nodes
+985926 robot industrial
+985927 shoe formal
+985928 shoe heel
+985929 silo
+985930 box cutter off
+985931 tab minus
+985932 tab remove
+985933 tape measure
+985934 telescope
+985935 yahoo
+985936 account alert outline
+985937 account arrow left
+985938 account arrow left outline
+985939 account arrow right
+985940 account arrow right outline
+985941 account circle outline
+985942 account clock
+985943 account clock outline
+985944 account group outline
+985945 account question
+985946 account question outline
+985947 artstation
+985948 backspace outline
+985949 barley off
+985950 barn
+985951 bat
+985952 application settings
+985953 billiards
+985954 billiards rack
+985955 book open outline
+985956 book outline
+985957 boxing glove
+985958 calendar blank outline
+985959 calendar outline
+985960 calendar range outline
+985961 camera control
+985962 camera enhance outline
+985963 car door
+985964 car electric
+985965 car key
+985966 car multiple
+985967 card
+985968 card bulleted
+985969 card bulleted off
+985970 card bulleted off outline
+985971 card bulleted outline
+985972 card bulleted settings
+985973 card bulleted settings outline
+985974 card outline
+985975 card text
+985976 card text outline
+985977 chat
+985978 chat alert
+985979 chat processing
+985980 chef hat
+985981 cloud download outline
+985982 cloud upload outline
+985983 coffin
+985984 compass off
+985985 compass off outline
+985986 controller classic
+985987 controller classic outline
+985988 cube scan
+985989 currency brl
+985990 database edit
+985991 deathly hallows
+985992 delete circle outline
+985993 delete forever outline
+985994 diamond
+985995 diamond outline
+985996 dns outline
+985997 dots horizontal circle outline
+985998 dots vertical circle outline
+985999 download outline
+986000 drag variant
+986001 eject outline
+986002 email mark as unread
+986003 export variant
+986004 eye circle
+986005 eye circle outline
+986006 face man outline
+986007 file find outline
+986008 file remove
+986009 flag minus
+986010 flag plus
+986011 flag remove
+986012 folder account outline
+986013 folder plus outline
+986014 folder remove outline
+986015 folder star outline
+986016 gitlab
+986017 gog
+986018 grave stone
+986019 halloween
+986020 hat fedora
+986021 help rhombus
+986022 help rhombus outline
+986023 home variant outline
+986024 inbox multiple outline
+986025 library shelves
+986026 mapbox
+986027 menu open
+986028 molecule
+986029 one up
+986030 open source initiative
+986031 pac man
+986032 page next
+986033 page next outline
+986034 page previous
+986035 page previous outline
+986036 pan
+986037 pan bottom left
+986038 pan bottom right
+986039 pan down
+986040 pan horizontal
+986041 pan left
+986042 pan right
+986043 pan top left
+986044 pan top right
+986045 pan up
+986046 pan vertical
+986047 pumpkin
+986048 rollupjs
+986049 script
+986050 script text
+986051 script text outline
+986052 shield key
+986053 shield key outline
+986054 skull crossbones
+986055 skull crossbones outline
+986056 skull outline
+986057 space invaders
+986058 spider web
+986059 view split horizontal
+986060 view split vertical
+986061 swap horizontal bold
+986062 swap vertical bold
+986063 tag heart outline
+986064 target account
+986065 timeline
+986066 timeline outline
+986067 timeline text
+986068 timeline text outline
+986069 tooltip image outline
+986070 tooltip plus
+986071 tooltip text outline
+986072 train car
+986073 triforce
+986074 ubisoft
+986075 video off outline
+986076 video outline
+986077 wallet outline
+986078 waze
+986079 wrap disabled
+986080 wrench outline
+986081 access point network off
+986082 account check outline
+986083 account heart outline
+986084 account key outline
+986085 account multiple minus outline
+986086 account network outline
+986087 account off outline
+986088 account star outline
+986089 airbag
+986090 alarm light outline
+986091 alpha a box outline
+986092 alpha a circle
+986093 alpha a circle outline
+986094 alpha b box outline
+986095 alpha b circle
+986096 alpha b circle outline
+986097 alpha c box outline
+986098 alpha c circle
+986099 alpha c circle outline
+986100 alpha d box outline
+986101 alpha d circle
+986102 alpha d circle outline
+986103 alpha e box outline
+986104 alpha e circle
+986105 alpha e circle outline
+986106 alpha f box outline
+986107 alpha f circle
+986108 alpha f circle outline
+986109 alpha g box outline
+986110 alpha g circle
+986111 alpha g circle outline
+986112 alpha h box outline
+986113 alpha h circle
+986114 alpha h circle outline
+986115 alpha i box outline
+986116 alpha i circle
+986117 alpha i circle outline
+986118 alpha j box outline
+986119 alpha j circle
+986120 alpha j circle outline
+986121 alpha k box outline
+986122 alpha k circle
+986123 alpha k circle outline
+986124 alpha l box outline
+986125 alpha l circle
+986126 alpha l circle outline
+986127 alpha m box outline
+986128 alpha m circle
+986129 alpha m circle outline
+986130 alpha n box outline
+986131 alpha n circle
+986132 alpha n circle outline
+986133 alpha o box outline
+986136 alpha p box outline
+986137 alpha p circle
+986138 alpha p circle outline
+986139 alpha q box outline
+986140 alpha q circle
+986141 alpha q circle outline
+986142 alpha r box outline
+986143 alpha r circle
+986144 alpha r circle outline
+986145 alpha s box outline
+986146 alpha s circle
+986147 alpha s circle outline
+986148 alpha t box outline
+986149 alpha t circle
+986150 alpha t circle outline
+986151 alpha u box outline
+986152 alpha u circle
+986153 alpha u circle outline
+986154 alpha v box outline
+986155 alpha v circle
+986156 alpha v circle outline
+986157 alpha w box outline
+986158 alpha w circle
+986159 alpha w circle outline
+986160 alpha x box outline
+986161 alpha x circle
+986162 alpha x circle outline
+986163 alpha y box outline
+986164 alpha y circle
+986165 alpha y circle outline
+986166 alpha z box outline
+986167 alpha z circle
+986168 alpha z circle outline
+986169 ballot recount
+986170 ballot recount outline
+986171 basketball hoop
+986172 basketball hoop outline
+986173 briefcase download outline
+986174 briefcase edit outline
+986175 briefcase minus outline
+986176 briefcase plus outline
+986177 briefcase remove outline
+986178 briefcase search outline
+986179 briefcase upload outline
+986180 calendar check outline
+986181 calendar remove outline
+986182 calendar text outline
+986183 car brake abs
+986184 car brake alert
+986185 car esp
+986186 car light dimmed
+986187 car light fog
+986188 car light high
+986189 car tire alert
+986190 cart arrow right
+986191 charity
+986192 chart bell curve
+986193 checkbox multiple outline
+986194 checkbox outline
+986195 check network
+986196 check network outline
+986197 clipboard account outline
+986198 clipboard arrow down outline
+986199 clipboard arrow up
+986200 clipboard arrow up outline
+986201 clipboard play
+986202 clipboard play outline
+986203 clipboard text play
+986204 clipboard text play outline
+986205 close box multiple
+986206 close box multiple outline
+986207 close network outline
+986208 console network outline
+986209 currency ils
+986210 delete sweep outline
+986211 diameter
+986212 diameter outline
+986213 diameter variant
+986214 download network outline
+986215 dump truck
+986216 emoticon
+986217 emoticon angry
+986218 emoticon angry outline
+986219 emoticon cool
+986220 emoticon cry
+986221 emoticon cry outline
+986222 emoticon dead
+986223 emoticon devil
+986224 emoticon excited
+986225 emoticon happy
+986226 emoticon kiss
+986227 emoticon kiss outline
+986228 emoticon neutral
+986229 emoticon poop outline
+986230 emoticon sad
+986231 emoticon tongue outline
+986232 emoticon wink
+986233 emoticon wink outline
+986234 eslint
+986235 face recognition
+986236 file search
+986237 file search outline
+986238 file table
+986239 file table outline
+986240 folder key network outline
+986241 folder network outline
+986242 folder text
+986243 folder text outline
+986244 food apple outline
+986245 fuse
+986246 fuse blade
+986247 google ads
+986248 google street view
+986249 hazard lights
+986250 help network outline
+986251 application brackets
+986252 application brackets outline
+986253 image size select actual
+986254 image size select large
+986255 image size select small
+986256 ip network outline
+986257 ipod
+986258 language haskell
+986259 leaf maple
+986260 link plus
+986261 map marker check
+986262 math cos
+986263 math sin
+986264 math tan
+986265 microwave
+986266 minus network outline
+986267 network off
+986268 network off outline
+986269 network outline
+986270 alpha o circle
+986271 alpha o circle outline
+986272 numeric 1 circle
+986273 numeric 1 circle outline
+986274 numeric 2 circle
+986275 numeric 2 circle outline
+986276 numeric 3 circle
+986277 numeric 3 circle outline
+986278 numeric 4 circle
+986279 numeric 4 circle outline
+986280 numeric 5 circle
+986281 numeric 5 circle outline
+986282 numeric 6 circle
+986283 numeric 6 circle outline
+986284 numeric 7 circle
+986285 numeric 7 circle outline
+986286 numeric 8 circle
+986287 numeric 8 circle outline
+986288 numeric 9 circle
+986289 numeric 9 circle outline
+986290 numeric 9 plus circle
+986291 numeric 9 plus circle outline
+986292 parachute
+986293 parachute outline
+986294 pencil outline
+986295 play network outline
+986296 playlist music
+986297 playlist music outline
+986298 plus network outline
+986299 postage stamp
+986300 progress alert
+986301 progress wrench
+986302 radio am
+986303 radio fm
+986304 radius
+986305 radius outline
+986306 ruler square
+986307 seat
+986308 seat outline
+986309 seatbelt
+986310 sheep
+986311 shield airplane outline
+986312 shield check outline
+986313 shield cross
+986314 shield cross outline
+986315 shield home outline
+986316 shield lock outline
+986317 sort variant lock
+986318 sort variant lock open
+986319 source repository
+986320 source repository multiple
+986321 spa
+986322 spa outline
+986323 toaster oven
+986324 truck check
+986325 turnstile
+986326 turnstile outline
+986327 turtle
+986328 upload network outline
+986329 vibrate off
+986330 watch vibrate off
+986331 arrow down circle
+986332 arrow down circle outline
+986333 arrow left circle
+986334 arrow left circle outline
+986335 arrow right circle
+986336 arrow right circle outline
+986337 arrow up circle
+986338 arrow up circle outline
+986339 account tie
+986340 alert box outline
+986341 alert decagram outline
+986342 alert octagon outline
+986343 alert octagram outline
+986344 ammunition
+986345 account music outline
+986346 beaker
+986347 blender
+986348 blood bag
+986349 cross bolnisi
+986350 bread slice
+986351 bread slice outline
+986352 briefcase account
+986353 briefcase account outline
+986354 brightness percent
+986355 bullet
+986356 cash register
+986357 cross celtic
+986358 cross outline
+986359 clipboard alert outline
+986360 clipboard arrow left outline
+986361 clipboard arrow right
+986362 clipboard arrow right outline
+986363 content save edit
+986364 content save edit outline
+986365 cursor default click
+986366 cursor default click outline
+986367 database sync
+986368 database remove
+986369 database settings
+986370 drama masks
+986371 email box
+986372 eye check
+986373 eye check outline
+986374 fast forward 30
+986375 order alphabetical descending
+986376 flower poppy
+986377 folder pound
+986378 folder pound outline
+986379 folder sync
+986380 folder sync outline
+986381 format list numbered rtl
+986382 format text wrapping clip
+986383 format text wrapping overflow
+986384 format text wrapping wrap
+986385 format textbox
+986386 fountain pen
+986387 fountain pen tip
+986388 heart broken outline
+986389 home city
+986390 home city outline
+986391 hubspot
+986392 filmstrip box multiple
+986393 play box multiple
+986394 link box
+986395 link box outline
+986396 link box variant
+986397 link box variant outline
+986398 map clock
+986399 map clock outline
+986400 map marker path
+986401 mother nurse
+986402 microsoft outlook
+986403 perspective less
+986404 perspective more
+986405 podium
+986406 podium bronze
+986407 podium gold
+986408 podium silver
+986409 quora
+986410 rewind 10
+986411 roller skate
+986412 rollerblade
+986413 language ruby
+986414 sack
+986415 sack percent
+986416 safety goggles
+986417 select color
+986418 selection ellipse
+986419 shield link variant
+986420 shield link variant outline
+986421 skate
+986422 skew less
+986423 skew more
+986424 speaker multiple
+986425 stamper
+986426 tank
+986427 tortoise
+986428 transit connection
+986429 transit connection variant
+986430 transmission tower
+986431 weight gram
+986432 youtube subscription
+986433 zigbee
+986434 email alert outline
+986435 air filter
+986436 air purifier
+986437 android messages
+986438 apps box
+986439 atm
+986440 axis
+986441 axis arrow
+986442 axis arrow lock
+986443 axis lock
+986444 axis x arrow
+986445 axis x arrow lock
+986446 axis x rotate clockwise
+986447 axis x rotate counterclockwise
+986448 axis x y arrow lock
+986449 axis y arrow
+986450 axis y arrow lock
+986451 axis y rotate clockwise
+986452 axis y rotate counterclockwise
+986453 axis z arrow
+986454 axis z arrow lock
+986455 axis z rotate clockwise
+986456 axis z rotate counterclockwise
+986457 bell alert
+986458 bell circle
+986459 bell circle outline
+986460 calendar minus
+986461 camera outline
+986462 car brake hold
+986463 car brake parking
+986464 car cruise control
+986465 car defrost front
+986466 car defrost rear
+986467 car parking lights
+986468 car traction control
+986469 bag carry on check
+986470 cart arrow down
+986471 cart arrow up
+986472 cart minus
+986473 cart remove
+986474 contactless payment
+986475 creative commons
+986476 credit card wireless outline
+986477 cricket
+986478 dev to
+986479 domain off
+986480 face agent
+986481 fast forward 10
+986482 flare
+986483 format text rotation down
+986484 format text rotation none
+986485 forwardburger
+986486 gesture swipe
+986487 gesture tap hold
+986488 file gif box
+986489 go kart
+986490 go kart track
+986491 goodreads
+986492 grain
+986493 hdr
+986494 hdr off
+986495 hiking
+986496 home floor 1
+986497 home floor 2
+986498 home floor 3
+986499 home floor a
+986500 home floor b
+986501 home floor g
+986502 home floor l
+986503 kabaddi
+986504 mailbox open
+986505 mailbox open outline
+986506 mailbox open up
+986507 mailbox open up outline
+986508 mailbox outline
+986509 mailbox up
+986510 mailbox up outline
+986511 mixed martial arts
+986512 monitor off
+986513 motion sensor
+986514 point of sale
+986515 racing helmet
+986516 racquetball
+986517 restart off
+986518 rewind 30
+986519 room service outline
+986520 rotate orbit
+986521 rugby
+986522 shield search
+986523 solar panel
+986524 solar panel large
+986525 subway alert variant
+986526 tea
+986527 tea outline
+986528 tennis
+986529 transfer down
+986530 transfer left
+986531 transfer up
+986532 trophy broken
+986533 wind turbine
+986534 wiper wash
+986535 badge account
+986536 badge account alert
+986537 badge account alert outline
+986538 badge account outline
+986539 card account details outline
+986540 air horn
+986541 application export
+986542 application import
+986543 bandage
+986544 bank minus
+986545 bank plus
+986546 bank remove
+986547 bolt
+986548 bugle
+986549 cactus
+986550 camera wireless
+986551 camera wireless outline
+986552 cash marker
+986553 chevron triple down
+986554 chevron triple left
+986555 chevron triple right
+986556 chevron triple up
+986557 closed caption outline
+986558 credit card marker outline
+986559 diving flippers
+986560 diving helmet
+986561 diving scuba
+986562 diving scuba flag
+986563 diving scuba tank
+986564 diving scuba tank multiple
+986565 diving snorkel
+986566 file cancel
+986567 file cancel outline
+986568 file document edit
+986569 file document edit outline
+986570 file eye
+986571 file eye outline
+986572 folder alert
+986573 folder alert outline
+986574 folder edit outline
+986575 folder open outline
+986576 format list bulleted square
+986577 gantry crane
+986578 home floor 0
+986579 home floor negative 1
+986580 home group
+986581 jabber
+986582 key outline
+986583 leak
+986584 leak off
+986585 marker cancel
+986586 mine
+986587 monitor lock
+986588 monitor star
+986589 movie outline
+986590 music note plus
+986591 nail
+986592 ocarina
+986593 passport biometric
+986594 pen lock
+986595 pen minus
+986596 pen off
+986597 pen plus
+986598 pen remove
+986599 pencil lock outline
+986600 pencil minus
+986601 pencil minus outline
+986602 pencil off outline
+986603 pencil plus
+986604 pencil plus outline
+986605 pencil remove
+986606 pencil remove outline
+986607 phone off
+986608 phone outline
+986609 pi hole
+986610 playlist star
+986611 screw flat top
+986612 screw lag
+986613 screw machine flat top
+986614 screw machine round top
+986615 screw round top
+986616 send circle
+986617 send circle outline
+986618 shoe print
+986619 signature
+986620 signature freehand
+986621 signature image
+986622 signature text
+986623 slope downhill
+986624 slope uphill
+986625 thermometer alert
+986626 thermometer chevron down
+986627 thermometer chevron up
+986628 thermometer minus
+986629 thermometer plus
+986630 translate off
+986631 upload outline
+986632 volume variant off
+986633 wallpaper
+986634 water outline
+986635 wifi star
+986636 palette outline
+986637 badge account horizontal
+986638 badge account horizontal outline
+986639 aws
+986640 bag personal
+986641 bag personal off
+986642 bag personal off outline
+986643 bag personal outline
+986644 biathlon
+986645 bookmark multiple
+986646 bookmark multiple outline
+986647 calendar month
+986648 calendar month outline
+986649 camera retake
+986650 camera retake outline
+986651 car back
+986652 car off
+986653 cast education
+986654 check bold
+986655 check underline
+986656 check underline circle
+986657 check underline circle outline
+986658 circular saw
+986659 comma
+986660 comma box outline
+986661 comma circle
+986662 comma circle outline
+986663 content save move
+986664 content save move outline
+986665 file check outline
+986666 file music outline
+986667 comma box
+986668 file video outline
+986669 file png box
+986670 fireplace
+986671 fireplace off
+986672 firework
+986673 format color highlight
+986674 format text variant
+986675 gamepad circle
+986676 gamepad circle down
+986677 gamepad circle left
+986678 gamepad circle outline
+986679 gamepad circle right
+986680 gamepad circle up
+986681 gamepad down
+986682 gamepad left
+986683 gamepad right
+986684 gamepad round
+986685 gamepad round down
+986686 gamepad round left
+986687 gamepad round outline
+986688 gamepad round right
+986689 gamepad round up
+986690 gamepad up
+986691 gatsby
+986692 gift
+986693 grill
+986694 hand back left
+986695 hand back right
+986696 hand saw
+986697 image frame
+986698 invert colors off
+986699 keyboard off outline
+986700 layers minus
+986701 layers plus
+986702 layers remove
+986703 lightbulb off
+986704 lightbulb off outline
+986705 monitor screenshot
+986706 ice cream off
+986707 nfc search variant
+986708 nfc variant off
+986709 notebook multiple
+986710 hoop house
+986711 picture in picture bottom right
+986712 picture in picture bottom right outline
+986713 picture in picture top right
+986714 picture in picture top right outline
+986715 printer 3d nozzle
+986716 printer 3d nozzle outline
+986717 printer off
+986718 rectangle
+986719 rectangle outline
+986720 rivet
+986721 saw blade
+986722 seed
+986723 seed outline
+986724 signal distance variant
+986725 spade
+986726 sprout
+986727 sprout outline
+986728 table tennis
+986729 tree outline
+986730 view comfy
+986731 view compact
+986732 view compact outline
+986733 vuetify
+986734 weather cloudy arrow right
+986735 microsoft xbox controller menu
+986736 microsoft xbox controller view
+986737 alarm note
+986738 alarm note off
+986739 arrow left right
+986740 arrow left right bold
+986741 arrow top left bottom right
+986742 arrow top left bottom right bold
+986743 arrow top right bottom left
+986744 arrow top right bottom left bold
+986745 arrow up down
+986746 arrow up down bold
+986747 atom variant
+986748 baby face
+986749 baby face outline
+986750 backspace reverse
+986751 backspace reverse outline
+986752 bank outline
+986753 bell alert outline
+986754 book play
+986755 book play outline
+986756 book search
+986757 book search outline
+986758 boom gate
+986759 boom gate alert
+986760 boom gate alert outline
+986761 boom gate arrow down
+986762 boom gate arrow down outline
+986763 boom gate outline
+986764 boom gate arrow up
+986765 boom gate arrow up outline
+986766 calendar sync
+986767 calendar sync outline
+986768 cellphone nfc
+986769 chart areaspline variant
+986770 chart scatter plot
+986771 chart timeline variant
+986772 chart tree
+986773 circle double
+986774 circle expand
+986775 clock digital
+986776 card account mail outline
+986777 card account phone
+986778 card account phone outline
+986779 account cowboy hat
+986780 currency rial
+986781 delete empty outline
+986782 dolly
+986783 electric switch
+986784 ellipse
+986785 ellipse outline
+986786 equalizer
+986787 equalizer outline
+986788 ferris wheel
+986789 file delimited outline
+986790 text box check
+986791 text box check outline
+986792 text box minus
+986793 text box minus outline
+986794 text box plus
+986795 text box plus outline
+986796 text box remove
+986797 text box remove outline
+986798 text box search
+986799 text box search outline
+986800 file image outline
+986801 fingerprint off
+986802 format list bulleted triangle
+986803 format overline
+986804 frequently asked questions
+986805 gamepad square
+986806 gamepad square outline
+986807 gamepad variant outline
+986808 gas station outline
+986809 google podcast
+986810 home analytics
+986811 mail
+986812 map check
+986813 map check outline
+986814 ruler square compass
+986815 notebook outline
+986816 penguin
+986817 radioactive off
+986818 record circle
+986819 record circle outline
+986820 remote off
+986821 remote tv
+986822 remote tv off
+986823 rotate 3d
+986824 sail boat
+986825 scatter plot
+986826 scatter plot outline
+986827 segment
+986828 shield alert
+986829 shield alert outline
+986830 tablet dashboard
+986831 television play
+986832 unicode
+986833 video 3d variant
+986834 video wireless
+986835 video wireless outline
+986836 account voice off
+986837 bacteria
+986838 bacteria outline
+986839 calendar account
+986840 calendar account outline
+986841 calendar weekend
+986842 calendar weekend outline
+986843 camera plus
+986844 camera plus outline
+986845 campfire
+986846 chat outline
+986847 cpu 32 bit
+986848 cpu 64 bit
+986849 credit card clock
+986850 credit card clock outline
+986851 email edit
+986852 email edit outline
+986853 email minus
+986854 email minus outline
+986855 email multiple
+986856 email multiple outline
+986857 email open multiple
+986858 email open multiple outline
+986859 file cad
+986860 file cad box
+986861 file plus outline
+986862 filter minus
+986863 filter minus outline
+986864 filter plus
+986865 filter plus outline
+986866 fire extinguisher
+986867 fishbowl
+986868 fishbowl outline
+986869 fit to page
+986870 fit to page outline
+986871 flash alert
+986872 flash alert outline
+986873 heart flash
+986874 home flood
+986875 human male height
+986876 human male height variant
+986877 ice pop
+986878 identifier
+986879 image filter center focus strong
+986880 image filter center focus strong outline
+986881 jellyfish
+986882 jellyfish outline
+986883 lasso
+986884 music box multiple outline
+986885 map marker alert
+986886 map marker alert outline
+986887 map marker question
+986888 map marker question outline
+986889 map marker remove
+986890 map marker remove variant
+986891 necklace
+986892 newspaper minus
+986893 newspaper plus
+986894 numeric 0 box multiple
+986895 numeric 1 box multiple
+986896 numeric 2 box multiple
+986897 numeric 3 box multiple
+986898 numeric 4 box multiple
+986899 numeric 5 box multiple
+986900 numeric 6 box multiple
+986901 numeric 7 box multiple
+986902 numeric 8 box multiple
+986903 numeric 9 box multiple
+986904 numeric 9 plus box multiple
+986905 oil lamp
+986906 phone alert
+986907 play outline
+986908 purse
+986909 purse outline
+986910 railroad light
+986911 reply all outline
+986912 reply outline
+986913 rss off
+986914 selection ellipse arrow inside
+986915 share off
+986916 share off outline
+986917 skip backward outline
+986918 skip forward outline
+986919 skip next outline
+986920 skip previous outline
+986921 snowflake alert
+986922 snowflake variant
+986923 stretch to page
+986924 stretch to page outline
+986925 typewriter
+986926 wave
+986927 weather cloudy alert
+986928 weather hazy
+986929 weather night partly cloudy
+986930 weather partly lightning
+986931 weather partly rainy
+986932 weather partly snowy
+986933 weather partly snowy rainy
+986934 weather snowy heavy
+986935 weather sunny alert
+986936 weather tornado
+986937 baby bottle
+986938 baby bottle outline
+986939 bag carry on
+986940 bag carry on off
+986941 bag checked
+986942 baguette
+986943 bus multiple
+986944 car shift pattern
+986945 cellphone information
+986946 content save alert
+986947 content save alert outline
+986948 content save all outline
+986949 crosshairs off
+986950 cupboard
+986951 cupboard outline
+986952 chair rolling
+986953 draw
+986954 dresser
+986955 dresser outline
+986956 emoticon frown
+986957 emoticon frown outline
+986958 focus auto
+986959 focus field
+986960 focus field horizontal
+986961 focus field vertical
+986962 foot print
+986963 handball
+986964 home thermometer
+986965 home thermometer outline
+986966 kettle outline
+986967 latitude
+986968 layers triple
+986969 layers triple outline
+986970 longitude
+986971 language markdown outline
+986972 merge
+986973 middleware
+986974 middleware outline
+986975 monitor speaker
+986976 monitor speaker off
+986977 moon first quarter
+986978 moon full
+986979 moon last quarter
+986980 moon new
+986981 moon waning crescent
+986982 moon waning gibbous
+986983 moon waxing crescent
+986984 moon waxing gibbous
+986985 music accidental double flat
+986986 music accidental double sharp
+986987 music accidental flat
+986988 music accidental natural
+986989 music accidental sharp
+986990 music clef alto
+986991 music clef bass
+986992 music clef treble
+986993 music note eighth dotted
+986994 music note half dotted
+986995 music note off outline
+986996 music note outline
+986997 music note quarter dotted
+986998 music note sixteenth dotted
+986999 music note whole dotted
+987000 music rest eighth
+987001 music rest half
+987002 music rest quarter
+987003 music rest sixteenth
+987004 music rest whole
+987005 numeric 10 box
+987006 numeric 10 box outline
+987007 page layout header footer
+987008 patio heater
+987009 warehouse
+987010 select group
+987011 shield car
+987012 shopping search
+987013 speedometer medium
+987014 speedometer slow
+987015 table large plus
+987016 table large remove
+987017 television pause
+987018 television stop
+987019 transit detour
+987020 video input scart
+987021 view grid plus
+987022 wallet plus
+987023 wallet plus outline
+987024 wardrobe
+987025 wardrobe outline
+987026 water boiler
+987027 water pump off
+987028 web box
+987029 timeline alert
+987030 timeline plus
+987031 timeline plus outline
+987032 timeline alert outline
+987033 timeline help
+987034 timeline help outline
+987035 home export outline
+987036 home import outline
+987037 account filter outline
+987038 approximately equal
+987039 approximately equal box
+987040 baby carriage off
+987041 bee
+987042 bee flower
+987043 car child seat
+987044 car seat
+987045 car seat cooler
+987046 car seat heater
+987047 chart bell curve cumulative
+987048 clock check
+987049 clock check outline
+987050 coffee off
+987051 coffee off outline
+987052 credit card minus
+987053 credit card minus outline
+987054 credit card remove
+987055 credit card remove outline
+987056 devices
+987057 email newsletter
+987058 expansion card variant
+987059 power socket ch
+987060 file swap
+987061 file swap outline
+987062 folder swap
+987063 folder swap outline
+987064 format letter ends with
+987065 format letter matches
+987066 format letter starts with
+987067 format text rotation angle down
+987068 format text rotation angle up
+987069 format text rotation down vertical
+987070 format text rotation up
+987071 format text rotation vertical
+987072 id card
+987073 image auto adjust
+987074 key wireless
+987075 license
+987076 location enter
+987077 location exit
+987078 lock open variant
+987079 lock open variant outline
+987080 math integral
+987081 math integral box
+987082 math norm
+987083 math norm box
+987084 message lock
+987085 message text lock
+987086 movie open
+987087 movie open outline
+987088 bed queen
+987089 bed king outline
+987090 bed king
+987091 bed double outline
+987092 bed double
+987093 microsoft azure devops
+987094 arm flex outline
+987095 arm flex
+987096 protocol
+987097 seal variant
+987098 select place
+987099 bed queen outline
+987100 sign direction plus
+987101 sign direction remove
+987102 silverware clean
+987103 slash forward
+987104 slash forward box
+987105 swap horizontal circle
+987106 swap horizontal circle outline
+987107 swap vertical circle
+987108 swap vertical circle outline
+987109 tanker truck
+987110 texture box
+987111 tram side
+987112 vector link
+987113 numeric 10
+987114 numeric 10 box multiple
+987115 numeric 10 box multiple outline
+987116 numeric 10 circle
+987117 numeric 10 circle outline
+987118 numeric 9 plus
+987119 credit card
+987120 credit card multiple
+987121 credit card off
+987122 credit card plus
+987123 credit card refund
+987124 credit card scan
+987125 credit card settings
+987126 hospital
+987127 hospital box outline
+987128 oil temperature
+987129 stadium
+987130 zip box outline
+987131 account edit outline
+987132 peanut
+987133 peanut off
+987134 peanut outline
+987135 peanut off outline
+987136 sign direction minus
+987137 newspaper variant
+987138 newspaper variant multiple
+987139 newspaper variant multiple outline
+987140 newspaper variant outline
+987141 overscan
+987142 pig variant
+987143 piggy bank
+987144 post
+987145 post outline
+987146 account box multiple outline
+987147 airballoon outline
+987148 alphabetical off
+987149 alphabetical variant
+987150 alphabetical variant off
+987151 apache kafka
+987152 billboard
+987153 blinds open
+987154 bus stop
+987155 bus stop covered
+987156 bus stop uncovered
+987157 car 2 plus
+987158 car 3 plus
+987159 car brake retarder
+987160 car clutch
+987161 car coolant level
+987162 car turbocharger
+987163 car windshield
+987164 car windshield outline
+987165 cards diamond outline
+987166 cast audio
+987167 cellphone play
+987168 coach lamp
+987169 comment quote
+987170 comment quote outline
+987171 domino mask
+987172 electron framework
+987173 excavator
+987174 eye minus
+987175 eye minus outline
+987176 file account outline
+987177 file chart outline
+987178 file cloud outline
+987179 file code outline
+987180 file excel box outline
+987181 file excel outline
+987182 file export outline
+987183 file import outline
+987184 file lock outline
+987185 file move outline
+987186 file multiple outline
+987187 file percent outline
+987188 file powerpoint box outline
+987189 file powerpoint outline
+987190 file question outline
+987191 file remove outline
+987192 file restore outline
+987193 file send outline
+987194 file star
+987195 file star outline
+987196 file undo outline
+987197 file word box outline
+987198 file word outline
+987199 filter variant remove
+987200 floor lamp dual
+987201 floor lamp torchiere variant
+987202 fruit cherries
+987203 fruit citrus
+987204 fruit grapes
+987205 fruit grapes outline
+987206 fruit pineapple
+987207 fruit watermelon
+987208 google my business
+987209 graph
+987210 graph outline
+987211 harddisk plus
+987212 harddisk remove
+987213 home circle outline
+987214 instrument triangle
+987215 island
+987216 keyboard space
+987217 led strip variant
+987218 numeric negative 1
+987219 oil level
+987220 outdoor lamp
+987221 palm tree
+987222 party popper
+987223 printer pos
+987224 robber
+987225 routes clock
+987226 scale off
+987227 cog transfer
+987228 cog transfer outline
+987229 shield sun
+987230 shield sun outline
+987231 sprinkler
+987232 sprinkler variant
+987233 table chair
+987234 terraform
+987235 toaster
+987236 tools
+987237 transfer
+987238 valve
+987239 valve closed
+987240 valve open
+987241 video check
+987242 video check outline
+987243 water well
+987244 water well outline
+987245 bed single
+987246 bed single outline
+987247 book information variant
+987248 bottle soda
+987249 bottle soda classic
+987250 bottle soda outline
+987251 calendar blank multiple
+987252 card search
+987253 card search outline
+987254 face woman profile
+987255 face woman
+987256 face woman outline
+987257 file settings
+987258 file settings outline
+987259 file cog
+987260 file cog outline
+987261 folder settings
+987262 folder settings outline
+987263 folder cog
+987264 folder cog outline
+987265 furigana horizontal
+987266 furigana vertical
+987267 golf tee
+987268 lungs
+987269 math log
+987270 moped
+987271 router network
+987272 alpha i
+987273 roman numeral 2
+987274 roman numeral 3
+987275 roman numeral 4
+987276 alpha v
+987277 roman numeral 6
+987278 roman numeral 7
+987279 roman numeral 8
+987280 roman numeral 9
+987281 alpha x
+987282 soldering iron
+987283 stomach
+987284 table eye
+987285 form textarea
+987286 trumpet
+987287 account cash
+987288 account cash outline
+987289 air humidifier
+987290 ansible
+987291 api
+987292 bicycle
+987293 car door lock
+987294 coat rack
+987295 coffee maker
+987296 web minus
+987297 decimal
+987298 decimal comma
+987299 decimal comma decrease
+987300 decimal comma increase
+987301 delete alert
+987302 delete alert outline
+987303 delete off
+987304 delete off outline
+987305 dock bottom
+987306 dock left
+987307 dock right
+987308 dock window
+987309 domain plus
+987310 domain remove
+987311 door closed lock
+987312 download off
+987313 download off outline
+987314 flag minus outline
+987315 flag plus outline
+987316 flag remove outline
+987317 folder home
+987318 folder home outline
+987319 folder information
+987320 folder information outline
+987321 iv bag
+987322 link lock
+987323 message plus outline
+987324 phone cancel
+987325 smart card
+987326 smart card outline
+987327 smart card reader
+987328 smart card reader outline
+987329 storefront outline
+987330 thermometer high
+987331 thermometer low
+987332 ufo
+987333 ufo outline
+987334 upload off
+987335 upload off outline
+987336 account child outline
+987337 account settings outline
+987338 account tie outline
+987339 alien outline
+987340 battery alert variant
+987341 battery alert variant outline
+987342 beehive outline
+987343 boomerang
+987344 briefcase clock
+987345 briefcase clock outline
+987346 cellphone message off
+987347 circle off outline
+987348 clipboard list
+987349 clipboard list outline
+987350 code braces box
+987351 code parentheses box
+987352 consolidate
+987353 electric switch closed
+987354 email receive
+987355 email receive outline
+987356 email send
+987357 email send outline
+987358 emoticon confused
+987359 emoticon confused outline
+987360 epsilon
+987361 file table box
+987362 file table box multiple
+987363 file table box multiple outline
+987364 file table box outline
+987365 filter menu
+987366 filter menu outline
+987367 flip horizontal
+987368 flip vertical
+987369 folder download outline
+987370 folder heart
+987371 folder heart outline
+987372 folder key outline
+987373 folder upload outline
+987374 gamma
+987375 hair dryer
+987376 hair dryer outline
+987377 hand heart
+987378 hexagon multiple outline
+987379 horizontal rotate clockwise
+987380 horizontal rotate counterclockwise
+987381 application array
+987382 application array outline
+987383 application braces
+987384 application braces outline
+987385 application parentheses
+987386 application parentheses outline
+987387 application variable
+987388 application variable outline
+987389 khanda
+987390 kubernetes
+987391 link variant minus
+987392 link variant plus
+987393 link variant remove
+987394 map marker down
+987395 map marker up
+987396 monitor shimmer
+987397 nix
+987398 nuxt
+987399 power socket de
+987400 power socket fr
+987401 power socket jp
+987402 progress close
+987403 reload alert
+987404 restart alert
+987405 restore alert
+987406 shaker
+987407 shaker outline
+987408 television shimmer
+987409 variable box
+987410 filter variant minus
+987411 filter variant plus
+987412 slot machine
+987413 slot machine outline
+987414 glass mug variant
+987415 clipboard flow outline
+987416 sign real estate
+987417 antenna
+987418 centos
+987419 redhat
+987420 window shutter
+987421 window shutter alert
+987422 window shutter open
+987423 bike fast
+987424 volume source
+987425 volume vibrate
+987426 movie edit
+987427 movie edit outline
+987428 movie filter
+987429 movie filter outline
+987430 diabetes
+987431 cursor default gesture
+987432 cursor default gesture outline
+987433 toothbrush
+987434 toothbrush paste
+987435 home roof
+987436 toothbrush electric
+987437 account supervisor outline
+987438 bottle tonic
+987439 bottle tonic outline
+987440 bottle tonic plus
+987441 bottle tonic plus outline
+987442 bottle tonic skull
+987443 bottle tonic skull outline
+987444 calendar arrow left
+987445 calendar arrow right
+987446 crosshairs question
+987447 fire hydrant
+987448 fire hydrant alert
+987449 fire hydrant off
+987450 ocr
+987451 shield star
+987452 shield star outline
+987453 text recognition
+987454 handcuffs
+987455 gender male female variant
+987456 gender non binary
+987457 minus box multiple
+987458 minus box multiple outline
+987459 plus box multiple outline
+987460 pencil box multiple
+987461 pencil box multiple outline
+987462 printer check
+987463 sort variant remove
+987464 sort alphabetical ascending variant
+987465 sort alphabetical descending variant
+987466 dice 1 outline
+987467 dice 2 outline
+987468 dice 3 outline
+987469 dice 4 outline
+987470 dice 5 outline
+987471 dice 6 outline
+987472 dice d4
+987473 dice d6
+987474 dice d8
+987475 dice d10
+987476 dice d12
+987477 dice d20
+987478 dice multiple outline
+987479 paper roll
+987480 paper roll outline
+987481 home edit
+987482 home edit outline
+987483 arrow horizontal lock
+987484 arrow vertical lock
+987485 weight lifter
+987486 account lock
+987487 account lock outline
+987488 pasta
+987489 send check
+987490 send check outline
+987491 send clock
+987492 send clock outline
+987493 send outline
+987494 send lock outline
+987495 police badge
+987496 police badge outline
+987497 gate arrow right
+987498 gate open
+987499 bell badge
+987500 message image outline
+987501 message lock outline
+987502 message minus
+987503 message minus outline
+987504 message processing outline
+987505 message settings outline
+987506 message cog outline
+987507 message text clock
+987508 message text clock outline
+987509 message text lock outline
+987510 checkbox blank badge
+987511 file link
+987512 file link outline
+987513 file phone
+987514 file phone outline
+987515 meditation
+987516 yoga
+987517 leek
+987518 noodles
+987519 pound box outline
+987520 school outline
+987521 basket outline
+987522 phone in talk outline
+987523 bash
+987524 file key
+987525 file key outline
+987526 file certificate
+987527 file certificate outline
+987528 certificate outline
+987529 cigar
+987530 grill outline
+987531 qrcode plus
+987532 qrcode minus
+987533 qrcode remove
+987534 phone alert outline
+987535 phone bluetooth outline
+987536 phone cancel outline
+987537 phone forward outline
+987538 phone hangup outline
+987539 phone incoming outline
+987540 phone lock outline
+987541 phone log outline
+987542 phone message
+987543 phone message outline
+987544 phone minus outline
+987545 phone outgoing outline
+987546 phone paused outline
+987547 phone plus outline
+987548 phone return outline
+987549 phone settings outline
+987550 key star
+987551 key link
+987552 shield edit
+987553 shield edit outline
+987554 shield sync
+987555 shield sync outline
+987556 golf cart
+987557 phone missed outline
+987558 phone off outline
+987559 format quote open outline
+987560 format quote close outline
+987561 phone check
+987562 phone check outline
+987563 phone ring
+987564 phone ring outline
+987565 share circle
+987566 reply circle
+987567 fridge off
+987568 fridge off outline
+987569 fridge alert
+987570 fridge alert outline
+987571 water boiler alert
+987572 water boiler off
+987573 amplifier off
+987574 audio video off
+987575 toaster off
+987576 dishwasher alert
+987577 dishwasher off
+987578 tumble dryer alert
+987579 tumble dryer off
+987580 washing machine alert
+987581 washing machine off
+987582 car info
+987583 comment edit
+987584 printer 3d nozzle alert
+987585 printer 3d nozzle alert outline
+987586 align horizontal left
+987587 align horizontal center
+987588 align horizontal right
+987589 align vertical bottom
+987590 align vertical center
+987591 align vertical top
+987592 distribute horizontal left
+987593 distribute horizontal center
+987594 distribute horizontal right
+987595 distribute vertical bottom
+987596 distribute vertical center
+987597 distribute vertical top
+987598 alert rhombus
+987599 alert rhombus outline
+987600 crown outline
+987601 image off outline
+987602 movie search
+987603 movie search outline
+987604 rv truck
+987605 shopping outline
+987606 strategy
+987607 note text outline
+987608 view agenda outline
+987609 view grid outline
+987610 view grid plus outline
+987611 window closed variant
+987612 window open variant
+987613 cog clockwise
+987614 cog counterclockwise
+987615 chart sankey
+987616 chart sankey variant
+987617 vanity light
+987618 router
+987619 image edit
+987620 image edit outline
+987621 bell check
+987622 bell check outline
+987623 file edit
+987624 file edit outline
+987625 human scooter
+987626 spider
+987627 spider thread
+987628 plus thick
+987629 alert circle check
+987630 alert circle check outline
+987631 state machine
+987632 usb port
+987633 cloud lock
+987634 cloud lock outline
+987635 robot mower outline
+987636 share all
+987637 share all outline
+987638 google cloud
+987639 robot mower
+987640 fast forward 5
+987641 rewind 5
+987642 shape oval plus
+987643 timeline clock
+987644 timeline clock outline
+987645 mirror
+987646 account multiple check outline
+987647 card plus
+987648 card plus outline
+987649 checkerboard plus
+987650 checkerboard minus
+987651 checkerboard remove
+987652 select search
+987653 selection search
+987654 layers search
+987655 layers search outline
+987656 lightbulb cfl
+987657 lightbulb cfl off
+987658 account multiple remove
+987659 account multiple remove outline
+987660 magnify remove cursor
+987661 magnify remove outline
+987662 archive outline
+987663 battery heart
+987664 battery heart outline
+987665 battery heart variant
+987666 bus marker
+987667 chart multiple
+987668 emoticon lol
+987669 emoticon lol outline
+987670 file sync
+987671 file sync outline
+987672 handshake
+987673 language kotlin
+987674 language fortran
+987675 offer
+987676 radio off
+987677 table headers eye
+987678 table headers eye off
+987679 tag minus outline
+987680 tag off
+987681 tag off outline
+987682 tag plus outline
+987683 tag remove outline
+987684 tag text
+987685 vector polyline edit
+987686 vector polyline minus
+987687 vector polyline plus
+987688 vector polyline remove
+987689 beaker alert
+987690 beaker alert outline
+987691 beaker check
+987692 beaker check outline
+987693 beaker minus
+987694 beaker minus outline
+987695 beaker plus
+987696 beaker plus outline
+987697 beaker question
+987698 beaker question outline
+987699 beaker remove
+987700 beaker remove outline
+987701 bicycle basket
+987702 barcode off
+987703 digital ocean
+987704 exclamation thick
+987705 desk
+987706 flask empty minus
+987707 flask empty minus outline
+987708 flask empty plus
+987709 flask empty plus outline
+987710 flask empty remove
+987711 flask empty remove outline
+987712 flask minus
+987713 flask minus outline
+987714 flask plus
+987715 flask plus outline
+987716 flask remove
+987717 flask remove outline
+987718 folder move outline
+987719 home remove
+987720 webrtc
+987721 seat passenger
+987722 web clock
+987723 flask round bottom
+987724 flask round bottom empty
+987725 flask round bottom empty outline
+987726 flask round bottom outline
+987727 gold
+987728 message star outline
+987729 home lightbulb
+987730 home lightbulb outline
+987731 lightbulb group
+987732 lightbulb group outline
+987733 lightbulb multiple
+987734 lightbulb multiple outline
+987735 api off
+987736 allergy
+987737 archive arrow down
+987738 archive arrow down outline
+987739 archive arrow up
+987740 archive arrow up outline
+987741 battery off
+987742 battery off outline
+987743 bookshelf
+987744 cash minus
+987745 cash plus
+987746 cash remove
+987747 clipboard check multiple
+987748 clipboard check multiple outline
+987749 clipboard file
+987750 clipboard file outline
+987751 clipboard multiple
+987752 clipboard multiple outline
+987753 clipboard play multiple
+987754 clipboard play multiple outline
+987755 clipboard text multiple
+987756 clipboard text multiple outline
+987757 folder marker
+987758 folder marker outline
+987759 format list text
+987760 inbox arrow down outline
+987761 inbox arrow up outline
+987762 inbox full
+987763 inbox full outline
+987764 inbox outline
+987765 lightbulb cfl spiral
+987766 magnify scan
+987767 map marker multiple outline
+987768 percent outline
+987769 phone classic off
+987770 play box
+987771 account eye outline
+987772 safe square
+987773 safe square outline
+987774 scoreboard
+987775 scoreboard outline
+987776 select marker
+987777 select multiple
+987778 select multiple marker
+987779 selection marker
+987780 selection multiple marker
+987781 selection multiple
+987782 star box multiple
+987783 star box multiple outline
+987784 toy brick
+987785 toy brick marker
+987786 toy brick marker outline
+987787 toy brick minus
+987788 toy brick minus outline
+987789 toy brick outline
+987790 toy brick plus
+987791 toy brick plus outline
+987792 toy brick remove
+987793 toy brick remove outline
+987794 toy brick search
+987795 toy brick search outline
+987796 tray
+987797 tray alert
+987798 tray full
+987799 tray minus
+987800 tray plus
+987801 tray remove
+987802 truck check outline
+987803 truck delivery outline
+987804 truck fast outline
+987805 truck outline
+987806 usb flash drive
+987807 usb flash drive outline
+987808 water polo
+987809 battery low
+987810 battery medium
+987811 battery high
+987812 battery charging low
+987813 battery charging medium
+987814 battery charging high
+987815 hexadecimal
+987816 gesture tap button
+987817 gesture tap box
+987818 lan check
+987819 keyboard f1
+987820 keyboard f2
+987821 keyboard f3
+987822 keyboard f4
+987823 keyboard f5
+987824 keyboard f6
+987825 keyboard f7
+987826 keyboard f8
+987827 keyboard f9
+987828 keyboard f10
+987829 keyboard f11
+987830 keyboard f12
+987831 keyboard esc
+987832 toslink
+987833 cheese
+987834 string lights
+987835 string lights off
+987836 whistle outline
+987837 stairs up
+987838 stairs down
+987839 escalator up
+987840 escalator down
+987841 elevator up
+987842 elevator down
+987843 lightbulb cfl spiral off
+987844 comment edit outline
+987845 tooltip edit outline
+987846 monitor edit
+987847 email sync
+987848 email sync outline
+987849 chat alert outline
+987850 chat processing outline
+987851 snowflake melt
+987852 cloud check outline
+987853 lightbulb group off
+987854 lightbulb group off outline
+987855 lightbulb multiple off
+987856 lightbulb multiple off outline
+987857 chat sleep
+987858 chat sleep outline
+987859 garage variant
+987860 garage open variant
+987861 garage alert variant
+987862 cloud sync outline
+987863 globe light
+987864 cellphone nfc off
+987865 leaf off
+987866 leaf maple off
+987867 map marker left
+987868 map marker right
+987869 map marker left outline
+987870 map marker right outline
+987871 account cancel
+987872 account cancel outline
+987873 file clock
+987874 file clock outline
+987875 folder table
+987876 folder table outline
+987877 hydro power
+987878 doorbell
+987879 bulma
+987880 iobroker
+987881 oci
+987882 label percent
+987883 label percent outline
+987884 checkbox blank off
+987885 checkbox blank off outline
+987886 square off
+987887 square off outline
+987888 drag horizontal variant
+987889 drag vertical variant
+987890 message arrow left
+987891 message arrow left outline
+987892 message arrow right
+987893 message arrow right outline
+987894 database marker
+987895 tag multiple outline
+987896 map marker plus outline
+987897 map marker minus outline
+987898 map marker remove outline
+987899 map marker check outline
+987900 map marker radius outline
+987901 map marker off outline
+987902 molecule co
+987903 jump rope
+987904 kettlebell
+987905 account convert outline
+987906 bunk bed
+987907 fleur de lis
+987908 ski
+987909 ski cross country
+987910 ski water
+987911 snowboard
+987912 account tie voice
+987913 account tie voice outline
+987914 account tie voice off
+987915 account tie voice off outline
+987916 beer outline
+987917 glass pint outline
+987918 coffee to go outline
+987919 cup outline
+987920 bottle wine outline
+987921 earth arrow right
+987922 key arrow right
+987923 format color marker cancel
+987924 mother heart
+987925 currency eur off
+987926 semantic web
+987927 kettle alert
+987928 kettle alert outline
+987929 kettle steam
+987930 kettle steam outline
+987931 kettle off
+987932 kettle off outline
+987933 simple icons
+987934 briefcase check outline
+987935 clipboard plus outline
+987936 download lock
+987937 download lock outline
+987938 hammer screwdriver
+987939 hammer wrench
+987940 hydraulic oil level
+987941 hydraulic oil temperature
+987942 medal outline
+987943 rodent
+987944 abjad arabic
+987945 abjad hebrew
+987946 abugida devanagari
+987947 abugida thai
+987948 alphabet aurebesh
+987949 alphabet cyrillic
+987950 alphabet greek
+987951 alphabet latin
+987952 alphabet piqad
+987953 ideogram cjk
+987954 ideogram cjk variant
+987955 syllabary hangul
+987956 syllabary hiragana
+987957 syllabary katakana
+987958 syllabary katakana halfwidth
+987959 alphabet tengwar
+987960 head alert
+987961 head alert outline
+987962 head check
+987963 head check outline
+987964 head cog
+987965 head cog outline
+987966 head dots horizontal
+987967 head dots horizontal outline
+987968 head flash
+987969 head flash outline
+987970 head heart
+987971 head heart outline
+987972 head lightbulb
+987973 head lightbulb outline
+987974 head minus
+987975 head minus outline
+987976 head plus
+987977 head plus outline
+987978 head question
+987979 head question outline
+987980 head remove
+987981 head remove outline
+987982 head snowflake
+987983 head snowflake outline
+987984 head sync
+987985 head sync outline
+987986 hvac
+987987 pencil ruler
+987988 pipe wrench
+987989 widgets outline
+987990 television ambient light
+987991 propane tank
+987992 propane tank outline
+987993 folder music
+987994 folder music outline
+987995 klingon
+987996 palette swatch outline
+987997 form textbox lock
+987998 head
+987999 head outline
+988000 shield half
+988001 store outline
+988002 google downasaur
+988003 bottle soda classic outline
+988004 sticker
+988005 sticker alert
+988006 sticker alert outline
+988007 sticker check
+988008 sticker check outline
+988009 sticker minus
+988010 sticker minus outline
+988011 sticker outline
+988012 sticker plus
+988013 sticker plus outline
+988014 sticker remove
+988015 sticker remove outline
+988016 account cog
+988017 account cog outline
+988018 account details outline
+988019 upload lock
+988020 upload lock outline
+988021 label multiple
+988022 label multiple outline
+988023 refresh circle
+988024 sync circle
+988025 bookmark music outline
+988026 bookmark remove outline
+988027 bookmark check outline
+988028 traffic cone
+988029 cup off outline
+988030 auto download
+988031 shuriken
+988032 chart ppf
+988033 elevator passenger
+988034 compass rose
+988035 space station
+988036 order bool descending
+988037 sort bool ascending
+988038 sort bool ascending variant
+988039 sort bool descending
+988040 sort bool descending variant
+988041 sort numeric ascending
+988042 sort numeric descending
+988043 human baby changing table
+988044 human male child
+988045 human wheelchair
+988046 microsoft access
+988047 microsoft excel
+988048 microsoft powerpoint
+988049 microsoft sharepoint
+988050 microsoft word
+988051 nintendo game boy
+988052 cable data
+988053 circle half
+988054 circle half full
+988055 cellphone charging
+988056 close thick
+988057 escalator box
+988058 lock check
+988059 lock open alert
+988060 lock open check
+988061 recycle variant
+988062 stairs box
+988063 hand water
+988064 table refresh
+988065 table sync
+988066 size xxs
+988067 size xs
+988068 size s
+988069 size m
+988070 alpha l
+988071 size xl
+988072 size xxl
+988073 size xxxl
+988074 ticket confirmation outline
+988075 timer
+988076 timer off
+988077 book account
+988078 book account outline
+988079 rocket outline
+988080 home search
+988081 home search outline
+988082 car arrow left
+988083 car arrow right
+988084 monitor eye
+988085 lipstick
+988086 virus
+988087 virus outline
+988088 text search
+988089 table account
+988090 table alert
+988091 table arrow down
+988092 table arrow left
+988093 table arrow right
+988094 table arrow up
+988095 table cancel
+988096 table check
+988097 table clock
+988098 table cog
+988099 table eye off
+988100 table heart
+988101 table key
+988102 table lock
+988103 table minus
+988104 table multiple
+988105 table network
+988106 table off
+988107 table star
+988108 car cog
+988109 car settings
+988110 cog off
+988111 cog off outline
+988112 credit card check
+988113 credit card check outline
+988114 file tree outline
+988115 folder star multiple
+988116 folder star multiple outline
+988117 home minus outline
+988118 home plus outline
+988119 home remove outline
+988120 scan helper
+988121 video 3d off
+988122 shield bug
+988123 shield bug outline
+988124 eyedropper plus
+988125 eyedropper minus
+988126 eyedropper remove
+988127 eyedropper off
+988128 baby buggy
+988129 umbrella closed variant
+988130 umbrella closed outline
+988131 email off
+988132 email off outline
+988133 food variant off
+988134 play box multiple outline
+988135 bell cancel
+988136 bell cancel outline
+988137 bell minus
+988138 bell minus outline
+988139 bell remove
+988140 bell remove outline
+988141 beehive off outline
+988142 cheese off
+988143 corn off
+988144 egg off
+988145 egg off outline
+988146 egg outline
+988147 fish off
+988148 flask empty off
+988149 flask empty off outline
+988150 flask off
+988151 flask off outline
+988152 fruit cherries off
+988153 fruit citrus off
+988154 mushroom off
+988155 mushroom off outline
+988156 soy sauce off
+988157 seed off
+988158 seed off outline
+988159 tailwind
+988160 form dropdown
+988161 form select
+988162 pump
+988163 earth plus
+988164 earth minus
+988165 earth remove
+988166 earth box plus
+988167 earth box minus
+988168 earth box remove
+988169 gas station off
+988170 gas station off outline
+988171 lightning bolt
+988172 lightning bolt outline
+988173 smoking pipe
+988174 axis arrow info
+988175 chat plus
+988176 chat minus
+988177 chat remove
+988178 chat plus outline
+988179 chat minus outline
+988180 chat remove outline
+988181 bucket
+988182 bucket outline
+988183 pail
+988184 image remove
+988185 image minus
+988186 pine tree fire
+988187 cigar off
+988188 cube off
+988189 cube off outline
+988190 dome light
+988191 food drumstick
+988192 food drumstick outline
+988193 incognito circle
+988194 incognito circle off
+988195 microwave off
+988196 power plug off outline
+988197 power plug outline
+988198 puzzle check
+988199 puzzle check outline
+988200 smoking pipe off
+988201 spoon sugar
+988202 table split cell
+988203 ticket percent outline
+988204 fuse off
+988205 fuse alert
+988206 heart plus
+988207 heart minus
+988208 heart remove
+988209 heart plus outline
+988210 heart minus outline
+988211 heart remove outline
+988212 heart off outline
+988213 motion sensor off
+988214 pail plus
+988215 pail minus
+988216 pail remove
+988217 pail off
+988218 pail outline
+988219 pail plus outline
+988220 pail minus outline
+988221 pail remove outline
+988222 pail off outline
+988223 clock time one
+988224 clock time two
+988225 clock time three
+988226 clock time four
+988227 clock time five
+988228 clock time six
+988229 clock time seven
+988230 clock time eight
+988231 clock time nine
+988232 clock time ten
+988233 clock time eleven
+988234 clock time twelve
+988235 clock time one outline
+988236 clock time two outline
+988237 clock time three outline
+988238 clock time four outline
+988239 clock time five outline
+988240 clock time six outline
+988241 clock time seven outline
+988242 clock time eight outline
+988243 clock time nine outline
+988244 clock time ten outline
+988245 clock time eleven outline
+988246 clock time twelve outline
+988247 printer search
+988248 printer eye
+988249 minus circle off
+988250 minus circle off outline
+988251 content save cog
+988252 content save cog outline
+988253 set square
+988254 cog refresh
+988255 cog refresh outline
+988256 cog sync
+988257 cog sync outline
+988258 download box
+988259 download box outline
+988260 download circle
+988261 download circle outline
+988262 air humidifier off
+988263 chili off
+988264 food drumstick off
+988265 food drumstick off outline
+988266 food steak
+988267 food steak off
+988268 fan alert
+988269 fan chevron down
+988270 fan chevron up
+988271 fan plus
+988272 fan minus
+988273 fan remove
+988274 fan speed 1
+988275 fan speed 2
+988276 fan speed 3
+988277 rug
+988278 lingerie
+988279 wizard hat
+988280 hours 24
+988281 cosine wave
+988282 sawtooth wave
+988283 square wave
+988284 triangle wave
+988285 waveform
+988286 folder multiple plus
+988287 folder multiple plus outline
+988288 current ac
+988289 watering can
+988290 watering can outline
+988291 monitor share
+988292 laser pointer
+988293 view array outline
+988294 view carousel outline
+988295 view column outline
+988296 view comfy outline
+988297 view dashboard variant outline
+988298 view day outline
+988299 view list outline
+988300 view module outline
+988301 view parallel outline
+988302 view quilt outline
+988303 view sequential outline
+988304 view stream outline
+988305 view week outline
+988306 compare horizontal
+988307 compare vertical
+988308 briefcase variant
+988309 briefcase variant outline
+988310 relation many to many
+988311 relation many to one
+988312 relation many to one or many
+988313 relation many to only one
+988314 relation many to zero or many
+988315 relation many to zero or one
+988316 relation one or many to many
+988317 relation one or many to one
+988318 relation one or many to one or many
+988319 relation one or many to only one
+988320 relation one or many to zero or many
+988321 relation one or many to zero or one
+988322 relation one to many
+988323 relation one to one
+988324 relation one to one or many
+988325 relation one to only one
+988326 relation one to zero or many
+988327 relation one to zero or one
+988328 relation only one to many
+988329 relation only one to one
+988330 relation only one to one or many
+988331 relation only one to only one
+988332 relation only one to zero or many
+988333 relation only one to zero or one
+988334 relation zero or many to many
+988335 relation zero or many to one
+988336 relation zero or many to one or many
+988337 relation zero or many to only one
+988338 relation zero or many to zero or many
+988339 relation zero or many to zero or one
+988340 relation zero or one to many
+988341 relation zero or one to one
+988342 relation zero or one to one or many
+988343 relation zero or one to only one
+988344 relation zero or one to zero or many
+988345 relation zero or one to zero or one
+988346 alert plus
+988347 alert minus
+988348 alert remove
+988349 alert plus outline
+988350 alert minus outline
+988351 alert remove outline
+988352 carabiner
+988353 fencing
+988354 skateboard
+988355 polo
+988356 tractor variant
+988357 radiology box
+988358 radiology box outline
+988359 skull scan
+988360 skull scan outline
+988361 plus minus variant
+988362 source branch plus
+988363 source branch minus
+988364 source branch remove
+988365 source branch refresh
+988366 source branch sync
+988367 source branch check
+988368 puzzle plus
+988369 puzzle minus
+988370 puzzle remove
+988371 puzzle edit
+988372 puzzle heart
+988373 puzzle star
+988374 puzzle plus outline
+988375 puzzle minus outline
+988376 puzzle remove outline
+988377 puzzle edit outline
+988378 puzzle heart outline
+988379 puzzle star outline
+988380 rhombus medium outline
+988381 rhombus split outline
+988382 rocket launch
+988383 rocket launch outline
+988384 set merge
+988385 set split
+988386 beekeeper
+988387 snowflake off
+988388 weather sunny off
+988389 clipboard edit
+988390 clipboard edit outline
+988391 notebook edit
+988392 human edit
+988393 notebook edit outline
+988394 cash lock
+988395 cash lock open
+988396 account supervisor circle outline
+988397 car outline
+988398 cash check
+988399 filter off
+988400 filter off outline
+988401 spirit level
+988402 wheel barrow
+988403 book check
+988404 book check outline
+988405 notebook check
+988406 notebook check outline
+988407 book open variant
+988408 sign pole
+988409 shore
+988410 shape square rounded plus
+988411 square rounded
+988412 square rounded outline
+988413 archive alert
+988414 archive alert outline
+988415 power socket it
+988416 square circle
+988417 symbol
+988418 water alert
+988419 water alert outline
+988420 water check
+988421 water check outline
+988422 water minus
+988423 water minus outline
+988424 water off outline
+988425 water percent alert
+988426 water plus
+988427 water plus outline
+988428 water remove
+988429 water remove outline
+988430 snake
+988431 format text variant outline
+988432 grass
+988433 access point off
+988434 currency mnt
+988435 dock top
+988436 share variant outline
+988437 transit skip
+988438 yurt
+988439 file document multiple
+988440 file document multiple outline
+988441 ev plug ccs1
+988442 ev plug ccs2
+988443 ev plug chademo
+988444 ev plug tesla
+988445 ev plug type1
+988446 ev plug type2
+988447 office building outline
+988448 office building marker
+988449 office building marker outline
+988450 progress question
+988451 basket minus
+988452 basket minus outline
+988453 basket off
+988454 basket off outline
+988455 basket plus
+988456 basket plus outline
+988457 basket remove
+988458 basket remove outline
+988459 account reactivate
+988460 account reactivate outline
+988461 car lifted pickup
+988462 video high definition
+988463 phone remove
+988464 phone remove outline
+988465 thermometer off
+988466 timeline check
+988467 timeline check outline
+988468 timeline minus
+988469 timeline minus outline
+988470 timeline remove
+988471 timeline remove outline
+988472 access point check
+988473 access point minus
+988474 access point plus
+988475 access point remove
+988476 data matrix
+988477 data matrix edit
+988478 data matrix minus
+988479 data matrix plus
+988480 data matrix remove
+988481 data matrix scan
+988482 tune variant
+988483 tune vertical variant
+988484 rake
+988485 shimmer
+988486 transit connection horizontal
+988487 sort calendar ascending
+988488 sort calendar descending
+988489 sort clock ascending
+988490 sort clock ascending outline
+988491 sort clock descending
+988492 sort clock descending outline
+988493 chart box
+988494 chart box outline
+988495 chart box plus outline
+988496 mouse move down
+988497 mouse move up
+988498 mouse move vertical
+988499 pitchfork
+988500 vanish quarter
+988501 application settings outline
+988502 delete clock
+988503 delete clock outline
+988504 kangaroo
+988505 phone dial
+988506 phone dial outline
+988507 star off outline
+988508 tooltip check
+988509 tooltip check outline
+988510 tooltip minus
+988511 tooltip minus outline
+988512 tooltip remove
+988513 tooltip remove outline
+988514 pretzel
+988515 star plus
+988516 star minus
+988517 star remove
+988518 star check
+988519 star plus outline
+988520 star minus outline
+988521 star remove outline
+988522 star check outline
+988523 eiffel tower
+988524 submarine
+988525 sofa outline
+988526 sofa single
+988527 sofa single outline
+988528 text account
+988529 human queue
+988530 food halal
+988531 food kosher
+988532 key chain
+988533 key chain variant
+988534 lamps
+988535 application cog outline
+988536 dance pole
+988537 social distance 2 meters
+988538 social distance 6 feet
+988539 calendar cursor
+988540 emoticon sick
+988541 emoticon sick outline
+988542 hand heart outline
+988543 hand wash
+988544 hand wash outline
+988545 human cane
+988546 lotion
+988547 lotion outline
+988548 lotion plus
+988549 lotion plus outline
+988550 face mask
+988551 face mask outline
+988552 reiterate
+988553 butterfly
+988554 butterfly outline
+988555 bag suitcase
+988556 bag suitcase outline
+988557 bag suitcase off
+988558 bag suitcase off outline
+988559 motion play
+988560 motion pause
+988561 motion play outline
+988562 motion pause outline
+988563 arrow top left thin circle outline
+988564 arrow top right thin circle outline
+988565 arrow bottom right thin circle outline
+988566 arrow bottom left thin circle outline
+988567 arrow up thin circle outline
+988568 arrow right thin circle outline
+988569 arrow down thin circle outline
+988570 arrow left thin circle outline
+988571 human capacity decrease
+988572 human capacity increase
+988573 human greeting proximity
+988574 hvac off
+988575 inbox remove
+988576 inbox remove outline
+988577 handshake outline
+988578 ladder
+988579 router wireless off
+988580 seesaw
+988581 slide
+988582 calculator variant outline
+988583 shield account variant
+988584 shield account variant outline
+988585 message flash
+988586 message flash outline
+988587 list status
+988588 message bookmark
+988589 message bookmark outline
+988590 comment bookmark
+988591 comment bookmark outline
+988592 comment flash
+988593 comment flash outline
+988594 motion
+988595 motion outline
+988596 bicycle electric
+988597 car electric outline
+988598 chart timeline variant shimmer
+988599 moped electric
+988600 moped electric outline
+988601 moped outline
+988602 motorbike electric
+988603 rickshaw
+988604 rickshaw electric
+988605 scooter
+988606 scooter electric
+988607 horse
+988608 horse human
+988609 horse variant
+988610 unicorn
+988611 unicorn variant
+988612 alarm panel
+988613 alarm panel outline
+988614 bird
+988615 shoe cleat
+988616 shoe sneaker
+988617 human female dance
+988618 shoe ballet
+988619 numeric positive 1
+988620 face man shimmer
+988621 face man shimmer outline
+988622 face woman shimmer
+988623 face woman shimmer outline
+988624 home alert outline
+988625 lock alert outline
+988626 lock open alert outline
+988627 sim alert outline
+988628 sim off outline
+988629 sim outline
+988630 book open page variant outline
+988631 fire alert
+988632 ray start vertex end
+988633 camera flip
+988634 camera flip outline
+988635 orbit variant
+988636 circle box
+988637 circle box outline
+988638 mustache
+988639 comment minus
+988640 comment minus outline
+988641 comment off
+988642 comment off outline
+988643 eye remove
+988644 eye remove outline
+988645 unicycle
+988646 glass cocktail off
+988647 glass mug off
+988648 glass mug variant off
+988649 bicycle penny farthing
+988650 cart check
+988651 cart variant
+988652 baseball diamond
+988653 baseball diamond outline
+988654 fridge industrial
+988655 fridge industrial alert
+988656 fridge industrial alert outline
+988657 fridge industrial off
+988658 fridge industrial off outline
+988659 fridge industrial outline
+988660 fridge variant
+988661 fridge variant alert
+988662 fridge variant alert outline
+988663 fridge variant off
+988664 fridge variant off outline
+988665 fridge variant outline
+988666 windsock
+988667 dance ballroom
+988668 dots grid
+988669 dots square
+988670 dots triangle
+988671 dots hexagon
+988672 card minus
+988673 card minus outline
+988674 card off
+988675 card off outline
+988676 card remove
+988677 card remove outline
+988678 torch
+988679 navigation outline
+988680 map marker star
+988681 map marker star outline
+988682 manjaro
+988683 fast forward 60
+988684 rewind 60
+988685 image text
+988686 family tree
+988687 car emergency
+988688 notebook minus
+988689 notebook minus outline
+988690 notebook plus
+988691 notebook plus outline
+988692 notebook remove
+988693 notebook remove outline
+988694 connection
+988695 language rust
+988696 clipboard minus
+988697 clipboard minus outline
+988698 clipboard off
+988699 clipboard off outline
+988700 clipboard remove
+988701 clipboard remove outline
+988702 clipboard search
+988703 clipboard search outline
+988704 clipboard text off
+988705 clipboard text off outline
+988706 clipboard text search
+988707 clipboard text search outline
+988708 database alert outline
+988709 database arrow down outline
+988710 database arrow left outline
+988711 database arrow right outline
+988712 database arrow up outline
+988713 database check outline
+988714 database clock outline
+988715 database edit outline
+988716 database export outline
+988717 database import outline
+988718 database lock outline
+988719 database marker outline
+988720 database minus outline
+988721 database off outline
+988722 database outline
+988723 database plus outline
+988724 database refresh outline
+988725 database remove outline
+988726 database search outline
+988727 database settings outline
+988728 database sync outline
+988729 minus thick
+988730 database alert
+988731 database arrow down
+988732 database arrow left
+988733 database arrow right
+988734 database arrow up
+988735 database clock
+988736 database off
+988737 calendar lock
+988738 calendar lock outline
+988739 content save off
+988740 content save off outline
+988741 credit card refresh
+988742 credit card refresh outline
+988743 credit card search
+988744 credit card search outline
+988745 credit card sync
+988746 credit card sync outline
+988747 database cog
+988748 database cog outline
+988749 message off
+988750 message off outline
+988751 note minus
+988752 note minus outline
+988753 note remove
+988754 note remove outline
+988755 note search
+988756 note search outline
+988757 bank check
+988758 bank off
+988759 bank off outline
+988760 briefcase off
+988761 briefcase off outline
+988762 briefcase variant off
+988763 briefcase variant off outline
+988764 ghost off outline
+988765 ghost outline
+988766 store minus
+988767 store plus
+988768 store remove
+988769 email remove
+988770 email remove outline
+988771 heart cog
+988772 heart cog outline
+988773 heart settings
+988774 heart settings outline
+988775 pentagram
+988776 star cog
+988777 star cog outline
+988778 star settings
+988779 star settings outline
+988780 calendar end
+988781 calendar start
+988782 cannabis off
+988783 mower
+988784 mower bag
+988785 lock off
+988786 lock off outline
+988787 shark fin
+988788 shark fin outline
+988789 paw outline
+988790 paw off outline
+988791 snail
+988792 pig variant outline
+988793 piggy bank outline
+988794 robot outline
+988795 robot off outline
+988796 book alert
+988797 book alert outline
+988798 book arrow down
+988799 book arrow down outline
+988800 book arrow left
+988801 book arrow left outline
+988802 book arrow right
+988803 book arrow right outline
+988804 book arrow up
+988805 book arrow up outline
+988806 book cancel
+988807 book cancel outline
+988808 book clock
+988809 book clock outline
+988810 book cog
+988811 book cog outline
+988812 book edit
+988813 book edit outline
+988814 book lock open outline
+988815 book lock outline
+988816 book marker
+988817 book marker outline
+988818 book minus outline
+988819 book music outline
+988820 book off
+988821 book off outline
+988822 book plus outline
+988823 book refresh
+988824 book refresh outline
+988825 book remove outline
+988826 book settings
+988827 book settings outline
+988828 book sync
+988829 robot angry
+988830 robot angry outline
+988831 robot confused
+988832 robot confused outline
+988833 robot dead
+988834 robot dead outline
+988835 robot excited
+988836 robot excited outline
+988837 robot love
+988838 robot love outline
+988839 robot off
+988840 lock check outline
+988841 lock minus
+988842 lock minus outline
+988843 lock open check outline
+988844 lock open minus
+988845 lock open minus outline
+988846 lock open plus
+988847 lock open plus outline
+988848 lock open remove
+988849 lock open remove outline
+988850 lock plus outline
+988851 lock remove
+988852 lock remove outline
+988853 wifi alert
+988854 wifi arrow down
+988855 wifi arrow left
+988856 wifi arrow left right
+988857 wifi arrow right
+988858 wifi arrow up
+988859 wifi arrow up down
+988860 wifi cancel
+988861 wifi check
+988862 wifi cog
+988863 wifi lock
+988864 wifi lock open
+988865 wifi marker
+988866 wifi minus
+988867 wifi plus
+988868 wifi refresh
+988869 wifi remove
+988870 wifi settings
+988871 wifi sync
+988872 book sync outline
+988873 book education
+988874 book education outline
+988875 wifi strength 1 lock open
+988876 wifi strength 2 lock open
+988877 wifi strength 3 lock open
+988878 wifi strength 4 lock open
+988879 wifi strength lock open outline
+988880 cookie alert
+988881 cookie alert outline
+988882 cookie check
+988883 cookie check outline
+988884 cookie cog
+988885 cookie cog outline
+988886 cookie plus
+988887 cookie plus outline
+988888 cookie remove
+988889 cookie remove outline
+988890 cookie minus
+988891 cookie minus outline
+988892 cookie settings
+988893 cookie settings outline
+988894 cookie outline
+988895 tape drive
+988896 abacus
+988897 calendar clock outline
+988898 clipboard clock
+988899 clipboard clock outline
+988900 cookie clock
+988901 cookie clock outline
+988902 cookie edit
+988903 cookie edit outline
+988904 cookie lock
+988905 cookie lock outline
+988906 cookie off
+988907 cookie off outline
+988908 cookie refresh
+988909 cookie refresh outline
+988910 dog side off
+988911 gift off
+988912 gift off outline
+988913 gift open
+988914 gift open outline
+988915 movie check
+988916 movie check outline
+988917 movie cog
+988918 movie cog outline
+988919 movie minus
+988920 movie minus outline
+988921 movie off
+988922 movie off outline
+988923 movie open check
+988924 movie open check outline
+988925 movie open cog
+988926 movie open cog outline
+988927 movie open edit
+988928 movie open edit outline
+988929 movie open minus
+988930 movie open minus outline
+988931 movie open off
+988932 movie open off outline
+988933 movie open play
+988934 movie open play outline
+988935 movie open plus
+988936 movie open plus outline
+988937 movie open remove
+988938 movie open remove outline
+988939 movie open settings
+988940 movie open settings outline
+988941 movie open star
+988942 movie open star outline
+988943 movie play
+988944 movie play outline
+988945 movie plus
+988946 movie plus outline
+988947 movie remove
+988948 movie remove outline
+988949 movie settings
+988950 movie settings outline
+988951 movie star
+988952 movie star outline
+988953 robot happy
+988954 robot happy outline
+988955 turkey
+988956 food turkey
+988957 fan auto
+988958 alarm light off
+988959 alarm light off outline
+988960 broadcast
+988961 broadcast off
+988962 fire off
+988963 firework off
+988964 projector screen outline
+988965 script text key
+988966 script text key outline
+988967 script text play
+988968 script text play outline
+988969 surround sound 2 1
+988970 surround sound 5 1 2
+988971 tag arrow down
+988972 tag arrow down outline
+988973 tag arrow left
+988974 tag arrow left outline
+988975 tag arrow right
+988976 tag arrow right outline
+988977 tag arrow up
+988978 tag arrow up outline
+988979 train car passenger
+988980 train car passenger door
+988981 train car passenger door open
+988982 train car passenger variant
+988983 webcam off
+988984 chat question
+988985 chat question outline
+988986 message question
+988987 message question outline
+988988 kettle pour over
+988989 message reply outline
+988990 message reply text outline
+988991 koala
+988992 check decagram outline
+988993 star shooting
+988994 star shooting outline
+988995 table picnic
+988996 kitesurfing
+988997 paragliding
+988998 surfing
+988999 floor lamp torchiere
+989000 mortar pestle
+989001 cast audio variant
+989002 gradient horizontal
+989003 archive cancel
+989004 archive cancel outline
+989005 archive check
+989006 archive check outline
+989007 archive clock
+989008 archive clock outline
+989009 archive cog
+989010 archive cog outline
+989011 archive edit
+989012 archive edit outline
+989013 archive eye
+989014 archive eye outline
+989015 archive lock
+989016 archive lock open
+989017 archive lock open outline
+989018 archive lock outline
+989019 archive marker
+989020 archive marker outline
+989021 archive minus
+989022 archive minus outline
+989023 archive music
+989024 archive music outline
+989025 archive off
+989026 archive off outline
+989027 archive plus
+989028 archive plus outline
+989029 archive refresh
+989030 archive refresh outline
+989031 archive remove
+989032 archive remove outline
+989033 archive search
+989034 archive search outline
+989035 archive settings
+989036 archive settings outline
+989037 archive star
+989038 archive star outline
+989039 archive sync
+989040 archive sync outline
+989041 brush off
+989042 file image marker
+989043 file image marker outline
+989044 file marker
+989045 file marker outline
+989046 hamburger check
+989047 hamburger minus
+989048 hamburger off
+989049 hamburger plus
+989050 hamburger remove
+989051 image marker
+989052 image marker outline
+989053 note alert
+989054 note alert outline
+989055 note check
+989056 note check outline
+989057 note edit
+989058 note edit outline
+989059 note off
+989060 note off outline
+989061 printer off outline
+989062 printer outline
+989063 progress pencil
+989064 progress star
+989065 sausage off
+989066 folder eye
+989067 folder eye outline
+989068 information off
+989069 information off outline
+989070 sticker text
+989071 sticker text outline
+989072 web cancel
+989073 web refresh
+989074 web sync
+989075 chandelier
+989076 home switch
+989077 home switch outline
+989078 sun snowflake
+989079 ceiling fan
+989080 ceiling fan light
+989081 smoke
+989082 fence
+989083 light recessed
+989084 battery lock
+989085 battery lock open
+989086 folder hidden
+989087 mirror rectangle
+989088 mirror variant
+989089 arrow down left
+989090 arrow down left bold
+989091 arrow down right
+989092 arrow down right bold
+989093 arrow left bottom
+989094 arrow left bottom bold
+989095 arrow left top
+989096 arrow left top bold
+989097 arrow right bottom
+989098 arrow right bottom bold
+989099 arrow right top
+989100 arrow right top bold
+989101 arrow u down left
+989102 arrow u down left bold
+989103 arrow u down right
+989104 arrow u down right bold
+989105 arrow u left bottom
+989106 arrow u left bottom bold
+989107 arrow u left top
+989108 arrow u left top bold
+989109 arrow u right bottom
+989110 arrow u right bottom bold
+989111 arrow u right top
+989112 arrow u right top bold
+989113 arrow u up left
+989114 arrow u up left bold
+989115 arrow u up right
+989116 arrow u up right bold
+989117 arrow up left
+989118 arrow up left bold
+989119 arrow up right
+989120 arrow up right bold
+989121 select remove
+989122 selection ellipse remove
+989123 selection remove
+989124 human greeting
+989125 ph
+989126 water sync
+989127 ceiling light outline
+989128 floor lamp outline
+989129 wall sconce flat outline
+989130 wall sconce flat variant outline
+989131 wall sconce outline
+989132 wall sconce round outline
+989133 wall sconce round variant outline
+989134 floor lamp dual outline
+989135 floor lamp torchiere variant outline
+989136 lamp outline
+989137 lamps outline
+989138 candelabra
+989139 candelabra fire
+989140 menorah
+989141 menorah fire
+989142 floor lamp torchiere outline
+989143 credit card edit
+989144 credit card edit outline
+989145 briefcase eye
+989146 briefcase eye outline
+989147 soundbar
+989148 crown circle
+989149 crown circle outline
+989150 battery arrow down
+989151 battery arrow down outline
+989152 battery arrow up
+989153 battery arrow up outline
+989154 battery check
+989155 battery check outline
+989156 battery minus
+989157 battery minus outline
+989158 battery plus
+989159 battery plus outline
+989160 battery remove
+989161 battery remove outline
+989162 chili alert
+989163 chili alert outline
+989164 chili hot outline
+989165 chili medium outline
+989166 chili mild outline
+989167 chili off outline
+989168 cake variant outline
+989169 card multiple
+989170 card multiple outline
+989171 account cowboy hat outline
+989172 lightbulb spot
+989173 lightbulb spot off
+989174 fence electric
+989175 gate arrow left
+989176 gate alert
+989177 boom gate up
+989178 boom gate up outline
+989179 garage lock
+989180 garage variant lock
+989181 cellphone check
+989182 sun wireless
+989183 sun wireless outline
+989184 lightbulb auto
+989185 lightbulb auto outline
+989186 lightbulb variant
+989187 lightbulb variant outline
+989188 lightbulb fluorescent tube
+989189 lightbulb fluorescent tube outline
+989190 water circle
+989191 fire circle
+989192 smoke detector outline
+989193 smoke detector off
+989194 smoke detector off outline
+989195 smoke detector variant
+989196 smoke detector variant off
+989197 projector screen off
+989198 projector screen off outline
+989199 projector screen variant
+989200 projector screen variant off
+989201 projector screen variant off outline
+989202 projector screen variant outline
+989203 brush variant
+989204 car wrench
+989205 account injury
+989206 account injury outline
+989207 balcony
+989208 bathtub
+989209 bathtub outline
+989210 blender outline
+989211 coffee maker outline
+989212 countertop
+989213 countertop outline
+989214 door sliding
+989215 door sliding lock
+989216 door sliding open
+989217 hand wave
+989218 hand wave outline
+989219 human male female child
+989220 iron
+989221 iron outline
+989222 liquid spot
+989223 mosque
+989224 shield moon
+989225 shield moon outline
+989226 traffic light outline
+989227 hand front left
+989228 hand back left outline
+989229 hand back right outline
+989230 hand front left outline
+989231 hand front right outline
+989232 hand back left off
+989233 hand back right off
+989234 hand back left off outline
+989235 hand back right off outline
+989236 battery sync
+989237 battery sync outline
+989238 food takeout box
+989239 food takeout box outline
+989240 iron board
+989241 police station
+989242 cellphone marker
+989243 tooltip cellphone
+989244 table pivot
+989245 tunnel
+989246 tunnel outline
+989247 arrow projectile multiple
+989248 arrow projectile
+989249 bow arrow
+989250 axe battle
+989251 mace
+989252 magic staff
+989253 spear
+989254 curtains
+989255 curtains closed
+989256 human non binary
+989257 waterfall
+989258 egg fried
+989259 food hot dog
+989260 induction
+989261 pipe valve
+989262 shipping pallet
+989263 earbuds
+989264 earbuds off
+989265 earbuds off outline
+989266 earbuds outline
+989267 circle opacity
+989268 square opacity
+989269 water opacity
+989270 vector polygon variant
+989271 vector square close
+989272 vector square open
+989273 waves arrow left
+989274 waves arrow right
+989275 waves arrow up
+989276 cash fast
+989277 radioactive circle
+989278 radioactive circle outline
+989279 cctv off
+989280 format list group
+989281 clock plus
+989282 clock plus outline
+989283 clock minus
+989284 clock minus outline
+989285 clock remove
+989286 clock remove outline
+989287 account arrow up
+989288 account arrow down
+989289 account arrow down outline
+989290 account arrow up outline
+989291 audio input rca
+989292 audio input stereo minijack
+989293 audio input xlr
+989294 horse variant fast
+989295 email fast
+989296 email fast outline
+989297 camera document
+989298 camera document off
+989299 glass fragile
+989300 magnify expand
+989301 town hall
+989302 monitor small
+989303 diversify
+989304 car wireless
+989305 car select
+989306 airplane alert
+989307 airplane check
+989308 airplane clock
+989309 airplane cog
+989310 airplane edit
+989311 airplane marker
+989312 airplane minus
+989313 airplane plus
+989314 airplane remove
+989315 airplane search
+989316 airplane settings
+989317 flower pollen
+989318 flower pollen outline
+989319 hammer sickle
+989320 view gallery
+989321 view gallery outline
+989322 umbrella beach
+989323 umbrella beach outline
+989324 cabin a frame
+989325 all inclusive box
+989326 all inclusive box outline
+989327 hand coin
+989328 hand coin outline
+989329 truck flatbed
+989330 layers edit
+989331 multicast
+989332 hydrogen station
+989333 thermometer bluetooth
+989334 tire
+989335 forest
+989336 account tie hat
+989337 account tie hat outline
+989338 account wrench
+989339 account wrench outline
+989340 bicycle cargo
+989341 calendar collapse horizontal
+989342 calendar expand horizontal
+989343 cards club outline
+989344 heart outline
+989345 cards playing
+989346 cards playing club
+989347 cards playing club multiple
+989348 cards playing club multiple outline
+989349 cards playing club outline
+989350 cards playing diamond
+989351 cards playing diamond multiple
+989352 cards playing diamond multiple outline
+989353 cards playing diamond outline
+989354 cards playing heart
+989355 cards playing heart multiple
+989356 cards playing heart multiple outline
+989357 cards playing heart outline
+989358 cards playing spade
+989359 cards playing spade multiple
+989360 cards playing spade multiple outline
+989361 cards playing spade outline
+989362 cards spade outline
+989363 compare remove
+989364 dolphin
+989365 fuel cell
+989366 hand extended
+989367 hand extended outline
+989368 printer 3d nozzle heat
+989369 printer 3d nozzle heat outline
+989370 shark
+989371 shark off
+989372 shield crown
+989373 shield crown outline
+989374 shield sword
+989375 shield sword outline
+989376 sickle
+989377 store alert
+989378 store alert outline
+989379 store check
+989380 store check outline
+989381 store clock
+989382 store clock outline
+989383 store cog
+989384 store cog outline
+989385 store edit
+989386 store edit outline
+989387 store marker
+989388 store marker outline
+989389 store minus outline
+989390 store off
+989391 store off outline
+989392 store plus outline
+989393 store remove outline
+989394 store search
+989395 store search outline
+989396 store settings
+989397 store settings outline
+989398 sun thermometer
+989399 sun thermometer outline
+989400 truck cargo container
+989401 vector square edit
+989402 vector square minus
+989403 vector square plus
+989404 vector square remove
+989405 ceiling light multiple
+989406 ceiling light multiple outline
+989407 wiper wash alert
+989408 cart heart
+989409 virus off
+989410 virus off outline
+989411 map marker account
+989412 map marker account outline
+989413 basket check
+989414 basket check outline
+989415 credit card lock
+989416 credit card lock outline
+989417 format underline wavy
+989418 content save check
+989419 content save check outline
+989420 filter check
+989421 filter check outline
+989422 flag off
+989423 flag off outline
+989424 near me
+989425 navigation variant outline
+989426 refresh auto
+989427 tilde off
+989428 fit to screen
+989429 fit to screen outline
+989430 weather cloudy clock
+989431 smart card off
+989432 smart card off outline
+989433 clipboard text clock
+989434 clipboard text clock outline
+989435 teddy bear
+989436 cow off
+989437 eye arrow left
+989438 eye arrow left outline
+989439 eye arrow right
+989440 eye arrow right outline
+989441 home battery
+989442 home battery outline
+989443 home lightning bolt
+989444 home lightning bolt outline
+989445 leaf circle
+989446 leaf circle outline
+989447 tag search
+989448 tag search outline
+989449 car brake fluid level
+989450 car brake low pressure
+989451 car brake temperature
+989452 car brake worn linings
+989453 car light alert
+989454 car speed limiter
+989455 credit card chip
+989456 credit card chip outline
+989457 credit card fast
+989458 credit card fast outline
+989459 integrated circuit chip
+989460 thumbs up down outline
+989461 food off outline
+989462 food outline
+989463 format page split
+989464 chart waterfall
+989465 gamepad outline
+989466 network strength 4 cog
+989467 account sync
+989468 account sync outline
+989469 bus electric
+989470 liquor
+989471 database eye
+989472 database eye off
+989473 database eye off outline
+989474 database eye outline
+989475 timer settings
+989476 timer settings outline
+989477 timer cog
+989478 timer cog outline
+989479 checkbox marked circle plus outline
+989480 panorama horizontal
+989481 panorama vertical
+989482 advertisements
+989483 advertisements off
+989484 transmission tower export
+989485 transmission tower import
+989486 smoke detector alert
+989487 smoke detector alert outline
+989488 smoke detector variant alert
+989489 coffee maker check
+989490 coffee maker check outline
+989491 cog pause
+989492 cog pause outline
+989493 cog play
+989494 cog play outline
+989495 cog stop
+989496 cog stop outline
+989497 copyleft
+989498 fast forward 15
+989499 file image minus
+989500 file image minus outline
+989501 file image plus
+989502 file image plus outline
+989503 file image remove
+989504 file image remove outline
+989505 message badge
+989506 message badge outline
+989507 newspaper check
+989508 newspaper remove
+989509 publish off
+989510 rewind 15
+989511 view dashboard edit
+989512 view dashboard edit outline
+989513 office building cog
+989514 office building cog outline
+989515 hand clap
+989516 cone
+989517 cone off
+989518 cylinder
+989519 cylinder off
+989520 octahedron
+989521 octahedron off
+989522 pyramid
+989523 pyramid off
+989524 sphere
+989525 sphere off
+989526 format letter spacing
+989527 french fries
+989528 scent
+989529 scent off
+989530 palette swatch variant
+989531 email seal
+989532 email seal outline
+989533 stool
+989534 stool outline
+989535 panorama wide angle
+989536 account lock open
+989537 account lock open outline
+989538 align horizontal distribute
+989539 align vertical distribute
+989540 arrow bottom left bold box
+989541 arrow bottom left bold box outline
+989542 arrow bottom right bold box
+989543 arrow bottom right bold box outline
+989544 arrow top left bold box
+989545 arrow top left bold box outline
+989546 arrow top right bold box
+989547 arrow top right bold box outline
+989548 bookmark box multiple
+989549 bookmark box multiple outline
+989550 bullhorn variant
+989551 bullhorn variant outline
+989552 candy
+989553 candy off
+989554 candy off outline
+989555 candy outline
+989556 car clock
+989557 crowd
+989558 currency rupee
+989559 diving
+989560 dots circle
+989561 elevator passenger off
+989562 elevator passenger off outline
+989563 elevator passenger outline
+989564 eye refresh
+989565 eye refresh outline
+989566 folder check
+989567 folder check outline
+989568 human dolly
+989569 human white cane
+989570 ip outline
+989571 key alert
+989572 key alert outline
+989573 kite
+989574 kite outline
+989575 light flood down
+989576 light flood up
+989577 microphone question
+989578 microphone question outline
+989579 cradle
+989580 panorama outline
+989581 panorama sphere
+989582 panorama sphere outline
+989583 panorama variant
+989584 panorama variant outline
+989585 cradle outline
+989586 fraction one half
+989587 phone refresh
+989588 phone refresh outline
+989589 phone sync
+989590 phone sync outline
+989591 razor double edge
+989592 razor single edge
+989593 rotate 360
+989594 shield lock open
+989595 shield lock open outline
+989596 sitemap outline
+989597 sprinkler fire
+989598 tab search
+989599 timer sand complete
+989600 timer sand paused
+989601 vacuum
+989602 vacuum outline
+989603 wrench clock
+989604 pliers
+989605 sun compass
+989606 truck snowflake
+989607 camera marker
+989608 camera marker outline
+989609 video marker
+989610 video marker outline
+989611 wind turbine alert
+989612 wind turbine check
+989613 truck plus
+989614 truck minus
+989615 truck remove
+989616 arrow right thin
+989617 arrow left thin
+989618 arrow up thin
+989619 arrow down thin
+989620 arrow top right thin
+989621 arrow top left thin
+989622 arrow bottom left thin
+989623 arrow bottom right thin
+989624 scale unbalanced
+989625 draw pen
+989626 clock edit
+989627 clock edit outline
+989628 truck plus outline
+989629 truck minus outline
+989630 truck remove outline
+989631 camera off outline
+989632 home group plus
+989633 home group minus
+989634 home group remove
+989635 file sign
+989636 attachment lock
+989637 cellphone arrow down variant
+989638 file chart check
+989639 file chart check outline
+989640 file lock open
+989641 file lock open outline
+989642 folder question
+989643 folder question outline
+989644 message fast
+989645 message fast outline
+989646 message text fast
+989647 message text fast outline
+989648 monitor arrow down
+989649 monitor arrow down variant
+989650 needle off
+989651 numeric off
+989652 package variant closed minus
+989653 package variant closed plus
+989654 package variant closed remove
+989655 package variant minus
+989656 package variant plus
+989657 package variant remove
+989658 paperclip lock
+989659 phone clock
+989660 receipt outline
+989661 transmission tower off
+989662 truck alert
+989663 truck alert outline
+989664 bone off
+989665 lightbulb alert
+989666 lightbulb alert outline
+989667 lightbulb question
+989668 lightbulb question outline
+989669 battery clock
+989670 battery clock outline
+989671 autorenew off
+989672 folder arrow down
+989673 folder arrow down outline
+989674 folder arrow left
+989675 folder arrow left outline
+989676 folder arrow left right
+989677 folder arrow left right outline
+989678 folder arrow right
+989679 folder arrow right outline
+989680 folder arrow up
+989681 folder arrow up down
+989682 folder arrow up down outline
+989683 folder arrow up outline
+989684 folder cancel
+989685 folder cancel outline
+989686 folder file
+989687 folder file outline
+989688 folder off
+989689 folder off outline
+989690 folder play
+989691 folder play outline
+989692 folder wrench
+989693 folder wrench outline
+989694 image refresh
+989695 image refresh outline
+989696 image sync
+989697 image sync outline
+989698 percent box
+989699 percent box outline
+989700 percent circle
+989701 percent circle outline
+989702 sale outline
+989703 square rounded badge
+989704 square rounded badge outline
+989705 triangle small down
+989706 triangle small up
+989707 notebook heart
+989708 notebook heart outline
+989709 brush outline
+989710 fruit pear
+989711 raw
+989712 raw off
+989713 wall fire
+989714 home clock
+989715 home clock outline
+989716 camera lock
+989717 camera lock outline
+989718 play box lock
+989719 play box lock open
+989720 play box lock open outline
+989721 play box lock outline
+989722 robot industrial outline
+989723 gas burner
+989724 video 2d
+989725 book heart
+989726 book heart outline
+989727 account hard hat outline
+989728 account school
+989729 account school outline
+989730 library outline
+989731 projector off
+989732 light switch off
+989733 toggle switch variant
+989734 toggle switch variant off
+989735 asterisk circle outline
+989736 barrel outline
+989737 bell cog
+989738 bell cog outline
+989739 blinds horizontal
+989740 blinds horizontal closed
+989741 blinds vertical
+989742 blinds vertical closed
+989743 bulkhead light
+989744 calendar today outline
+989745 calendar week begin outline
+989746 calendar week end
+989747 calendar week end outline
+989748 calendar week outline
+989749 cloud percent
+989750 cloud percent outline
+989751 coach lamp variant
+989752 compost
+989753 currency fra
+989754 fan clock
+989755 file rotate left
+989756 file rotate left outline
+989757 file rotate right
+989758 file rotate right outline
+989759 filter multiple
+989760 filter multiple outline
+989761 gymnastics
+989762 hand clap off
+989763 heat pump
+989764 heat pump outline
+989765 heat wave
+989766 home off
+989767 home off outline
+989768 landslide
+989769 landslide outline
+989770 laptop account
+989771 led strip variant off
+989772 lightbulb night
+989773 lightbulb night outline
+989774 lightbulb on 10
+989775 lightbulb on 20
+989776 lightbulb on 30
+989777 lightbulb on 40
+989778 lightbulb on 50
+989779 lightbulb on 60
+989780 lightbulb on 70
+989781 lightbulb on 80
+989782 lightbulb on 90
+989783 meter electric
+989784 meter electric outline
+989785 meter gas
+989786 meter gas outline
+989787 monitor account
+989788 pill off
+989789 plus lock
+989790 plus lock open
+989791 pool thermometer
+989792 post lamp
+989793 rabbit variant
+989794 rabbit variant outline
+989795 receipt text check
+989796 receipt text check outline
+989797 receipt text minus
+989798 receipt text minus outline
+989799 receipt text plus
+989800 receipt text plus outline
+989801 receipt text remove
+989802 receipt text remove outline
+989803 roller shade
+989804 roller shade closed
+989805 seed plus
+989806 seed plus outline
+989807 shopping search outline
+989808 snowflake check
+989809 snowflake thermometer
+989810 snowshoeing
+989811 solar power variant
+989812 solar power variant outline
+989813 storage tank
+989814 storage tank outline
+989815 sun clock
+989816 sun clock outline
+989817 sun snowflake variant
+989818 tag check
+989819 tag check outline
+989820 text box edit
+989821 text box edit outline
+989822 text search variant
+989823 thermometer check
+989824 thermometer water
+989825 tsunami
+989826 turbine
+989827 volcano
+989828 volcano outline
+989829 water thermometer
+989830 water thermometer outline
+989831 wheelchair
+989832 wind power
+989833 wind power outline
+989834 window shutter cog
+989835 window shutter settings
+989836 account tie woman
+989837 briefcase arrow left right
+989838 briefcase arrow left right outline
+989839 briefcase arrow up down
+989840 briefcase arrow up down outline
+989841 cash clock
+989842 cash sync
+989843 file arrow left right
+989844 file arrow left right outline
+989845 file arrow up down
+989846 file arrow up down outline
+989847 file document alert
+989848 file document alert outline
+989849 file document check
+989850 file document check outline
+989851 file document minus
+989852 file document minus outline
+989853 file document plus
+989854 file document plus outline
+989855 file document remove
+989856 file document remove outline
+989857 file minus
+989858 file minus outline
+989859 filter cog
+989860 filter cog outline
+989861 filter settings
+989862 filter settings outline
+989863 folder lock open outline
+989864 folder lock outline
+989865 forum minus
+989866 forum minus outline
+989867 forum plus
+989868 forum plus outline
+989869 forum remove
+989870 forum remove outline
+989871 heating coil
+989872 image lock
+989873 image lock outline
+989874 land fields
+989875 land plots
+989876 land plots circle
+989877 land plots circle variant
+989878 land rows horizontal
+989879 land rows vertical
+989880 medical cotton swab
+989881 rolodex
+989882 rolodex outline
+989883 sort variant off
+989884 tally mark 1
+989885 tally mark 2
+989886 tally mark 3
+989887 tally mark 4
+989888 tally mark 5
+989889 attachment check
+989890 attachment minus
+989891 attachment off
+989892 attachment plus
+989893 attachment remove
+989894 paperclip check
+989895 paperclip minus
+989896 paperclip off
+989897 paperclip plus
+989898 paperclip remove
+989899 network pos
+989900 timer alert
+989901 timer alert outline
+989902 timer cancel
+989903 timer cancel outline
+989904 timer check
+989905 timer check outline
+989906 timer edit
+989907 timer edit outline
+989908 timer lock
+989909 timer lock open
+989910 timer lock open outline
+989911 timer lock outline
+989912 timer marker
+989913 timer marker outline
+989914 timer minus
+989915 timer minus outline
+989916 timer music
+989917 timer music outline
+989918 timer pause
+989919 timer pause outline
+989920 timer play
+989921 timer play outline
+989922 timer plus
+989923 timer plus outline
+989924 timer refresh
+989925 timer refresh outline
+989926 timer remove
+989927 timer remove outline
+989928 timer star
+989929 timer star outline
+989930 timer stop
+989931 timer stop outline
+989932 timer sync
+989933 timer sync outline
+989934 ear hearing loop
+989935 sail boat sink
+989936 lecturn
 1048573 <plane 15 private use, last>
 1048576 <plane 16 private use, first>
 1114109 <plane 16 private use, last>


### PR DESCRIPTION
Nerd Fonts started migrating symbols from the misused region to the Unicode plane 15 private area.
This version contains both areas to ease the transition.

https://github.com/ryanoasis/nerd-fonts/releases/tag/v2.3.3
https://github.com/ryanoasis/nerd-fonts/releases/tag/v2.3.0

> The old codepoints will be dropped with v3.0.0 because they are wrong/forbidden and cause a lot of problems for people that use non-latin letters. The old codepoints are F500 - FD46. The new codepoints are F0001 - F1AF0.