### PR TITLE
docs: add note for fixing run a command prompt issue

### DIFF
--- a/docs/binary.rst
+++ b/docs/binary.rst
@@ -78,6 +78,16 @@ particular desktop, but it should work for most major desktop environments.
         cd ~/.local/stow
         stow -v kitty.app
 
+.. note::
+    If you have a trouble to run kitty with Linux's run a command prompt(Alt + F2),
+    add :file:`kitty.desktop` 's Exec path($HOME/.local/kitty.app/bin) to /etc/environment file,
+    if /etc/environment file doesn't exist, then make it.
+
+    .. code-block:: sh
+
+        # add kitty.app/bin path to /etc/environment's path
+        PATH="$HOME/.local/kitty.app/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
+
 
 Customizing the installation
 --------------------------------


### PR DESCRIPTION
### What
Added docs instruction(Note) for those have trouble to run a command (which is runnable by press Alt+F2 key in Linux desktop)

### Why
when the trouble occurs, user cannot run kitty with that prompt with error
`command not found`
(I think many Linux user unable to run command by the prompt, without follow this step. as long as I understand, because it runs in GNOME env, basic step for adding path to rc file (bashrc, profile, zshrc,,, does not have effect to fix this.)

Actually, I wanted to add it to  
`### Desktop integration on Linux`
section, but as this Note informs to edit /etc/environment, I thought it is better not to be added in that section, because to maintain the section's code runnable without privileges.