### PR TITLE
Docs: fix heredoc issue in iplot snippet

### DIFF
--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -143,7 +143,7 @@ kitty with the following bash snippet:
         set object 1 rectangle from screen 0,0 to screen 1,1 fillcolor rgb"#fdf6e3" behind
         plot $@
         set output '/dev/null'
-        EOF
+    EOF
     }
 
 Add this to bashrc and then to plot a function, simply do:


### PR DESCRIPTION
Just a minor issue in the docs, but [here document delimiters should not include trailing spaces](https://tldp.org/LDP/abs/html/here-docs.html#:~:text=The%20closing%20limit%20string%2C%20on%20the%20final%20line%20of%20a%20here%20document%2C%20must%20start%20in%20the%20first%20character%20position.%20There%20can%20be%20no%20leading%20whitespace.).

The `iplot` function snippet includes leading spaces before `EOF` , so if you run it as is you'll run into some issues.
<details>
<summary>Leading spaces included screenshot</summary>

![image](https://user-images.githubusercontent.com/5954994/232167536-de338ff7-dc2d-434f-b99b-cae9bed1f19a.png)
</details>

Removing the leading spaces fixes this
<details>
<summary>Leading spaces removed screenshot</summary>

![image](https://user-images.githubusercontent.com/5954994/232167824-8dbfb9db-e58c-448d-8bbd-934ad135776c.png)
</details>

