### PR TITLE
Fix usage of window vs windows

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1011,8 +1011,8 @@ class Boss:
             if tm is not None:
                 tm.set_active_tab(tab)
         self.confirm(_(
-            'Are you sure you want to close this tab, it has {}'
-            ' windows running?').format(num),
+            'Are you sure you want to close this tab? It has {}'
+            ' {} running.').format(num, "window" if num == 1 else "windows"),
             self.handle_close_tab_confirmation, tab.id,
             window=tab.active_window,
         )
@@ -1602,8 +1602,8 @@ class Boss:
         if tm is not None:
             w = tm.active_window
             self.confirm(
-                _('Are you sure you want to close this OS window, it has {}'
-                  ' windows running?').format(num),
+                _('Are you sure you want to close this OS window? It has {}'
+                  ' {} running.').format(num, "window" if num == 1 else "windows"),
                 self.handle_close_os_window_confirmation, os_window_id,
                 window=w,
             )
@@ -1642,7 +1642,7 @@ class Boss:
             return
         assert tm is not None
         self.confirm(
-            _('Are you sure you want to quit kitty, it has {} windows running?').format(num),
+            _('Are you sure you want to quit kitty? It has {} {} running.').format(num, "window" if num == 1 else "windows"),
             self.handle_quit_confirmation,
             window=tm.active_window,
         )


### PR DESCRIPTION
Changes `boss.py` to use say "Are you sure you want to close this tab? It has 1 window running." instead of "Are you sure you want to close this tab, it has 1 windows running?" (same for other usages of the same line)

I haven't tested the code but I believe it should work