### PR TITLE
add option to scale window_logo via window_logo_scale

### DIFF
--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -1160,11 +1160,12 @@ faded and one being fully opaque.
 '''
     )
 
-opt('window_logo_scale', '0',
-    option_type='int', ctype='int',
+opt('window_logo_scale', '0.0 -1.0',
+    option_type='window_logo_scale', ctype='!window_logo_scale',
     long_text='''
-The percentage [1-100] of the window which the logo should scale to.
-0 to disable.
+The percentage [1-100] of the window which the logo should scale to. 
+Optionally setting 2 seperate values allows individual Width/Height scaling.
+Value of 0 in a given dimension disables scaling in that direction, single 0 to disable scaling.
 '''
     )
 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -1160,6 +1160,13 @@ faded and one being fully opaque.
 '''
     )
 
+opt('window_logo_scale', '0',
+    option_type='int', ctype='int',
+    long_text='''
+The percentage [1-100] of the window which the logo should scale to.
+0 to disable.
+'''
+    )
 
 opt('resize_debounce_time', '0.1 0.5',
     option_type='resize_debounce_time', ctype='!resize_debounce_time',

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -18,7 +18,8 @@ from kitty.options.utils import (
     shell_integration, store_multiple, symbol_map, tab_activity_symbol, tab_bar_edge,
     tab_bar_margin_height, tab_bar_min_tabs, tab_fade, tab_font_style, tab_separator,
     tab_title_template, titlebar_color, to_cursor_shape, to_font_size, to_layout_names, to_modifiers,
-    url_prefixes, url_style, visual_window_select_characters, window_border_width, window_size
+    url_prefixes, url_style, visual_window_select_characters, window_border_width, window_logo_scale,
+    window_size
 )
 
 
@@ -1391,7 +1392,7 @@ class Parser:
     choices_for_window_logo_position = choices_for_placement_strategy
 
     def window_logo_scale(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
-        ans['window_logo_scale'] = int(val)
+        ans['window_logo_scale'] = window_logo_scale(val)
 
     def window_margin_width(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['window_margin_width'] = edge_width(val)

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -1388,7 +1388,10 @@ class Parser:
             raise ValueError(f"The value {val} is not a valid choice for window_logo_position")
         ans["window_logo_position"] = val
 
-    choices_for_window_logo_position = frozenset(('top-left', 'top', 'top-right', 'left', 'center', 'right', 'bottom-left', 'bottom', 'bottom-right'))
+    choices_for_window_logo_position = choices_for_placement_strategy
+
+    def window_logo_scale(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        ans['window_logo_scale'] = int(val)
 
     def window_margin_width(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['window_margin_width'] = edge_width(val)

--- a/kitty/options/to-c-generated.h
+++ b/kitty/options/to-c-generated.h
@@ -618,7 +618,7 @@ convert_from_opts_window_logo_alpha(PyObject *py_opts, Options *opts) {
 
 static void
 convert_from_python_window_logo_scale(PyObject *val, Options *opts) {
-    opts->window_logo_scale = PyLong_AsLong(val);
+    window_logo_scale(val, opts);
 }
 
 static void

--- a/kitty/options/to-c-generated.h
+++ b/kitty/options/to-c-generated.h
@@ -617,6 +617,19 @@ convert_from_opts_window_logo_alpha(PyObject *py_opts, Options *opts) {
 }
 
 static void
+convert_from_python_window_logo_scale(PyObject *val, Options *opts) {
+    opts->window_logo_scale = PyLong_AsLong(val);
+}
+
+static void
+convert_from_opts_window_logo_scale(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "window_logo_scale");
+    if (ret == NULL) return;
+    convert_from_python_window_logo_scale(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
 convert_from_python_resize_debounce_time(PyObject *val, Options *opts) {
     resize_debounce_time(val, opts);
 }
@@ -1231,6 +1244,8 @@ convert_opts_from_python_opts(PyObject *py_opts, Options *opts) {
     convert_from_opts_window_logo_position(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_window_logo_alpha(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_window_logo_scale(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_resize_debounce_time(py_opts, opts);
     if (PyErr_Occurred()) return false;

--- a/kitty/options/to-c.h
+++ b/kitty/options/to-c.h
@@ -339,6 +339,12 @@ tab_bar_margin_height(PyObject *val, Options *opts) {
 }
 
 static void
+window_logo_scale(PyObject *src, Options *opts) {
+    opts->window_logo_scale.width = PyFloat_AsFloat(PyTuple_GET_ITEM(src, 0));
+    opts->window_logo_scale.height = PyFloat_AsFloat(PyTuple_GET_ITEM(src, 1));
+}
+
+static void
 resize_debounce_time(PyObject *src, Options *opts) {
     opts->resize_debounce_time.on_end = s_double_to_monotonic_t(PyFloat_AsDouble(PyTuple_GET_ITEM(src, 0)));
     opts->resize_debounce_time.on_pause = s_double_to_monotonic_t(PyFloat_AsDouble(PyTuple_GET_ITEM(src, 1)));

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -34,7 +34,7 @@ choices_for_tab_switch_strategy = typing.Literal['last', 'left', 'previous', 'ri
 choices_for_terminfo_type = typing.Literal['path', 'direct', 'none']
 choices_for_undercurl_style = typing.Literal['thin-sparse', 'thin-dense', 'thick-sparse', 'thick-dense']
 choices_for_underline_hyperlinks = typing.Literal['hover', 'always', 'never']
-choices_for_window_logo_position = typing.Literal['top-left', 'top', 'top-right', 'left', 'center', 'right', 'bottom-left', 'bottom', 'bottom-right']
+choices_for_window_logo_position = choices_for_placement_strategy
 
 option_names = (  # {{{
  'action_alias',
@@ -459,6 +459,7 @@ option_names = (  # {{{
  'window_logo_alpha',
  'window_logo_path',
  'window_logo_position',
+ 'window_logo_scale',
  'window_margin_width',
  'window_padding_width',
  'window_resize_step_cells',
@@ -619,6 +620,7 @@ class Options:
     window_logo_alpha: float = 0.5
     window_logo_path: typing.Optional[str] = None
     window_logo_position: choices_for_window_logo_position = 'bottom-right'
+    window_logo_scale: int = 0
     window_margin_width: FloatEdges = FloatEdges(left=0, top=0, right=0, bottom=0)
     window_padding_width: FloatEdges = FloatEdges(left=0, top=0, right=0, bottom=0)
     window_resize_step_cells: int = 2

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -620,7 +620,7 @@ class Options:
     window_logo_alpha: float = 0.5
     window_logo_path: typing.Optional[str] = None
     window_logo_position: choices_for_window_logo_position = 'bottom-right'
-    window_logo_scale: int = 0
+    window_logo_scale: typing.Tuple[float, float] = (0, -1.0)
     window_margin_width: FloatEdges = FloatEdges(left=0, top=0, right=0, bottom=0)
     window_padding_width: FloatEdges = FloatEdges(left=0, top=0, right=0, bottom=0)
     window_resize_step_cells: int = 2

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -646,6 +646,13 @@ def resize_draw_strategy(x: str) -> int:
     return cmap.get(x.lower(), 0)
 
 
+def window_logo_scale(x: str) -> Tuple[float, float]:
+    parts = x.split(maxsplit=1)
+    if len(parts) == 1:
+        return positive_float(parts[0]), -1.0
+    return positive_float(parts[0]), positive_float(parts[1])
+
+
 def resize_debounce_time(x: str) -> Tuple[float, float]:
     parts = x.split(maxsplit=1)
     if len(parts) == 1:

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -747,9 +747,6 @@ draw_window_logo(ssize_t vao_idx, OSWindow *os_window, const WindowLogoRenderDat
 
         logo_height_gl = gl_size(scaled_wl_height, os_window->viewport_height);
         logo_width_gl = gl_size(scaled_wl_width, os_window->viewport_width);
-    } else {
-        logo_height_gl = 0;
-        logo_width_gl = 0;
     }
 
     GLfloat logo_left_gl = clamp_position_to_nearest_pixel(

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -733,16 +733,34 @@ draw_window_logo(ssize_t vao_idx, OSWindow *os_window, const WindowLogoRenderDat
     GLfloat logo_width_gl = gl_size(wl->instance->width, os_window->viewport_width);
     GLfloat logo_height_gl = gl_size(wl->instance->height, os_window->viewport_height);
 
-    if (OPT(window_logo_scale) != 0) {
-        unsigned int scaled_wl_width;
-        unsigned int scaled_wl_height;
+    if (OPT(window_logo_scale.width) > 0 || OPT(window_logo_scale.height) > 0) {
+        unsigned int scaled_wl_width = os_window->viewport_width;
+        unsigned int scaled_wl_height = os_window->viewport_height;
 
-        if (os_window->viewport_height < os_window->viewport_width) {
-            scaled_wl_height = os_window->viewport_height * OPT(window_logo_scale) / 100;
-            scaled_wl_width = wl->instance->width * scaled_wl_height / wl->instance->height;
-        } else {
-            scaled_wl_width = os_window->viewport_width * OPT(window_logo_scale) / 100;
-            scaled_wl_height = wl->instance->height * scaled_wl_width / wl->instance->width;
+        // [sx] Scales logo to sx % of the viewports shortest dimension, preserving aspect ratio
+        if (OPT(window_logo_scale.height) < 0) {
+            if (os_window->viewport_height < os_window->viewport_width) {
+                scaled_wl_height = (int)(os_window->viewport_height * OPT(window_logo_scale.width) / 100);
+                scaled_wl_width = wl->instance->width * scaled_wl_height / wl->instance->height;
+            } else {
+                scaled_wl_width = (int)(os_window->viewport_width * OPT(window_logo_scale.width) / 100);
+                scaled_wl_height = wl->instance->height * scaled_wl_width / wl->instance->width;
+            }
+        }
+        // [0 sy] Scales logo's y dimension to sy % of viewporty keeping original x dimension
+        else if (OPT(window_logo_scale.width) == 0.0) {
+            scaled_wl_height = (int)(scaled_wl_height * OPT(window_logo_scale.height) / 100);
+            scaled_wl_width = wl->instance->width;
+        }
+        // [sx 0] Scales logo's x dimension to sx % of viewportx keeping original y dimension
+        else if (OPT(window_logo_scale.height) == 0.0) {
+            scaled_wl_width = (int)(scaled_wl_width * OPT(window_logo_scale.width) / 100);
+            scaled_wl_height = wl->instance->height;
+        }
+        // [sx sy] Scales logo's x and y dimension to sx and sy % of viewportx and viewporty respectively
+        else {
+            scaled_wl_height = (int)(scaled_wl_height * OPT(window_logo_scale.height) / 100);
+            scaled_wl_width = (int)(scaled_wl_width * OPT(window_logo_scale.width) / 100);
         }
 
         logo_height_gl = gl_size(scaled_wl_height, os_window->viewport_height);

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -732,6 +732,26 @@ draw_window_logo(ssize_t vao_idx, OSWindow *os_window, const WindowLogoRenderDat
     BLEND_PREMULT;
     GLfloat logo_width_gl = gl_size(wl->instance->width, os_window->viewport_width);
     GLfloat logo_height_gl = gl_size(wl->instance->height, os_window->viewport_height);
+
+    if (OPT(window_logo_scale) != 0) {
+        unsigned int scaled_wl_width;
+        unsigned int scaled_wl_height;
+
+        if (os_window->viewport_height < os_window->viewport_width) {
+            scaled_wl_height = os_window->viewport_height * OPT(window_logo_scale) / 100;
+            scaled_wl_width = wl->instance->width * scaled_wl_height / wl->instance->height;
+        } else {
+            scaled_wl_width = os_window->viewport_width * OPT(window_logo_scale) / 100;
+            scaled_wl_height = wl->instance->height * scaled_wl_width / wl->instance->width;
+        }
+
+        logo_height_gl = gl_size(scaled_wl_height, os_window->viewport_height);
+        logo_width_gl = gl_size(scaled_wl_width, os_window->viewport_width);
+    } else {
+        logo_height_gl = 0;
+        logo_width_gl = 0;
+    }
+
     GLfloat logo_left_gl = clamp_position_to_nearest_pixel(
             crd->gl.xstart + crd->gl.width * wl->position.canvas_x - logo_width_gl * wl->position.image_x, os_window->viewport_width);
     GLfloat logo_top_gl = clamp_position_to_nearest_pixel(

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -65,6 +65,7 @@ typedef struct {
     ImageAnchorPosition window_logo_position;
     bool background_image_linear;
     float background_tint, background_tint_gaps, window_logo_alpha;
+    unsigned int window_logo_scale;
 
     bool dynamic_background_opacity;
     float inactive_text_alpha;

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -65,7 +65,7 @@ typedef struct {
     ImageAnchorPosition window_logo_position;
     bool background_image_linear;
     float background_tint, background_tint_gaps, window_logo_alpha;
-    unsigned int window_logo_scale;
+    struct { float width, height; } window_logo_scale;
 
     bool dynamic_background_opacity;
     float inactive_text_alpha;


### PR DESCRIPTION
Implements what was discussed in #7532.

New option `window_logo_scale` takes int 0-100, scales the window logo image to x% of the window dimensions (smallest dimension sets scale).

Problem, using the current window_logo, you are able to position and clamp, but unable to enable scaling such that the logo does not take up too much space on a small terminal or be too small on a large terminal. Alternative solution would be to use background_image with cscale, yet if you want to have a logo anywhere other than the centre of the terminal, this quickly falls apart once you begin resizing the terminal outside the aspect ratio of the original image.
![image](https://github.com/kovidgoyal/kitty/assets/51936412/3e62dfee-9a84-4823-8259-9036a95e066a)

Adding the option to scale the window logo allows for the original goal of #7532 while being quite generic and overall a very minor code addition.
Here is an example of the proposed implementation to demonstrate the new option.
![image](https://github.com/kovidgoyal/kitty/assets/51936412/e4157fd5-02d4-442f-8406-27b34fb54ea4)
