### PR TITLE
Add Yazi terminal file manager to the list of software implementing kitty's graphics protocol

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -29,6 +29,7 @@ Some programs and libraries that use the kitty graphics protocol:
 
 * `termpdf.py <https://github.com/dsanson/termpdf.py>`_ - a terminal PDF/DJVU/CBR viewer
 * `ranger <https://github.com/ranger/ranger>`_ - a terminal file manager, with image previews
+* `Yazi <https://github.com/sxyazi/yazi>`_ - Blazing fast terminal file manager written in Rust, based on async I/O
 * :doc:`kitty-diff <kittens/diff>` - a side-by-side terminal diff program with support for images
 * `tpix <https://github.com/jesvedberg/tpix>`_ - a statically compiled binary that can be used to display images and easily installed on remote servers without root access
 * `mpv <https://github.com/mpv-player/mpv/commit/874e28f4a41a916bb567a882063dd2589e9234e1>`_ - A video player that can play videos in the terminal

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -46,6 +46,13 @@ graphics protocol.
 Another terminal file manager, with previews of file contents powered by kitty's
 graphics protocol.
 
+.. _tool_yazi:
+
+`Yazi <https://github.com/sxyazi/yazi>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Blazing fast terminal file manager, with built-in kitty graphics protocol support
+(implemented both Classic protocol and Unicode placeholders).
+
 .. _tool_hunter:
 
 `hunter <https://github.com/rabite0/hunter>`_

--- a/docs/keyboard-protocol.rst
+++ b/docs/keyboard-protocol.rst
@@ -49,7 +49,7 @@ In addition to kitty, this protocol is also implemented in:
 * The `dte text editor <https://gitlab.com/craigbarnes/dte/-/issues/138>`__
 * The `Helix text editor <https://github.com/helix-editor/helix/pull/4939>`__
 * The `far2l file manager <https://github.com/elfmz/far2l/commit/e1f2ee0ef2b8332e5fa3ad7f2e4afefe7c96fc3b>`__
-* The `yazi file manager <https://github.com/sxyazi/yazi>`__
+* The `Yazi file manager <https://github.com/sxyazi/yazi>`__
 * The `awrit web browser <https://github.com/chase/awrit>`__
 * The `nushell shell <https://github.com/nushell/nushell/pull/10540>`__
 * The `fish shell <https://github.com/fish-shell/fish-shell/commit/8bf8b10f685d964101f491b9cc3da04117a308b4>`__


### PR DESCRIPTION
Fixes https://github.com/kovidgoyal/kitty/issues/7505