### PR TITLE
Use semicolon to respond to OSC 22

### DIFF
--- a/kitty/window.py
+++ b/kitty/window.py
@@ -1317,7 +1317,7 @@ class Window:
         if code == 22:
             ret = set_pointer_shape(self.screen, value, self.os_window_id)
             if ret:
-                self.screen.send_escape_code_to_child(ESC_OSC, '22:' + ret)
+                self.screen.send_escape_code_to_child(ESC_OSC, '22;' + ret)
 
         dirtied = default_bg_changed = False
         def change(which: DynamicColor, val: str) -> None:


### PR DESCRIPTION
Today, with version 0.39.1:
```
❯ echo -ne '\e]22;?__current__\e\\'; cat
^[]22:0^[\
```

Per https://sw.kovidgoyal.net/kitty/pointer-shapes/#querying-support I would expect `^[]22;0^[\`.