### PR TITLE
fix: Properly find wrapped lines in history buffer

### DIFF
--- a/kitty/history.c
+++ b/kitty/history.c
@@ -198,7 +198,7 @@ historybuf_init_line(HistoryBuf *self, index_type lnum, Line *l) {
 
 bool
 historybuf_is_line_continued(HistoryBuf *self, index_type lnum) {
-    return hb_line_is_continued(self, index_of(self, lnum + 1));
+    return hb_line_is_continued(self, index_of(self, lnum));
 }
 
 bool


### PR DESCRIPTION
Off-by-one error in f412ec617ce23a72ee69c47a7db2a6b35a0a69bd. Kitty is failing to find the previous prompt when trying to page the last command output (via `ctrl+shift+g`) when the executed command is long enough that it wraps and the output is long enough to put the prompt in the history buffer. The result is either:
- Paged cmd output is empty; or
- Paged output contains cmd outputs from up to the first prompt that has a non-wrapping command; or
- The last wrapped line of the command is included in the paged output when paging via mouse (`ctrl+shift+rclick`)