### PR TITLE
fix typo in dependency name

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -116,7 +116,7 @@ Build-time dependencies:
   - ``libssl-dev``
   - ``libpython3-dev``
   - ``libxxhash-dev``
-  - ``libsmide-dev``
+  - ``libsimde-dev``
 
 
 Build and run from source with Nix


### PR DESCRIPTION
recently built from source and noticed this minor typo