### PR TITLE
Add Python APIs to get and set os-window position

### DIFF
--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -1396,6 +1396,12 @@ def get_os_window_size(os_window_id: int) -> Optional[OSWindowSize]:
     pass
 
 
+def get_os_window_pos(os_window_id: int) -> Tuple[int, int]:
+    pass
+
+def set_os_window_pos(os_window_id: int, x: int, y: int) -> None:
+    pass
+
 def get_all_processes() -> Tuple[int, ...]:
     pass
 

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -805,6 +805,16 @@ set_os_window_size(OSWindow *os_window, int x, int y) {
     glfwSetWindowSize(os_window->handle, x, y);
 }
 
+void
+get_os_window_pos(OSWindow *os_window, int *x, int *y) {
+    glfwGetWindowPos(os_window->handle, x, y);
+}
+
+void
+set_os_window_pos(OSWindow *os_window, int x, int y) {
+    glfwSetWindowPos(os_window->handle, x, y);
+}
+
 static void
 get_window_content_scale(GLFWwindow *w, float *xscale, float *yscale, double *xdpi, double *ydpi) {
     // if you change this function also change createSurface() in wl_window.c

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -1072,6 +1072,26 @@ PYWRAP1(get_os_window_size) {
     Py_RETURN_NONE;
 }
 
+PYWRAP1(get_os_window_pos) {
+    id_type os_window_id;
+    PA("K", &os_window_id);
+    WITH_OS_WINDOW(os_window_id)
+        int x, y;
+        get_os_window_pos(os_window, &x, &y);
+        return Py_BuildValue("ii", x, y);
+    END_WITH_OS_WINDOW
+    Py_RETURN_NONE;
+}
+
+PYWRAP1(set_os_window_pos) {
+    id_type os_window_id;
+    int x, y;
+    PA("Kii", &os_window_id, &x, &y);
+    WITH_OS_WINDOW(os_window_id)
+        set_os_window_pos(os_window, x, y);
+    END_WITH_OS_WINDOW
+    Py_RETURN_NONE;
+}
 
 PYWRAP1(set_boss) {
     Py_CLEAR(global_state.boss);
@@ -1379,6 +1399,8 @@ static PyMethodDef module_methods[] = {
     MW(sync_os_window_title, METH_VARARGS),
     MW(get_os_window_title, METH_VARARGS),
     MW(set_os_window_title, METH_VARARGS),
+    MW(get_os_window_pos, METH_VARARGS),
+    MW(set_os_window_pos, METH_VARARGS),
     MW(global_font_size, METH_VARARGS),
     MW(set_background_image, METH_VARARGS),
     MW(os_window_font_size, METH_VARARGS),

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -288,6 +288,8 @@ bool remove_os_window(id_type os_window_id);
 void* make_os_window_context_current(OSWindow *w);
 void set_os_window_size(OSWindow *os_window, int x, int y);
 void get_os_window_size(OSWindow *os_window, int *w, int *h, int *fw, int *fh);
+void get_os_window_pos(OSWindow *os_window, int *x, int *y);
+void set_os_window_pos(OSWindow *os_window, int x, int y);
 void get_os_window_content_scale(OSWindow *os_window, double *xdpi, double *ydpi, float *xscale, float *yscale);
 void update_os_window_references(void);
 void mark_os_window_for_close(OSWindow* w, CloseRequest cr);


### PR DESCRIPTION
Useful when using floating window managers to get a floating terminal placed appropriately with either a shell, compiler output or a man page or other reference material to be temporarily available at a glance.