### PR TITLE
shell-integration/ssh: Support arch=arm64, for MacOS

### DIFF
--- a/shell-integration/ssh/kitten
+++ b/shell-integration/ssh/kitten
@@ -72,6 +72,7 @@ case "$(command uname -m)" in
     amd64|x86_64) arch="amd64";;
     aarch64*) arch="arm64";;
     armv8*) arch="arm64";;
+    arm64) arch="arm64";;
     arm|armv7l) arch="arm";;
     i386) arch="386";;
     i686) arch="386";;

--- a/shell-integration/ssh/kitty
+++ b/shell-integration/ssh/kitty
@@ -78,6 +78,7 @@ if [ "$OS" = "linux" ]; then
         amd64|x86_64) arch="x86_64";;
         aarch64*) arch="arm64";;
         armv8*) arch="arm64";;
+        arm64) arch="arm64";;
         i386) arch="i686";;
         i686) arch="i686";;
         *) die "Unknown CPU architecture $(command uname -m)";;


### PR DESCRIPTION
On some Macs (e.g. M1, 2020), `uname` returns 'Darwin' and `uname -m` retuns 'arm64', this case is not handled in shell-integration. As a result, ssh kitten transfer fails with:

> Unknown CPU architecture arm64

Fix this by adding the case for arch=arm64 in kitten and kitty shell-integration scripts.

Tested this on Mac Pro (M1, 2020).