### PR TITLE
Add `new-tab-neighbor` option to `detach_window`

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -2675,10 +2675,9 @@ class Boss:
                         tm = q
                     else:
                         tm = self.os_window_map[target_os_window_id]
-                    if target_tab_id == 'new':
-                        target_tab = tm.new_tab(empty_tab=True)
-                    elif target_tab_id == 'new_as_neighbor':
-                        target_tab = tm.new_tab(empty_tab=True, as_neighbor=True)
+                    if target_tab_id.startswith('new'):
+                        # valid values for target_tab_id are 'new', 'new_after' and 'new_before'
+                        target_tab = tm.new_tab(empty_tab=True, location=(target_tab_id[4:] or 'last'))
                     else:
                         target_tab = tm.tab_at_location(target_tab_id) or tm.new_tab(empty_tab=True)
                 else:
@@ -2769,11 +2768,13 @@ class Boss:
     def detach_window(self, *args: str) -> None:
         if not args or args[0] == 'new':
             return self._move_window_to(target_os_window_id='new')
-        if args[0] in ('new-tab', 'tab-prev', 'tab-left', 'tab-right', 'new-tab-neighbor'):
+        if args[0] in ('new-tab', 'tab-prev', 'tab-left', 'tab-right', 'new-tab-left', 'new-tab-right'):
             if args[0] == 'new-tab':
                 where = 'new'
-            elif args[0] == 'new-tab-neighbor':
-                where = 'new_as_neighbor'
+            elif args[0] == 'new-tab-right':
+                where = 'new_after'
+            elif args[0] == 'new-tab-left':
+                where = 'new_before'
             else:
                 where = args[0][4:]
             return self._move_window_to(target_tab_id=where)

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -2677,6 +2677,8 @@ class Boss:
                         tm = self.os_window_map[target_os_window_id]
                     if target_tab_id == 'new':
                         target_tab = tm.new_tab(empty_tab=True)
+                    elif target_tab_id == 'new_as_neighbor':
+                        target_tab = tm.new_tab(empty_tab=True, as_neighbor=True)
                     else:
                         target_tab = tm.tab_at_location(target_tab_id) or tm.new_tab(empty_tab=True)
                 else:
@@ -2767,8 +2769,13 @@ class Boss:
     def detach_window(self, *args: str) -> None:
         if not args or args[0] == 'new':
             return self._move_window_to(target_os_window_id='new')
-        if args[0] in ('new-tab', 'tab-prev', 'tab-left', 'tab-right'):
-            where = 'new' if args[0] == 'new-tab' else args[0][4:]
+        if args[0] in ('new-tab', 'tab-prev', 'tab-left', 'tab-right', 'new-tab-neighbor'):
+            if args[0] == 'new-tab':
+                where = 'new'
+            elif args[0] == 'new-tab-neighbor':
+                where = 'new_as_neighbor'
+            else:
+                where = args[0][4:]
             return self._move_window_to(target_tab_id=where)
         ct = self.active_tab
         items: List[Tuple[Union[str, int], str]] = [(t.id, t.effective_title) for t in self.all_tabs if t is not ct]

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -144,7 +144,7 @@ def goto_tab_parse(func: str, rest: str) -> FuncArgsType:
 
 @func_with_args('detach_window')
 def detach_window_parse(func: str, rest: str) -> FuncArgsType:
-    if rest not in ('new', 'new-tab', 'ask', 'tab-prev', 'tab-left', 'tab-right'):
+    if rest not in ('new', 'new-tab', 'new-tab-neighbor', 'ask', 'tab-prev', 'tab-left', 'tab-right'):
         log_error(f'Ignoring invalid detach_window argument: {rest}')
         rest = 'new'
     return func, (rest,)

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -144,7 +144,7 @@ def goto_tab_parse(func: str, rest: str) -> FuncArgsType:
 
 @func_with_args('detach_window')
 def detach_window_parse(func: str, rest: str) -> FuncArgsType:
-    if rest not in ('new', 'new-tab', 'new-tab-neighbor', 'ask', 'tab-prev', 'tab-left', 'tab-right'):
+    if rest not in ('new', 'new-tab', 'new-tab-left', 'new-tab-right', 'ask', 'tab-prev', 'tab-left', 'tab-right'):
         log_error(f'Ignoring invalid detach_window argument: {rest}')
         rest = 'new'
     return func, (rest,)


### PR DESCRIPTION
This should be pretty self-explanatory.

Rationale: I usually have plenty of different tabs open in which I'm doing different things (work/system troubleshooting/configuring nvim/htop/...) and use `detach_window` when my current tab gets too crowded. I would like related tabs to stay together, so an option to detach a window to a new tab, _which gets created next to the current tab_ would be useful.