### PR TITLE
switch to recent os window: nth_os_window -1

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -92,6 +92,7 @@ from .fast_data_types import (
     get_os_window_size,
     global_font_size,
     is_modifier_key,
+    last_focused_counter,
     last_focused_os_window_id,
     mark_os_window_for_close,
     os_window_font_size,
@@ -1711,6 +1712,14 @@ class Boss:
             ids = list(self.os_window_map.keys())
             os_window_id = ids[min(num, len(ids)) - 1]
             focus_os_window(os_window_id, True)
+        elif self.os_window_map and num == -1:
+            ids = list(self.os_window_map.keys())
+            if len(ids) <= 1:
+                return
+            counters = [(x, last_focused_counter(x)) for x in ids]
+            counters = sorted(counters, key=lambda x: x[1])
+            focus_os_window(counters[-2][0], True)
+
 
     @ac('win', 'Close the currently active OS Window')
     def close_os_window(self) -> None:

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1706,7 +1706,15 @@ class Boss:
                         text = '\n'.join(urls)
                 w.paste_text(text)
 
-    @ac('win', 'Focus the nth OS window')
+    @ac('win', '''
+        Focus the nth OS window. -1 for the previously focused OS window.
+        For example::
+
+            # focus the previously focused kitty OS window
+            map f1 nth_os_window -1
+            # focus the first kitty OS window
+            map f1 nth_os_window 1
+        ''')
     def nth_os_window(self, num: int = 1) -> None:
         if self.os_window_map and num > 0:
             ids = list(self.os_window_map.keys())

--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -815,6 +815,8 @@ def destroy_global_data() -> None:
 def current_os_window() -> Optional[int]:
     pass
 
+def last_focused_counter(os_window_id: int) -> int:
+    pass
 
 def last_focused_os_window_id() -> int:
     pass

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -105,6 +105,17 @@ current_os_window(void) {
 }
 
 static id_type
+last_focused_counter(id_type os_window_id) {
+    for (size_t i = 0; i < global_state.num_os_windows; i++) {
+        OSWindow *w = &global_state.os_windows[i];
+        if (w->id == os_window_id) {
+            return w->last_focused_counter;
+        }
+    }
+    return 0;
+}
+
+static id_type
 last_focused_os_window_id(void) {
     id_type ans = 0, max_fc_count = 0;
     for (size_t i = 0; i < global_state.num_os_windows; i++) {
@@ -693,6 +704,10 @@ PYWRAP1(update_ime_position_for_window) {
 
 PYWRAP0(next_window_id) {
     return PyLong_FromUnsignedLongLong(global_state.window_id_counter + 1);
+}
+
+PYWRAP1(last_focused_counter) {
+    return PyLong_FromUnsignedLongLong(last_focused_counter(PyLong_AsUnsignedLongLong(args)));
 }
 
 PYWRAP0(last_focused_os_window_id) {
@@ -1334,6 +1349,7 @@ static PyMethodDef module_methods[] = {
     MW(update_pointer_shape, METH_VARARGS),
     MW(current_os_window, METH_NOARGS),
     MW(next_window_id, METH_NOARGS),
+    MW(last_focused_counter, METH_O),
     MW(last_focused_os_window_id, METH_NOARGS),
     MW(current_focused_os_window_id, METH_NOARGS),
     MW(set_options, METH_VARARGS),


### PR DESCRIPTION
fix #7008

1. expose `last_focused_counter(os_window_id) -> int`
2. allow mappable action `nth_os_window -1` to switch to last focused OS window
