### PR TITLE
fix CENTER_CLAMPED background image layout and add CENTER_SCALED option

### DIFF
--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -70,7 +70,7 @@ typedef enum MouseTrackingModes { NO_TRACKING, BUTTON_MODE, MOTION_MODE, ANY_MOD
 typedef enum MouseTrackingProtocols { NORMAL_PROTOCOL, UTF8_PROTOCOL, SGR_PROTOCOL, URXVT_PROTOCOL, SGR_PIXEL_PROTOCOL} MouseTrackingProtocol;
 typedef enum MouseShapes { BEAM, HAND, ARROW } MouseShape;
 typedef enum { NONE, MENUBAR, WINDOW, ALL } WindowTitleIn;
-typedef enum { TILING, SCALED, MIRRORED, CLAMPED, CENTER_CLAMPED } BackgroundImageLayout;
+typedef enum { TILING, SCALED, MIRRORED, CLAMPED, CENTER_CLAMPED, CENTER_SCALED } BackgroundImageLayout;
 typedef struct ImageAnchorPosition {
     float canvas_x, canvas_y, image_x, image_y;
 } ImageAnchorPosition;

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -77,7 +77,7 @@ class Parser:
             raise ValueError(f"The value {val} is not a valid choice for background_image_layout")
         ans["background_image_layout"] = val
 
-    choices_for_background_image_layout = frozenset(('mirror-tiled', 'scaled', 'tiled', 'clamped', 'centered'))
+    choices_for_background_image_layout = frozenset(('mirror-tiled', 'scaled', 'tiled', 'clamped', 'centered', 'cscaled'))
 
     def background_image_linear(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['background_image_linear'] = to_bool(val)

--- a/kitty/options/to-c.h
+++ b/kitty/options/to-c.h
@@ -65,7 +65,7 @@ bglayout(PyObject *layout_name) {
         case 'm': return MIRRORED;
         case 's': return SCALED;
         case 'c': {
-            return name[1] == 'l' ? CLAMPED : CENTER_CLAMPED;
+            return name[1] == 'l' ? CLAMPED : (name[1] == 's' ? CENTER_SCALED : CENTER_CLAMPED);
         }
         default: break;
     }

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -431,13 +431,13 @@ draw_background_image(OSWindow *w) {
     GLfloat iheight = (GLfloat)w->bgimage->height;
     GLfloat vwidth = (GLfloat)window_width;
     GLfloat vheight = (GLfloat)window_height;
-    if (OPT(background_image_layout) == CENTER_SCALED) {
+    if (CENTER_SCALED == OPT(background_image_layout)) {
       GLfloat ifrac = iwidth / iheight;
       if (ifrac > (vwidth / vheight)) {
         iheight = vheight;
         iwidth = iheight * ifrac;
       } else {
-        iwidth = (GLfloat)window_width;
+        iwidth = vwidth;
         iheight = iwidth / ifrac;
       }
     }

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -427,8 +427,22 @@ draw_background_image(OSWindow *w) {
 #else
     int window_width = w->viewport_width, window_height = w->viewport_height;
 #endif
+    GLfloat iwidth = (GLfloat)w->bgimage->width;
+    GLfloat iheight = (GLfloat)w->bgimage->height;
+    GLfloat vwidth = (GLfloat)window_width;
+    GLfloat vheight = (GLfloat)window_height;
+    if (OPT(background_image_layout) == CENTER_SCALED) {
+      GLfloat ifrac = iwidth / iheight;
+      if (ifrac > (vwidth / vheight)) {
+        iheight = vheight;
+        iwidth = iheight * ifrac;
+      } else {
+        iwidth = (GLfloat)window_width;
+        iheight = iwidth / ifrac;
+      }
+    }
     glUniform4f(bgimage_program_layout.uniforms.sizes,
-        (GLfloat)window_width, (GLfloat)window_height, (GLfloat)w->bgimage->width, (GLfloat)w->bgimage->height);
+        vwidth, vheight, iwidth, iheight);
     glUniform1f(bgimage_program_layout.uniforms.premult, w->is_semi_transparent ? 1.f : 0.f);
     GLfloat tiled = 0.f;;
     GLfloat left = -1.0, top = 1.0, right = 1.0, bottom = -1.0;
@@ -438,15 +452,14 @@ draw_background_image(OSWindow *w) {
         case SCALED:
             tiled = 0.f; break;
         case CENTER_CLAMPED:
-            tiled = 1.f;
-            if (window_width > (int)w->bgimage->width) {
-                GLfloat frac = (window_width - w->bgimage->width) / (GLfloat)window_width;
-                left += frac; right += frac;
-            }
-            if (window_height > (int)w->bgimage->height) {
-                GLfloat frac = (window_height - w->bgimage->height) / (GLfloat)window_height;
-                top -= frac; bottom -= frac;
-            }
+        case CENTER_SCALED:
+            tiled = 0.f;
+            GLfloat wfrac = (vwidth - iwidth) / vwidth;
+            GLfloat hfrac = (vheight - iheight) / vheight;
+            left += wfrac;
+            right -= wfrac;
+            top -= hfrac;
+            bottom += hfrac;
             break;
     }
     glUniform1f(bgimage_program_layout.uniforms.tiled, tiled);

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -169,7 +169,9 @@ send_bgimage_to_gpu(BackgroundImageLayout layout, BackgroundImage *bgimage) {
     RepeatStrategy r = REPEAT_DEFAULT;
     switch (layout) {
         case SCALED:
-        case CLAMPED: case CENTER_CLAMPED:
+        case CLAMPED:
+        case CENTER_CLAMPED:
+        case CENTER_SCALED:
             r = REPEAT_CLAMP; break;
         case MIRRORED:
             r = REPEAT_MIRROR; break;


### PR DESCRIPTION
Currently `centered` (`CENTER_CLAMPED`) layout option works only for backgrounds less than window size. This pull-request fixes that to work with any background image sizes. Also it adds one new `background_image_layout` option `cscaled` (`CENTER_SCALED`). This new option scales the background image to fill the window as `scaled` do but with proportions of initial background image and centering it in the view.