### PR TITLE
Config line breaks

### DIFF
--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -32,6 +32,9 @@ Comments can be added to the config file as lines starting with the ``#``
 character. This works only if the ``#`` character is the first character in the
 line.
 
+Lines can be split by starting the next line with the ``\\`` character.
+All leading whitespace and the ``\\`` character are removed.
+
 .. _include:
 
 You can include secondary config files via the :code:`include` directive. If

--- a/kittens/ssh/config_test.go
+++ b/kittens/ssh/config_test.go
@@ -47,6 +47,24 @@ func TestSSHConfigParsing(t *testing.T) {
 	rt()
 	conf = "env a=b"
 	rt(`export 'a'="b"`)
+
+	conf = "env a=\\"
+	rt(`export 'a'="\\"`)
+	conf = `env
+		\ a=
+		\\`
+	conf = "env\n \t \\ a=\n\\\\"
+	rt(`export 'a'="\\"`)
+	conf = `
+		e
+		\n
+		\v
+		\ a
+		\=
+		\\
+		\`
+	rt(`export 'a'="\\"`)
+
 	conf = "env a=b\nhostname 2\nenv a=c\nenv b=b"
 	rt(`export 'a'="b"`)
 	hostname = "2"

--- a/kitty/conf/utils.py
+++ b/kitty/conf/utils.py
@@ -262,14 +262,50 @@ def _parse(
     else:
         from ..constants import config_dir
         base_path_for_includes = config_dir
-    for i, line in enumerate(lines):
+
+    it = iter(lines)
+    line: str;
+    nextLine: str = ""
+    nextLineNum = 0;
+
+    while True:
         try:
-            with currently_parsing.set_line(line, i + 1):
-                parse_line(line, parse_conf_item, ans, base_path_for_includes, accumulate_bad_lines)
-        except Exception as e:
-            if accumulate_bad_lines is None:
-                raise
-            accumulate_bad_lines.append(BadLine(i + 1, line.rstrip(), e, currently_parsing.file))
+            if nextLine != "":
+                line = nextLine
+            else:
+                line = next(it).lstrip()
+                nextLineNum += 1
+            lineNum = nextLineNum
+
+            try:
+                nextLine = next(it).lstrip()
+                nextLineNum += 1
+
+                while nextLine.startswith('\\'):
+                    if line.endswith("\n"):
+                        line = line[:-1]
+                    line += nextLine[1:]
+                    try:
+                        nextLine = next(it).lstrip()
+                        nextLineNum += 1
+                    except StopIteration:
+                        nextLine = ""
+                        break
+            except StopIteration:
+                nextLine = ""
+                pass
+
+            # code
+
+            try:
+                with currently_parsing.set_line(line, lineNum):
+                    parse_line(line, parse_conf_item, ans, base_path_for_includes, accumulate_bad_lines)
+            except Exception as e:
+                if accumulate_bad_lines is None:
+                    raise
+                accumulate_bad_lines.append(BadLine(lineNum, line.rstrip(), e, currently_parsing.file))
+        except StopIteration:
+            break
 
 
 def parse_config_base(

--- a/kitty/conf/utils.py
+++ b/kitty/conf/utils.py
@@ -264,9 +264,9 @@ def _parse(
         base_path_for_includes = config_dir
 
     it = iter(lines)
-    line: str;
+    line: str
     nextLine: str = ""
-    nextLineNum = 0;
+    nextLineNum = 0
 
     while True:
         try:
@@ -294,8 +294,6 @@ def _parse(
             except StopIteration:
                 nextLine = ""
                 pass
-
-            # code
 
             try:
                 with currently_parsing.set_line(line, lineNum):

--- a/kitty_tests/options.py
+++ b/kitty_tests/options.py
@@ -124,3 +124,16 @@ class TestConfParsing(BaseTest):
         opts = p('macos_hide_titlebar y' if is_macos else 'x11_hide_window_decorations y')
         self.assertTrue(opts.hide_window_decorations)
         self.ae(len(self.error_messages), 1)
+
+        # line breaks
+        opts = p("    font",
+                 " \t  \t    \\_size",
+                 "    \\ 12",
+                 "\\.35",
+                 "col",
+                 "\\o",
+                 "\t \t\\r",
+                 "\\25",
+                 " \\ blue")
+        self.ae(opts.font_size, 12.35)
+        self.ae(opts.color25, Color(0, 0, 255))

--- a/tools/config/api_test.go
+++ b/tools/config/api_test.go
@@ -19,13 +19,18 @@ func TestConfigParsing(t *testing.T) {
 	os.Mkdir(filepath.Join(tdir, "sub"), 0o700)
 	os.WriteFile(conf_file, []byte(
 		`error main
-# ignore me
+# igno
+     \re me
 a one
 #: other
-include sub/b.conf
+include
+\ sub/b.conf
 b
-include non-existent
-globinclude sub/c?.conf
+include non-exis
+\tent
+globin
+\clude sub/c?.c
+   \onf
 `), 0o600)
 	os.WriteFile(filepath.Join(tdir, "sub/b.conf"), []byte("incb cool\ninclude a.conf"), 0o600)
 	os.WriteFile(filepath.Join(tdir, "sub/c1.conf"), []byte("inc1 cool"), 0o600)


### PR DESCRIPTION
This pull requests adds the line break syntax proposed in #6600.

With these changes, lines beginning with a backslash will be joined with the line above. The leading whitespace and backslash are removed.

```
map ctrl+1 combine
    \ : send_text all \
    \ : set_colors ~/path/to/theme.conf

becomes

map ctrl+1 combine : send_text all \ : set_colors ~/path/to/theme.conf
```

No whitespace is added upon line joining which allows for word breaks.

```
map ctrl+1 send_
    \text all \

becomes

map ctrl+1 send_text all \
```

The changes affect both the python and go config parsers.
These changes pass all tests as well as some additional ones.