### PR TITLE
Fixed missing C header file by adding "simde" dependency to the optionals field for stdenv.isLinux in file shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -45,6 +45,7 @@ in
           openssl
           xxHash
           dbus
+          simde
         ]
         ++ checkInputs;
 


### PR DESCRIPTION
Fixes error when building Kitty on Linux using the provided shell.nix file.