### PR TITLE
Graphics protocol: add image chains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ __pycache__/
 .cache
 bypy/b
 bypy/virtual-machines.conf
+.idea

--- a/gen-apc-parsers.py
+++ b/gen-apc-parsers.py
@@ -276,6 +276,10 @@ def graphics_parser() -> None:
         'z': ('z_index', 'int'),
         'C': ('cursor_movement', 'uint'),
         'U': ('unicode_placement', 'uint'),
+        'P': ('parent_id', 'uint'),
+        'g': ('parent_placement_id', 'uint'),
+        'j': ('parent_offset_x', 'int'),
+        'k': ('parent_offset_y', 'int')
     }
     text = generate('parse_graphics_code', 'screen_handle_graphics_command', 'graphics_command', keymap, 'GraphicsCommand')
     write_header(text, 'kitty/parse-graphics-command.h')

--- a/kitty/graphics.h
+++ b/kitty/graphics.h
@@ -22,6 +22,8 @@ typedef struct {
     union { int32_t z_index, gap; };
     size_t payload_sz;
     bool unicode_placement;
+    uint32_t parent_id, parent_placement_id;
+    int32_t parent_offset_x, parent_offset_y;
 } GraphicsCommand;
 
 typedef struct {
@@ -41,7 +43,23 @@ typedef struct {
     // Virtual refs are not displayed but they can be used as prototypes for
     // refs placed using unicode placeholders.
     bool is_virtual_ref;
+    // Image chains:
+    struct {
+      uint32_t id, placement_id;
+      int32_t row_offset, col_offset;
+    } parent, root;
+    struct {
+      size_t capacity, count;
+      struct {
+        uint32_t id, placement_id;
+      } *data;
+    } children;
+    // Real refs that were created by a virtual ref, and are part of an image
+    // chain
+    bool is_source_virtual;
 } ImageRef;
+
+
 
 typedef struct {
     uint32_t gap, id, width, height, x, y, base_frame_id, bgcolor;
@@ -67,6 +85,12 @@ typedef struct {
     uint32_t max_loops, current_loop;
     monotonic_t current_frame_shown_at;
 } Image;
+
+typedef struct {
+    Image *img;
+    ImageRef *ref;
+    ImageRef *parent;
+} ImageChainData;
 
 typedef struct {
     uint32_t texture_id;

--- a/kitty/parse-graphics-command.h
+++ b/kitty/parse-graphics-command.h
@@ -40,7 +40,11 @@ static inline void parse_graphics_code(Screen *screen,
     cell_y_offset = 'Y',
     z_index = 'z',
     cursor_movement = 'C',
-    unicode_placement = 'U'
+    unicode_placement = 'U',
+    parent_id = 'P',
+    parent_placement_id = 'g',
+    parent_offset_x = 'j',
+    parent_offset_y = 'k'
   };
 
   enum KEYS key = 'a';
@@ -127,6 +131,18 @@ static inline void parse_graphics_code(Screen *screen,
         break;
       case unicode_placement:
         value_state = UINT;
+        break;
+      case parent_id:
+        value_state = UINT;
+        break;
+      case parent_placement_id:
+        value_state = UINT;
+        break;
+      case parent_offset_x:
+        value_state = INT;
+        break;
+      case parent_offset_y:
+        value_state = INT;
         break;
       default:
         REPORT_ERROR("Malformed GraphicsCommand control block, invalid key "
@@ -240,6 +256,8 @@ static inline void parse_graphics_code(Screen *screen,
       READ_UINT;
       switch (key) {
         I(z_index);
+        I(parent_offset_x);
+        I(parent_offset_y);
       default:
         break;
       }
@@ -273,6 +291,8 @@ static inline void parse_graphics_code(Screen *screen,
         U(cell_y_offset);
         U(cursor_movement);
         U(unicode_placement);
+        U(parent_id);
+        U(parent_placement_id);
       default:
         break;
       }
@@ -332,7 +352,7 @@ static inline void parse_graphics_code(Screen *screen,
 
   REPORT_VA_COMMAND(
       "s {sc sc sc sc sI sI sI sI sI sI sI sI sI sI sI sI sI sI sI sI sI sI sI "
-      "sI si sI} y#",
+      "sI sI sI si si si sI} y#",
       "graphics_command", "action", g.action, "delete_action", g.delete_action,
       "transmission_type", g.transmission_type, "compressed", g.compressed,
       "format", (unsigned int)g.format, "more", (unsigned int)g.more, "id",
@@ -347,8 +367,11 @@ static inline void parse_graphics_code(Screen *screen,
       (unsigned int)g.num_lines, "cell_x_offset", (unsigned int)g.cell_x_offset,
       "cell_y_offset", (unsigned int)g.cell_y_offset, "cursor_movement",
       (unsigned int)g.cursor_movement, "unicode_placement",
-      (unsigned int)g.unicode_placement, "z_index", (int)g.z_index,
-      "payload_sz", g.payload_sz, payload, g.payload_sz);
+      (unsigned int)g.unicode_placement, "parent_id", (unsigned int)g.parent_id,
+      "parent_placement_id", (unsigned int)g.parent_placement_id, "z_index",
+      (int)g.z_index, "parent_offset_x", (int)g.parent_offset_x,
+      "parent_offset_y", (int)g.parent_offset_y, "payload_sz", g.payload_sz,
+      payload, g.payload_sz);
 
   screen_handle_graphics_command(screen, &g, payload);
 }

--- a/kitty_tests/parser.py
+++ b/kitty_tests/parser.py
@@ -420,7 +420,8 @@ class TestParser(BaseTest):
             for f in 'action delete_action transmission_type compressed'.split():
                 k.setdefault(f, b'\0')
             for f in ('format more id data_sz data_offset width height x_offset y_offset data_height data_width cursor_movement'
-                      ' num_cells num_lines cell_x_offset cell_y_offset z_index placement_id image_number quiet unicode_placement').split():
+                      ' num_cells num_lines cell_x_offset cell_y_offset z_index placement_id image_number quiet unicode_placement'
+                      ' parent_id parent_offset_x parent_offset_y parent_placement_id').split():
                 k.setdefault(f, 0)
             p = k.pop('payload', '').encode('utf-8')
             k['payload_sz'] = len(p)


### PR DESCRIPTION
This PR adds the ability to display images relative to other images, discussed a bit already in #6400.

- Images can be positioned relative to a parent image by passing `F=1` in a put command.
- You need reference the parent with its id (`e`) and placement id (`g`).
- You can add a cell offset relative to parent with the `j` and `k` keys, corresponding to x and y offset.
- If you move an image, all of its child will move with it.
- When an image is deleted, all of its child will also be deleted.

The code should work, but I only tested it with simple scenarios (mostly chains of lengths 1 starting with a unicode placeholder).

I'm making this a draft PR as there is still some small issues to be addressed: 
- There is a few recursive functions, they should probably be converted to iterative functions, or I can set a recursion limit.
- The control data keys used should probably be renamed to something else, but most meaningful letters are already used.
- I need to write some tests.
- I need to write the documentation for the website.

Please tell me if you have any suggestions or any more changes are needed.
