### PR TITLE
cli/command: remove redundant nil check

### DIFF
--- a/tools/cli/command.go
+++ b/tools/cli/command.go
@@ -417,12 +417,9 @@ func (self *Command) FindOptions(name_with_hyphens string) []*Option {
 	depth := 0
 	for p := self.Parent; p != nil; p = p.Parent {
 		depth++
-		x := p.FindOptions(name_with_hyphens)
-		if x != nil {
-			for _, po := range x {
-				if po.Depth >= depth {
-					ans = append(ans, po)
-				}
+		for _, po := range p.FindOptions(name_with_hyphens) {
+			if po.Depth >= depth {
+				ans = append(ans, po)
 			}
 		}
 	}


### PR DESCRIPTION
From the Go specification:

> "1. For a nil slice, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary. Example: https://go.dev/play/p/UkEZpnzmm5a