### PR TITLE
Buffer Overflow on screen.c

### DIFF
--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -1683,7 +1683,12 @@ screen_erase_in_display(Screen *self, unsigned int how, bool private) {
             return;
     }
     if (b > a) {
-        if (how != 3) screen_dirty_line_graphics(self, a, b);
+        if (how == 0) {
+            screen_dirty_line_graphics(self, a, self->lines - 1);
+        } else if (how != 3) {
+            screen_dirty_line_graphics(self, a, b);
+        }
+
         for (unsigned int i=a; i < b; i++) {
             linebuf_init_line(self->linebuf, i);
             if (private) {


### PR DESCRIPTION
This PR closes the issue #6306.

There is a buffer overflow on the function `screen_dirty_line_graphics`.

This function loops from `[top, bottom]` inclusive, but the function `screen_erase_in_display` calls `screen_dirty_line_graphics` for the range `[cursor, num_lines]`, causing a buffer overflow on `linebuf->line_attrs`.

Checking the value of `how` before calling the functions solves the issue, the other calls to `screen_dirty_line_graphics` seems fine.