### PR TITLE
feat: don't draw visible tab bar margins if width is 0

### DIFF
--- a/kitty/tab_bar.py
+++ b/kitty/tab_bar.py
@@ -599,7 +599,7 @@ class TabBar:
                     blank_rects.append(Border(0, tab_bar.bottom + 1, vw, central.top, bg))
         g = self.window_geometry
         left_bg = right_bg = bg
-        if opts.tab_bar_margin_color is None:
+        if opts.tab_bar_margin_color is None or opts.tab_bar_margin_width == 0:
             left_bg = BorderColor.tab_bar_left_edge_color
             right_bg = BorderColor.tab_bar_right_edge_color
         if g.left > 0:


### PR DESCRIPTION
On thinking more about the related issue (#7871) I realized that the desired result can be obtained much more simply by suppressing the display of left/right margins whenever the user has set `tab_bar_margin_width` to `0.0` (which is the default).

### Before: Tab bar with three different font sizes

Left and right margins pop in and out depending on blank space:

<img width="1512" alt="before large" src="https://github.com/user-attachments/assets/5e352bcb-41a2-44ba-93f5-7ec29515ab6c">

<img width="1512" alt="before medium" src="https://github.com/user-attachments/assets/2e6e41d6-a7a3-444b-b2c0-793380d282ca">

![before small](https://github.com/user-attachments/assets/ee0676f1-ea02-4152-93fb-2b93c13bd9a4)

### After: Tab bar with three different font sizes

Left and right margins are not shown:

<img width="1512" alt="after large" src="https://github.com/user-attachments/assets/8be2ea48-691a-4159-b80f-097853f81893">

<img width="1512" alt="after medium" src="https://github.com/user-attachments/assets/03e10ce9-08bf-49c5-a364-2363fe0c9b85">

<img width="1512" alt="after small" src="https://github.com/user-attachments/assets/1af4d06e-8660-42ee-ba23-7d347b410352">

Closes: https://github.com/kovidgoyal/kitty/issues/7871