### PR TITLE
Fix fullscreen via ctrl+shift+f11

### DIFF
--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -1106,7 +1106,7 @@ create_window_desktop_surface(_GLFWwindow* window)
 
 #ifdef XDG_TOPLEVEL_WM_CAPABILITIES_SINCE_VERSION
     if (_glfw.wl.xdg_wm_base_version < XDG_TOPLEVEL_WM_CAPABILITIES_SINCE_VERSION)
-        memset(&window->wl.wm_capabilities, 0x00, sizeof(window->wl.wm_capabilities));
+        memset(&window->wl.wm_capabilities, 0x01, sizeof(window->wl.wm_capabilities));
 #endif
     xdg_toplevel_add_listener(window->wl.xdg.toplevel, &xdgToplevelListener, window);
     if (_glfw.wl.decorationManager) {


### PR DESCRIPTION
Followup to https://github.com/kovidgoyal/kitty/pull/7554

Ctrl+Shift+F11 didn't work and prints the error:

    [6,051] [glfw error 65544]: Wayland compositor does not support full screen

However changing it to 0x01 fixes the full screen and the title bar is full length with tree window buttons. 

