### PR TITLE
Fix Wayland cursor-shape-v1 cursor not updating

### DIFF
--- a/glfw/wl_init.c
+++ b/glfw/wl_init.c
@@ -99,7 +99,7 @@ static void pointerHandleEnter(void* data UNUSED,
             return;
     }
     window->wl.decorations.focus = focus;
-    _glfw.wl.serial = serial; _glfw.wl.input_serial = serial; _glfw.wl.pointer_serial = serial;
+    _glfw.wl.serial = serial; _glfw.wl.input_serial = serial; _glfw.wl.pointer_serial = serial; _glfw.wl.pointer_enter_serial = serial;
     _glfw.wl.pointerFocus = window;
 
     window->wl.hovered = true;

--- a/glfw/wl_platform.h
+++ b/glfw/wl_platform.h
@@ -295,7 +295,7 @@ typedef struct _GLFWlibraryWayland
 
     struct wl_surface*          cursorSurface;
     GLFWCursorShape             cursorPreviousShape;
-    uint32_t                    serial, input_serial, pointer_serial, keyboard_enter_serial;
+    uint32_t                    serial, input_serial, pointer_serial, pointer_enter_serial, keyboard_enter_serial;
 
     int32_t                     keyboardRepeatRate;
     monotonic_t                 keyboardRepeatDelay;

--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -200,7 +200,7 @@ setCursorImage(_GLFWwindow* window, bool on_theme_change) {
     if (_glfw.wl.wp_cursor_shape_device_v1) {
         int which = glfw_cursor_shape_to_wayland_cursor_shape(cursorWayland->shape);
         if (which > -1) {
-            wp_cursor_shape_device_v1_set_shape(_glfw.wl.wp_cursor_shape_device_v1, _glfw.wl.serial, (uint32_t)which);
+            wp_cursor_shape_device_v1_set_shape(_glfw.wl.wp_cursor_shape_device_v1, _glfw.wl.pointer_enter_serial, (uint32_t)which);
             return;
         }
     }


### PR DESCRIPTION
According to https://wayland.app/protocols/cursor-shape-v1#wp_cursor_shape_device_v1:request:set_shape
> The serial parameter must match the latest wl_pointer.enter or
> zwp_tablet_tool_v2.proximity_in serial number sent to the client.

So we can't use wl.serial or wl.pointer_serial, because they are also updated in other places.

The symtom:
1. In KDE, open kitty.
2. Ctrl-shift-T to open a new tab.
3. Cursor not updating.
4. Move cursor outside of the kitty window then back fixed the problem.