### PR TITLE
Fixed method declarations ( resolves #8157 )

### DIFF
--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -354,7 +354,7 @@ get_dock_menu(id self UNUSED, SEL _cmd UNUSED, NSApplication *sender UNUSED) {
 static PyObject *notification_activated_callback = NULL;
 
 static PyObject*
-set_notification_activated_callback(PyObject *self UNUSED, PyObject *callback) {
+cocoa_set_notification_activated_callback(PyObject *self UNUSED, PyObject *callback) {
     Py_CLEAR(notification_activated_callback);
     if (callback != Py_None) notification_activated_callback = Py_NewRef(callback);
     Py_RETURN_NONE;
@@ -595,6 +595,7 @@ set_notification_categories(UNUserNotificationCenter *center, PyObject *categori
     [center setNotificationCategories:[NSSet setWithArray:ans]];
     return true;
 }
+
 
 static PyObject*
 cocoa_send_notification(PyObject *self UNUSED, PyObject *args, PyObject *kw) {
@@ -939,7 +940,7 @@ cocoa_get_workspace_ids(void *w, size_t *workspace_ids, size_t array_sz) {
 }
 
 static PyObject*
-cocoa_get_lang(PyObject UNUSED *self) {
+cocoa_get_lang(PyObject UNUSED *_self, PyObject UNUSED *_args) {
     @autoreleasepool {
     NSString* lang_code = [[NSLocale currentLocale] languageCode];
     NSString* country_code = [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode];
@@ -1154,7 +1155,7 @@ render_emoji(NSString *text, unsigned image_size, const char *output_path) {
 
 
 static PyObject*
-bundle_image_as_png(PyObject *self UNUSED, PyObject *args, PyObject *kw) {@autoreleasepool {
+cocoa_bundle_image_as_png(PyObject *self UNUSED, PyObject *args, PyObject *kw) {@autoreleasepool {
     const char *b, *output_path = NULL; int image_type = 1; unsigned image_size = 256;
     static const char* kwlist[] = {"path_or_identifier", "output_path", "image_size", "image_type", NULL};
     if (!PyArg_ParseTupleAndKeywords(args, kw, "s|sIi", (char**)kwlist, &b, &output_path, &image_size, &image_type)) return NULL;
@@ -1187,25 +1188,25 @@ bundle_image_as_png(PyObject *self UNUSED, PyObject *args, PyObject *kw) {@autor
 }}
 
 static PyObject*
-play_system_sound_by_id_async(PyObject *self UNUSED, PyObject *which) {
+cocoa_play_system_sound_by_id_async(PyObject *self UNUSED, PyObject *which) {
     if (!PyLong_Check(which)) { PyErr_SetString(PyExc_TypeError, "system sound id must be an integer"); return NULL; }
     AudioServicesPlaySystemSound(PyLong_AsUnsignedLong(which));
     Py_RETURN_NONE;
 }
 
 static PyMethodDef module_methods[] = {
-    {"cocoa_play_system_sound_by_id_async", play_system_sound_by_id_async, METH_O, ""},
-    {"cocoa_get_lang", (PyCFunction)cocoa_get_lang, METH_NOARGS, ""},
-    {"cocoa_set_global_shortcut", (PyCFunction)cocoa_set_global_shortcut, METH_VARARGS, ""},
-    {"cocoa_send_notification", (PyCFunction)(void(*)(void))cocoa_send_notification, METH_VARARGS | METH_KEYWORDS, ""},
-    {"cocoa_remove_delivered_notification", (PyCFunction)cocoa_remove_delivered_notification, METH_O, ""},
-    {"cocoa_live_delivered_notifications", (PyCFunction)cocoa_live_delivered_notifications, METH_NOARGS, ""},
-    {"cocoa_set_notification_activated_callback", (PyCFunction)set_notification_activated_callback, METH_O, ""},
-    {"cocoa_set_url_handler", (PyCFunction)cocoa_set_url_handler, METH_VARARGS, ""},
-    {"cocoa_set_app_icon", (PyCFunction)cocoa_set_app_icon, METH_VARARGS, ""},
-    {"cocoa_set_dock_icon", (PyCFunction)cocoa_set_dock_icon, METH_VARARGS, ""},
-    {"cocoa_bundle_image_as_png", (PyCFunction)(void(*)(void))bundle_image_as_png, METH_VARARGS | METH_KEYWORDS, ""},
-    {NULL, NULL, 0, NULL}        /* Sentinel */
+    METHODB(cocoa_play_system_sound_by_id_async, METH_O),
+    METHODB(cocoa_get_lang, METH_NOARGS),
+    METHODB(cocoa_set_global_shortcut, METH_VARARGS),
+    METHODKW(cocoa_send_notification, METH_VARARGS | METH_KEYWORDS),
+    METHODB(cocoa_remove_delivered_notification, METH_O),
+    METHODB(cocoa_live_delivered_notifications, METH_NOARGS),
+    METHODB(cocoa_set_notification_activated_callback, METH_O),
+    METHODB(cocoa_set_url_handler, METH_VARARGS),
+    METHODB(cocoa_set_app_icon,  METH_VARARGS),
+    METHODB(cocoa_set_dock_icon, METH_VARARGS),
+    METHODKW(cocoa_bundle_image_as_png,  METH_VARARGS | METH_KEYWORDS),
+    {NULL}  /* Sentinel */
 };
 
 bool

--- a/kitty/core_text.m
+++ b/kitty/core_text.m
@@ -98,7 +98,7 @@ ct_face(CTFontRef font, PyObject *features) {
         self->path = get_path_for_font(self->ct_font);
         if (self->family_name == NULL || self->full_name == NULL || self->postscript_name == NULL || self->path == NULL) { Py_CLEAR(self); }
         else {
-            if (!create_features_for_face(postscript_name_for_face((PyObject*)self), features, &self->font_features)) { Py_CLEAR(self); }
+            if (!create_features_for_face(postscript_name_for_face((PyObject*)self, NULL), features, &self->font_features)) { Py_CLEAR(self); }
         }
     }
     return self;
@@ -1035,7 +1035,7 @@ get_best_name(CTFace *self, PyObject *nameid) {
 }
 
 static PyObject*
-get_variation(CTFace *self) {
+get_variation(CTFace *self, PyObject UNUSED *_args) {
     RAII_CoreFoundation(CFDictionaryRef, src, CTFontCopyVariation(self->ct_font));
     return variation_to_python(src);
 }
@@ -1062,7 +1062,7 @@ get_features(CTFace *self, PyObject *a UNUSED) {
 
 
 static PyObject*
-get_variable_data(CTFace *self) {
+get_variable_data(CTFace *self, PyObject UNUSED *_args) {
     if (!ensure_name_table(self)) return NULL;
     RAII_PyObject(output, PyDict_New());
     if (!output) return NULL;
@@ -1078,7 +1078,7 @@ get_variable_data(CTFace *self) {
 }
 
 static PyObject*
-identify_for_debug(CTFace *self) {
+identify_for_debug(CTFace *self, PyObject UNUSED *_args) {
     RAII_PyObject(features, PyTuple_New(self->font_features.count)); if (!features) return NULL;
     char buf[128];
     for (unsigned i = 0; i < self->font_features.count; i++) {
@@ -1095,13 +1095,13 @@ identify_for_debug(CTFace *self) {
 // Boilerplate {{{
 
 static PyObject*
-display_name(CTFace *self) {
+display_name(CTFace *self, PyObject UNUSED *_args) {
     CFStringRef dn = CTFontCopyDisplayName(self->ct_font);
     return convert_cfstring(dn, true);
 }
 
 static PyObject*
-postscript_name(CTFace *self) {
+postscript_name(CTFace *self, PyObject UNUSED *_args) {
     return self->postscript_name ? Py_BuildValue("O", self->postscript_name) : PyUnicode_FromString("");
 }
 
@@ -1121,7 +1121,7 @@ static PyMethodDef methods[] = {
 };
 
 const char*
-postscript_name_for_face(const PyObject *face_) {
+postscript_name_for_face(const PyObject *face_, PyObject UNUSED *_args) {
     const CTFace *self = (const CTFace*)face_;
     if (self->postscript_name) return PyUnicode_AsUTF8(self->postscript_name);
     return "";

--- a/kitty/data-types.c
+++ b/kitty/data-types.c
@@ -42,14 +42,14 @@
 #include <xlocale.h>
 
 static PyObject*
-user_cache_dir(void) {
+user_cache_dir(PyObject UNUSED *_self, PyObject UNUSED *_args) {
     static char buf[1024];
     if (!confstr(_CS_DARWIN_USER_CACHE_DIR, buf, sizeof(buf) - 1)) return PyErr_SetFromErrno(PyExc_OSError);
     return PyUnicode_FromString(buf);
 }
 
 static PyObject*
-process_group_map(void) {
+process_group_map(PyObject UNUSED *_self, PyObject UNUSED *_args) {
     int num_of_processes = proc_listallpids(NULL, 0);
     size_t bufsize = sizeof(pid_t) * (num_of_processes + 1024);
     RAII_ALLOC(pid_t, buf, malloc(bufsize));

--- a/kitty/data-types.h
+++ b/kitty/data-types.h
@@ -139,6 +139,23 @@ typedef struct ImageAnchorPosition {
 
 #define METHOD(name, arg_type) {#name, (PyCFunction)name, arg_type, name##_doc},
 #define METHODB(name, arg_type) {#name, (PyCFunction)name, arg_type, ""}
+#define METHODKW(name, arg_type) \
+    { \
+        #name, \
+        /* Suppress warnings for casting function types */ \
+        /* Handle Clang-specific warnings */ \
+        _Pragma("clang diagnostic push") \
+        _Pragma("clang diagnostic ignored \"-Wcast-function-type-mismatch\"") \
+        /* Handle GCC-specific warnings */ \
+        _Pragma("GCC diagnostic push") \
+        _Pragma("GCC diagnostic ignored \"-Wcast-function-type\"") \
+        (PyCFunction)(PyCFunctionWithKeywords)(name), \
+        /* Restore warnings after the cast */ \
+        _Pragma("clang diagnostic pop") \
+        _Pragma("GCC diagnostic pop") \
+        arg_type, \
+        "" \
+    }
 
 #define BOOL_GETSET(type, x) \
     static PyObject* x##_get(type *self, void UNUSED *closure) { PyObject *ans = self->x ? Py_True : Py_False; Py_INCREF(ans); return ans; } \

--- a/kitty/fonts.h
+++ b/kitty/fonts.h
@@ -47,7 +47,7 @@ PyObject* face_from_path(const char *path, int index, FONTS_DATA_HANDLE);
 PyObject* face_from_descriptor(PyObject*, FONTS_DATA_HANDLE);
 PyObject* iter_fallback_faces(FONTS_DATA_HANDLE fgh, ssize_t *idx);
 bool face_equals_descriptor(PyObject *face_, PyObject *descriptor);
-const char* postscript_name_for_face(const PyObject*);
+const char* postscript_name_for_face(const PyObject*, PyObject UNUSED *_args);
 
 void sprite_tracker_current_layout(FONTS_DATA_HANDLE data, unsigned int *x, unsigned int *y, unsigned int *z);
 void render_alpha_mask(const uint8_t *alpha_mask, pixel* dest, Region *src_rect, Region *dest_rect, size_t src_stride, size_t dest_stride, pixel color_rgb);


### PR DESCRIPTION
This PR fixes #8157 by:
- declaring new macro for `PyCFunctionWithKeywords` python type
- adding missing parameters to methods and fixing corresponding invocations

also, `module_methods[]` table in `kitty/cocoa_window.m` was updated to use `METHOD*` macros
