### PR TITLE
for #7009

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1733,7 +1733,7 @@ class Boss:
             focus_os_window(os_window_id, True)
         elif num < 0:
             fc_map = os_window_focus_counters()
-            s = sorted(fc_map.keys(), key=fc_map.__getitem__, reverse=True)
+            s = sorted(fc_map.keys(), key=fc_map.__getitem__)
             if not s:
                 return
             try:


### PR DESCRIPTION
Oops, the num is already negative index, no need to reverse here.

Alternatively this is shorter:

```
    def nth_os_window(self, num: int = 1) -> None:
        if not self.os_window_map:
            return

        if num == 0:
            os_window_id = current_focused_os_window_id() or last_focused_os_window_id()
        elif num > 0:
            ids = tuple(self.os_window_map.keys())
            os_window_id = ids[min(num, len(ids)) - 1]
        else:
            fc_map = os_window_focus_counters()
            ids = sorted(fc_map.keys(), key=fc_map.__getitem__, reverse=True)
            os_window_id = ids[min(-num, len(ids)-1)]
        focus_os_window(os_window_id, True)
```
