### PR TITLE
docs: use the hyphenated kitten name

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -151,7 +151,7 @@ I cannot use the key combination X in program Y?
 
 First, run::
 
-    kitten show_key -m kitty
+    kitten show-key -m kitty
 
 Press the key combination X. If the kitten reports the key press
 that means kitty is correctly sending the key press to terminal programs.

--- a/docs/keyboard-protocol.rst
+++ b/docs/keyboard-protocol.rst
@@ -28,7 +28,7 @@ issues in that proposal, listed at the :ref:`bottom of this document
 
 You can see this protocol with all enhancements in action by running::
 
-    kitten show_key -m kitty
+    kitten show-key -m kitty
 
 inside the kitty terminal to report key events.
 

--- a/docs/kittens/hyperlinked_grep.rst
+++ b/docs/kittens/hyperlinked_grep.rst
@@ -28,7 +28,7 @@ following contents:
 .. code:: conf
 
     # Open any file with a fragment in vim, fragments are generated
-    # by the hyperlink_grep kitten and nothing else so far.
+    # by the hyperlink-grep kitten and nothing else so far.
     protocol file
     fragment_matches [0-9]+
     action launch --type=overlay --cwd=current vim +${FRAGMENT} ${FILE_PATH}
@@ -40,7 +40,7 @@ following contents:
 
 Now, run a search with::
 
-    kitten hyperlinked_grep something
+    kitten hyperlinked-grep something
 
 Hold down the :kbd:`Ctrl+Shift` keys and click on any of the result lines, to
 open the file in :program:`vim` at the matching line. If you use some editor
@@ -51,7 +51,7 @@ accordingly. TO open links with the keyboard instead, use
 Finally, add an alias to your shell's rc files to invoke the kitten as
 :command:`hg`::
 
-    alias hg="kitten hyperlinked_grep"
+    alias hg="kitten hyperlinked-grep"
 
 
 You can now run searches with::


### PR DESCRIPTION
This applies the suggestion in https://github.com/kovidgoyal/kitty/issues/7402#issuecomment-2084726356

Fixes: https://github.com/kovidgoyal/kitty/issues/7402