### PR TITLE
Fix cursor trail update blocks key input when repaint_delay is 0

### DIFF
--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -753,7 +753,7 @@ prepare_to_render_os_window(OSWindow *os_window, monotonic_t now, unsigned int *
                 *active_window_bg = window_bg;
                 if (OPT(cursor_trail) && update_cursor_trail(&tab->cursor_trail, w, now, os_window)) {
                     needs_render = true;
-                    set_maximum_wait(OPT(repaint_delay));
+                    set_maximum_wait(MAX(OPT(repaint_delay), ms_to_monotonic_t(1ll)));
                 }
             } else {
                 if (WD.screen->cursor_render_info.render_even_when_unfocused) {


### PR DESCRIPTION
Fixes issue  https://github.com/kovidgoyal/kitty/pull/7970#issuecomment-2466687264

I haven't looked into the details, but calling `set_maximum_wait(0)` makes it skip handling key input until the next render. Giving it a minimal value of 1ms seems to mitigate the issue effectively.