### PR TITLE
Explicit GO111MODULE=on when getting required Go version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -971,7 +971,7 @@ def build_static_kittens(
     go = shutil.which('go')
     if not go:
         raise SystemExit('The go tool was not found on this system. Install Go')
-    required_go_version = subprocess.check_output([go] + 'list -f {{.GoVersion}} -m'.split()).decode().strip()
+    required_go_version = subprocess.check_output([go] + 'list -f {{.GoVersion}} -m'.split(), env=dict(os.environ, GO111MODULE="on")).decode().strip()
     current_go_version = subprocess.check_output([go, 'version']).decode().strip().split()[2][2:]
     if parse_go_version(required_go_version) > parse_go_version(current_go_version):
         raise SystemExit(f'The version of go on this system ({current_go_version}) is too old. go >= {required_go_version} is needed')


### PR DESCRIPTION
Rather than assuming that GO111MODULE hasn't been modified, this PR makes it so GO111MODULE is explicitly set when running `go list` to extract the required Go version from go.mod, ensuring the version check works even outside of module-aware mode.

Taken from [Debian](https://salsa.debian.org/debian/kitty/-/blob/debian/sid/debian/patches/0011-fix-go-version-check.patch).