### PR TITLE
Fix typo in ssh kitten

### DIFF
--- a/kittens/ssh/main.py
+++ b/kittens/ssh/main.py
@@ -201,7 +201,7 @@ egr()  # }}}
 
 
 def main(args: List[str]) -> Optional[str]:
-    raise SystemExit('This should be run as kitten unicode_input')
+    raise SystemExit('This should be run as kitten ssh')
 
 if __name__ == '__main__':
     main([])


### PR DESCRIPTION
It looks like this was copied from the unicode input kitten and forgotten to modify it.

I also found another issue.
It reports an error after pressing the default shortcut `ctrl+shift+p>w`.

```log
... error parsing regexp: invalid or unsupported Perl syntax: `(?u`
```

tools/cmd/hints/marks.go
```go
... `(?u)[%s\pL\pN]{%d,}` ...
```