### PR TITLE
Suppress getpwuid() exceptions

### DIFF
--- a/kitty_tests/ssh.py
+++ b/kitty_tests/ssh.py
@@ -173,7 +173,11 @@ env COLORTERM
                 methods.append('using_passwd')
         self.assertTrue(methods)
         import pwd
-        expected_login_shell = pwd.getpwuid(os.geteuid()).pw_shell
+        try:
+            expected_login_shell = pwd.getpwuid(os.geteuid()).pw_shell
+        except KeyError:
+            with suppress(Exception):
+                self.skipTest('Skipping login shell detection as getpwuid() failed to read login shell')
         if os.path.basename(expected_login_shell) == 'nologin':
             self.skipTest('Skipping login shell detection as login shell is set to nologin')
         for m in methods:

--- a/shell-integration/ssh/bootstrap.py
+++ b/shell-integration/ssh/bootstrap.py
@@ -20,7 +20,12 @@ echo_on = int('ECHO_ON')
 data_dir = shell_integration_dir = ''
 request_data = int('REQUEST_DATA')
 leading_data = b''
-login_shell = pwd.getpwuid(os.geteuid()).pw_shell or os.environ.get('SHELL') or 'sh'
+try:
+    login_shell = pwd.getpwuid(os.geteuid()).pw_shell or os.environ.get('SHELL') or '/bin/sh'
+except KeyError:
+    login_shell = os.environ.get('SHELL') or '/bin/sh'
+    with suppress(Exception):
+        print('Failed to read login shell via getpwuid() for current user, falling back to', login_shell, file=sys.stderr)
 export_home_cmd = b'EXPORT_HOME_CMD'
 if export_home_cmd:
     HOME = base64.standard_b64decode(export_home_cmd).decode('utf-8')


### PR DESCRIPTION
More or less [the same issue already solved][1], where `getpwuid()` fails and raises a `KeyError` exception because the effective user ID isn't listed in the `/etc/passwd` file. The exception then directly fails the test before workarounds can be applied.

[1]: https://github.com/kovidgoyal/kitty/commit/89e5ae28bb60d5bf3aaadf25d62ea0864e5136bb