### PR TITLE
Fix Python.h being included after system headers

### DIFF
--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -7,8 +7,12 @@
 
 #pragma once
 
+#ifdef _POSIX_C_SOURCE
+#error "Must include \"data-types.h\" before any system headers"
+#endif
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+
 #include <assert.h>
 #include <stdint.h>
 #include <stdbool.h>

--- a/kitty/launcher/main.c
+++ b/kitty/launcher/main.c
@@ -6,6 +6,8 @@
  */
 
 #define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #include <libgen.h>
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
@@ -18,7 +20,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <wchar.h>
-#include <Python.h>
 #include <fcntl.h>
 #include "launcher.h"
 

--- a/kitty/launcher/single-instance.c
+++ b/kitty/launcher/single-instance.c
@@ -5,6 +5,8 @@
  * Distributed under terms of the GPL3 license.
  */
 
+#include "../data-types.h"
+
 #ifdef __APPLE__
 // Needed for _CS_DARWIN_USER_CACHE_DIR
 #define _DARWIN_C_SOURCE
@@ -347,4 +349,3 @@ single_instance_main(int argc, char *argv[], const CLIOptions *opts) {
         else fail_on_errno("Failed to bind single instance socket");
     } else set_single_instance_socket(s);
 }
-

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -10,6 +10,7 @@
     if (PyModule_AddFunctions(module, module_methods) != 0) return false; \
 }
 
+#include "data-types.h"
 #include "control-codes.h"
 #include "state.h"
 #include "iqsort.h"


### PR DESCRIPTION
My "./dev.sh build" failed with

    Compiling kitty/screen.c ...
    gcc -MMD -DNDEBUG -DPRIMARY_VERSION=4000 -DSECONDARY_VERSION=37 -DXT_VERSION="0.37.0" -I/home/johannes/git/kitty/dependencies/linux-amd64/include -Wextra -Wfloat-conversion -Wno-missing-field-initializers -Wall -Wstrict-prototypes -std=c11 -pedantic-errors -Werror -O3 -fwrapv -fstack-protector-strong -pipe -fvisibility=hidden -fno-plt -fPIC -D_FORTIFY_SOURCE=2 -flto -fcf-protection=full -march=native -mtune=native -pthread -I/home/johannes/git/kitty/dependencies/linux-amd64/include/libpng16 -I/home/johannes/git/kitty/dependencies/linux-amd64/include -I/home/johannes/git/kitty/dependencies/linux-amd64/include -I/home/johannes/git/kitty/dependencies/linux-amd64/include -I/home/johannes/git/kitty/dependencies/linux-amd64/include/freetype2 -I/home/johannes/git/kitty/dependencies/linux-amd64/include/libpng16 -I/usr/include/uuid -I/home/johannes/git/kitty/dependencies/linux-amd64/include/harfbuzz -I/home/johannes/git/kitty/dependencies/linux-amd64/include/freetype2 -I/home/johannes/git/kitty/dependencies/linux-amd64/include/libpng16 -I/home/johannes/git/kitty/dependencies/linux-amd64/include -I/home/johannes/git/kitty/dependencies/linux-amd64/include/python3.12 -c kitty/screen.c -o build/fast_data_types-kitty-screen.c.o
    In file included from /home/johannes/git/kitty/dependencies/linux-amd64/include/python3.12/Python.h:12,
                     from kitty/data-types.h:11,
                     from kitty/text-cache.h:10,
                     from kitty/line.h:10,
                     from kitty/history.h:10,
                     from kitty/lineops.h:9,
                     from kitty/fonts.h:9,
                     from kitty/screen.c:19:
    /home/johannes/git/kitty/dependencies/linux-amd64/include/python3.12/pyconfig.h:1875:9: error: "_POSIX_C_SOURCE" redefined
     1875 | #define _POSIX_C_SOURCE 200809L
          |         ^~~~~~~~~~~~~~~
    In file included from /usr/include/bits/libc-header-start.h:33,
                     from /usr/include/stdint.h:26,
                     from /usr/lib/gcc/x86_64-pc-linux-gnu/14.2.1/include/stdint.h:9,
                     from kitty/charsets.h:9,
                     from kitty/screen.c:17:
    /usr/include/features.h:329:10: note: this is the location of the previous definition
      329 | # define _POSIX_C_SOURCE 199506L
          |          ^~~~~~~~~~~~~~~
    The following build command failed: /home/johannes/git/kitty/dependencies/linux-amd64/bin/python setup.py develop
    exit status 1

[Python docs](https://docs.python.org/3/c-api/intro.html) say:

> Since Python may define some pre-processor definitions which affect
> the standard headers on some systems, you must include Python.h
> before any standard headers are included.

Make it so. Since data-types.h is already included first in a lot of
*.c and *.h files, let's use that one.
Also fix the include in launcher.c.

This is similar to commit 8e84b2145 (Re-order includes for
"_POSIX_C_SOURCE", 2018-06-02).

Also add an explicit error for this case, to make the resolution more
obvious? Here's the error when I try to include <stdlib.h> in screen.c:

    In file included from kitty/screen.c:14:
    kitty/data-types.h:11:2: error: #error "Must include \"data-types.h\" before any system headers"
       11 | #error "Must include \"data-types.h\" before any system headers"
          |  ^~~~~
    In file included from /home/johannes/git/kitty/dependencies/linux-amd64/include/python3.12/Python.h:12,
                     from kitty/data-types.h:14:
    /home/johannes/git/kitty/dependencies/linux-amd64/include/python3.12/pyconfig.h:1875:9: error: "_POSIX_C_SOURCE" redefined
     1875 | #define _POSIX_C_SOURCE 200809L
          |         ^~~~~~~~~~~~~~~
    In file included from /usr/include/bits/libc-header-start.h:33,
                     from /usr/include/stdlib.h:26,
                     from kitty/screen.c:13:
    /usr/include/features.h:329:10: note: this is the location of the previous definition
      329 | # define _POSIX_C_SOURCE 199506L
          |          ^~~~~~~~~~~~~~~
    The following build command failed: /home/johannes/git/kitty/dependencies/linux-amd64/bin/python setup.py develop
    exit status 1
