### PR TITLE
Enable macOS universal autofill

### DIFF
--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -755,6 +755,13 @@ cocoa_create_global_menu(void) {
     MENU_ITEM(appMenu, ([NSString stringWithFormat:@"Quit %@", app_name]), quit);
     [appMenu release];
 
+    NSMenuItem* editMenuItem = [bar addItemWithTitle:@"Edit"
+                                              action:NULL
+                                       keyEquivalent:@""];
+    NSMenu* editMenu = [[NSMenu alloc] initWithTitle:@"Edit"];
+    [editMenuItem setSubmenu:editMenu];
+    [editMenu addItem:[NSMenuItem separatorItem]];  // forces macOS to show the AutoFill submenu
+
     NSMenuItem* shellMenuItem =
         [bar addItemWithTitle:@"Shell"
                        action:NULL


### PR DESCRIPTION
Implements #8173

This is the bare minimum of menu items I could add to coax macOS into providing the requested AutoFill > Passwords... menu. Unfortunately you cannot just create an Edit menu, it has to have at least one child for the AutoFill (and also the Start Dictation... menu item) to appear: hence the lone `separatorItem`


After changes:

<img width="756" alt="Screenshot 2025-01-04 at 10 19 37 PM" src="https://github.com/user-attachments/assets/e60c4997-307c-4feb-876d-10cfb9384a83" />

Before changes:

<img width="786" alt="Screenshot 2025-01-04 at 10 33 12 PM" src="https://github.com/user-attachments/assets/600c035b-5825-42a8-aa33-b71816e1596f" />
