### PR TITLE
Fix themes kitten not displaying colors in narrow windows

### DIFF
--- a/kittens/themes/ui.go
+++ b/kittens/themes/ui.go
@@ -451,10 +451,11 @@ func (self *handler) draw_theme_demo() {
 				if intense {
 					s = "bright-" + s
 				}
-				if len(s) > trunc {
-					s = s[:trunc]
+				sTrunc := s
+				if len(sTrunc) > trunc {
+					sTrunc = sTrunc[:trunc]
 				}
-				buf.WriteString(self.lp.SprintStyled("fg="+s, s))
+				buf.WriteString(self.lp.SprintStyled("fg="+s, sTrunc))
 				buf.WriteString(" ")
 			}
 			text := strings.TrimSpace(buf.String())


### PR DESCRIPTION
The themes kitten used the truncated color name when formatting the colors themselves, which leads to broken coloring when the window is narrow enough to cause truncation to occur.