### PR TITLE
Fix config patching to only modify values provided by the theme

### DIFF
--- a/tools/themes/collection.go
+++ b/tools/themes/collection.go
@@ -595,10 +595,8 @@ func patch_conf(text, theme_name string, theme *Theme) string {
 		ntext = text + addition
 	}
 	pat = utils.MustCompile(fmt.Sprintf(`(?m)^\s*(%s)\b`, strings.Join(maps.Keys(AllColorSettingNames), "|")))
-
 	return pat.ReplaceAllStringFunc(ntext, func(color_name string) string {
 		_, sets_color := theme.settings[color_name]
-
 		if (sets_color) {
 			return fmt.Sprintf("# %s", color_name);
 		} else {


### PR DESCRIPTION
Checks to see if a theme supplies a color before commenting out it's value in the patched config. This fixes an issue where a setting like `macos_titlebar_color background` may not be provided by a theme but switching themes would disable it.