### PR TITLE
Minor fixes about cursor trail 

### DIFF
--- a/kitty/cursor_trail.c
+++ b/kitty/cursor_trail.c
@@ -45,6 +45,7 @@ update_cursor_trail_target(CursorTrail *ct, Window *w) {
         EDGE(x, 1) = right;
         EDGE(y, 0) = top;
         EDGE(y, 1) = bottom;
+        ct->screen = WD.screen;
     }
 }
 
@@ -119,13 +120,9 @@ update_cursor_trail(CursorTrail *ct, Window *w, monotonic_t now, OSWindow *os_wi
         ct->needs_render = true;
     }
 
-    if (ct->needs_render) {
-        ColorProfile *cp = WD.screen->color_profile;
-        ct->color = colorprofile_to_color(cp, cp->overridden.cursor_color, cp->configured.cursor_color).rgb;
-    }
-
-#undef WD
-#undef EDGE
     // returning true here will cause the cells to be drawn
     return ct->needs_render || needs_render_prev;
 }
+
+#undef WD
+#undef EDGE

--- a/kitty/cursor_trail.c
+++ b/kitty/cursor_trail.c
@@ -42,8 +42,10 @@ update_cursor_trail(CursorTrail *ct, Window *w, monotonic_t now, OSWindow *os_wi
 
 #define EDGE(axis, index) ct->cursor_edge_##axis[index]
 
-    if (!WD.screen->paused_rendering.expires_at && !get_cursor_edge(&EDGE(x, 0), &EDGE(x, 1), &EDGE(y, 0), &EDGE(y, 1), w)) {
-        return needs_render_prev;
+    if (!WD.screen->paused_rendering.expires_at && OPT(cursor_trail) < now - WD.screen->cursor->updated_at) {
+        if (!get_cursor_edge(&EDGE(x, 0), &EDGE(x, 1), &EDGE(y, 0), &EDGE(y, 1), w)) {
+            return needs_render_prev;
+        }
     }
 
     // the decay time for the trail to reach 1/1024 of its distance from the cursor corner
@@ -55,7 +57,8 @@ update_cursor_trail(CursorTrail *ct, Window *w, monotonic_t now, OSWindow *os_wi
             ct->corner_x[i] = EDGE(x, ci[i][0]);
             ct->corner_y[i] = EDGE(y, ci[i][1]);
         }
-    } else if (OPT(cursor_trail) < now - WD.screen->cursor->position_changed_by_client_at && ct->updated_at < now) {
+    }
+    else if (ct->updated_at < now) {
         float cursor_center_x = (EDGE(x, 0) + EDGE(x, 1)) * 0.5f;
         float cursor_center_y = (EDGE(y, 0) + EDGE(y, 1)) * 0.5f;
         float cursor_diag_2 = norm(EDGE(x, 1) - EDGE(x, 0), EDGE(y, 1) - EDGE(y, 0)) * 0.5f;

--- a/kitty/cursor_trail.c
+++ b/kitty/cursor_trail.c
@@ -50,10 +50,12 @@ update_cursor_trail_target(CursorTrail *ct, Window *w) {
 }
 
 static bool
-update_cursor_trail_corners(CursorTrail *ct, monotonic_t now, OSWindow *os_window, float dx_threshold, float dy_threshold) {
+update_cursor_trail_corners(CursorTrail *ct, Window *w, monotonic_t now, OSWindow *os_window) {
     // the trail corners move towards the cursor corner at a speed proportional to their distance from the cursor corner.
     // equivalent to exponential ease out animation.
     static const int ci[4][2] = {{1, 0}, {1, 1}, {0, 1}, {0, 0}};
+    const float dx_threshold = WD.dx / WD.screen->cell_size.width;
+    const float dy_threshold = WD.dy / WD.screen->cell_size.height;
 
     // the decay time for the trail to reach 1/1024 of its distance from the cursor corner
     float decay_fast = OPT(cursor_trail_decay_fast);
@@ -107,16 +109,14 @@ update_cursor_trail_corners(CursorTrail *ct, monotonic_t now, OSWindow *os_windo
 
 bool
 update_cursor_trail(CursorTrail *ct, Window *w, monotonic_t now, OSWindow *os_window) {
-    const float dx_threshold = WD.dx / WD.screen->cell_size.width;
-    const float dy_threshold = WD.dy / WD.screen->cell_size.height;
-    bool needs_render_prev = ct->needs_render;
-    ct->needs_render = false;
-
     if (!WD.screen->paused_rendering.expires_at && OPT(cursor_trail) < now - WD.screen->cursor->position_changed_by_client_at) {
         update_cursor_trail_target(ct, w);
     }
 
-    if (update_cursor_trail_corners(ct, now, os_window, dx_threshold, dy_threshold)) {
+    bool needs_render_prev = ct->needs_render;
+    ct->needs_render = false;
+
+    if (update_cursor_trail_corners(ct, w, now, os_window)) {
         ct->needs_render = true;
     }
 

--- a/kitty/cursor_trail.c
+++ b/kitty/cursor_trail.c
@@ -10,7 +10,7 @@ static void
 update_cursor_trail_target(CursorTrail *ct, Window *w) {
 #define EDGE(axis, index) ct->cursor_edge_##axis[index]
 #define WD w->render_data
-    float left, right, top, bottom;
+    float left = FLT_MAX, right = FLT_MAX, top = FLT_MAX, bottom = FLT_MAX;
     switch (WD.screen->cursor_render_info.shape) {
         case CURSOR_BLOCK:
         case CURSOR_HOLLOW:
@@ -18,10 +18,8 @@ update_cursor_trail_target(CursorTrail *ct, Window *w) {
         case CURSOR_UNDERLINE:
             left = WD.xstart + WD.screen->cursor_render_info.x * WD.dx;
             bottom = WD.ystart - (WD.screen->cursor_render_info.y + 1) * WD.dy;
-            break;
         default:
-            left = FLT_MAX;
-            bottom = FLT_MAX;
+            break;
     }
     switch (WD.screen->cursor_render_info.shape) {
         case CURSOR_BLOCK:

--- a/kitty/screen.h
+++ b/kitty/screen.h
@@ -97,6 +97,7 @@ typedef struct {
     struct {
         unsigned int cursor_x, cursor_y, scrolled_by;
         index_type lines, columns;
+        color_type cursor_bg;
     } last_rendered;
     bool is_dirty, scroll_changed, reload_all_gpu_data;
     Cursor *cursor;

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -1154,7 +1154,9 @@ draw_cursor_trail(CursorTrail *trail) {
     glUniform2fv(trail_program_layout.uniforms.cursor_edge_x, 1, trail->cursor_edge_x);
     glUniform2fv(trail_program_layout.uniforms.cursor_edge_y, 1, trail->cursor_edge_y);
 
-    color_vec3(trail_program_layout.uniforms.trail_color, trail->color);
+    ColorProfile *cp = trail->screen->color_profile;
+    color_type color = colorprofile_to_color(cp, cp->overridden.cursor_color, cp->configured.cursor_color).rgb;
+    color_vec3(trail_program_layout.uniforms.trail_color, color);
 
     glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -385,6 +385,9 @@ cell_update_uniform_block(ssize_t vao_idx, Screen *screen, int uniform_buffer, c
 #undef COLOR
     rd->url_color = OPT(url_color); rd->url_style = OPT(url_style);
 
+    // store last rendered cursor color for trail rendering
+    screen->last_rendered.cursor_bg = rd->cursor_bg;
+
     unmap_vao_buffer(vao_idx, uniform_buffer); rd = NULL;
 }
 
@@ -1154,9 +1157,7 @@ draw_cursor_trail(CursorTrail *trail) {
     glUniform2fv(trail_program_layout.uniforms.cursor_edge_x, 1, trail->cursor_edge_x);
     glUniform2fv(trail_program_layout.uniforms.cursor_edge_y, 1, trail->cursor_edge_y);
 
-    ColorProfile *cp = trail->screen->color_profile;
-    color_type color = colorprofile_to_color(cp, cp->overridden.cursor_color, cp->configured.cursor_color).rgb;
-    color_vec3(trail_program_layout.uniforms.trail_color, color);
+    color_vec3(trail_program_layout.uniforms.trail_color, trail->screen->last_rendered.cursor_bg);
 
     glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -218,7 +218,7 @@ typedef struct {
 typedef struct {
     bool needs_render;
     monotonic_t updated_at;
-    color_type color;
+    Screen* screen;
     float corner_x[4];
     float corner_y[4];
     float cursor_edge_x[2];


### PR DESCRIPTION
two main changes
* Reuse cursor color computed in `cell_update_uniform_block` to render cursor trail
* Refactored cursor trail update logic. So its behavior can be more easily grasped looking at the code.

> Similarly, I want to basically ensure no trail is started while in
rendering paused mode and that for cursor movements that happen in that
mode the position_changed_by_client_at field is the time at which
rendering was resumed. 

I believe the current implementation already addresses your concern. Here's why:

1. The trail only displays when the current trail position and target cursor position are not equal:

```c
ct->needs_render = false;

if (update_cursor_trail_corners(ct, w, now, os_window)) {
    ct->needs_render = true;
}
```

2. The target cursor position does not change while in the paused_rendering state:

```c
if (!WD.screen->paused_rendering.expires_at && OPT(cursor_trail) < now - WD.screen->cursor->position_changed_by_client_at) {
    update_cursor_trail_target(ct, w);
}
```

3. Given points 1 and 2, while in paused rendering, the cursor movement doesn't change target position of the trail(`cursor_edge_x` and `cursor_edge_y`). Instead, the trail position updated toward the target position last set before entering paused_rendering. Once trail reaches its target position, it keeps position and rendering not be triggered until pausing end.