### PR TITLE
Add special flag to shell integration protocol to request real click events

### DIFF
--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -485,7 +485,19 @@ move_cursor_to_mouse_if_at_shell_prompt(Window *w) {
     Screen *screen = w->render_data.screen;
     int y = screen_cursor_at_a_shell_prompt(screen);
     if (y < 0 || (unsigned)y > w->mouse_pos.cell_y) return false;
-    return screen_fake_move_cursor_to_position(screen, w->mouse_pos.cell_x, w->mouse_pos.cell_y);
+
+    if (screen_prompt_supports_click_events(screen)) {
+        int sz = encode_mouse_event_impl(&w->mouse_pos, SGR_PROTOCOL, 1, PRESS, 0);
+        if (sz > 0) {
+            mouse_event_buf[sz] = 0;
+            write_escape_code_to_child(screen, ESC_CSI, mouse_event_buf);
+            return true;
+        }
+
+        return false;
+    } else {
+        return screen_fake_move_cursor_to_position(screen, w->mouse_pos.cell_x, w->mouse_pos.cell_y);
+    }
 }
 
 

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -1792,6 +1792,11 @@ screen_cursor_at_a_shell_prompt(const Screen *self) {
 }
 
 bool
+screen_prompt_supports_click_events(const Screen *self) {
+    return (bool) self->prompt_settings.supports_click_events;
+}
+
+bool
 screen_fake_move_cursor_to_position(Screen *self, index_type start_x, index_type start_y) {
     SelectionBoundary a = {.x=start_x, .y=start_y}, b = {.x=self->cursor->x, .y=self->cursor->y};
     SelectionBoundary *start, *end; int key;
@@ -2308,6 +2313,7 @@ parse_prompt_mark(Screen *self, char *buf, PromptKind *pk) {
         if (strcmp(token, "k=s") == 0) *pk = SECONDARY_PROMPT;
         else if (strcmp(token, "redraw=0") == 0) self->prompt_settings.redraws_prompts_at_all = 0;
         else if (strcmp(token, "special_key=1") == 0) self->prompt_settings.uses_special_keys_for_cursor_movement = 1;
+        else if (strcmp(token, "click_events=1") == 0) self->prompt_settings.supports_click_events = 1;
     }
 }
 

--- a/kitty/screen.h
+++ b/kitty/screen.h
@@ -133,6 +133,7 @@ typedef struct {
         struct {
             unsigned int redraws_prompts_at_all: 1;
             unsigned int uses_special_keys_for_cursor_movement: 1;
+            unsigned int supports_click_events: 1;
         };
         unsigned int val;
     } prompt_settings;
@@ -274,6 +275,7 @@ uint8_t screen_current_key_encoding_flags(Screen *self);
 void screen_report_key_encoding_flags(Screen *self);
 int screen_detect_url(Screen *screen, unsigned int x, unsigned int y);
 int screen_cursor_at_a_shell_prompt(const Screen *);
+bool screen_prompt_supports_click_events(const Screen *);
 bool screen_fake_move_cursor_to_position(Screen *, index_type x, index_type y);
 bool screen_send_signal_for_key(Screen *, char key);
 bool get_line_edge_colors(Screen *self, color_type *left, color_type *right);


### PR DESCRIPTION
This adds a new flag to the `<OSC>133;A` escape sequence from [Kitty's shell integration protocol](https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers), `click_events=1`.

If this flag is used, Kitty will emit SGR mouse events rather than faked keypresses when the prompt is clicked.

**Note:** this does not update the shell integration code to actually use this new flag. Unclear if that should be in this PR or a separate one, due to the complexity involved.