### PR TITLE
Fix invalid escape sequence warning with reset_terminal long_text

### DIFF
--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -4113,7 +4113,7 @@ map('Reset background opacity',
 
 map('Reset the terminal',
     'reset_terminal kitty_mod+delete clear_terminal reset active',
-    long_text='''
+    long_text=r'''
 You can create shortcuts to clear/reset the terminal. For example::
 
     # Reset the terminal


### PR DESCRIPTION
Building from source with python 3.12 from macports on macOS you get the following warnings:

```
...
kitty/options/definition.py:4116: SyntaxWarning: invalid escape sequence '\e'
  long_text='''
kitty/options/definition.py:4116: SyntaxWarning: invalid escape sequence '\e'
  long_text='''
kitty/options/definition.py:4116: SyntaxWarning: invalid escape sequence '\e'
  long_text='''
...
```

Making long_text a raw string or escaping the \\'s also fixes this warning.
