### PR TITLE
Fix empty folders being considered as kitten

### DIFF
--- a/kittens/runner.py
+++ b/kittens/runner.py
@@ -133,7 +133,7 @@ def run_kitten(kitten: str, run_name: str = '__main__') -> None:
 def all_kitten_names() -> FrozenSet[str]:
     ans = []
     for name in list_kitty_resources('kittens'):
-        if '__' not in name and '.' not in name and name != 'tui':
+        if '__' not in name and '.' not in name and 'main.py' in list_kitty_resources(f'kittens.{name}'):
             ans.append(name)
     return frozenset(ans)
 


### PR DESCRIPTION
When pulling a git commit that contains delete folder actions, the local folders will not be deleted.

After pulling the latest master branch, the build fails.
```log
# git pull
# make app

python3 setup.py kitty.app 
...
ImportError: No module named kittens.choose.main
make: *** [app] Error 1
```