### PR TITLE
Add option to enable/disable "fake" scroll

### DIFF
--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -936,7 +936,7 @@ scroll_event(double xoffset, double yoffset, int flags, int modifiers) {
                 }
             } else {
                 if (screen->linebuf == screen->main_linebuf) screen_history_scroll(screen, abs(s), upwards);
-                else fake_scroll(w, abs(s), upwards);
+                else if (OPT(wheel_scroll_use_fake)) fake_scroll(w, abs(s), upwards);
             }
         }
     }

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -420,6 +420,11 @@ negative number, the minimum number of lines will always be added.
 '''
     )
 
+opt('wheel_scroll_use_fake', 'yes',
+    option_type='to_bool', ctype='bool',
+    long_text='Perform a "fake" scroll if kitty is in alternate screen mode.'
+    )
+
 opt('touch_scroll_multiplier', '1.0',
     option_type='float', ctype='double',
     long_text='''

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -1332,6 +1332,9 @@ class Parser:
     def wheel_scroll_multiplier(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['wheel_scroll_multiplier'] = float(val)
 
+    def wheel_scroll_use_fake(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        ans['wheel_scroll_use_fake'] = to_bool(val)
+
     def window_alert_on_bell(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['window_alert_on_bell'] = to_bool(val)
 

--- a/kitty/options/to-c-generated.h
+++ b/kitty/options/to-c-generated.h
@@ -188,6 +188,19 @@ convert_from_opts_wheel_scroll_min_lines(PyObject *py_opts, Options *opts) {
 }
 
 static void
+convert_from_python_wheel_scroll_use_fake(PyObject *val, Options *opts) {
+    opts->wheel_scroll_use_fake = PyObject_IsTrue(val);
+}
+
+static void
+convert_from_opts_wheel_scroll_use_fake(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "wheel_scroll_use_fake");
+    if (ret == NULL) return;
+    convert_from_python_wheel_scroll_use_fake(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
 convert_from_python_touch_scroll_multiplier(PyObject *val, Options *opts) {
     opts->touch_scroll_multiplier = PyFloat_AsDouble(val);
 }
@@ -1074,6 +1087,8 @@ convert_opts_from_python_opts(PyObject *py_opts, Options *opts) {
     convert_from_opts_wheel_scroll_multiplier(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_wheel_scroll_min_lines(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_wheel_scroll_use_fake(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_touch_scroll_multiplier(py_opts, opts);
     if (PyErr_Occurred()) return false;

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -459,6 +459,7 @@ option_names = (  # {{{
  'wayland_titlebar_color',
  'wheel_scroll_min_lines',
  'wheel_scroll_multiplier',
+ 'wheel_scroll_use_fake',
  'window_alert_on_bell',
  'window_border_width',
  'window_logo_alpha',
@@ -471,16 +472,16 @@ option_names = (  # {{{
 
 
 class Options:
-    active_border_color: typing.Optional[kitty.fast_data_types.Color] = Color(0, 255, 0)
+    active_border_color: typing.Union[kitty.fast_data_types.Color, None] = Color(0, 255, 0)
     active_tab_background: Color = Color(238, 238, 238)
     active_tab_font_style: typing.Tuple[bool, bool] = (True, True)
     active_tab_foreground: Color = Color(0, 0, 0)
-    active_tab_title_template: typing.Optional[str] = None
+    active_tab_title_template: typing.Union[str, None] = None
     allow_cloning: choices_for_allow_cloning = 'ask'
     allow_hyperlinks: int = 1
     allow_remote_control: choices_for_allow_remote_control = 'no'
     background: Color = Color(0, 0, 0)
-    background_image: typing.Optional[str] = None
+    background_image: typing.Union[str, None] = None
     background_image_layout: choices_for_background_image_layout = 'tiled'
     background_image_linear: bool = False
     background_opacity: float = 1.0
@@ -488,7 +489,7 @@ class Options:
     background_tint_gaps: float = 1.0
     bell_border_color: Color = Color(255, 90, 0)
     bell_on_tab: str = '🔔 '
-    bell_path: typing.Optional[str] = None
+    bell_path: typing.Union[str, None] = None
     bold_font: str = 'auto'
     bold_italic_font: str = 'auto'
     box_drawing_scale: typing.Tuple[float, float, float, float] = (0.001, 1.0, 1.5, 2.0)
@@ -502,16 +503,16 @@ class Options:
     command_on_bell: typing.List[str] = ['none']
     confirm_os_window_close: int = -1
     copy_on_select: str = ''
-    cursor: typing.Optional[kitty.fast_data_types.Color] = Color(204, 204, 204)
+    cursor: typing.Union[kitty.fast_data_types.Color, None] = Color(204, 204, 204)
     cursor_beam_thickness: float = 1.5
     cursor_blink_interval: float = -1.0
     cursor_shape: int = 1
     cursor_stop_blinking_after: float = 15.0
-    cursor_text_color: typing.Optional[kitty.fast_data_types.Color] = Color(17, 17, 17)
+    cursor_text_color: typing.Union[kitty.fast_data_types.Color, None] = Color(17, 17, 17)
     cursor_underline_thickness: float = 2.0
     default_pointer_shape: choices_for_default_pointer_shape = 'beam'
     detect_urls: bool = True
-    dim_opacity: float = 0.75
+    dim_opacity: float = 0.4
     disable_ligatures: int = 0
     draw_minimal_borders: bool = True
     dynamic_background_opacity: bool = False
@@ -571,20 +572,20 @@ class Options:
     scrollback_pager_history_size: int = 0
     select_by_word_characters: str = '@-./_~?&=%+#'
     select_by_word_characters_forward: str = ''
-    selection_background: typing.Optional[kitty.fast_data_types.Color] = Color(255, 250, 205)
-    selection_foreground: typing.Optional[kitty.fast_data_types.Color] = Color(0, 0, 0)
+    selection_background: typing.Union[kitty.fast_data_types.Color, None] = Color(255, 250, 205)
+    selection_foreground: typing.Union[kitty.fast_data_types.Color, None] = Color(0, 0, 0)
     shell: str = '.'
     shell_integration: typing.FrozenSet[str] = frozenset({'enabled'})
     show_hyperlink_targets: bool = False
     single_window_margin_width: FloatEdges = FloatEdges(left=-1.0, top=-1.0, right=-1.0, bottom=-1.0)
-    startup_session: typing.Optional[str] = None
+    startup_session: typing.Union[str, None] = None
     strip_trailing_spaces: choices_for_strip_trailing_spaces = 'never'
     sync_to_monitor: bool = True
     tab_activity_symbol: str = ''
     tab_bar_align: choices_for_tab_bar_align = 'left'
-    tab_bar_background: typing.Optional[kitty.fast_data_types.Color] = None
+    tab_bar_background: typing.Union[kitty.fast_data_types.Color, None] = None
     tab_bar_edge: int = 3
-    tab_bar_margin_color: typing.Optional[kitty.fast_data_types.Color] = None
+    tab_bar_margin_color: typing.Union[kitty.fast_data_types.Color, None] = None
     tab_bar_margin_height: TabBarMarginHeight = TabBarMarginHeight(outer=0, inner=0)
     tab_bar_margin_width: float = 0
     tab_bar_min_tabs: int = 2
@@ -605,16 +606,17 @@ class Options:
     url_excluded_characters: str = ''
     url_prefixes: typing.Tuple[str, ...] = ('file', 'ftp', 'ftps', 'gemini', 'git', 'gopher', 'http', 'https', 'irc', 'ircs', 'kitty', 'mailto', 'news', 'sftp', 'ssh')
     url_style: int = 3
-    visual_bell_color: typing.Optional[kitty.fast_data_types.Color] = None
+    visual_bell_color: typing.Union[kitty.fast_data_types.Color, None] = None
     visual_bell_duration: float = 0
     visual_window_select_characters: str = '1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ'
     wayland_titlebar_color: int = 0
     wheel_scroll_min_lines: int = 1
     wheel_scroll_multiplier: float = 5.0
+    wheel_scroll_use_fake: bool = True
     window_alert_on_bell: bool = True
     window_border_width: typing.Tuple[float, str] = (0.5, 'pt')
     window_logo_alpha: float = 0.5
-    window_logo_path: typing.Optional[str] = None
+    window_logo_path: typing.Union[str, None] = None
     window_logo_position: choices_for_window_logo_position = 'bottom-right'
     window_margin_width: FloatEdges = FloatEdges(left=0, top=0, right=0, bottom=0)
     window_padding_width: FloatEdges = FloatEdges(left=0, top=0, right=0, bottom=0)

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -27,6 +27,7 @@ typedef struct {
     monotonic_t visual_bell_duration, cursor_blink_interval, cursor_stop_blinking_after, mouse_hide_wait, click_interval;
     double wheel_scroll_multiplier, touch_scroll_multiplier;
     int wheel_scroll_min_lines;
+    bool wheel_scroll_use_fake;
     bool enable_audio_bell;
     CursorShape cursor_shape;
     float cursor_beam_thickness;


### PR DESCRIPTION
This change adds a new boolean option "wheel_scroll_use_fake" which, when set to "no", will disable the "fake" scroll that is performed when Kitty is in "alternate screen" mode.

NOTE: Since this option's default value is "yes", this change will
      not alter Kitty's behavior unless "wheel_scroll_use_fake" is
      explicitly set to "no".