### PR TITLE
fix: Paging edge cases for very small scrollback lines

### DIFF
--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -1302,6 +1302,9 @@ class Screen:
     def scroll_to_prompt(self, num_of_prompts: int = -1) -> bool:
         pass
 
+    def set_last_visited_prompt(self, visual_y: int = 0) -> bool:
+        pass
+
     def reverse_scroll(self, amt: int, fill_from_scrollback: bool = False) -> bool:
         pass
 

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -4122,7 +4122,8 @@ find_cmd_output(Screen *self, OutputOffset *oo, index_type start_screen_y, unsig
         }
         if (y1 < upward_limit) {
             oo->reached_upper_limit = true;
-            found_output = true; start = upward_limit;
+            found_output = direction != 0; start = upward_limit;
+            found_prompt = direction != 0;
         }
     }
 

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -4133,8 +4133,13 @@ find_cmd_output(Screen *self, OutputOffset *oo, index_type start_screen_y, unsig
             if (on_screen_only && !found_output && y2 > screen_limit) break;
             line = checked_range_line(self, y2);
             if (line && line->attrs.prompt_kind == PROMPT_START) {
-                if (!found_prompt) found_prompt = true;
-                else if (found_prompt && !found_output) {
+                if (!found_prompt) {
+                    if (direction == 0) {
+                        found_next_prompt = true; end = y2;
+                        break;
+                    }
+                    found_prompt = true;
+                } else if (found_prompt && !found_output) {
                     // skip fetching wrapped prompt lines
                     while (range_line_is_continued(self, y2)) {
                         y2++;

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -4702,6 +4702,13 @@ scroll_to_prompt(Screen *self, PyObject *args) {
     Py_RETURN_FALSE;
 }
 
+static PyObject*
+set_last_visited_prompt(Screen *self, PyObject *args) {
+    index_type visual_y = 0;
+    if (!PyArg_ParseTuple(args, "|I", &visual_y)) return NULL;
+    if (screen_set_last_visited_prompt(self, visual_y)) { Py_RETURN_TRUE; }
+    Py_RETURN_FALSE;
+}
 
 bool
 screen_is_selection_dirty(Screen *self) {
@@ -5550,6 +5557,7 @@ static PyMethodDef methods[] = {
     MND(is_rectangle_select, METH_NOARGS)
     MND(scroll, METH_VARARGS)
     MND(scroll_to_prompt, METH_VARARGS)
+    MND(set_last_visited_prompt, METH_VARARGS)
     MND(send_escape_code_to_child, METH_VARARGS)
     MND(pause_rendering, METH_VARARGS)
     MND(hyperlink_at, METH_VARARGS)

--- a/kitty_tests/screen.py
+++ b/kitty_tests/screen.py
@@ -1331,6 +1331,30 @@ class TestScreen(BaseTest):
         s.scroll_to_prompt(1)
         self.ae(lvco(), '0wrapout\n0y')
 
+        # test: losing markers past scrollback
+        s = self.create_screen(lines=10, scrollback=0)
+        draw_prompt('a' * (s.columns * 3))
+        draw_output(1, 'v' * (s.columns * 2)), draw_output(1, 'w', False)
+        draw_prompt('b')
+        draw_output(1, 'x')
+        # remove prompt start above, set last visited to within prompt
+        s.clear_scrollback()
+        s.scroll_to_prompt(1)
+        self.ae(lvco(), '0vvvvvvvvvv\n0w')
+        # remove output start above, set last visited to within output
+        draw_output(3, 'y', False), draw_output(1, 'z', False)
+        s.clear_scrollback()
+        s.scroll_to_prompt(1)
+        self.ae(lvco(), 'vvvvvv\n0w')
+        draw_output(1, 'end', False)
+        s.clear_scrollback()
+        s.scroll_to_prompt(1)
+        self.ae(lvco(), 'v\n0w')
+        # clear last visited line without setting new one
+        draw_output(1, 'end', False)
+        s.clear_scrollback()
+        self.ae(lvco(), '')
+
         # test that post rewrap prompt lines have correct attributes
         s = self.create_screen(cols=5, lines=5, scrollback=15)
         draw_prompt('P' * (s.columns - 2))

--- a/kitty_tests/screen.py
+++ b/kitty_tests/screen.py
@@ -1294,41 +1294,35 @@ class TestScreen(BaseTest):
         self.ae(lvco(), '0x\n1x')
         # test: obscure prompt
         s.scroll(2, False)
+        s.set_last_visited_prompt()
         self.ae(lvco(), '0x\n1x')
         # test: prompts without output
         s.scroll(s.scrolled_by, False)
+        s.resize(5, s.columns + 5)
         draw_prompt('4')
-        # resizing resets last visited, rely on scroll_to_prompt
-        s.resize(2, s.columns + 4)
-        s.scroll_to_prompt()
-        s.scroll_to_prompt(1)
-        self.ae(str(s.visual_line(0)), '$ 4')
+        s.set_last_visited_prompt(2)
         self.ae(lvco(), '')
-        s.resize(5, s.columns)
         draw_prompt('wrapcmd')
-        s.scroll_to_prompt(1)
         self.ae(lvco(), '')
         draw_output(1, 'wrapout'), draw_output(1, 'y', False)
+        s.set_last_visited_prompt(0)
         self.ae(lvco(), '0wrapout\n0y\n')
         # wrap long prompt with long output
-        s.resize(5, s.columns - 4)
-        self.ae(str(s.visual_line(0)), 'pcmd')
+        s.resize(5, s.columns - 5)
         # test: set last visited to previous empty prompt
         s.scroll_to_prompt(-2)
         self.ae(str(s.visual_line(0)), '$ 4')
         self.ae(lvco(), '0wrapout\n0y\n')
-        mark_prompt(), s.draw('$ end')
+        draw_prompt('end')
+        s.scroll_to_prompt(-1)
+        self.ae(lvco(), '0wrapout\n0y')
+        s.scroll_to_prompt(1)
         self.ae(lvco(), '0wrapout\n0y')
         # test: set last visited to continued line of long prompt
-        s.scroll_to_prompt(2)
-        self.ae(str(s.visual_line(0)), 'pcmd')
-        self.ae(lvco(), '0wrapout\n0y')
-        s.scroll_to_prompt()
+        s.set_last_visited_prompt(1)
         self.ae(lvco(), '0wrapout\n0y')
         # test: set last visited to continued line of output
-        s.carriage_return(), s.index()
-        draw_output(1, 'z')
-        s.scroll_to_prompt(1)
+        s.set_last_visited_prompt(3)
         self.ae(lvco(), '0wrapout\n0y')
 
         # test: losing markers past scrollback
@@ -1339,16 +1333,16 @@ class TestScreen(BaseTest):
         draw_output(1, 'x')
         # remove prompt start above, set last visited to within prompt
         s.clear_scrollback()
-        s.scroll_to_prompt(1)
+        s.set_last_visited_prompt(0)
         self.ae(lvco(), '0vvvvvvvvvv\n0w')
         # remove output start above, set last visited to within output
         draw_output(3, 'y', False), draw_output(1, 'z', False)
         s.clear_scrollback()
-        s.scroll_to_prompt(1)
+        s.set_last_visited_prompt(0)
         self.ae(lvco(), 'vvvvvv\n0w')
         draw_output(1, 'end', False)
         s.clear_scrollback()
-        s.scroll_to_prompt(1)
+        s.set_last_visited_prompt(0)
         self.ae(lvco(), 'v\n0w')
         # clear last visited line without setting new one
         draw_output(1, 'end', False)


### PR DESCRIPTION
Forgot I had some of these stashed, just some small fixes to paging logic. Tests pass locally.

Let me know if you deem the last commit unnecessary. It's only really applicable in this section of the code, but it better expresses the intent of selecting a specific line in the visible screen (like with the related select-by-mouse code) instead of wrestling with `scroll_to_prompt`.