### PR TITLE
Correct typo in graphics protocol specification

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -542,7 +542,7 @@ and ``U+30D`` corresponds to ``1``. So these two commands create the following
 ``2x2`` placeholder:
 
 ========== ==========
-(0, 0)     (1, 0)
+(0, 0)     (0, 1)
 (1, 0)     (1, 1)
 ========== ==========
 


### PR DESCRIPTION
Correct swapped row/column index in description of virtual placements.