### PR TITLE
tui: explicitly turn off in-band resize mode

### DIFF
--- a/tools/tui/loop/terminal-state.go
+++ b/tools/tui/loop/terminal-state.go
@@ -169,6 +169,9 @@ func (self *TerminalStateOptions) ResetStateEscapeCodes() string {
 	} else {
 		sb.WriteString(SAVE_CURSOR)
 	}
+	if self.in_band_resize_notification {
+		reset_modes(&sb, INBAND_RESIZE_NOTIFICATION)
+	}
 	sb.WriteString(RESTORE_PRIVATE_MODE_VALUES)
 	if self.restore_colors {
 		sb.WriteString(RESTORE_COLORS)


### PR DESCRIPTION
Explicitly turn off in-band resize notifications if they were requested as part of the loop. Kitty implicitly resets this mode when `XTRESTORE` (`CSI ? r`) is seen, however some terminals implementing mode 2048 (eg foot and Ghostty) follow the xterm behavior of only restoring the state of explicitly passed modes. Some of the kittens have become very useful outside of just Kitty (`show-key`, for example) - but when mode 2048 is left enabled in this way, escape codes are dumped to the screen. 

Add an explicit reset of mode 2048 to support the behavior of other terminal emulators.