### PR TITLE
Adjust the size of the alternative icon on the FAQ page

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -347,7 +347,7 @@ many alternate icons available, click on an icon to visit its homepage:
    :target: https://github.com/hristost/kitty-alternative-icon
    :width: 256
 
-.. image:: https://github.com/igrmk/whiskers/raw/main/whiskers.svg
+.. image:: https://github.com/igrmk/whiskers/raw/main/whiskers_512x512.png
    :target: https://github.com/igrmk/whiskers
    :width: 256
 


### PR DESCRIPTION
The FAQ page currently uses the SVG version of the whiskers icon. This SVG serves as the 'source' for PNG icons, with additional padding added during PNG creation, varying by OS (on macOS, the icon has slightly more padding). Since the source lacks any padding, the icon appears too large