### PR TITLE
Fix bad code block formatting in docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
           - name: Test for trailing whitespace
             run: if grep -Inr '\s$' kitty kitty_tests kittens docs *.py *.asciidoc *.rst *.go .gitattributes .gitignore; then echo Trailing whitespace found, aborting.; exit 1; fi
 
+          - name: Test for bad code block formatting
+            run: if grep -Inr ':code:`\s' kitty kitty_tests kittens docs *.py *.asciidoc *.rst *.go .gitattributes .gitignore; then echo Space at code block start found, aborting.; exit 1; fi
+
           - name: Set up Python
             uses: actions/setup-python@v4
             with:

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -271,14 +271,14 @@ Useful when working with applications that use colors that do not contrast
 well with your preferred color scheme. The default value is :code:`0`, which means no color overriding is performed.
 There are two modes of operation:
 
-A value with the suffix :code:` ratio` represents the minimum accepted contrast ratio between the foreground and background color.
+A value with the suffix :code:`ratio` represents the minimum accepted contrast ratio between the foreground and background color.
 Possible values range from :code:`0.0 ratio` to :code:`21.0 ratio`.
 For example, to meet :link:`WCAG level AA <https://en.wikipedia.org/wiki/Web_Content_Accessibility_Guidelines>`
 a value of :code:`4.5 ratio` can be provided.
 The algorithm is implemented using :link:`HSLuv <https://www.hsluv.org/>` which enables it to change
 the perceived lightness of a color just as much as needed without really changing its hue and saturation.
 
-A value with the suffix :code:` %` represents the minimum accepted difference in luminance
+A value with the suffix :code:`%` represents the minimum accepted difference in luminance
 between the foreground and background color, below which kitty will override the foreground color.
 It is percentage ranging from :code:`0 %` to :code:`100 %`. If the difference in luminance of the
 foreground and background is below this threshold, the foreground color will be set


### PR DESCRIPTION
I noticed that
<https://sw.kovidgoyal.net/kitty/conf/#opt-kitty.text_fg_override_threshold>
said
```
:code:` ratio`
```
instead of being formatted as code. I assume that's because of a space after \`.

Fixed 2 cases where I found the issue.
Added a simple code block check to CI.