### PR TITLE
Enhance Cursor Trail: Improved Animation, Fades, and New Distance Threshold Option

### DIFF
--- a/kitty/cursor_trail.c
+++ b/kitty/cursor_trail.c
@@ -52,11 +52,10 @@ should_skip_cursor_trail_update(CursorTrail *ct, Window *w, OSWindow *os_window)
         return true;
     }
 
-    int distance_threshold = 2;  // make it option
-    if (distance_threshold > 0 && !ct->needs_render) {
+    if (OPT(cursor_trail_distance_threshold) > 0 && !ct->needs_render) {
         int dx = (int)round((ct->corner_x[0] - EDGE(x, 1)) / WD.dx);
         int dy = (int)round((ct->corner_y[0] - EDGE(y, 0)) / WD.dy);
-        if (abs(dx) + abs(dy) <= distance_threshold) {
+        if (abs(dx) + abs(dy) <= OPT(cursor_trail_distance_threshold)) {
             return true;
         }
     }

--- a/kitty/cursor_trail.c
+++ b/kitty/cursor_trail.c
@@ -123,6 +123,21 @@ update_cursor_trail_state(CursorTrail *ct, Window *w, monotonic_t now, OSWindow 
         }
     }
 
+
+    const bool cursor_trail_always_visible = false;
+    if (cursor_trail_always_visible) {
+        log_error("A: cursor trail always visible");
+        ct->opacity = 1.0f;
+    } else if (WD.screen->modes.mDECTCEM) {
+        log_error("B: cursor is visible");
+      ct->opacity += monotonic_t_to_s_double(now - ct->updated_at) / OPT(cursor_trail_decay_slow);
+      ct->opacity = fminf(ct->opacity, 1.0f);
+    } else {
+        log_error("C: cursor is invisible");
+      ct->opacity -= monotonic_t_to_s_double(now - ct->updated_at) / OPT(cursor_trail_decay_slow);
+      ct->opacity = fmaxf(ct->opacity, 0.0f);
+    }
+
     ct->updated_at = now;
     ct->needs_render = false;
 

--- a/kitty/cursor_trail.c
+++ b/kitty/cursor_trail.c
@@ -51,8 +51,8 @@ update_cursor_trail_corners(CursorTrail *ct, Window *w, monotonic_t now, OSWindo
     // the trail corners move towards the cursor corner at a speed proportional to their distance from the cursor corner.
     // equivalent to exponential ease out animation.
     static const int ci[4][2] = {{1, 0}, {1, 1}, {0, 1}, {0, 0}};
-    const float dx_threshold = WD.dx / WD.screen->cell_size.width;
-    const float dy_threshold = WD.dy / WD.screen->cell_size.height;
+    const float dx_threshold = WD.dx / WD.screen->cell_size.width * 0.5f;
+    const float dy_threshold = WD.dy / WD.screen->cell_size.height * 0.5f;
 
     // the decay time for the trail to reach 1/1024 of its distance from the cursor corner
     float decay_fast = OPT(cursor_trail_decay_fast);
@@ -78,9 +78,9 @@ update_cursor_trail_corners(CursorTrail *ct, Window *w, monotonic_t now, OSWindo
         for (int i = 0; i < 4; ++i) {
             dx[i] = EDGE(x, ci[i][0]) - ct->corner_x[i];
             dy[i] = EDGE(y, ci[i][1]) - ct->corner_y[i];
-            if (fabsf(dx[i]) < dx_threshold && fabsf(dy[i]) < dy_threshold) {
+            if (fabsf(dx[i]) < 1e-6 && fabsf(dy[i]) < 1e-6) {
                 dx[i] = dy[i] = 0.0f;
-                dot[i] = 1.0f;
+                dot[i] = 0.0f;
                 continue;
             }
             dot[i] = (dx[i] * (EDGE(x, ci[i][0]) - cursor_center_x) +
@@ -95,8 +95,6 @@ update_cursor_trail_corners(CursorTrail *ct, Window *w, monotonic_t now, OSWindo
 
         for (int i = 0; i < 4; ++i) {
             if ((dx[i] == 0 && dy[i] == 0) || min_dot == FLT_MAX) {
-                ct->corner_x[i] = EDGE(x, ci[i][0]);
-                ct->corner_y[i] = EDGE(y, ci[i][1]);
                 continue;
             }
 

--- a/kitty/cursor_trail.c
+++ b/kitty/cursor_trail.c
@@ -128,10 +128,10 @@ update_cursor_trail_opacity(CursorTrail *ct, Window *w, monotonic_t now) {
     if (cursor_trail_always_visible) {
         ct->opacity = 1.0f;
     } else if (WD.screen->modes.mDECTCEM) {
-        ct->opacity += monotonic_t_to_s_double(now - ct->updated_at) / OPT(cursor_trail_decay_slow);
+        ct->opacity += (float)monotonic_t_to_s_double(now - ct->updated_at) / OPT(cursor_trail_decay_slow);
         ct->opacity = fminf(ct->opacity, 1.0f);
     } else {
-        ct->opacity -= monotonic_t_to_s_double(now - ct->updated_at) / OPT(cursor_trail_decay_slow);
+        ct->opacity -= (float)monotonic_t_to_s_double(now - ct->updated_at) / OPT(cursor_trail_decay_slow);
         ct->opacity = fmaxf(ct->opacity, 0.0f);
     }
 }

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -365,7 +365,7 @@ See :opt:`cursor_trail_decay` to control the animation speed.
 '''
     )
 
-opt('cursor_trail_decay', '0.1 0.3',
+opt('cursor_trail_decay', '0.1 0.4',
     option_type='cursor_trail_decay',
     ctype='!cursor_trail_decay',
     long_text='''

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -379,8 +379,18 @@ Adjust these values to control how quickly the cursor trail fades away.
 ''',
     )
 
-egr()  # }}}
+opt('cursor_trail_distance_threshold', '2',
+    option_type='positive_int', ctype='int',
+    long_text='''
+Set the distance threshold for updating the cursor trail. This option accepts a
+positive integer value that represents the minimum distance (in cell units) the
+cursor must move before the trail is updated. When the cursor moves less than
+this threshold, the trail update is skipped, reducing unnecessary cursor trail
+animation.
+'''
+    )
 
+egr()  # }}}
 
 # scrollback {{{
 agr('scrollback', 'Scrollback')

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -937,6 +937,9 @@ class Parser:
     def cursor_trail_decay(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['cursor_trail_decay'] = cursor_trail_decay(val)
 
+    def cursor_trail_distance_threshold(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
+        ans['cursor_trail_distance_threshold'] = positive_int(val)
+
     def cursor_underline_thickness(self, val: str, ans: typing.Dict[str, typing.Any]) -> None:
         ans['cursor_underline_thickness'] = positive_float(val)
 

--- a/kitty/options/to-c-generated.h
+++ b/kitty/options/to-c-generated.h
@@ -188,6 +188,19 @@ convert_from_opts_cursor_trail_decay(PyObject *py_opts, Options *opts) {
 }
 
 static void
+convert_from_python_cursor_trail_distance_threshold(PyObject *val, Options *opts) {
+    opts->cursor_trail_distance_threshold = PyLong_AsLong(val);
+}
+
+static void
+convert_from_opts_cursor_trail_distance_threshold(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "cursor_trail_distance_threshold");
+    if (ret == NULL) return;
+    convert_from_python_cursor_trail_distance_threshold(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
 convert_from_python_scrollback_indicator_opacity(PyObject *val, Options *opts) {
     opts->scrollback_indicator_opacity = PyFloat_AsFloat(val);
 }
@@ -1152,6 +1165,8 @@ convert_opts_from_python_opts(PyObject *py_opts, Options *opts) {
     convert_from_opts_cursor_trail(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_cursor_trail_decay(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_cursor_trail_distance_threshold(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_scrollback_indicator_opacity(py_opts, opts);
     if (PyErr_Occurred()) return false;

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -514,7 +514,7 @@ class Options:
     cursor_stop_blinking_after: float = 15.0
     cursor_text_color: typing.Optional[kitty.fast_data_types.Color] = Color(17, 17, 17)
     cursor_trail: int = 0
-    cursor_trail_decay: typing.Tuple[float, float] = (0.1, 0.3)
+    cursor_trail_decay: typing.Tuple[float, float] = (0.1, 0.4)
     cursor_trail_distance_threshold: int = 2
     cursor_underline_thickness: float = 2.0
     default_pointer_shape: choices_for_default_pointer_shape = 'beam'

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -336,6 +336,7 @@ option_names = (  # {{{
  'cursor_text_color',
  'cursor_trail',
  'cursor_trail_decay',
+ 'cursor_trail_distance_threshold',
  'cursor_underline_thickness',
  'default_pointer_shape',
  'detect_urls',
@@ -514,6 +515,7 @@ class Options:
     cursor_text_color: typing.Optional[kitty.fast_data_types.Color] = Color(17, 17, 17)
     cursor_trail: int = 0
     cursor_trail_decay: typing.Tuple[float, float] = (0.1, 0.3)
+    cursor_trail_distance_threshold: int = 2
     cursor_underline_thickness: float = 2.0
     default_pointer_shape: choices_for_default_pointer_shape = 'beam'
     detect_urls: bool = True

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -1149,6 +1149,8 @@ init_trail_program(void) {
 void
 draw_cursor_trail(CursorTrail *trail, Window *active_window) {
     bind_program(TRAIL_PROGRAM);
+    glEnable(GL_BLEND);
+    BLEND_ONTO_OPAQUE;
 
     glUniform4fv(trail_program_layout.uniforms.x_coords, 1, trail->corner_x);
     glUniform4fv(trail_program_layout.uniforms.y_coords, 1, trail->corner_y);
@@ -1157,9 +1159,10 @@ draw_cursor_trail(CursorTrail *trail, Window *active_window) {
     glUniform2fv(trail_program_layout.uniforms.cursor_edge_y, 1, trail->cursor_edge_y);
 
     color_vec3(trail_program_layout.uniforms.trail_color, active_window ? active_window->render_data.screen->last_rendered.cursor_bg : OPT(foreground));
+    glUniform1fv(trail_program_layout.uniforms.trail_opacity, 1, &trail->opacity);
 
     glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
-
+    glDisable(GL_BLEND);
     unbind_program();
 }
 

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -49,6 +49,7 @@ typedef struct {
     monotonic_t cursor_trail;
     float cursor_trail_decay_fast;
     float cursor_trail_decay_slow;
+    float cursor_trail_distance_threshold;
     unsigned int url_style;
     unsigned int scrollback_pager_history_size;
     bool scrollback_fill_enlarged_window;

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -219,6 +219,7 @@ typedef struct {
 typedef struct {
     bool needs_render;
     monotonic_t updated_at;
+    float opacity;
     float corner_x[4];
     float corner_y[4];
     float cursor_edge_x[2];

--- a/kitty/trail_fragment.glsl
+++ b/kitty/trail_fragment.glsl
@@ -1,6 +1,7 @@
 uniform vec2 cursor_edge_x;
 uniform vec2 cursor_edge_y;
 uniform vec3 trail_color;
+uniform float trail_opacity;
 
 in vec2 frag_pos;
 out vec4 final_color;
@@ -10,6 +11,6 @@ void main() {
         cursor_edge_y[1] <= frag_pos.y && frag_pos.y <= cursor_edge_y[0]) {
         discard;
     } else {
-        final_color = vec4(trail_color, 1.0);
+        final_color = vec4(trail_color, trail_opacity);
     }
 }


### PR DESCRIPTION
continued from https://github.com/kovidgoyal/kitty/pull/7970. 3 main changes

1. Improved cursor trail animation. It now looks uniform regardless of its moving direction. The movement appears smoother, especially when the cursor moves horizontally.


https://github.com/user-attachments/assets/9c089fb9-666a-4057-80ed-ab1036ce5231

https://github.com/user-attachments/assets/618fbf65-487a-423a-9ad3-afda22c4de2d

https://github.com/user-attachments/assets/4ec4c3c7-3aeb-4285-bcc5-c539f041b352

https://github.com/user-attachments/assets/a06cc8c8-2bcf-4f8e-b975-c918e4da6441


2. The trail now fades in and out when moving between windows with different cursor visibility. One caveat: the trail will not be visible when moving from a window where the cursor is hidden to another window where the cursor is also hidden. However, this scenario is likely rare.

https://github.com/user-attachments/assets/e2372378-b243-4e9d-9657-7e0464999a6e

https://github.com/user-attachments/assets/fc767669-f9c5-414c-8db5-6fc85b78ed10



3. Added a new option `cursor_trail_distance_threshold`. The cursor trail will not be initiated when the cursor jump distance is below this threshold.

