### PR TITLE
Add support for os_window_name in startup sessions.

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -167,6 +167,8 @@ option in :file:`kitty.conf`. An example, showing all available commands:
     os_window_size 80c 24c
     # Set the --class for the new OS window
     os_window_class mywindow
+    # Set the --name for the new OS window
+    os_window_name myname
     # Change the OS window state to normal, fullscreen, maximized or minimized
     os_window_state normal
     launch sh

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -437,7 +437,7 @@ class Boss:
         if os_window_id is None:
             size_data = get_os_window_sizing_data(opts_for_size or get_options(), startup_session)
             wclass = wclass or getattr(startup_session, 'os_window_class', None) or self.args.cls or appname
-            wname = wname or self.args.name or wclass
+            wname = wname or getattr(startup_session, 'os_window_name', None) or self.args.name or wclass
             wtitle = override_title or self.args.title
             window_state = window_state or getattr(startup_session, 'os_window_state', None)
             wstate = parse_os_window_state(window_state) if window_state is not None else None

--- a/kitty/launch.py
+++ b/kitty/launch.py
@@ -88,10 +88,12 @@ Where to launch the child process:
     A new :term:`kitty window <window>` in the current tab
 
 :code:`tab`
-    A new :term:`tab` in the current OS window
+    A new :term:`tab` in the current OS window. Not available when the
+    :doc:`launch <launch>` command is used in :ref:`startup sessions <sessions>`.
 
 :code:`os-window`
-    A new :term:`operating system window <os_window>`
+    A new :term:`operating system window <os_window>`.  Not available when the
+    :doc:`launch <launch>` command is used in :ref:`startup sessions <sessions>`.
 
 :code:`overlay`
     An :term:`overlay window <overlay>` covering the current active kitty window

--- a/kitty/main.py
+++ b/kitty/main.py
@@ -223,6 +223,7 @@ def _run_app(opts: Options, args: CLIOptions, bad_lines: Sequence[BadLine] = (),
     with cached_values_for(run_app.cached_values_name) as cached_values:
         startup_sessions = tuple(create_sessions(opts, args, default_session=opts.startup_session))
         wincls = (startup_sessions[0].os_window_class if startup_sessions else '') or args.cls or appname
+        winname = (startup_sessions[0].os_window_name if startup_sessions else '') or args.name or wincls or appname
         window_state = (args.start_as if args.start_as and args.start_as != 'normal' else None) or (
             getattr(startup_sessions[0], 'os_window_state', None) if startup_sessions else None
         )
@@ -231,7 +232,7 @@ def _run_app(opts: Options, args: CLIOptions, bad_lines: Sequence[BadLine] = (),
             window_id = create_os_window(
                     run_app.initial_window_size_func(get_os_window_sizing_data(opts, startup_sessions[0] if startup_sessions else None), cached_values),
                     pre_show_callback,
-                    args.title or appname, args.name or args.cls or appname,
+                    args.title or appname, winname,
                     wincls, wstate, load_all_shaders, disallow_override_title=bool(args.title), layer_shell_config=run_app.layer_shell_config)
         boss = Boss(opts, args, cached_values, global_shortcuts, talk_fd)
         boss.start(window_id, startup_sessions)

--- a/kitty/session.py
+++ b/kitty/session.py
@@ -77,6 +77,7 @@ class Session:
         self.default_title = default_title
         self.os_window_size: WindowSizes | None = None
         self.os_window_class: str | None = None
+        self.os_window_name: str | None = None
         self.os_window_state: str | None = None
         self.focus_os_window: bool = False
 
@@ -211,6 +212,8 @@ def parse_session(raw: str, opts: Options, environ: Mapping[str, str] | None = N
                 ans.os_window_size = WindowSizes(WindowSize(*w), WindowSize(*h))
             elif cmd == 'os_window_class':
                 ans.os_window_class = rest
+            elif cmd == 'os_window_name':
+                ans.os_window_name = rest
             elif cmd == 'os_window_state':
                 ans.os_window_state = rest
             elif cmd == 'resize_window':


### PR DESCRIPTION
You can now specify `os_window_name` in addition to `os_window_class` in
startup sessions.  It works for the initial session as well as new sessions
started with `new_os_window`.

Updated documentation in overview.rst to add `os_window_name` in the
Startup Session examples.

Although not related to this feature. The documentation in launch.py
was updated to note that the `launch --type` `tab` and `os-window` options
aren't supported when launch is invoked from a startup script.  There's
already a note to that effect in the "Startup Sessions" section in
overview.rst but if you're looking at the launch syntax page like I was,
you wouldn't realize the limitation. This was throwing me for a loop while
wotking on this PR.

Resolves: #8387
