### PR TITLE
A small doc patch.

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -540,3 +540,8 @@ The correct command will depend on your situation and hardware.
 system, which will wake the NVIDIA card during device enumeration.
 ``MESA_LOADER_DRIVER_OVERRIDE`` also assures that Mesa won't offer any NVIDIA
 card during enumeration, and will instead just use :file:`radeonsi_dri.so`.
+
+Mouse pointer configuration in X11
+----------------------------------
+To change the mouse pointer, run kitty with environment variables, like this:
+    XCURSOR_SIZE=<size> XCURSOR_THEME=<cursor theme> kitty <options>...

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -50,6 +50,7 @@ Glossary
       inside kitty windows and provide it with lots of powerful and flexible
       features such as viewing images, connecting conveniently to remote
       computers, transferring files, inputting unicode characters, etc.
+      See :doc:`the index of kittens</kittens_intro>` for more.
 
    easing function
       A function that controls how an animation progresses over time. kitty

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,8 @@ kitty
 
 *The fast, feature-rich, GPU based terminal emulator*
 
+\<`Website <https://sw.kovidgoyal.net/kitty/>`> \<`Source repo<https://github.com/kovidgoyal/kitty>`>
+
 .. toctree::
     :hidden:
 

--- a/docs/kittens/ssh.rst
+++ b/docs/kittens/ssh.rst
@@ -98,6 +98,9 @@ so any :opt:`hostname <kitten-ssh.hostname>` directives are ignored.
    shell prompt appears may be lost. So ideally don't start typing till you see
    the shell prompt. 😇
 
+.. warning::
+
+   If you forward X over ssh, do *not* use this kitten, or it fails.
 
 .. _real_world_ssh_kitten_config:
 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -272,7 +272,9 @@ egr()  # }}}
 
 
 # cursor {{{
-agr('cursor', 'Cursor customization')
+agr('cursor', 'Cursor customization', '''
+This section is about the text cursor. For the mouse pointer, see FAQ.
+''')
 
 opt('cursor', '#cccccc',
     option_type='to_color_or_none',


### PR DESCRIPTION
Hi. I created a small documentation patch. I can't build the doc, so it's not tested. If you like it, please use it. Feel free to modify.

Changes are:

1 Added links to the website (https://sw.kovidgoyal.net/kitty/) and the github repo in index.rst.
2 Mouse pointer config note.
3 Waring about "ssh" kitten; do not use it to forward X.
4 Glossary -> kitten: Added a link to kitten_intro.

Most points must be ok, but the rationale for the point 1 is: I always install the doc locally in my PC. In that case the kitty.png points the local home, not the upstream home.

Thanks a lot for developping kitty. Best wishes.