### PR TITLE
Update rules for inactive_text_alpha

### DIFF
--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -792,12 +792,13 @@ render_prepared_os_window(OSWindow *os_window, unsigned int active_window_id, co
     BorderRects *br = &tab->border_rects;
     draw_borders(br->vao_idx, br->num_border_rects, br->rect_buf, br->is_dirty, os_window->viewport_width, os_window->viewport_height, active_window_bg, num_visible_windows, all_windows_have_same_bg, os_window);
     br->is_dirty = false;
-    if (TD.screen && os_window->num_tabs >= OPT(tab_bar_min_tabs)) draw_cells(TD.vao_idx, &TD, os_window, true, false, NULL);
+    if (TD.screen && os_window->num_tabs >= OPT(tab_bar_min_tabs)) draw_cells(TD.vao_idx, &TD, os_window, true, true, false, NULL);
+    bool is_single_window = tab->num_windows == 1;
     for (unsigned int i = 0; i < tab->num_windows; i++) {
         Window *w = tab->windows + i;
         if (w->visible && WD.screen) {
             bool is_active_window = i == tab->active_window;
-            draw_cells(WD.vao_idx, &WD, os_window, is_active_window, true, w);
+            draw_cells(WD.vao_idx, &WD, os_window, is_active_window, false, is_single_window, w);
             if (WD.screen->start_visual_bell_at != 0) {
                 set_maximum_wait(OPT(repaint_delay));
             }

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -960,7 +960,7 @@ get_visual_bell_intensity(Screen *screen) {
 }
 
 void
-draw_cells(ssize_t vao_idx, const WindowRenderData *srd, OSWindow *os_window, bool is_active_window, bool can_be_focused, Window *window) {
+draw_cells(ssize_t vao_idx, const WindowRenderData *srd, OSWindow *os_window, bool is_active_window, bool is_tab_bar, bool is_single_window, Window *window) {
     float x_ratio = 1., y_ratio = 1.;
     if (os_window->live_resize.in_progress) {
         x_ratio = (float) os_window->viewport_width / (float) os_window->live_resize.width;
@@ -978,7 +978,11 @@ draw_cells(ssize_t vao_idx, const WindowRenderData *srd, OSWindow *os_window, bo
     bind_vao_uniform_buffer(vao_idx, uniform_buffer, cell_program_layouts[CELL_PROGRAM].render_data.index);
     bind_vertex_array(vao_idx);
 
-    float current_inactive_text_alpha = (!can_be_focused || screen->cursor_render_info.is_focused) && is_active_window ? 1.0f : (float)OPT(inactive_text_alpha);
+    // We draw with inactive text alpha if:
+    // - We're not drawing the tab bar
+    // - There's only a single window and the os window is not focused
+    // - There are multiple windows and the current window is not active
+    float current_inactive_text_alpha = is_tab_bar || (!is_single_window && is_active_window) || (is_single_window && screen->cursor_render_info.is_focused) ? 1.0f : (float)OPT(inactive_text_alpha);
     set_cell_uniforms(current_inactive_text_alpha, screen->reload_all_gpu_data);
     screen->reload_all_gpu_data = false;
     bool has_underlying_image = has_bgimage(os_window);

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -313,7 +313,7 @@ ssize_t create_cell_vao(void);
 ssize_t create_graphics_vao(void);
 ssize_t create_border_vao(void);
 bool send_cell_data_to_gpu(ssize_t, float, float, float, float, Screen *, OSWindow *);
-void draw_cells(ssize_t, const WindowRenderData*, OSWindow *, bool, bool, Window*);
+void draw_cells(ssize_t, const WindowRenderData*, OSWindow *, bool, bool, bool, Window*);
 void draw_centered_alpha_mask(OSWindow *w, size_t screen_width, size_t screen_height, size_t width, size_t height, uint8_t *canvas, float);
 void update_surface_size(int, int, uint32_t);
 void free_texture(uint32_t*);


### PR DESCRIPTION
As discussed in #7301.

Previously, all windows would be drawn with inactive_text_alpha if the os window was unfocused. This changes the rules to the following:

- If there is a single window and the os window is unfocused, use inactive_text_alpha.
- If there are multiple windows, use inactive_text_alpha for all non-active windows, regardless of os window focus.

---

I've renamed the `can_be_focused` argument to `is_tab_bar`, since this makes the condition much more readable, and that's effectively what it signifies. Tell me if you want me to undo this rename.