### PR TITLE
Skip crypto test if RLIMIT_MEMLOCK is too low

### DIFF
--- a/kitty_tests/crypto.py
+++ b/kitty_tests/crypto.py
@@ -3,12 +3,27 @@
 
 
 import os
+import unittest
 
 from . import BaseTest
 
 
+def is_rlimit_memlock_too_low() -> bool:
+    ''' On supported systems, return true if the MEMLOCK limit is too low to
+    run the crypto test. '''
+    try:
+        import resource
+    except ModuleNotFoundError:
+        return False
+
+    memlock_limit, _ = resource.getrlimit(resource.RLIMIT_MEMLOCK)
+    pagesize = resource.getpagesize()
+    return memlock_limit <= pagesize
+
+
 class TestCrypto(BaseTest):
 
+    @unittest.skipIf(is_rlimit_memlock_too_low(), 'RLIMIT_MEMLOCK is too low')
     def test_elliptic_curve_data_exchange(self):
         from kitty.fast_data_types import AES256GCMDecrypt, AES256GCMEncrypt, CryptoError, EllipticCurveKey
         alice = EllipticCurveKey()


### PR DESCRIPTION
Hello,

I talked about submitting a patch in https://github.com/kovidgoyal/kitty/issues/5466 but forgot to do it until today - so here it is.

On systems where the max locked memory (a.k.a., RLIMIT_MEMLOCK) is too low, the crypto test fails with "Cannot allocate memory".

Distros such as Debian and Ubuntu run the test-suite as part of the build process. This results in failed builds if the build machine itself does not have a sufficiently high value for RLIMIT_MEMLOCK. That said, the resulting builds would run perfectly when installed on machines that meet the requirements.

On supported systems, we now check if the RLIMIT_MEMLOCK is high enough and skip the crypto test if it is not.

NOTE: I only have access to Linux systems so I have run the test-suite only in Linux. I think it should work for other OSes too (this is the point of the `try... except NoduleNotFoundError` construct) but I haven't confirmed it.

```bash
$ ./test.py
[...]
test_elliptic_curve_data_exchange (kitty_tests.crypto.TestCrypto.test_elliptic_curve_data_exchange) ... ok

$ ulimit -l 4
$ ./test.py
[...]
test_elliptic_curve_data_exchange (kitty_tests.crypto.TestCrypto.test_elliptic_curve_data_exchange) ... skipped 'RLIMIT_MEMLOCK is too low'
```

Thanks!
Olivier