### PR TITLE
Drawing method for U+1FB98 and U+1FB99

### DIFF
--- a/kitty/fonts.c
+++ b/kitty/fonts.c
@@ -577,8 +577,7 @@ START_ALLOW_CASE_RANGE
         case 0x2574 ... 0x259f:
         case 0x2800 ... 0x28ff:
         case 0xe0b0 ... 0xe0bf:    // powerline box drawing
-        case 0x1fb00 ... 0x1fb97:  // symbols for legacy computing
-        case 0x1fb9a ... 0x1fbae:  // symbols for legacy computing
+        case 0x1fb00 ... 0x1fbae:  // symbols for legacy computing
             return BOX_FONT;
         default:
             *is_emoji_presentation = has_emoji_presentation(cpu_cell, gpu_cell);
@@ -615,10 +614,10 @@ START_ALLOW_CASE_RANGE
             return ch - 0x2500; // IDs from 0x00 to 0x9f
         case 0xe0b0 ... 0xe0d4:
             return 0xa0 + ch - 0xe0b0;  // IDs from 0xa0 to 0xc4
-        case 0x2800 ... 0x28ff:
-            return 0xc5 + ch - 0x2800; // IDs from 0xc5 to 0x1c4
         case 0x1fb00 ... 0x1fbae:
-            return 0x1c5 + ch - 0x1fb00;  // IDs from 0x1c5 to 0x273
+            return 0xc5 + ch - 0x1fb00; // IDs from 0xc5 to 0x173
+        case 0x2800 ... 0x28ff:
+            return 0x174 + ch - 0x2800;
         default:
             return 0xffff;
     }

--- a/kitty/fonts/box_drawing.py
+++ b/kitty/fonts/box_drawing.py
@@ -281,6 +281,25 @@ def cross_line(buf: SSByteArray, width: int, height: int, left: bool = True, lev
 
 
 @supersampled()
+def cross_shade(buf: SSByteArray, width: int, height: int, rotate: bool = False) -> None:
+    slice_count = width // 10 if width // 10 >= 2 else 2
+
+    x = tuple([(width - 1) * slice // slice_count for slice in range(1,slice_count)])
+    y = tuple([(height - 1) * slice // slice_count for slice in range(1,slice_count)])
+
+    if rotate:
+        thick_line(buf, width, height, buf.supersample_factor * thickness(1), (0, height - 1), (width - 1, 0))
+        for slice in range(slice_count-1):
+            thick_line(buf, width, height, buf.supersample_factor * thickness(1), (x[slice], height - 1), (width - 1, y[slice]))
+            thick_line(buf, width, height, buf.supersample_factor * thickness(1), (0, height - 1 - y[slice]), (width - 1 - x[slice], 0))
+    else:
+        thick_line(buf, width, height, buf.supersample_factor * thickness(1), (0, 0), (width - 1, height - 1))
+        for slice in range(slice_count-1):
+            thick_line(buf, width, height, buf.supersample_factor * thickness(1), (x[slice], 0), (width - 1, height - 1 - y[slice]))
+            thick_line(buf, width, height, buf.supersample_factor * thickness(1), (0, height - 1 - y[slice]), (x[slice], height - 1))
+
+
+@supersampled()
 def half_cross_line(buf: SSByteArray, width: int, height: int, which: str = 'tl', level: int = 1) -> None:
     thickness_in_pixels = thickness(level) * buf.supersample_factor
     my = (height - 1) // 2
@@ -926,6 +945,8 @@ box_chars: Dict[str, List[Callable[[BufType, int, int], Any]]] = {
     '🮝': [shade, p(mask, p(corner_triangle, corner='top-right'))],
     '🮞': [shade, p(mask, p(corner_triangle, corner='bottom-right'))],
     '🮟': [shade, p(mask, p(corner_triangle, corner='bottom-left'))],
+    '🮘': [cross_shade],
+    '🮙': [p(cross_shade, rotate=True)],
 
     '▔': [p(eight_bar, horizontal=True)],
     '▕': [p(eight_bar, which=7)],


### PR DESCRIPTION
I don't know if perhaps there are any corner cases where the implementation in this new shading method might have undesired results. I've only tested with the cell size configured on my system.

Produces some interesting moiré patterns.

![Screenshot_20240211_140956](https://github.com/kovidgoyal/kitty/assets/45847/5ef3c442-1a0f-41ae-abd5-fdd8024c5e8d)
