### PR TITLE
fix: Report OSC 30101 bg change as via escape code

### DIFF
--- a/kitty/window.py
+++ b/kitty/window.py
@@ -1293,7 +1293,7 @@ class Window:
 
     def color_profile_popped(self, bg_changed: bool) -> None:
         if bg_changed:
-            get_boss().default_bg_changed_for(self.id)
+            get_boss().default_bg_changed_for(self.id, via_escape_code=True)
 
     def report_color(self, code: str, col: Color) -> None:
         r, g, b = col.red, col.green, col.blue


### PR DESCRIPTION
Been having issues with some programs like neovim where it puts the output of `report_color_scheme_preference` to the input prompt when suspending the editor, and at inconsistent times when quitting the editor. I'm guessing this was just missed from https://github.com/kovidgoyal/kitty/commit/6fbeb939de85c578260e3196b2f8f6e90925e3d3, but this change resolves the issue for me in a local build.

---

https://github.com/user-attachments/assets/35fbcc96-4cd3-4f7c-9cec-6836efd89b0b


