### PR TITLE
fish integration: drop redundant OSC 133 markers in upcoming fish 3.8

### DIFF
--- a/docs/keyboard-protocol.rst
+++ b/docs/keyboard-protocol.rst
@@ -52,6 +52,7 @@ In addition to kitty, this protocol is also implemented in:
 * The `yazi file manager <https://github.com/sxyazi/yazi>`__
 * The `awrit web browser <https://github.com/chase/awrit>`__
 * The `nushell shell <https://github.com/nushell/nushell/pull/10540>`__
+* The `fish shell <https://github.com/fish-shell/fish-shell/commit/8bf8b10f685d964101f491b9cc3da04117a308b4>`__
 
 .. versionadded:: 0.20.0
 

--- a/docs/shell-integration.rst
+++ b/docs/shell-integration.rst
@@ -85,6 +85,8 @@ no-cwd
 no-prompt-mark
     Turn off marking of prompts. This disables jumping to prompt, browsing
     output of last command and click to move cursor functionality.
+    Note that for the fish shell this does not take effect, since fish always
+    marks prompts.
 
 no-complete
     Turn off completion for the kitty command.


### PR DESCRIPTION
The upcoming fish 3.8 release will output OSC 133 sequences unconditionally [1].

I tested ctrl-shift-{g,x,z} bindings both without and with kitty's shell integration on top; everything seems to work.

Let's simplify kitty integration by removing the markers for the upcoming fish >= 3.8.

I have hopes that the native OSC 133 implementation address #7200 though I'm not sure if I could reproduce this bug
(I only saw a similar bug when `fish_handle_reflow` was not enabled, which fish also does now (same commit)).
cc @iacore, let me know if you can reproduce #7200 with latest fish master.

[1]: https://github.com/fish-shell/fish-shell/commit/3b9e3e251bf9d4c7d0b31275cac55df68fe0127a
