### PR TITLE
Fix unicode Cell diagonals (1fba0 - 1fbae)

### DIFF
--- a/kitty/fonts/box_drawing.py
+++ b/kitty/fonts/box_drawing.py
@@ -311,17 +311,15 @@ def half_cross_line(buf: SSByteArray, width: int, height: int, which: str = 'tl'
 
 @supersampled()
 def mid_lines(buf: SSByteArray, width: int, height: int, level: int = 1, pts: Iterable[str] = ('lt',)) -> None:
-    mid_x, mid_y = width // 2, height // 2
-
     def pt_to_coords(p: str) -> Tuple[int, int]:
         if p == 'l':
-            return 0, mid_y
+            return 0, height // 2
         if p == 't':
-            return mid_x, 0
+            return width // 2, height // 4
         if p == 'r':
-            return width - 1, mid_y
+            return width - 1, height // 2
         if p == 'b':
-            return mid_x, height - 1
+            return width // 2, 3 * height // 4
         raise KeyError(f'Unknown p: {p}')
 
     for x in pts:


### PR DESCRIPTION
Cell diagonals from "Symbol for Legacy Computing" are currently drawn to the top and bottom edges which is a wrong behavior. Top and bottom middle coordinates should be `top: (0.5, 0.25)` and `bottom:(0.5, 0.75)` instead of `top:(0.5, 0), bottom:(0.5, 1)`

My reasoning for that comes from [their names](https://unicode.org/charts/nameslist/n_1FB00.html), and also because the "Smooth mosaic terminal graphic characters" have the same wording for UPPER and LOWER MIDDLE, and they connect to the 0.25 and 0.75

Before:
![image](https://github.com/kovidgoyal/kitty/assets/10760409/04ecc2f7-5c04-4cc9-955f-c944ff3f9a63)

After:
![image](https://github.com/kovidgoyal/kitty/assets/10760409/4685244b-c53a-4c95-9eb3-f8ee0bf015da)


Fix #7233 