### PR TITLE
Wayland: Updated anchor for edge=none to be consistent with documentation

### DIFF
--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -1010,7 +1010,7 @@ layer_set_properties(_GLFWwindow *window) {
                     if (!window->wl.layer_shell.config.override_exclusive_zone) exclusive_zone = window->wl.width;
                     break;
                 case GLFW_EDGE_NONE:
-                    which_anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT | ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP | ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM; // None is anchored to "top left"
+                    which_anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT | ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP; // None is anchored to "top left"
                     panel_width = window->wl.width;
                     panel_height = window->wl.height;
                     break;


### PR DESCRIPTION
Before this commit specifying --edge=none for the panel kitten would anchor kitty like so:
```
+-----------------------------+
|                             |
|+----------+                 |
||          |                 |
|+----------+                 |
|                             |
+-----------------------------+
```
The docs state: "`none` anchors the panel to the top left corner by default".

After this commit the behavior is consistent with the documentation.