### PR TITLE
Make build reproducible

### DIFF
--- a/gen-go-code.py
+++ b/gen-go-code.py
@@ -822,6 +822,7 @@ def generate_ssh_kitten_data() -> None:
     def normalize(t: tarfile.TarInfo) -> tarfile.TarInfo:
         t.uid = t.gid = 0
         t.uname = t.gname = ''
+        t.mtime = 0
         return t
 
     if newer(dest, *files):

--- a/setup.py
+++ b/setup.py
@@ -843,7 +843,7 @@ def build_ref_map(skip_generation: bool = False) -> str:
     dest = 'kitty/docs_ref_map_generated.h'
     if not skip_generation:
         d = extract_rst_targets()
-        h = 'static const char docs_ref_map[] = {\n' + textwrap.fill(', '.join(map(str, bytearray(json.dumps(d).encode('utf-8'))))) + '\n};\n'
+        h = 'static const char docs_ref_map[] = {\n' + textwrap.fill(', '.join(map(str, bytearray(json.dumps(d, sort_keys=True).encode('utf-8'))))) + '\n};\n'
         q = ''
         with suppress(FileNotFoundError), open(dest) as f:
             q = f.read()
@@ -868,7 +868,7 @@ def build_uniforms_header(skip_generation: bool = False) -> str:
             for x in m.group(1).split(','):
                 yield x.strip().partition('[')[0]
 
-    for x in glob.glob('kitty/*.glsl'):
+    for x in sorted(glob.glob('kitty/*.glsl')):
         name = os.path.basename(x).partition('.')[0]
         name, sep, shader_type = name.partition('_')
         if not sep or shader_type not in ('fragment', 'vertex'):


### PR DESCRIPTION
Make openSUSE `kitty` package build reproducible

This needs 3 fixes:
* for an ordering issue in `docs_ref_map_generated.h`
* for a filesystem-order issue in `uniforms_generated.h`
* to normalize mtimes in the `data_generated.bin` tar

This patch was done while working on reproducible builds for openSUSE.