### PR TITLE
Add Warp to list of terminals supporting Kitty graphics protocol

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -61,6 +61,7 @@ Other terminals that have implemented the graphics protocol:
 * `Ghostty <https://ghostty.org>`_
 * `Konsole <https://invent.kde.org/utilities/konsole/-/merge_requests/594>`_
 * `st (with a patch) <https://st.suckless.org/patches/kitty-graphics-protocol>`_
+* `Warp <https://docs.warp.dev/getting-started/changelog#id-2025.03.26-v0.2025.03.26.08.10>`_
 * `wayst <https://github.com/91861/wayst>`_
 * `WezTerm <https://github.com/wez/wezterm/issues/986>`_
 


### PR DESCRIPTION
Warp version [v0.2025.03.26.08.10](https://docs.warp.dev/getting-started/changelog#id-2025.03.26-v0.2025.03.26.08.10) was just released. It implements the Kitty Image Protocol. I used a link to the changelog entry.
I added it to the list, preserving alphabetical order. I am [affiliated with Warp](https://www.warp.dev/about) (Support Engineer).