### PR TITLE
More cases of #5477 functions with empty argument lists

### DIFF
--- a/glfw/cocoa_init.m
+++ b/glfw/cocoa_init.m
@@ -1014,7 +1014,7 @@ static pthread_t main_thread;
 static NSLock *tick_lock = NULL;
 
 
-void _glfwDispatchTickCallback() {
+void _glfwDispatchTickCallback(void) {
     if (tick_lock && tick_callback) {
         [tick_lock lock];
         while(tick_callback_requested) {
@@ -1026,7 +1026,7 @@ void _glfwDispatchTickCallback() {
 }
 
 static void
-request_tick_callback() {
+request_tick_callback(void) {
     if (!tick_callback_requested) {
         tick_callback_requested = true;
         [NSApp performSelectorOnMainThread:@selector(tick_callback) withObject:nil waitUntilDone:NO];

--- a/glfw/cocoa_monitor.m
+++ b/glfw/cocoa_monitor.m
@@ -323,7 +323,7 @@ static double getFallbackRefreshRate(CGDirectDisplayID displayID)
 //////                       GLFW internal API                      //////
 //////////////////////////////////////////////////////////////////////////
 
-void _glfwClearDisplayLinks() {
+void _glfwClearDisplayLinks(void) {
     for (size_t i = 0; i < _glfw.ns.displayLinks.count; i++) {
         if (_glfw.ns.displayLinks.entries[i].displayLink) {
             CVDisplayLinkStop(_glfw.ns.displayLinks.entries[i].displayLink);

--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -960,7 +960,7 @@ cocoa_set_dock_icon(PyObject UNUSED *self, PyObject *args) {
 static NSSound *beep_sound = nil;
 
 static void
-cleanup() {
+cleanup(void) {
     @autoreleasepool {
 
     if (dockMenu) [dockMenu release];

--- a/kitty/core_text.m
+++ b/kitty/core_text.m
@@ -155,7 +155,7 @@ font_descriptor_from_python(PyObject *src) {
 static CTFontCollectionRef all_fonts_collection_data = NULL;
 
 static CTFontCollectionRef
-all_fonts_collection() {
+all_fonts_collection(void) {
     if (all_fonts_collection_data == NULL) all_fonts_collection_data = CTFontCollectionCreateFromAvailableFonts(NULL);
     return all_fonts_collection_data;
 }

--- a/kitty/data-types.c
+++ b/kitty/data-types.c
@@ -47,7 +47,7 @@ user_cache_dir(void) {
 }
 
 static PyObject*
-process_group_map() {
+process_group_map(void) {
     int num_of_processes = proc_listallpids(NULL, 0);
     size_t bufsize = sizeof(pid_t) * (num_of_processes + 1024);
     FREE_AFTER_FUNCTION pid_t *buf = malloc(bufsize);

--- a/kitty/macos_process_info.c
+++ b/kitty/macos_process_info.c
@@ -24,7 +24,7 @@ cwd_of_process(PyObject *self UNUSED, PyObject *pid_) {
 
 // Read the maximum argument size for processes
 static int
-get_argmax() {
+get_argmax(void) {
     int argmax;
     int mib[] = { CTL_KERN, KERN_ARGMAX };
     size_t size = sizeof(argmax);


### PR DESCRIPTION
Building on macOS 13.3.1 (22E261) clang 14.0.3 (clang-1403.0.22.14.1)
running to errors like #5477 where functions without argument lists at
least need void.

Looking for possible suspect functions via:

  git grep -E "^([A-Za-z_]+ )?[A-Za-z_]+\()" \*.c \*.m
