### PR TITLE
Add support for using main font for box drawing

### DIFF
--- a/kitty/fonts.c
+++ b/kitty/fonts.c
@@ -579,6 +579,10 @@ START_ALLOW_CASE_RANGE
         case 0xe0b0 ... 0xe0bf:    // powerline box drawing
         case 0x1fb00 ... 0x1fb97:  // symbols for legacy computing
         case 0x1fb9a ... 0x1fbae:  // symbols for legacy computing
+            if (OPT(box_drawing_main_font) && has_cell_text(fg->fonts + fg->medium_font_idx, cpu_cell)) {
+                *is_main_font = true;
+                return fg->medium_font_idx;
+            }
             return BOX_FONT;
         default:
             *is_emoji_presentation = has_emoji_presentation(cpu_cell, gpu_cell);

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -216,6 +216,14 @@ glyphs inside the cell and decreasing it lowers them. Decreasing the cell size
 might cause rendering artifacts, so use with care.
 ''')
 
+opt('box_drawing_main_font', 'no',
+    option_type='to_bool', ctype='bool',
+    long_text='''
+Use the main font for box drawing if the box drawing character is defined in the
+font.
+'''
+    )
+
 opt('box_drawing_scale', '0.001, 1, 1.5, 2',
     option_type='box_drawing_scale',
     long_text='''

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -106,6 +106,9 @@ class Parser:
     def bold_italic_font(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['bold_italic_font'] = str(val)
 
+    def box_drawing_main_font(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        ans['box_drawing_main_font'] = to_bool(val)
+
     def box_drawing_scale(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['box_drawing_scale'] = box_drawing_scale(val)
 

--- a/kitty/options/to-c-generated.h
+++ b/kitty/options/to-c-generated.h
@@ -58,6 +58,19 @@ convert_from_opts_modify_font(PyObject *py_opts, Options *opts) {
 }
 
 static void
+convert_from_python_box_drawing_main_font(PyObject *val, Options *opts) {
+    opts->box_drawing_main_font = PyObject_IsTrue(val);
+}
+
+static void
+convert_from_opts_box_drawing_main_font(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "box_drawing_main_font");
+    if (ret == NULL) return;
+    convert_from_python_box_drawing_main_font(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
 convert_from_python_text_composition_strategy(PyObject *val, Options *opts) {
     text_composition_strategy(val, opts);
 }
@@ -1119,6 +1132,8 @@ convert_opts_from_python_opts(PyObject *py_opts, Options *opts) {
     convert_from_opts_disable_ligatures(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_modify_font(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_box_drawing_main_font(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_text_composition_strategy(py_opts, opts);
     if (PyErr_Occurred()) return false;

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -58,6 +58,7 @@ option_names = (  # {{{
  'bell_path',
  'bold_font',
  'bold_italic_font',
+ 'box_drawing_main_font',
  'box_drawing_scale',
  'clear_all_mouse_actions',
  'clear_all_shortcuts',
@@ -483,6 +484,7 @@ class Options:
     bell_path: typing.Optional[str] = None
     bold_font: str = 'auto'
     bold_italic_font: str = 'auto'
+    box_drawing_main_font: bool = False
     box_drawing_scale: typing.Tuple[float, float, float, float] = (0.001, 1.0, 1.5, 2.0)
     clear_all_mouse_actions: bool = False
     clear_all_shortcuts: bool = False

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -69,6 +69,7 @@ typedef struct {
     unsigned long tab_bar_min_tabs;
     DisableLigature disable_ligatures;
     bool force_ltr;
+    bool box_drawing_main_font;
     bool resize_in_steps;
     bool sync_to_monitor;
     bool close_on_child_death;


### PR DESCRIPTION
I have a font that is designed for pixel perfect rendering. Box drawing characters from the font works without the need for rendering them separately, and I would prefer to use the font characters.

This implements an option to prefer the main font for box drawing:

<img width="524" alt="image" src="https://github.com/kovidgoyal/kitty/assets/7736494/0f4f8b5c-26cf-43a8-95ae-ce5b0c5ac69c">
