### PR TITLE
kitten: Use /dev/fd/2 for stderr

### DIFF
--- a/shell-integration/ssh/kitten
+++ b/shell-integration/ssh/kitten
@@ -6,7 +6,7 @@
 { \unalias command; \unset -f command; } >/dev/null 2>&1
 
 
-die() { printf "\033[31m%s\033[m\n\r" "$*" > /dev/stderr; exit 1; }
+die() { printf "\033[31m%s\033[m\n\r" "$*" > /dev/fd/2; exit 1; }
 
 exec_kitty() {
     [ -n "$kitty_exe" ] && exec "$kitty_exe" "$@"


### PR DESCRIPTION
This is a fix for termux under android:

> $ kitten --version
/data/data/com.termux/files/home/.local/share/kitty-ssh-kitten/kitty/bin/kitten: 9: cannot create /dev/stderr: Permission denied