### PR TITLE
Add shade_transparency option

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -2375,7 +2375,7 @@ class Boss:
         patch_global_colors(spec, configured)
 
     def apply_new_options(self, opts: Options) -> None:
-        from .fonts.box_drawing import set_scale
+        from .fonts.box_drawing import set_scale, set_shade_transparency
         # Update options storage
         set_options(opts, is_wayland(), self.args.debug_rendering, self.args.debug_font_fallback)
         apply_options_update()
@@ -2383,6 +2383,7 @@ class Boss:
         set_default_env(opts.env.copy())
         # Update font data
         set_scale(opts.box_drawing_scale)
+        set_shade_transparency(opts.shade_transparency)
         from .fonts.render import set_font_family
         set_font_family(opts, debug_font_matching=self.args.debug_font_fallback)
         for os_window_id, tm in self.os_window_map.items():

--- a/kitty/main.py
+++ b/kitty/main.py
@@ -44,7 +44,7 @@ from .fast_data_types import (
     set_default_window_icon,
     set_options,
 )
-from .fonts.box_drawing import set_scale
+from .fonts.box_drawing import set_scale, set_shade_transparency
 from .fonts.render import set_font_family
 from .options.types import Options
 from .options.utils import DELETE_ENV_VAR
@@ -269,6 +269,7 @@ class AppRunner:
 
     def __call__(self, opts: Options, args: CLIOptions, bad_lines: Sequence[BadLine] = ()) -> None:
         set_scale(opts.box_drawing_scale)
+        set_shade_transparency(opts.shade_transparency)
         set_options(opts, is_wayland(), args.debug_rendering, args.debug_font_fallback)
         try:
             set_font_family(opts, debug_font_matching=args.debug_font_fallback)

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -236,6 +236,14 @@ the curl will peak once per character, with dense twice.
 '''
     )
 
+opt('shade_transparency', 'no',
+    option_type='to_bool',
+    long_text='''
+Whether to render shade characters like :code:`░▒▓` as solid blocks with some
+transparency or using a "dither" effect.
+'''
+    )
+
 opt('text_composition_strategy', 'platform',
     ctype='!text_composition_strategy',
     long_text='''

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -1183,6 +1183,9 @@ class Parser:
     def selection_foreground(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['selection_foreground'] = to_color_or_none(val)
 
+    def shade_transparency(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        ans['shade_transparency'] = to_bool(val)
+
     def shell(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['shell'] = str(val)
 

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -420,6 +420,7 @@ option_names = (  # {{{
  'select_by_word_characters_forward',
  'selection_background',
  'selection_foreground',
+ 'shade_transparency',
  'shell',
  'shell_integration',
  'show_hyperlink_targets',
@@ -574,6 +575,7 @@ class Options:
     select_by_word_characters_forward: str = ''
     selection_background: typing.Optional[kitty.fast_data_types.Color] = Color(255, 250, 205)
     selection_foreground: typing.Optional[kitty.fast_data_types.Color] = Color(0, 0, 0)
+    shade_transparency: bool = False
     shell: str = '.'
     shell_integration: typing.FrozenSet[str] = frozenset({'enabled'})
     show_hyperlink_targets: bool = False


### PR DESCRIPTION
This makes the shade characters (U+2591 through U+2593) to be drawn as semitransparent blocks rather than discrete, full opacity dots in a dither effect. It is disabled by default to retain compatibility with previous versions of kitty and with the standard, though note that many other terminals (e.g., alacritty and most/all VTE-based terminals) do this by default.

I have seen that this was already addressed in kovidgoyal/kitty#6108, and was just making this as a patch for personal use. Since there is at least some desire in the community for this feature, I thought that it would be a good idea to contribute it to upstream.