### PR TITLE
Fix shade characters to follow unicode standard

### DIFF
--- a/kitty/fonts.c
+++ b/kitty/fonts.c
@@ -543,6 +543,7 @@ START_ALLOW_CASE_RANGE
         case 0xe0b0 ... 0xe0bf:  // powerline box drawing
         case 0x1fb00 ... 0x1fb8b:  // symbols for legacy computing
         case 0x1fba0 ... 0x1fbae:
+        case 0x1fb90:  // inverse medium shade
             return BOX_FONT;
         default:
             *is_emoji_presentation = has_emoji_presentation(cpu_cell, gpu_cell);
@@ -585,6 +586,9 @@ START_ALLOW_CASE_RANGE
             return 0x151 + ch - 0x1fba0;
         case 0x2800 ... 0x28ff:
             return 0x160 + ch - 0x2800;
+        case 0x1fb90:
+            //  Allocated to allow for 0x1fb8c ... 0x1fb94 eventually
+            return 0x25f + ch - 0x1fb8c;
         default:
             return 0xffff;
     }

--- a/kitty/fonts/box_drawing.py
+++ b/kitty/fonts/box_drawing.py
@@ -613,22 +613,20 @@ def inner_corner(buf: BufType, width: int, height: int, which: str = 'tl', level
     draw_vline(buf, width, y1, y2, width // 2 + (xd * hgap), level)
 
 
+@supersampled()
 def shade(buf: BufType, width: int, height: int, light: bool = False, invert: bool = False) -> None:
-    square_sz = max(1, width // 12)
-    number_of_rows = height // square_sz
-    number_of_cols = width // square_sz
-    nums = range(square_sz)
-
-    for r in range(number_of_rows):
-        for c in range(number_of_cols):
-            if invert ^ ((r % 2 != c % 2) or (light and r % 2 == 1)):
-                continue
-            for yr in nums:
-                y = r * square_sz + yr
-                offset = width * y
-                for xc in nums:
-                    x = c * square_sz + xc
-                    buf[offset + x] = 255
+    x_size = width / 4
+    y_size = height / 8
+    pattern_segments = 4 if light else 2
+    for y in range(height):
+        y_segment = y / y_size
+        offset = y * width
+        for x in range(width):
+            segment = x/x_size + y_segment
+            section = int(segment) % pattern_segments
+            enabled = section == 1
+            if invert ^ enabled:
+                buf[offset + x] = 255
 
 
 def quad(buf: BufType, width: int, height: int, x: int = 0, y: int = 0) -> None:

--- a/kitty/fonts/box_drawing.py
+++ b/kitty/fonts/box_drawing.py
@@ -865,6 +865,7 @@ box_chars: Dict[str, List[Callable[[BufType, int, int], Any]]] = {
     '░': [p(shade, light=True)],
     '▒': [shade],
     '▓': [p(shade, light=True, invert=True)],
+    '🮐': [p(shade, invert=True)],
     '▔': [p(eight_bar, horizontal=True)],
     '▕': [p(eight_bar, which=7)],
     '▖': [p(quad, y=1)],

--- a/kitty/fonts/box_drawing.py
+++ b/kitty/fonts/box_drawing.py
@@ -617,37 +617,18 @@ def shade(buf: BufType, width: int, height: int, light: bool = False, invert: bo
     square_sz = max(1, width // 12)
     number_of_rows = height // square_sz
     number_of_cols = width // square_sz
-    nums = tuple(range(square_sz))
-
-    dest = bytearray(width * height) if invert else buf
+    nums = range(square_sz)
 
     for r in range(number_of_rows):
-        is_odd = r % 2 != 0
-        if is_odd:
-            continue
-        fill_even = r % 4 == 0
-        for yr in nums:
-            y = r * square_sz + yr
-            if y >= height:
-                break
-            off = width * y
-            for c in range(number_of_cols):
-                if light:
-                    fill = (c % 4) == (0 if fill_even else 2)
-                else:
-                    fill = (c % 2 == 0) == fill_even
-                if fill:
-                    for xc in nums:
-                        x = (c * square_sz) + xc
-                        if x >= width:
-                            break
-                        dest[off + x] = 255
-    if invert:
-        for y in range(height):
-            off = width * y
-            for x in range(width):
-                q = off + x
-                buf[q] = 255 - dest[q]
+        for c in range(number_of_cols):
+            if invert ^ ((r % 2 != c % 2) or (light and r % 2 == 1)):
+                continue
+            for yr in nums:
+                y = r * square_sz + yr
+                offset = width * y
+                for xc in nums:
+                    x = c * square_sz + xc
+                    buf[offset + x] = 255
 
 
 def quad(buf: BufType, width: int, height: int, x: int = 0, y: int = 0) -> None:
@@ -883,7 +864,7 @@ box_chars: Dict[str, List[Callable[[BufType, int, int], Any]]] = {
     '▐': [p(eight_block, which=(4, 5, 6, 7))],
     '░': [p(shade, light=True)],
     '▒': [shade],
-    '▓': [p(shade, invert=True)],
+    '▓': [p(shade, light=True, invert=True)],
     '▔': [p(eight_bar, horizontal=True)],
     '▕': [p(eight_bar, which=7)],
     '▖': [p(quad, y=1)],

--- a/kitty/fonts/box_drawing.py
+++ b/kitty/fonts/box_drawing.py
@@ -613,20 +613,22 @@ def inner_corner(buf: BufType, width: int, height: int, which: str = 'tl', level
     draw_vline(buf, width, y1, y2, width // 2 + (xd * hgap), level)
 
 
-@supersampled()
 def shade(buf: BufType, width: int, height: int, light: bool = False, invert: bool = False) -> None:
-    x_size = width / 4
-    y_size = height / 8
-    pattern_segments = 4 if light else 2
-    for y in range(height):
-        y_segment = y / y_size
-        offset = y * width
-        for x in range(width):
-            segment = x/x_size + y_segment
-            section = int(segment) % pattern_segments
-            enabled = section == 1
-            if invert ^ enabled:
-                buf[offset + x] = 255
+    square_sz = max(1, width // 12)
+    number_of_rows = height // square_sz
+    number_of_cols = width // square_sz
+    nums = range(square_sz)
+
+    for r in range(number_of_rows):
+        for c in range(number_of_cols):
+            if invert ^ ((r % 2 != c % 2) or (light and r % 2 == 1)):
+                continue
+            for yr in nums:
+                y = r * square_sz + yr
+                offset = width * y
+                for xc in nums:
+                    x = c * square_sz + xc
+                    buf[offset + x] = 255
 
 
 def quad(buf: BufType, width: int, height: int, x: int = 0, y: int = 0) -> None:


### PR DESCRIPTION
Addresses discussion here: https://github.com/kovidgoyal/kitty/pull/6146#issuecomment-1489047598. (Sorry for taking so long on submitting this PR; I was busy with classes).

The characters were implemented as a checkerboard of the correct fill density (like in the example characters in the Standard), but this might look a little dated. Let me know if you want me change their appearance.
- Light shade: 25% fill
- Medium shade: 50% fill
- Dark shade: 75% fill (implemented as inverse of light shade)

Additionally, it is extremely easy to add support for the inverse medium shade character (`🮐`, U+1FB90) now, as it should just be `[p(shade, invert=True)]`. Let me know if you want me to include that in this PR (I have also enabled "Allow edits by maintainers" if you want to add it yourself).