### PR TITLE
use 64-bit off_t by default and stop using lfs64 interface

### DIFF
--- a/kitty/fast-file-copy.c
+++ b/kitty/fast-file-copy.c
@@ -83,7 +83,7 @@ copy_with_file_range(int infd, int outfd, off_t in_pos, size_t len, FastFileCopy
 #ifdef HAS_COPY_FILE_RANGE
     unsigned num_of_consecutive_zero_returns = 128;
     while (len) {
-        off64_t r = in_pos;
+        off_t r = in_pos;
         ssize_t n = copy_file_range(infd, &r, outfd, NULL, len, 0);
         if (n < 0) {
             if (errno == EAGAIN) continue;

--- a/setup.py
+++ b/setup.py
@@ -382,7 +382,7 @@ def init_env(
         'OVERRIDE_CFLAGS', (
             f'-Wextra {float_conversion} -Wno-missing-field-initializers -Wall -Wstrict-prototypes {std}'
             f' {werror} {optimize} {sanitize_flag} -fwrapv {stack_protector} {missing_braces}'
-            f' -pipe {march} -fvisibility=hidden {fortify_source}'
+            f' -pipe {march} -D_FILE_OFFSET_BITS=64 -fvisibility=hidden {fortify_source}'
         )
     )
     cflags = shlex.split(cflags_) + shlex.split(


### PR DESCRIPTION
fixes the build against musl 1.2.4  

```
kitty/fast-file-copy.c:86:9: error: unknown type name 'off64_t'; did you mean 'off_t'?
   86 |         off64_t r = in_pos;
      |         ^~~~~~~
      |         off_t
```

this is because the \*64 names are no longer exposed by default https://github.com/bminor/musl/commit/25e6fee27f4a293728dd15b659170e7b9c7db9bc