### PR TITLE
Remove duplicated "choose_fonts" command in kitten

### DIFF
--- a/kittens/choose_fonts/main.go
+++ b/kittens/choose_fonts/main.go
@@ -105,8 +105,4 @@ file, kitty.conf is edited. This is most useful if you add include
 fonts.conf to your kitty.conf and then have the kitten operate only on
 fonts.conf, allowing kitty.conf to remain unchanged.`,
 	})
-
-	clone := root.AddClone(ans.Group, ans)
-	clone.Hidden = false
-	clone.Name = "choose_fonts"
 }


### PR DESCRIPTION
# Description 

Hello,

The choose fonts command appears twice in the kitten command.

![image](https://github.com/user-attachments/assets/866a949e-6331-46bf-b208-5b50667f8e10)


I'm not sure if  this was intended (as a legacy commands or else, sorry for the PR if that's the case, i didn't find the information about it in issues/PR) or if the `Hidden` value should be set to ` true`