### PR TITLE
Update graphics-protocol.rst

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -29,6 +29,7 @@ Some programs and libraries that use the kitty graphics protocol:
 
 * `termpdf.py <https://github.com/dsanson/termpdf.py>`_ - a terminal PDF/DJVU/CBR viewer
 * `ranger <https://github.com/ranger/ranger>`_ - a terminal file manager, with image previews
+* `broot <https://dystroy.org/broot/>`_ - a terminal file explorer and manager, with preview of images, SVG, PDF, etc.
 * `Yazi <https://github.com/sxyazi/yazi>`_ - Blazing fast terminal file manager written in Rust, based on async I/O
 * :doc:`kitty-diff <kittens/diff>` - a side-by-side terminal diff program with support for images
 * `tpix <https://github.com/jesvedberg/tpix>`_ - a statically compiled binary that can be used to display images and easily installed on remote servers without root access


### PR DESCRIPTION
Add broot to the list of applications using Kitty's graphics protocol

IMO the list would be easier to read with an alphabetical sorting and by removing the gratuitous "blazing fast" assertions but that's out of scope of this PR.