### PR TITLE
Add check for wayland display env for panel kitten

### DIFF
--- a/kittens/panel/main.py
+++ b/kittens/panel/main.py
@@ -158,8 +158,8 @@ def layer_shell_config(opts: PanelCLIOptions) -> LayerShellConfig:
 
 def main(sys_args: List[str]) -> None:
     global args
-    if is_macos or not os.environ.get('DISPLAY'):
-        raise SystemExit('Currently the panel kitten is supported only on X11 desktops')
+    if is_macos or not (os.environ.get('DISPLAY') or os.environ.get('WAYLAND_DISPLAY')):
+        raise SystemExit('Currently the panel kitten is supported only on X11 or Wayland desktops')
     args, items = parse_panel_args(sys_args[1:])
     if not items:
         raise SystemExit('You must specify the program to run')


### PR DESCRIPTION
panel kitten previously checked only for `DISPLAY` env variable, but a wayland session has `WAYLAND_DISPLAY` env set. Due to this wayland sessions without xwayland could not run panel kitten.

This PR now checks if either `DISPLAY` or `WAYLAND_DISPLAY` is set before proceeding.