### PR TITLE
Added CLI Interfacing Doc for Developers building kittens

### DIFF
--- a/docs/kittens/cli_interfacing.rst
+++ b/docs/kittens/cli_interfacing.rst
@@ -1,0 +1,90 @@
+CLI Interfacing
+===============
+
+While developing Kittens for Kitty, interfacing with CLI is handy for passing values and arguments. For this purpose, Kitty has an internal implementation of CLI interfacing with kittens.
+
+*While working with kittens, Kitty relies on internal implementations rather than external, third-party dependencies. The same applies to CLI implementation.*
+
+Procedure to Add CLI into Kittens
+---------------------------------
+
+Modify the `gen/go_code.py`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Edit the line ``for kitten in wrapped_kittens() + ('pager',):`` (line 469) and modify it to ``for kitten in wrapped_kittens() + ('pager', '{KITTEN_NAME}',):``.
+
+Create a `__init__.py` File in Your Kittens Folder
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Since Kitty interfaces the CLI through Python, you need to create the ``__init__.py`` file in the kitten's directory you are working with.
+
+Template for `main.go`
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: go
+
+    package {KITTEN_NAME}
+
+    import (
+        "fmt"
+        "kitty/tools/cli"
+    )
+
+    var _ = fmt.Print
+
+    func main(_ *cli.Command, opts_ *Options, args []string) (rc int, err error) {
+        return
+    }
+
+    func EntryPoint(parent *cli.Command) {
+        create_cmd(parent, main)
+    }
+
+Template for `main.py`
+^^^^^^^^^^^^^^^^^^^^^^
+
+The ``main.py`` contains the CLI definition for Kitty. Here, you define the options, arguments, values, and finally the definition and help text.
+
+.. code-block:: python
+
+    #!/usr/bin/env python
+    # License: GPL v3 Copyright: 2018, Kovid Goyal <kovid at kovidgoyal.net>
+
+    import sys
+
+    OPTIONS = r'''
+    --identifier -i
+    The identifier of this notification. If a notification with the same identifier
+    is already displayed, it is replaced/updated.
+    --wait-till-closed
+    type=bool-set
+    Wait until the notification is closed. If the user activates the notification,
+    "activated" is printed to STDOUT before quitting.
+    '''.format
+
+    help_text = '''\
+    Send notifications to the user that are displayed to them via the
+    desktop environment's notifications service. Works over SSH as well.
+    '''
+
+    usage = 'TITLE [BODY ...]'
+
+    if __name__ == '__main__':
+        raise SystemExit('This should be run as kitten clipboard')
+    elif __name__ == '__doc__':
+        cd = sys.cli_docs  # type: ignore
+        cd['usage'] = usage
+        cd['options'] = OPTIONS
+        cd['help_text'] = help_text
+        cd['short_desc'] = 'Send notifications to the user'
+
+Edit the `tools/cmd/tool/main.go`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Add the entry point of the kitten into ``tools/cmd/tool/main.go``.
+
+First, import the kitten into this file. To do this, add ``"kitty/kittens/{KITTEN_NAME}"`` into the ``import ( ... )``.
+
+Finally, add ``{KITTEN_NAME}.EntryPoint(root)`` into the ``func KittyToolEntryPoints(root *cli.Command)`` and done!
+
+With these five steps, you are ready to interface your kitten with CLI as specified by Kitty.


### PR DESCRIPTION
## Docs for Devs in Kitty

Since I am working on the IV kitten, I am surfing through the source code and figuring out alternatives built into the kitty for third-party stuff. Thanks to @kovidgoyal, he is helping us out in this journey, So I decided to create docs for stuff I feel like developers must know while working with the development of kittens in the future. Currently, I am trying to understand through source code and hashed, but that's a bit friction and hence, I would like to have some dev-docs that are made for the devs who would be working with kittens (or any other things) in the future and they can find the docs for them in kitty's official guide. 

For us, CLI interfacing was something we want to find, which Kovid explained through a commit, but for next time, devs should be able to find this in the docs itself. 