### PR TITLE
Fix color fringing caused by gamma-incorrect blending in compositor when background_opacity is used

### DIFF
--- a/kitty/cell_fragment.glsl
+++ b/kitty/cell_fragment.glsl
@@ -37,6 +37,22 @@ in float colored_sprite;
 out vec4 final_color;
 
 // Util functions {{{
+float linear2srgb(float x) {
+    // Linear to sRGB conversion.
+    float lower = 12.92 * x;
+    float upper = 1.055 * pow(x, 1.0f / 2.4f) - 0.055f;
+
+    return mix(lower, upper, step(0.0031308f, x));
+}
+
+float srgb2linear(float x) {
+    // sRGB to linear conversion
+    float lower = x / 12.92;
+    float upper = pow((x + 0.055f) / 1.055f, 2.4f);
+
+    return mix(lower, upper, step(0.04045f, x));
+}
+
 vec4 alpha_blend(vec4 over, vec4 under) {
     // Alpha blend two colors returning the resulting color pre-multiplied by its alpha
     // and its alpha.
@@ -103,19 +119,8 @@ vec4 vec4_premul(vec4 rgba) {
 #ifdef NEEDS_FOREGROUND
 // sRGB luminance values
 const vec3 Y = vec3(0.2126, 0.7152, 0.0722);
-const float gamma_factor = 2.2;
 // Scaling factor for the extra text-alpha adjustment for luminance-difference.
 const float text_gamma_scaling = 0.5;
-
-float linear2srgb(float x) {
-    // Approximation of linear-to-sRGB conversion
-    return pow(x, 1.0 / gamma_factor);
-}
-
-float srgb2linear(float x) {
-    // Approximation of sRGB-to-linear conversion
-    return pow(x, gamma_factor);
-}
 
 float clamp_to_unit_float(float x) {
     // Clamp value to suitable output range

--- a/kitty/cell_fragment.glsl
+++ b/kitty/cell_fragment.glsl
@@ -184,6 +184,12 @@ void main() {
     vec4 fg = calculate_foreground(background);
 #ifdef TRANSPARENT
     final_color = alpha_blend_premul(fg, vec4_premul(background, bg_alpha));
+
+    // Adjust the transparent alpha-channel to account for incorrect
+    // gamma-blending performed by the compositor (true for at least wlroots,
+    // picom, GNOME, MacOS).
+    // This is the last pass:
+    final_color.a = linear2srgb(final_color.a);
 #else
     final_color = alpha_blend_premul(fg, background);
 #endif
@@ -207,6 +213,10 @@ void main() {
 
 #ifdef FOREGROUND
     final_color = calculate_foreground();  // pre-multiplied foreground
+
+    // This is the last pass, adjust alpha to compensate for gamma-incorrect
+    // blending in compositor:
+    final_color.a = linear2srgb(final_color.a);
 #endif
 
 }

--- a/kitty/cell_fragment.glsl
+++ b/kitty/cell_fragment.glsl
@@ -198,7 +198,7 @@ void main() {
 #endif
 
 #ifdef BACKGROUND
-#if defined(TRANSPARENT)
+#ifdef TRANSPARENT
     final_color = vec4_premul(background, bg_alpha);
 #else
     final_color = vec4(background, draw_bg);


### PR DESCRIPTION
This PR fixes #6209 by adjusting the alpha channel to account for gamma-incorrect blending performed by the compositor when background_opacity is < 1.0. At least wlroots, picom, GNOME, and MacOS perform gamma-incorrect blending by default with transparent windows.

It also includes a more precise sRGB-linear conversion to pretty much eliminate fringing completely.

This PR will however cause the following issues when using a transparent background:

* Some text will appear bolder, depending on the foreground color, the background, and the color of the pixels behind the semi-transparent window.
* Some of the transparent pixels will have incorrect hues due to incorrect blending.
* `background_opacity` will no longer be linear

See the following examples, the third variant of each is the current version with issues (100% transparency, old).

![image](https://user-images.githubusercontent.com/108100/234932046-9bf7ecc4-4ae5-47dd-87d4-f2ddd032ee8a.png)
![image (1)](https://user-images.githubusercontent.com/108100/234932066-56b3d302-bb9f-4f66-9c98-20752675e0ce.png)
