### PR TITLE
fix cursor trail not displaying in certain cases

### DIFF
--- a/kitty/cursor_trail.c
+++ b/kitty/cursor_trail.c
@@ -157,7 +157,7 @@ update_cursor_trail_needs_render(CursorTrail *ct, Window *w) {
 bool
 update_cursor_trail(CursorTrail *ct, Window *w, monotonic_t now, OSWindow *os_window) {
 
-    if (!WD.screen->paused_rendering.expires_at && OPT(cursor_trail) < now - WD.screen->cursor->position_changed_by_client_at) {
+    if (!WD.screen->paused_rendering.expires_at && OPT(cursor_trail)) {
         update_cursor_trail_target(ct, w);
     }
 


### PR DESCRIPTION
# The issue
The cursor trail will occasionally either not display when the cursor jumps, or more commonly it will initially not display, and then appear shortly after to create a glitchy-looking effect.

I found this is reproducible in vim/neovim depending on how you hold down the keys. If you do not immediately release a keypress, eg you hold '$' to go to the end of a line the trail will not appear. If you hold the key for a short while and then release, the animation will start when you release (although you are only catching the end of the animation). Under the right conditions, this can also be replicated by running a script that simply prints control codes to move the cursor (I can give more details if needed).

This may be difficult to reproduce yourself, because it is dependent on the system clock. It's reproducibility seems to be dependent on which file is open. Personally I could reproduce it 100% with a fresh vim config in kitty/cursor_trail.c.

# My diagnosis
[The line I have changed](https://github.com/coffe789/kitty/blob/d46f7662f793a8c81bbda828f8a8a85bcf0bbe27/kitty/cursor_trail.c#L160) previously compared the `cursor_trail` config option to the time since the cursor was changed. To me this seems unintentional, as `cursor_trail` is supposed to be treated like a boolean from my understanding. As a consequence if you set `cursor_trail` in your config to a large value (eg 100000000) the trail will stop working altogether.

Anyway, it seems it is possible for `now - WD.screen->cursor->position_changed_by_client_at` to return a negative value which will cause this condition to fail. I assume the reasoning for this is that `now` is not actually the current time, it was measured far up the stack, and it is possible for more measurements to occur before the next `now` is measured. If I print the value while using vim, I can see when I press a key a negative value is printed, and when I release the key a positive value is printed (hence why the animation only starts when you release).

I think what the author intended here was to stop checking for updates after the cursor trail animation is finished, so in pseudocode:
`OPT(cursor_trail) && sec_to_nanosec(OPT(cursor_trail_decay_slow)) < monotonic() - WD.screen->cursor->position_changed_by_client_at`

As it stands though my solution should be just as performant as the master branch, as the condition was essentially never false. If we are interested in adding some performance checks as described above I will consider it. Although going up the stack to ensure the `now` variable is used correctly will likely be too difficult given my knowledge of the codebase.