### PR TITLE
X11: Add support for custom window icon

### DIFF
--- a/kitty/notify.py
+++ b/kitty/notify.py
@@ -10,7 +10,7 @@ from typing import Callable, Dict, Optional
 from .constants import is_macos, logo_png_file
 from .fast_data_types import get_boss
 from .types import run_once
-from .utils import log_error
+from .utils import get_custom_window_icon, log_error
 
 NotifyImplementation = Callable[[str, str, str], None]
 
@@ -57,7 +57,7 @@ else:
     ) -> None:
         icf = ''
         if icon is True:
-            icf = logo_png_file
+            icf = get_custom_window_icon()[1] or logo_png_file
         alloc_id = dbus_send_notification(application, icf, title, body, 'Click to see changes', timeout)
         if alloc_id and identifier is not None:
             alloc_map[alloc_id] = identifier

--- a/kitty/utils.py
+++ b/kitty/utils.py
@@ -1183,3 +1183,23 @@ def cmdline_for_hold(cmd: Sequence[str] = (), opts: Optional['Options'] = None) 
     import shlex
     shell = shlex.join(resolved_shell(opts))
     return [kitten_exe(), 'run-shell', f'--shell={shell}', f'--shell-integration={ksi}'] + list(cmd)
+
+
+def safe_mtime(path: str) -> Optional[float]:
+    with suppress(OSError):
+        return os.path.getmtime(path)
+    return None
+
+
+@run_once
+def get_custom_window_icon() -> Union[Tuple[float, str], Tuple[None, None]]:
+    filenames = ['kitty.app.png']
+    if is_macos:
+        # On macOS, prefer icns to png.
+        filenames.insert(0, 'kitty.app.icns')
+    for name in filenames:
+        custom_icon_path = os.path.join(config_dir, name)
+        custom_icon_mtime = safe_mtime(custom_icon_path)
+        if custom_icon_mtime is not None:
+            return custom_icon_mtime, custom_icon_path
+    return None, None


### PR DESCRIPTION
I'm just getting into kitty and, while reading the FAQ, I fell in love with DinkDonk's "dark kitty" icon. Imagine my dismay when, after successfully setting it as the launch and taskbar icon, I discovered that a custom *window* icon is supported in macOS, but not X11!

![kitty window without custom icon 😞](https://github.com/kovidgoyal/kitty/assets/275142/088e202c-0d22-425d-9c67-e718f136832e)

This PR changes that. It uses the same logic (and filename) to locate a custom icon to use for X11. Specifically:

- For OS windows under X11, if a file named `<config_dir>/kitty.app.png` or `<config_dir>/kitty.app-128.png` exists (preferring the 128px image, per the note in the source[^1]), it will be set as the window icon. Otherwise, the 128px version of `logo_png_file` (`<base_dir>/logo/kitty-128.png`) is used.
- For notifications under X11, when `icon=True`, if a file named `<config_dir>/kitty.app.png` exists, it will be set as the notification icon. Otherwise, `logo_png_file` (`<base_dir>/logo/kitty.png`) is used.
- If no files named `<config_dir>/kitty.app.png` or `<config_dir>/kitty.app-128.png` exist, kitty's behavior under X11 remains unchanged.
- Under macOS, nothing should change (though some refactoring occurred), but I don't currently have access to a Mac to test this.
- Under Wayland, nothing should change, but I don't currently have access to a Wayland host, either.

![kitty window with custom icon 😻](https://github.com/kovidgoyal/kitty/assets/275142/c10f8370-fd74-4f56-ad08-f784ae26f06f)

[^1]: For what it's worth, I'm running 64-bit X11 and had no issues setting the window icon to a 1024px image, but I've retained the preference for 128px images on the theory that it may still be an issue for some others.