### PR TITLE
hold: Allow pressing the numeric keypad enter key to exit

### DIFF
--- a/tools/tui/hold.go
+++ b/tools/tui/hold.go
@@ -32,7 +32,7 @@ func HoldTillEnter(start_with_newline bool) {
 	}
 
 	lp.OnKeyEvent = func(event *loop.KeyEvent) error {
-		if event.MatchesPressOrRepeat("enter") || event.MatchesPressOrRepeat("esc") || event.MatchesPressOrRepeat("ctrl+c") || event.MatchesPressOrRepeat("ctrl+d") {
+		if event.MatchesPressOrRepeat("enter") || event.MatchesPressOrRepeat("kp_enter") || event.MatchesPressOrRepeat("esc") || event.MatchesPressOrRepeat("ctrl+c") || event.MatchesPressOrRepeat("ctrl+d") {
 			event.Handled = true
 			lp.Quit(0)
 		}


### PR DESCRIPTION
Also consider the Enter key on the numeric keypad to be a valid key for exiting.