### PR TITLE
Fix incorrect prefix in Arm NEON shift right narrow intrinsic

### DIFF
--- a/kitty/simd-string-impl.h
+++ b/kitty/simd-string-impl.h
@@ -241,7 +241,7 @@ static inline integer_t shuffle_impl256(const integer_t value, const integer_t s
 
 static inline uint64_t
 movemask_arm128(const simde__m128i vec) {
-    simde_uint8x8_t res = simde_vshrn_n_u16(simde_vreinterpretq_u16_u8((simde_uint8x16_t)vec), 4);
+    simde_uint8x8_t res = vshrn_n_u16(simde_vreinterpretq_u16_u8((simde_uint8x16_t)vec), 4);
     return simde_vget_lane_u64(simde_vreinterpret_u64_u8(res), 0);
 }
 


### PR DESCRIPTION
Fixes #7252 causing build error on MacOS 14.4 with Xcode 15 due to by `simde_vshrn_n_u16()` being seen as an undeclared function in Clang 15, where the `-Wimplicit-function-declaration` warning diagnostic defaults to an error in C99 and later.