### PR TITLE
nix: fix shell config for darwin

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,9 @@ in
           ncurses
           lcms2
           xxhash
+          xxHash
+          simde
+          go_1_23
         ]
         ++ optionals stdenv.isDarwin [
           Cocoa
@@ -43,9 +46,7 @@ in
           wayland-protocols
           wayland
           openssl
-          xxHash
           dbus
-          simde
         ]
         ++ checkInputs;
 

--- a/shell.nix
+++ b/shell.nix
@@ -12,7 +12,6 @@ in
           harfbuzzWithCoreText
           ncurses
           lcms2
-          xxhash
           xxHash
           simde
           go_1_23


### PR DESCRIPTION
With the change, I was able to build the binary with `make` and successfully execute the tests with `./test.py` on darwin aarch64.