### PR TITLE
Improve resilience of shell integration for sudo in fish

### DIFF
--- a/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
+++ b/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish
@@ -121,7 +121,7 @@ function __ksi_schedule --on-event fish_prompt -d "Setup kitty integration after
                     set is_sudoedit "y"
                     break
                 end
-                if not string match -r -q "^-" "$arg" and not string match -r -q "=" "$arg"
+                if not string match -r -q -- "^-" "$arg" and not string match -r -q -- "=" "$arg"
                     break  # reached the command
                 end
             end


### PR DESCRIPTION
Running `sudo --version` will now not error out.

Previously:

```
$ sudo --version
string match: --version: unknown option

Standard input (line 124):
                if not string match -r -q "^-" "$arg" and not string match -r -q "=" "$arg"
                   ^
in function 'sudo' with arguments '--version'

(Type 'help string' for related documentation)
Sudo version 1.9.15p2
Sudoers policy plugin version 1.9.15p2
Sudoers file grammar version 50
Sudoers I/O plugin version 1.9.15p2
Sudoers audit plugin version 1.9.15p2
```