### PR TITLE
fix: fallback to en_US when locale code is invalid

### DIFF
--- a/kitty/main.py
+++ b/kitty/main.py
@@ -297,10 +297,7 @@ def ensure_macos_locale() -> None:
         lang = cocoa_get_lang()
         if lang is not None:
             if not locale_is_valid(lang):
-                if lang.startswith('en_'):
-                    lang = 'en_US'
-                else:
-                    log_error(f'Could not set LANG Cocoa returns language as: {lang}')
+                lang = 'en_US'
             os.environ['LANG'] = f'{lang}.UTF-8'
             set_LANG_in_default_env(os.environ['LANG'])
 


### PR DESCRIPTION
https://github.com/kovidgoyal/kitty/commit/9e7253c179e883157b4f7bcb6d02c8d7c4fd009e fix a situation where a valid locale code could not be formed with the country when the language was `en`.

But this does not actually only happen when the language is `en`. 

If the language is `zh`(Chinese) and the country is US, then the locale code `zh_US` is invalid. This will result in [the situation mentioned in the FAQ where double-wide characters cannot be entered and the locale code must be set manually](https://sw.kovidgoyal.net/kitty/faq/#i-get-errors-about-the-terminal-being-unknown-or-opening-the-terminal-failing-or-functional-keys-like-arrow-keys-don-t-work) and make it impossible to enter CJK text.

---

I think this situation in the FAQ is entirely due to the invalid locale code, but suggest keeping this section for now in case there are other unknown reasons for this situation as well.