### PR TITLE
Fix segfault when font descriptor point to invalid font file

### DIFF
--- a/kitty/fontconfig.c
+++ b/kitty/fontconfig.c
@@ -520,7 +520,7 @@ face_from_descriptor:
             }
         }
         ans = face_from_descriptor(d, fg);
-        if (!glyph_found) glyph_found = has_cell_text(face_has_codepoint, ans, cell, false);
+        if (!glyph_found && ans) glyph_found = has_cell_text(face_has_codepoint, ans, cell, false);
     }
 end:
     Py_CLEAR(d);

--- a/kitty/freetype.c
+++ b/kitty/freetype.c
@@ -279,7 +279,7 @@ face_from_descriptor(PyObject *descriptor, FONTS_DATA_HANDLE fg) {
     if (retval != NULL) {
         Face *self = (Face *)retval;
         int error;
-        if ((error = FT_New_Face(library, path, index, &(self->face)))) { self->face = NULL; set_load_error(path, error); }
+        if ((error = FT_New_Face(library, path, index, &(self->face)))) { self->face = NULL; return set_load_error(path, error); }
         if (!init_ft_face(self, PyDict_GetItemString(descriptor, "path"), hinting, hint_style, fg)) return NULL;
         PyObject *ns = PyDict_GetItemString(descriptor, "named_style");
         if (ns) {


### PR DESCRIPTION
For some reason, `d`, the descriptor used to load the font face, points to a file that does not exist in my system, so `face_from_descriptor` returns `NULL`, and then `has_cell_text` segfaults. I don't know if it's a normal behavior. I also had to add a seemingly missing `return` (all the other lines had it, and it was segfaulting at `init_ft_face` otherwise). Maybe there is another root cause issue that should be fixed, but I don't know the code base enough to know.

Either way, have a great day!