### PR TITLE
Add fullscreen on startup option

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1147,6 +1147,9 @@ class Boss:
             run_update_check(get_options().update_check_interval * 60 * 60)
             self.update_check_started = True
 
+        if get_options().fullscreen_on_startup:
+            self.toggle_fullscreen(first_os_window_id)
+
     def handle_click_on_tab(self, os_window_id: int, x: int, button: int, modifiers: int, action: int) -> None:
         tm = self.os_window_map.get(os_window_id)
         if tm is not None:

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -1210,6 +1210,14 @@ currently running. Note that if you want confirmation when closing individual
 windows, you can map the :ac:`close_window_with_confirmation` action.
 '''
     )
+
+opt('fullscreen_on_startup', 'no',
+    option_type='to_bool', ctype='bool',
+    long_text='''
+Whether to enable full screen mode automatically when kitty starts.
+'''
+    )
+
 egr()  # }}}
 
 

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -993,6 +993,9 @@ class Parser:
     def forward_stdio(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['forward_stdio'] = to_bool(val)
 
+    def fullscreen_on_startup(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        ans['fullscreen_on_startup'] = to_bool(val)
+
     def hide_window_decorations(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['hide_window_decorations'] = hide_window_decorations(val)
 

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -351,6 +351,7 @@ option_names = (  # {{{
  'font_size',
  'force_ltr',
  'foreground',
+ 'fullscreen_on_startup',
  'forward_stdio',
  'hide_window_decorations',
  'inactive_border_color',
@@ -520,6 +521,7 @@ class Options:
     force_ltr: bool = False
     foreground: Color = Color(221, 221, 221)
     forward_stdio: bool = False
+    fullscreen_on_startup: bool = False
     hide_window_decorations: int = 0
     inactive_border_color: Color = Color(204, 204, 204)
     inactive_tab_background: Color = Color(153, 153, 153)


### PR DESCRIPTION
This adds a new feature: fullscreen on startup, which is controlled by a new configuration option: `fullscreen_on_startup`, which is set to `no` by default.