### PR TITLE
Rework of "suppress getpwuid() exceptions"

### DIFF
--- a/kitty_tests/ssh.py
+++ b/kitty_tests/ssh.py
@@ -176,7 +176,7 @@ env COLORTERM
         try:
             expected_login_shell = pwd.getpwuid(os.geteuid()).pw_shell
         except KeyError:
-            with suppress(Exception):
+            with suppress(KeyError):
                 self.skipTest('Skipping login shell detection as getpwuid() failed to read login shell')
         if os.path.basename(expected_login_shell) == 'nologin':
             self.skipTest('Skipping login shell detection as login shell is set to nologin')

--- a/shell-integration/ssh/bootstrap-utils.sh
+++ b/shell-integration/ssh/bootstrap-utils.sh
@@ -67,7 +67,7 @@ using_id() {
 }
 
 using_python() {
-    detect_python && output=$(command "$python" -c "import pwd, os; print(pwd.getpwuid(os.geteuid()).pw_shell)") \
+    detect_python && output=$(command "$python" -c "import pwd, os; exec(\"try:print(pwd.getpwuid(os.geteuid()).pw_shell)\nexcept:print(os.environ.get('SHELL')or'/bin/sh')\")") \
     && login_shell="$output" && login_shell_is_ok
 }
 

--- a/shell-integration/ssh/bootstrap.py
+++ b/shell-integration/ssh/bootstrap.py
@@ -22,10 +22,9 @@ request_data = int('REQUEST_DATA')
 leading_data = b''
 login_shell = os.environ.get('SHELL') or '/bin/sh'
 try:
-    login_shell = pwd.getpwuid(os.geteuid()).pw_shell or login_shell
+    login_shell = pwd.getpwuid(os.geteuid()).pw_shell
 except KeyError:
-    with contextlib.suppress(Exception):
-        print('Failed to read login shell via getpwuid() for current user, falling back to', login_shell, file=sys.stderr)
+    pass
 export_home_cmd = b'EXPORT_HOME_CMD'
 if export_home_cmd:
     HOME = base64.standard_b64decode(export_home_cmd).decode('utf-8')


### PR DESCRIPTION
This properly fixes https://github.com/kovidgoyal/kitty/pull/6118 that I submitted earlier. Starting another PR to fix a PR generally shouldn't happen and I am sorry for my negligence. Please feel free to make changes or clean up the commit. Thanks.

kitty_tests/ssh.py
------------------------
`suppress(Exception)` actually suppresses the `SkipTest` exception raised by `self.skipTest(...)`, making the call useless. The program then proceeds to line 181 and throws an `UnboundLocalError` exception because `expected_login_shell` is never defined in the `try` clause.

shell-integration/ssh/bootstrap-utils.sh
----------------------------------------------
This is a spot making use of `getpwuid()` that I missed. The `exec()` is an ugly workaround but it is hard to wrap `try` and `catch` clause in one line.

shell-integration/ssh/bootstrap.py
----------------------------------------
Printing the "Failed to read login shell" message will fail the `pty.screen_contents()` comparison.
```
AssertionError: 'Failed to read login shell via getpwuid()[71 chars]file' != 'UNTAR_DONE\nld:before_tarfile'
- Failed to read login shell via getpwuid() for current user, falling back to /bin
- /sh
  UNTAR_DONE
  ld:before_tarfile
```
