### PR TITLE
command done notification

### DIFF
--- a/docs/launch.rst
+++ b/docs/launch.rst
@@ -145,6 +145,10 @@ functions for the events you are interested in, for example:
         # when a title change was requested via escape code from the program
         # running in the terminal
 
+    def on_cmd_startstop(boss: Boss, window: Window, data: Dict[str, Any]) -> None:
+        # called when the shell starts/stops executing a command. Here
+        # data will contain is_start and time.
+
 Every callback is passed a reference to the global ``Boss`` object as well as
 the ``Window`` object the action is occurring on. The ``data`` object is a dict
 that contains event dependent data. Some useful methods and attributes for the

--- a/kitty/launch.py
+++ b/kitty/launch.py
@@ -398,6 +398,15 @@ def load_watch_modules(watchers: Iterable[str]) -> Optional[Watchers]:
         w = m.get('on_focus_change')
         if callable(w):
             ans.on_focus_change.append(w)
+        w = m.get('on_set_user_var')
+        if callable(w):
+            ans.on_set_user_var.append(w)
+        w = m.get('on_title_change')
+        if callable(w):
+            ans.on_title_change.append(w)
+        w = m.get('on_cmd_startstop')
+        if callable(w):
+            ans.on_cmd_startstop.append(w)
     return ans
 
 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -3149,6 +3149,39 @@ first valid match, in the order specified, is sourced.
 '''
     )
 
+opt('notify_on_cmd_finish', 'never',
+    choices=('never', 'unfocused', 'invisible', 'always'),
+    long_text='''
+Whether to send a desktop notification when a long-running command finishes
+(needs :opt:`shell_integration`).
+The possible values are:
+
+:code:`never`
+    Never send a notification.
+
+:code:`unfocused`
+    Only send a notification when the window does not have keyboard focus.
+
+:code:`invisible`
+    Only send a notification when the window both is unfocused and not visible
+    to the user, for example, because it is in an inactive tab or its OS window
+    is not currently active.
+
+:code:`always`
+    Always send a notification, even if the window is focused.
+'''
+    )
+
+opt('notify_on_cmd_finish_min_duration', '5.0',
+    option_type="float",
+    long_text='''
+Only send a notification if a command takes more than specified seconds of time.
+It's not recommended to set a value too small, as you probably don't want a
+notification when a command launches a new window and exit immediately (e.g. the
+`code` command from vscode).
+'''
+    )
+
 opt('term', 'xterm-kitty',
     long_text='''
 The value of the :envvar:`TERM` environment variable to set. Changing this can

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -1120,6 +1120,17 @@ class Parser:
         for k, v in narrow_symbols(val):
             ans["narrow_symbols"][k] = v
 
+    def notify_on_cmd_finish(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        val = val.lower()
+        if val not in self.choices_for_notify_on_cmd_finish:
+            raise ValueError(f"The value {val} is not a valid choice for notify_on_cmd_finish")
+        ans["notify_on_cmd_finish"] = val
+
+    choices_for_notify_on_cmd_finish = frozenset(('never', 'unfocused', 'invisible', 'always'))
+
+    def notify_on_cmd_finish_min_duration(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        ans['notify_on_cmd_finish_min_duration'] = float(val)
+
     def open_url_with(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['open_url_with'] = to_cmdline(val)
 

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -20,6 +20,7 @@ choices_for_default_pointer_shape = typing.Literal['arrow', 'beam', 'text', 'poi
 choices_for_linux_display_server = typing.Literal['auto', 'wayland', 'x11']
 choices_for_macos_colorspace = typing.Literal['srgb', 'default', 'displayp3']
 choices_for_macos_show_window_title_in = typing.Literal['all', 'menubar', 'none', 'window']
+choices_for_notify_on_cmd_finish = typing.Literal['never', 'unfocused', 'invisible', 'always']
 choices_for_placement_strategy = typing.Literal['center', 'top-left']
 choices_for_pointer_shape_when_dragging = choices_for_default_pointer_shape
 choices_for_pointer_shape_when_grabbed = choices_for_default_pointer_shape
@@ -386,6 +387,8 @@ option_names = (  # {{{
  'mouse_hide_wait',
  'mouse_map',
  'narrow_symbols',
+ 'notify_on_cmd_finish',
+ 'notify_on_cmd_finish_min_duration',
  'open_url_with',
  'paste_actions',
  'placement_strategy',
@@ -545,6 +548,8 @@ class Options:
     mark3_background: Color = Color(242, 116, 188)
     mark3_foreground: Color = Color(0, 0, 0)
     mouse_hide_wait: float = 0.0 if is_macos else 3.0
+    notify_on_cmd_finish: choices_for_notify_on_cmd_finish = 'never'
+    notify_on_cmd_finish_min_duration: float = 5.0
     open_url_with: typing.List[str] = ['default']
     paste_actions: typing.FrozenSet[str] = frozenset({'confirm', 'quote-urls-at-prompt'})
     placement_strategy: choices_for_placement_strategy = 'center'

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -2216,9 +2216,12 @@ shell_prompt_marking(Screen *self, PyObject *data) {
                 }
                 if (PyErr_Occurred()) PyErr_Print();
                 self->linebuf->line_attrs[self->cursor->y].prompt_kind = pk;
+                if (pk == PROMPT_START)
+                    CALLBACK("cmd_output_marking", "i", 0);
             } break;
             case 'C':
                 self->linebuf->line_attrs[self->cursor->y].prompt_kind = OUTPUT_START;
+                CALLBACK("cmd_output_marking", "i", 1);
                 break;
         }
     }


### PR DESCRIPTION
Just a Proof of Concept at the moment.

This implements "send desktop notification when a command is done in a background window" as plugins in various shells do (e.g. https://github.com/franciscolourenco/done), but should work in any shells with OSC 133 shell integration.

TODO:
1. configuration (notify_cmd_done=off/unfocused/invisible, notify_cmd_done_min_duration)

Open questions:
1. Whether to hard-code it as in the PoC, or to extend the Watcher API and implement it as a built-in Watcher.
2. To detect the end of command, should we generate and parse OSC 133;D (end of command output), instead of using OSC 133;A (start of prompt) as in the PoC? 
3. Should the notification include the cmdline? By generating and parsing OSC 133;B? Or by injecting code in each shell and sending it via OSC 1337?
4. Should we support changing the title (or somehow make it "flash") of an inactive tab in a focused window, instead of sending a notification?
5. How to use a C enum (e.g. PromptKind) in Python?