### PR TITLE
Add Ghosttty to list of terminals implementing the graphics protocol

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -57,6 +57,7 @@ Libraries:
 
 Other terminals that have implemented the graphics protocol:
 
+* `Ghostty <https://github.com/ghostty-org/ghostty/blob/a8e5eef11cc67f87f445626f9ca2993373774bf8/src/terminal/kitty/graphics.zig#L4>`_
 * `Konsole <https://invent.kde.org/utilities/konsole/-/merge_requests/594>`_
 * `wayst <https://github.com/91861/wayst>`_
 * `WezTerm <https://github.com/wez/wezterm/issues/986>`_


### PR DESCRIPTION
Ghostty 1.0 was just released. It implements the Kitty Graphics Protocol. I used a link to the specific code that implements the prototocol. Alternatively, could use the [feature page](https://ghostty.org/docs/features)  or [home page](https://ghostty.org). I added it first in the list to preserve alphabetical order. I am not affiliated with the Ghostty project. 