### PR TITLE
Fix Bash integration removing existing elements of PROMPT_COMMAND

### DIFF
--- a/shell-integration/bash/kitty.bash
+++ b/shell-integration/bash/kitty.bash
@@ -280,7 +280,7 @@ _ksi_main() {
     # from the shell
     builtin local pc
     pc='builtin declare -F _ksi_prompt_command > /dev/null 2> /dev/null && _ksi_prompt_command'
-    if [[ -z "${PROMPT_COMMAND}" ]]; then
+    if [[ -z "${PROMPT_COMMAND[*]}" ]]; then
         PROMPT_COMMAND=([0]="$pc")
     elif [[ $(builtin declare -p PROMPT_COMMAND 2> /dev/null) =~ 'declare -a PROMPT_COMMAND' ]]; then
         PROMPT_COMMAND+=("$pc")


### PR DESCRIPTION
### Problem: with `PROMPT_COMMAND=("" "<code>")`, `<code>` is lost by kitty's Bash integration

The Bash integration script entirely replaces `PROMPT_COMMAND` when it is *empty*. However, the current empty check is incomplete. When the first element `PROMPT_COMMAND[0]` is empty, `[[ -z "${PROMPT_COMMAND}" ]]` succeeds even if there are non-empty elements `PROMPT_COMMAND[i]` (with `i` >= 1). Then, the entire array is replaced by kitty's shell integration script so that all the settings set with index `i >= 1` are lost.

Note: It should be noted that in Bash/Ksh/Mksh etc, `$array_name` always means the 0th element of the array, which is different from Zsh. Also, in these shells, for a scalar variable (i.e. a variable that is not an array), `${scalar_variable[*]}` just picks its value.

### Context

The presented situation happens with the setting suggested for *a robust setup* in the Bash mailing list [1] at the design stage of the feature of the array `PROMPT_COMMAND` of Bash 5.1:

- [1] [Re: How to use PROMPT_COMMAND(S) without breaking other scripts](https://lists.gnu.org/archive/html/bug-bash/2020-08/msg00132.html)

The thread discusses a robust way to register a `PROMPT_COMMAND` hook to the array `PROMPT_COMMAND` assuming other scripts that may or may not support the array `PROMPT_COMMAND`. The conclusion is that a Bash configuration can use the following form for Bash >= 5.1.

```bash
PROMPT_COMMAND=${PROMPT_COMMAND-}
PROMPT_COMMAND+=("some command here")
```

When the configuration is the first one to register `PROMPT_COMMAND`, it results in `PROMPT_COMMAND=("" "some command here")`.

The original discussion didn't assume the case that another Bash configuration performs an empty check for a *scalar `PROMPT_COMMAND`* yet replaces `PROMPT_COMMAND` as an array.

### Solution

The empty check needs to test the entire `PROMPT_COMMAND` as an array if it replaces `PROMPT_COMMAND` as an array. This PR uses this approach.

An alternative solution is to keep the current test as the scalar `PROMPT_COMMAND` but to replace `PROMPT_COMMAND` as a scalar variable, as `PROMPT_COMMAND="$pc"`, which preserves the other elements.
