### PR TITLE
kitten: Add armv7l alias to arm

### DIFF
--- a/shell-integration/ssh/kitten
+++ b/shell-integration/ssh/kitten
@@ -63,7 +63,7 @@ case "$(command uname -m)" in
     amd64|x86_64) arch="amd64";;
     aarch64*) arch="arm64";;
     armv8*) arch="arm64";;
-    arm) arch="arm";;
+    arm|armv7l) arch="arm";;
     i386) arch="386";;
     i686) arch="386";;
     *) die "Unknown CPU architecture $(command uname -m)";;


### PR DESCRIPTION
Fix `Unknown CPU architecture armv7l` on raspberry pi 400