### PR TITLE
Add branch drawing symbols to box characters

### DIFF
--- a/kitty/fonts.c
+++ b/kitty/fonts.c
@@ -608,6 +608,7 @@ START_ALLOW_CASE_RANGE
         case 0xe0b0 ... 0xe0bf: case 0xe0d6 ... 0xe0d7:    // powerline box drawing
         case 0xee00 ... 0xee0b:    // fira code progress bar/spinner
         case 0x1fb00 ... 0x1fbae:  // symbols for legacy computing
+        case 0xf5d0 ... 0xf5fb:    // branch drawing characters
             return BOX_FONT;
         default:
             *is_emoji_presentation = has_emoji_presentation(cpu_cell, gpu_cell);
@@ -648,6 +649,8 @@ START_ALLOW_CASE_RANGE
             return 0xf00 + ch - 0x2800; // IDs from 0xf00 to 0xfff
         case 0x1fb00 ... 0x1fbae:
             return 0x1000 + ch - 0x1fb00; // IDs from 0x1000 to 0x10ae
+        case 0xf5d0 ... 0xf5fb:
+            return 0x2000 + ch - 0xf5d0; // IDs from 0x2000 to 0x202b
         default:
             return 0xffff;
     }


### PR DESCRIPTION
This symbols are for drawing git-like directed acyclic graphs in the terminal. Similar to box drawing characters, it is difficult to align these symbols perfectly when they're implemented only as font glyphs.

These codes are not based on any existing standard. I have implemented them using my experience creating the terminal-based branch viewer and vim plugin [vim-flog](https://github.com/rbong/vim-flog). I plan to use these symbols in flog.

Here is what the symbols look like in kitty, in order:

![kitty-syms](https://github.com/user-attachments/assets/45393f4a-526a-4ee5-b689-9096dcaa5ab6)

## Symbol order

The order is similar to the original box-drawing characters. Particularly, where there are symbols with a mix of light lines and heavy lines, I replace the heavy lines with curves. Otherwise, I try to follow a similar order.

## Symbol purposes

Some symbols effectively already exist, these ones in particular:

![existing-syms](https://github.com/user-attachments/assets/46a683a6-c29f-4226-98df-1cbca153a681)

Providing these symbols and not relying on the existing box symbols allows customizing line thickness and style only for branch viewers and not anything else that uses box drawing characters. This is not really required if we consider this unicode range only for a terminal that draws box drawing characters, but as a general standard symbol range I think it's good to have.

These symbols represent merging up into an existing branch from the right or left:

![merge up](https://github.com/user-attachments/assets/a6b824ea-a5b9-467d-a34c-f9564a994f2c)

These symbols represent forking out from an existing branch to the right or left:

![fork-out](https://github.com/user-attachments/assets/e478ac54-2353-4a5d-8734-af715f56f78b)

These symbols are for merges; merging into an ongoing merge line from the right or left; merging up from the right and left into a new branch above; merging up from the right and left into an existing branch (note the vertical alignment here is not as shown, see the first screenshot of all symbols for the actual alignment):

![octopus](https://github.com/user-attachments/assets/6ca6cf60-5089-4a99-a510-140010b38d1d)

A very particular, somewhat confusing situation, but possible while trying to preserve horizontal space; merge from the left while reordering the parent to the right under the branch:

![merge-and-rearrange](https://github.com/user-attachments/assets/94c76387-02ed-4fb2-9fd1-f25553983f50)

A branch "fading out" - used to represent branches that don't have any more parents in the otuput:

![fade](https://github.com/user-attachments/assets/d0a64ff2-3a06-4ecc-9ff7-bd21cb834634)

Merge commits and non-merge commits; disconnected, connected on one side, and connected on both sides:

![commts](https://github.com/user-attachments/assets/4ae9c8d9-aaf5-44d8-bbaa-529f65e850f1)

You might notice that the commit is not perfectly centered on the line. It does not look like this on every font size. This is because the line is aligned with non-supersampled lines, but the circles themselves are supersampled.

The symbols I detailed above are all the symbols you need to represent the typical left-aligned, top-to bottom git commit graph visualization. However, since this is meant to be a general standard, I have included symbols for aligning the graph in any other direction.

## Range selection

I selected a range (0xf5d0 - 0xf5fb) in a Unicode [Private Use Area](https://en.wikipedia.org/wiki/Private_Use_Areas) that is a reasonable distance from the previous icon set in Nerd icons.

This range is not in use by Fira Code or Nerd Fonts or any other icon/symbol set I could find.

Here is the unused range in Fira Code as visualized in FontForge:

![fira-code](https://github.com/user-attachments/assets/f9ba8a59-6e73-41ac-992d-cfc940b5272e)

Here is the unused range in a Nerd font:

![nerd](https://github.com/user-attachments/assets/ba1007e1-931c-4a87-ac64-17d640c70d28)

## New Code

* Added functions to draw branches fading out. I tried to apply the existing "hole" functions for this purpose, or at least implement similar functions, but it was much easier to draw only the solid part of these symbols rather than cutting out the holes. This is because they look best when they are symmetrical with their mirror images, not touching the side that they are fading out towards, and touching the side that they are fading out from. The existing hole functions were not ideal for expressing any of these properties, at least in a way I could find, even though you can fairly easily achieve similar spacing.

* Added a function for drawing circles. I could not find a great way to use any of the existing circular functions to create filled in circles; and at very small font sizes, these generate what look like rounded squares, not circles. In addition, it was easier to cut out the center of the center of non-merge commits than to draw tiny lines in the correct position in a way that works in every font size, and it looks more visually consistent than drawing arcs as well, so the circle function is used to both fill in and cut out circles.

## Code Changes

* Added the ability to account for supersample_factor in `draw_hline` and `draw_vline`. This is because of the number of lines I needed to draw in supersampled functions that had to line up with non-supersampled lines (namely commits and fading branches).
