### PR TITLE
Add awrit, a graphical web browser that runs in Kitty, to the docs 

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -45,6 +45,7 @@ Some programs and libraries that use the kitty graphics protocol:
 * `term-image <https://github.com/AnonymouX47/term-image>`_  - A Python library, CLI and TUI to display and browse images in the terminal
 * `glkitty <https://github.com/michaeljclark/glkitty>`_ - C library to draw OpenGL shaders in the terminal with a glgears demo
 * `twitch-tui <https://github.com/Xithrius/twitch-tui>`_ - Twitch chat in the terminal
+* `awrit <https://github.com/chase/awrit>`_ - Chromium-based web browser rendered in Kitty with mouse and keyboard support
 
 Other terminals that have implemented the graphics protocol:
 

--- a/docs/keyboard-protocol.rst
+++ b/docs/keyboard-protocol.rst
@@ -47,6 +47,7 @@ In addition to kitty, this protocol is also implemented in:
 * The `dte text editor <https://gitlab.com/craigbarnes/dte/-/issues/138>`__
 * The `Helix text editor <https://github.com/helix-editor/helix/pull/4939>`__
 * The `far2l file manager <https://github.com/elfmz/far2l/commit/e1f2ee0ef2b8332e5fa3ad7f2e4afefe7c96fc3b>`__
+* The `awrit web browser <https://github.com/chase/awrit>`__
 
 .. versionadded:: 0.20.0
 


### PR DESCRIPTION
## awrit - graphical web browser in Kitty
I created [a fully interactive Chromium-based web browser called awrit](https://github.com/chase/awrit) that renders in Kitty using the enhanced graphics and keyboard protocols.

It started as a fun little side project, but it might prove to actually be pretty useful to others, so I thought it might be nice to share it.

---

On a side note: I really appreciate all the hard work the contributors have put into Kitty becoming one of the best terminal emulators out there. The fact this is even possible is testament to how flexible and powerful it is.