### PR TITLE
Handle the edge case of someone running a development go build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1181,7 +1181,11 @@ def build_static_kittens(
     if not go:
         raise SystemExit('The go tool was not found on this system. Install Go')
     required_go_version = subprocess.check_output([go] + 'list -f {{.GoVersion}} -m'.split(), env=dict(os.environ, GO111MODULE="on")).decode().strip()
-    current_go_version = subprocess.check_output([go, 'version']).decode().strip().split()[2][2:]
+    go_version_raw = subprocess.check_output([go, 'version']).decode().strip().split()
+    if go_version_raw[2] != "devel":
+        current_go_version = go_version_raw[2][2:]
+    else:
+        current_go_version = go_version_raw[3][2:]
     if parse_go_version(required_go_version) > parse_go_version(current_go_version):
         raise SystemExit(f'The version of go on this system ({current_go_version}) is too old. go >= {required_go_version} is needed')
     if not for_platform:


### PR DESCRIPTION
When on a go development version, `setup.py` crashes due to trying to parse `vel` as a go version (which it is not), this change checks to see if the item at index 2 from the `go version` output is the literal string `devel`, and if it is then sets the go version to the string at index 3 instead.

`go version` output:
```
firepup650@FIREPUPS-LAPTOP:~/sources/kitty $ go version
go version devel go1.25-0694718389 Mon Mar 17 18:31:30 2025 -0700 linux/amd64
```

Before:
```
firepup650@FIREPUPS-LAPTOP:~/sources/kitty $ ./dev.sh build
[32/32] Generating wayland-wlr-layer-shell-unstable-v1-client-protocol.c ... done
[131/131] Compiling kitty/gl-wrapper.c ... done
[5/5] Linking launcher ... done
Traceback (most recent call last):
  File "/home/firepup650/sources/kitty/setup.py", line 2222, in <module>
    main()
  File "/home/firepup650/sources/kitty/setup.py", line 2218, in main
    do_build(args)
  File "/home/firepup650/sources/kitty/setup.py", line 2175, in do_build
    build_static_kittens(args, launcher_dir=launcher_dir)
  File "/home/firepup650/sources/kitty/setup.py", line 1185, in build_static_kittens
    if parse_go_version(required_go_version) > parse_go_version(current_go_version):
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/firepup650/sources/kitty/setup.py", line 1168, in parse_go_version
    ans = list(map(safe_int, x.split('.')))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/firepup650/sources/kitty/setup.py", line 1167, in safe_int
    return int(re.split(r'[-a-zA-Z]', x)[0])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: ''
The following build command failed: /home/firepup650/sources/kitty/dependencies/linux-amd64/bin/python setup.py develop
exit status 1
```
After:
```
firepup650@FIREPUPS-LAPTOP:~/sources/kitty $ ./dev.sh build
[32/32] Generating wayland-wlr-layer-shell-unstable-v1-client-protocol.c ... done
[131/131] Compiling kitty/gl-wrapper.c ... done
[5/5] Linking launcher ... done
go: downloading golang.org/x/sys v0.31.0
[Output truncated]
```