### PR TITLE
XTGETTCAP: Fix DCS response for empty capabilities

### DIFF
--- a/kitty/terminfo.py
+++ b/kitty/terminfo.py
@@ -521,10 +521,11 @@ def key_as_bytes(name: str) -> bytes:
 def get_capabilities(query_string: str, opts: 'Options', window_id: int = 0, os_window_id: int = 0) -> Generator[str, None, None]:
     from .fast_data_types import ERROR_PREFIX
 
-    def result(encoded_query_name: str, x: str | None = None) -> str:
-        if not x:
-            valid = 0 if x is None else 1
-            return f'{valid}+r{encoded_query_name}'
+    def result(encoded_query_name: str, x: str | bool | None = None) -> str:
+        if x is None:
+            return f'0+r{encoded_query_name}'
+        if isinstance(x, bool):
+            return f'{int(x)}+r{encoded_query_name}'
         return f'1+r{encoded_query_name}={hexlify(str(x).encode("utf-8")).decode("ascii")}'
 
     for encoded_query_name in query_string.split(';'):
@@ -543,7 +544,7 @@ def get_capabilities(query_string: str, opts: 'Options', window_id: int = 0, os_
                 yield result(encoded_query_name, rval)
         else:
             if name in bool_capabilities:
-                yield result(encoded_query_name, '')
+                yield result(encoded_query_name, True)
                 continue
             try:
                 val = queryable_capabilities[name]


### PR DESCRIPTION
Hi, i discovered this bug recently.

- Steps to reproduce
```sh
    $ printf '\eP+q2531\e\\\eP+q2638\e\\\eP+q4b34\e\\\eP+q4b35\e\\' ; cat -v
    ^[P1+r2531^[\^[P1+r2638^[\^[P1+r4b34^[\^[P1+r4b35^[\
```

- Expected response
One of the following:
```
    ^[P1+r2531=^[\^[P1+r2638=^[\^[P1+r4b34=^[\^[P1+r4b35=^[\
    ^[P0+r2531^[\^[P0+r2638^[\^[P0+r4b34^[\^[P0+r4b35^[\
    ^[P0+r^[\^[P0+r^[\^[P0+r^[\^[P0+r^[\
```

I was able to bisect this to commit 2bfeb13628, which seems to handle empty tcaps and boolean tcaps in the same way.
