### PR TITLE
bash_integration: Do not leak variable `i`

### DIFF
--- a/shell-integration/bash/kitty.bash
+++ b/shell-integration/bash/kitty.bash
@@ -80,7 +80,7 @@ _ksi_prompt=(
 )
 
 _ksi_main() {
-    builtin local ifs="$IFS"
+    builtin local ifs="$IFS" i
     IFS=" "
     for i in ${KITTY_SHELL_INTEGRATION[@]}; do
         case "$i" in


### PR DESCRIPTION
With shell-integration, the user would see the last value of this variable (as set by the shell-integration script.

Fix this by making it local.