### PR TITLE
Add `--help` option to `kitty list-fonts`

### DIFF
--- a/kitty/fonts/list.py
+++ b/kitty/fonts/list.py
@@ -23,6 +23,10 @@ def create_family_groups(monospaced: bool = True) -> Dict[str, List[ListedFont]]
 
 
 def main(argv: Sequence[str]) -> None:
+    if '--help' in argv or '-h' in argv:
+        print("Usage: kitty +list-fonts [--psnames]")
+        sys.exit(2)
+
     psnames = '--psnames' in argv
     isatty = sys.stdout.isatty()
     groups = create_family_groups()


### PR DESCRIPTION
I haven't tested this, but it should work. Feel free to take this as an FR instead of a PR.

I'm assuming that `kitty list-fonts` and `kitty +list-fonts` are equivalent.