### PR TITLE
kittens/hints: allow arbitrary text color

### DIFF
--- a/kittens/hints/main.go
+++ b/kittens/hints/main.go
@@ -167,7 +167,7 @@ func main(_ *cli.Command, o *Options, args []string) (rc int, err error) {
 	fctx := style.Context{AllowEscapeCodes: true}
 	faint := fctx.SprintFunc("dim")
 	hint_style := fctx.SprintFunc(fmt.Sprintf("fg=%s bg=%s bold", o.HintsForegroundColor, o.HintsBackgroundColor))
-	text_style := fctx.SprintFunc(fmt.Sprintf("fg=bright-%s bold", o.HintsTextColor))
+	text_style := fctx.SprintFunc(fmt.Sprintf("fg=%s bold", o.HintsTextColor))
 
 	highlight_mark := func(m *Mark, mark_text string) string {
 		hint := encode_hint(m.Index, alphabet)

--- a/kittens/hints/main.py
+++ b/kittens/hints/main.py
@@ -225,7 +225,7 @@ The background color for hints.
 
 
 --hints-text-color
-default=gray
+default=bright-gray
 type=str
 The foreground color for text pointed to by the hints.
 


### PR DESCRIPTION
The "bright-" prefix was preventing the use of arbitrary hex colours
for the hinted text. This patch removes this restriction.

The documented default has also been adjusted to the effective previous
value.
