### PR TITLE
Cleanup command finish notifications

### DIFF
--- a/kitty/notifications.py
+++ b/kitty/notifications.py
@@ -1062,5 +1062,8 @@ class NotificationManager:
             n.title, n.body = parts[0], (parts[1] if len(parts) > 1 else '')
             self.notify_with_command(n, channel_id)
 
+    def close_notification(self, desktop_notification_id: int) -> None:
+        self.desktop_integration.close_notification(desktop_notification_id)
+
     def cleanup(self) -> None:
         del self.icon_data_cache


### PR DESCRIPTION
Currently notifications emitted with `notify_on_cmd_finish` and unfocused left withing notification bar forever and user have to clear them by hand. This patch automatically clears notification when emitted window gained its focus back assuming that user is aware about action and not needs for notification any more.