### PR TITLE
Enable shadow for transparent window on macOS (fix #2827)

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -1825,7 +1825,7 @@ static bool createNativeWindow(_GLFWwindow* window,
     {
         [window->ns.object setOpaque:NO];
         [window->ns.object setHasShadow:YES];
-        [window->ns.object setBackgroundColor:[NSColor clearColor]];
+        [window->ns.object setBackgroundColor:[NSColor colorWithWhite: 0 alpha: 0.001f]];
     }
 
     [window->ns.object setContentView:window->ns.view];

--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -1824,7 +1824,7 @@ static bool createNativeWindow(_GLFWwindow* window,
     if (fbconfig->transparent)
     {
         [window->ns.object setOpaque:NO];
-        [window->ns.object setHasShadow:NO];
+        [window->ns.object setHasShadow:YES];
         [window->ns.object setBackgroundColor:[NSColor clearColor]];
     }
 


### PR DESCRIPTION
This PR enables the window shadow on macOS when `background_opacity` is set to a value smaller than 1.0.
Related issue was discussed in #2827.

A comparison is as follows.
<img width="1794" alt="image" src="https://github.com/kovidgoyal/kitty/assets/5498199/96887ffd-5cba-4dab-b5e3-5eb46dd27612">
