### PR TITLE
Call `_command_offset` from the `bash-completion` framework for Bash only if available

### DIFF
--- a/tools/cli/bash.go
+++ b/tools/cli/bash.go
@@ -35,9 +35,11 @@ func bash_output_serializer(completions []*Completions, shell_state map[string]s
 	f := func(format string, args ...any) { fmt.Fprintf(&output, format+"\n", args...) }
 	n := completions[0].Delegate.NumToRemove
 	if n > 0 {
-		f("compopt +o nospace")
-		f("COMP_WORDS[%d]=%s", n, utils.QuoteStringForSH(completions[0].Delegate.Command))
-		f("_command_offset %d", n)
+		f("if builtin declare -F _command_offset >/dev/null; then")
+		f("  compopt +o nospace")
+		f("  COMP_WORDS[%d]=%s", n, utils.QuoteStringForSH(completions[0].Delegate.Command))
+		f("  _command_offset %d", n)
+		f("fi")
 	} else {
 		for _, mg := range completions[0].Groups {
 			mg.remove_common_prefix()


### PR DESCRIPTION
## Problem: Error message on `kitty kitten a[TAB]` without bash-completion

When the user doesn't set up the `bash-completion` framework, the completion setting by the kitty shell integration causes an error message on attempting a completion:

```console
$ kitty kitten a[TAB]bash:_command_offset: command not found
[TAB]bash:_command_offset: command not found
[TAB]bash:_command_offset: command not found
```

## Context

This is because the completion [attempts to call the shell function `_command_offset`](https://github.com/kovidgoyal/kitty/blob/69e1534087698faf5d25fd094a7cc3a77920cb0d/tools/cli/bash.go#L38-L40), which is provided by the `bash-completion` framework.

It should be noted that `bash-completion` is a project separate from Bash itself, and `bash-completion` is not necessarily loaded in a Bash session. In fact, some users do not want to use `bash-completion` for performance reasons in low-power machines, etc.

Since the current kitty shell integration calls `_command_offset`, it has an implicit dependency on `bash-completion`. I tried to find whether the kitty documentation mentions `bash-completion` as a requirement, but the documentation doesn't seem to mention this dependency as far as I searched.

## Solution

In this PR, I suggest using `_command_offset` *only when `bash_completion` is loaded* in the current Bash session by checking its existence.

An alternative solution might be to document the requirement of `bash-completion` in the kitty's documentation and to print a message that kitty requires `bash-completion` when `_command_offset` does not exist. However, this anyway checks the existence of `_command_offset`, so I think it would be simpler that we just use `_command_offset` only when available.

If there are any requests for the PR (such as better solutions, adjustments, etc), I will happily update it. 