### PR TITLE
Add "amd64" as a potential value for "uname -m"

### DIFF
--- a/docs/installer.sh
+++ b/docs/installer.sh
@@ -46,7 +46,7 @@ detect_os() {
         'Linux')
             OS="linux"
             case "$(command uname -m)" in
-                x86_64) arch="x86_64";;
+                amd64|x86_64) arch="x86_64";;
                 aarch64*) arch="arm64";;
                 armv8*) arch="arm64";;
                 i386) arch="i686";;

--- a/shell-integration/ssh/kitten
+++ b/shell-integration/ssh/kitten
@@ -60,7 +60,7 @@ else
 fi
 
 case "$(command uname -m)" in
-    x86_64) arch="amd64";;
+    amd64|x86_64) arch="amd64";;
     aarch64*) arch="arm64";;
     armv8*) arch="arm64";;
     arm) arch="arm";;

--- a/shell-integration/ssh/kitty
+++ b/shell-integration/ssh/kitty
@@ -75,7 +75,7 @@ fi
 
 if [ "$OS" = "linux" ]; then
     case "$(command uname -m)" in
-        x86_64) arch="x86_64";;
+        amd64|x86_64) arch="x86_64";;
         aarch64*) arch="arm64";;
         armv8*) arch="arm64";;
         i386) arch="i686";;


### PR DESCRIPTION
This accommodates FreeBSD and perhaps others.

The change in `shell-integration/ssh/kitten` is the only one that matters; the other changes only run for Linux which, as far as I know, consistently uses "x86_64". But it's probably a good idea to keep all machine detection code more or less the same.