### PR TITLE
Conform to WMClass set by the application

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1351,6 +1351,7 @@ GenericName=Terminal emulator
 Comment=Fast, feature-rich, GPU based terminal
 TryExec=kitty
 StartupNotify=true
+StartupWMClass=kitty
 Exec=kitty
 Icon=kitty
 Categories=System;TerminalEmulator;


### PR DESCRIPTION
Since the renaming of the desktop file in 597710d from `kitty.desktop` to `kitty-terminal.desktop`, OS windows have been unable to associate with the desktop file due to a mismatch in the new default expected WMClass (kitty-terminal) and what I think is being set by the terminal on its own at launch (`appname` -> kitty). GNOME thus can't track the windows and can't group them together in the dock and window switcher, or assign desktop icons.

This just aligns it with previous behavior while still accomodating the file rename, but I feel it is ultimately a workaround instead of appropriately changing everything in-app.