### PR TITLE
added missing "Extending with kittens" docs link

### DIFF
--- a/docs/kittens_intro.rst
+++ b/docs/kittens_intro.rst
@@ -37,6 +37,10 @@ Some prominent kittens:
     Easily input arbitrary Unicode characters in |kitty| by name or hex code.
 
 
+:doc:`Themes <kittens/themes>`
+    Preview, select and quick switch between two hundred pre-build color themes.
+
+
 :doc:`Hints <kittens/hints>`
     Select and open/paste/insert arbitrary text snippets such as URLs,
     filenames, words, lines, etc. from the terminal screen.


### PR DESCRIPTION
[Changing kittens colors](https://sw.kovidgoyal.net/kitty/kittens/themes/) appears in the navigation bar of [Extend with kittens](https://sw.kovidgoyal.net/kitty/kittens_intro/), but is missing from the actual page.