### PR TITLE
Extend and tweak branch drawing symbols based on feedback

### DIFF
--- a/kitty/fonts.c
+++ b/kitty/fonts.c
@@ -608,7 +608,7 @@ START_ALLOW_CASE_RANGE
         case 0xe0b0 ... 0xe0bf: case 0xe0d6 ... 0xe0d7:    // powerline box drawing
         case 0xee00 ... 0xee0b:    // fira code progress bar/spinner
         case 0x1fb00 ... 0x1fbae:  // symbols for legacy computing
-        case 0xf5d0 ... 0xf5fb:    // branch drawing characters
+        case 0xf5d0 ... 0xf60d:    // branch drawing characters
             return BOX_FONT;
         default:
             *is_emoji_presentation = has_emoji_presentation(cpu_cell, gpu_cell);
@@ -649,8 +649,8 @@ START_ALLOW_CASE_RANGE
             return 0xf00 + ch - 0x2800; // IDs from 0xf00 to 0xfff
         case 0x1fb00 ... 0x1fbae:
             return 0x1000 + ch - 0x1fb00; // IDs from 0x1000 to 0x10ae
-        case 0xf5d0 ... 0xf5fb:
-            return 0x2000 + ch - 0xf5d0; // IDs from 0x2000 to 0x202b
+        case 0xf5d0 ... 0xf60d:
+            return 0x2000 + ch - 0xf5d0; // IDs from 0x2000 to 0x203d
         default:
             return 0xffff;
     }

--- a/kitty/fonts/box_drawing.py
+++ b/kitty/fonts/box_drawing.py
@@ -595,7 +595,7 @@ def draw_circle(buf: SSByteArray, width: int, height: int, scale: float = 1.0, g
 
 
 @supersampled()
-def commit(buf: SSByteArray, width: int, height: int, level: int = 1, scale: float = 0.75, line: str = 'none', solid: bool = True) -> None:
+def commit(buf: SSByteArray, width: int, height: int, level: int = 1, scale: float = 0.9, line: str = 'none', solid: bool = True) -> None:
     ' Draw a circular commit with the given scale. Commits can either be solid or hollow and can have vertical, horizontal, up, down, left, or right line(s) '
 
     factor = buf.supersample_factor

--- a/kitty/fonts/box_drawing.py
+++ b/kitty/fonts/box_drawing.py
@@ -595,21 +595,22 @@ def draw_circle(buf: SSByteArray, width: int, height: int, scale: float = 1.0, g
 
 
 @supersampled()
-def commit(buf: SSByteArray, width: int, height: int, level: int = 1, scale: float = 0.9, line: str = 'none', solid: bool = True) -> None:
+def commit(buf: SSByteArray, width: int, height: int, level: int = 1, scale: float = 0.9, lines: list[str] = [], solid: bool = True) -> None:
     ' Draw a circular commit with the given scale. Commits can either be solid or hollow and can have vertical, horizontal, up, down, left, or right line(s) '
 
     factor = buf.supersample_factor
     # Round half width/height to supersample factor to avoid misalignment with non-supersampled lines
     hwidth, hheight = factor * (width // 2 // factor), factor * (height // 2 // factor)
 
-    if line == 'horizontal' or line == 'right':
-        draw_hline(buf, width, hwidth, width, hheight, level, supersample_factor=factor)
-    if line == 'horizontal' or line == 'left':
-        draw_hline(buf, width, 0, hwidth, hheight, level, supersample_factor=factor)
-    if line == 'vertical' or line == 'down':
-        draw_vline(buf, width, hheight, height, hwidth, level, supersample_factor=factor)
-    if line == 'vertical' or line == 'up':
-        draw_vline(buf, width, 0, hheight, hwidth, level, supersample_factor=factor)
+    for line in lines:
+        if line == 'horizontal' or line == 'right':
+            draw_hline(buf, width, hwidth, width, hheight, level, supersample_factor=factor)
+        if line == 'horizontal' or line == 'left':
+            draw_hline(buf, width, 0, hwidth, hheight, level, supersample_factor=factor)
+        if line == 'vertical' or line == 'down':
+            draw_vline(buf, width, hheight, height, hwidth, level, supersample_factor=factor)
+        if line == 'vertical' or line == 'up':
+            draw_vline(buf, width, 0, hheight, hwidth, level, supersample_factor=factor)
 
     draw_circle(buf, width, height, scale=scale)
     if not solid:
@@ -1332,18 +1333,36 @@ box_chars: dict[str, list[Callable[[BufType, int, int], Any]]] = {
     '': [hline, p(rounded_corner, which='╮'), p(rounded_corner, which='╰')],
     '': [commit],
     '': [p(commit, solid=False)],
-    '': [p(commit, line='right')],
-    '': [p(commit, solid=False, line='right')],
-    '': [p(commit, line='left')],
-    '': [p(commit, solid=False, line='left')],
-    '': [p(commit, line='horizontal')],
-    '': [p(commit, solid=False, line='horizontal')],
-    '': [p(commit, line='down')],
-    '': [p(commit, solid=False, line='down')],
-    '': [p(commit, line='up')],
-    '': [p(commit, solid=False, line='up')],
-    '': [p(commit, line='vertical')],
-    '': [p(commit, solid=False, line='vertical')],
+    '': [p(commit, lines=['right'])],
+    '': [p(commit, solid=False, lines=['right'])],
+    '': [p(commit, lines=['left'])],
+    '': [p(commit, solid=False, lines=['left'])],
+    '': [p(commit, lines=['horizontal'])],
+    '': [p(commit, solid=False, lines=['horizontal'])],
+    '': [p(commit, lines=['down'])],
+    '': [p(commit, solid=False, lines=['down'])],
+    '': [p(commit, lines=['up'])],
+    '': [p(commit, solid=False, lines=['up'])],
+    '': [p(commit, lines=['vertical'])],
+    '': [p(commit, solid=False, lines=['vertical'])],
+    '': [p(commit, lines=['right', 'down'])],
+    '': [p(commit, solid=False, lines=['right', 'down'])],
+    '': [p(commit, lines=['left', 'down'])],
+    '': [p(commit, solid=False, lines=['left', 'down'])],
+    '': [p(commit, lines=['right', 'up'])],
+    '': [p(commit, solid=False, lines=['right', 'up'])],
+    '': [p(commit, lines=['left', 'up'])],
+    '': [p(commit, solid=False, lines=['left', 'up'])],
+    '': [p(commit, lines=['vertical', 'right'])],
+    '': [p(commit, solid=False, lines=['vertical', 'right'])],
+    '': [p(commit, lines=['vertical', 'left'])],
+    '': [p(commit, solid=False, lines=['vertical', 'left'])],
+    '': [p(commit, lines=['horizontal', 'down'])],
+    '': [p(commit, solid=False, lines=['horizontal', 'down'])],
+    '': [p(commit, lines=['horizontal', 'up'])],
+    '': [p(commit, solid=False, lines=['horizontal', 'up'])],
+    '': [p(commit, lines=['horizontal', 'vertical'])],
+    '': [p(commit, solid=False, lines=['horizontal', 'vertical'])],
 }
 
 t, f = 1, 3


### PR DESCRIPTION
I have been working with [other terminal branch viewer authors](https://github.com/SuperBo/fugit2.nvim/discussions/88) to determine how they feel about the [new extended branch characters](https://github.com/kovidgoyal/kitty/pull/7681).

The first change is to make commit circles slightly larger. There has been feedback that the circles are too small, which I agree with.

The second change is to add more commit symbols with branches connected to them at various angles.

Here are all the symbols, with the new symbols in the last two rows:

![all symbols](https://github.com/user-attachments/assets/32b8f5ba-3bb8-4373-8d3e-d5f6633c379b)

It can be hard to see what the new symbols are with the large commit circles, so here they are with lines next to them that show how they're connected:

![new symbols only](https://github.com/user-attachments/assets/9aad13cc-f768-4edf-925c-f5047bb2ca2c)

The new symbols allow drawing the commit graph with branches merging directly into the commit rather than showing merges/forks on separate lines from commits.
My original goal was to provide a way to draw branches in every possible way.
This way was something I originally missed.

In case you think this will be a pattern, I believe the likelihood of realizing we could add a significant number of new branch symbols after this is low.
I did think of these symbols before, I just didn't think they would be useful.
There are only so many variations you can add, and this covers the rest of the possibilities as far as I can tell.

The new symbols still don't get close to any other symbol sets included in Nerd Fonts or Fira Code.