### PR TITLE
Add twitch-tui to projects using the kitty graphics protocol

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -44,6 +44,7 @@ Some programs and libraries that use the kitty graphics protocol:
 * `hologram.nvim <https://github.com/edluffy/hologram.nvim>`_  - view images inside nvim
 * `term-image <https://github.com/AnonymouX47/term-image>`_  - A Python library, CLI and TUI to display and browse images in the terminal
 * `glkitty <https://github.com/michaeljclark/glkitty>`_ - C library to draw OpenGL shaders in the terminal with a glgears demo
+* `twitch-tui <https://github.com/Xithrius/twitch-tui>`_ - Twitch chat in the terminal
 
 Other terminals that have implemented the graphics protocol:
 


### PR DESCRIPTION
Hi, 

The project [twitch-tui](https://github.com/Xithrius/twitch-tui) now uses the kitty graphics protocol.