### PR TITLE
doc: add detailed step to enable shell integration for Nushell

### DIFF
--- a/docs/shell-integration.rst
+++ b/docs/shell-integration.rst
@@ -406,8 +406,7 @@ shells:
 
 * Jupyter console and IPython via a patch (:iss:`4475`)
 * `xonsh <https://github.com/xonsh/xonsh/issues/4623>`__
-* `nushell <https://github.com/nushell/nushell/discussions/12065>`__
-
+* `Nushell <https://github.com/nushell/nushell/discussions/12065>`__: Set ``$env.config.shell_integration = true`` in your ``config.nu`` to enable it.
 
 Notes for shell developers
 -----------------------------


### PR DESCRIPTION
Without the need to click the link to read the discussion. 

In my tests, all these work fine

- Open the output of the last command in a pager such as less [ctrl+shift+g]
- Jump to the previous/next prompt in the scrollback [ctrl+shift+z]
Click with the mouse anywhere in the current command to move the cursor there
- Hold Ctrl+Shift and right-click on any command output in the scrollback to view it in a pager
- The current working directory or the command being executed are automatically displayed in the kitty window titlebar/tab title