### PR TITLE
tests: apply `os.utime` to created symlinks too

### DIFF
--- a/kitty_tests/file_transmission.py
+++ b/kitty_tests/file_transmission.py
@@ -410,8 +410,10 @@ class TestFileTransmission(BaseTest):
             se(f.name)
             se(str(s))
             os.symlink('/', b/'abssym')
+            os.utime(b/'abssym', (1234.5, 1234.5), follow_symlinks=False)
             se(b/'abssym')
             os.symlink('sub/reg', b/'sym')
+            os.utime(b/'sym', (6789.1, 6789.1), follow_symlinks=False)
             se(b/'sym')
 
             with self.run_kitten(list(cmd) + [src, dest]) as pty:


### PR DESCRIPTION
Nanosecond precision is not universally available on all platforms. [For example](https://github.com/NixOS/nixpkgs/issues/143987#issuecomment-955749038), nixpkgs python is built using Apple SDK 10.12 that does not have `utimensat`. Because of that, python `os.stat` falls back to microsecond precision.

This patch applies `os.utime` with zeroed nanoseconds to symlinks created by the test case, the same way as it is already applied to other files tested for transfer.

The failure was observed [here](https://logs.ofborg.org/?key=nixos/nixpkgs.338070&attempt_id=4dffb1e2-ba17-4efe-a538-1155a147da75).

The error is:

```
AssertionError: {'simple': Entry(relpath='simple', mtime=13[498 chars]k=1)} != {'abssym': Entry(relpath='abssym', mtime=17[498 chars]k=1)}
- {'abssym': Entry(relpath='abssym', mtime=1727560356564990290, mode='0o120755', nlink=1),
?                                                          ^^
+ {'abssym': Entry(relpath='abssym', mtime=1727560356564990000, mode='0o120755', nlink=1),
?                                                          ^^
   'empty': Entry(relpath='empty', mtime=0, mode='0o40755', nlink=2),
   'hardlink': Entry(relpath='hardlink', mtime=1300000000, mode='0o100766', nlink=2),
   'simple': Entry(relpath='simple', mtime=1300000000, mode='0o100766', nlink=2),
   'sub': Entry(relpath='sub', mtime=0, mode='0o40755', nlink=3),
   'sub/reg': Entry(relpath='sub/reg', mtime=1171299999000, mode='0o100644', nlink=1),
-  'sym': Entry(relpath='sym', mtime=1727560356565132759, mode='0o120755', nlink=1)}
?                                                    ^^^
+  'sym': Entry(relpath='sym', mtime=1727560356565132000, mode='0o120755', nlink=1)}
?                                                    ^^^
```