### PR TITLE
fix: add `hollow` option to `cursor_shape` config option

### DIFF
--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -302,7 +302,7 @@ place your value after the lines where the theme file is included.
 opt('cursor_shape', 'block',
     option_type='to_cursor_shape', ctype='int',
     long_text='''
-The cursor shape can be one of :code:`block`, :code:`beam`, :code:`underline`.
+The cursor shape can be one of :code:`block`, :code:`beam`, :code:`underline`, :code:`hollow`.
 Note that when reloading the config this will be changed only if the cursor
 shape has not been set by the program running in the terminal. This sets the
 default cursor shape, applications running in the terminal can override it. In

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -524,7 +524,8 @@ def cursor_text_color(x: str) -> Optional[Color]:
 cshapes = {
     'block': CURSOR_BLOCK,
     'beam': CURSOR_BEAM,
-    'underline': CURSOR_UNDERLINE
+    'underline': CURSOR_UNDERLINE,
+    'hollow': NO_CURSOR_SHAPE
 }
 cshapes_unfocused = {
     'block': CURSOR_BLOCK,


### PR DESCRIPTION
I prefer a hollow cursor, and would like for it to be allowed.
