### PR TITLE
Improve reproducibility in kitty package by sorting completions and adjusting man page timestamps

### DIFF
--- a/tools/cli/fish.go
+++ b/tools/cli/fish.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"kitty/tools/cli/markup"
@@ -22,6 +23,7 @@ func fish_completion_script(commands []string) (string, error) {
 	}
 	if len(commands) == 0 {
 		commands = append(commands, utils.Keys(all_commands)...)
+		sort.Strings(commands)
 	}
 	script := strings.Builder{}
 	script.WriteString(`function __ksi_completions

--- a/tools/cli/help.go
+++ b/tools/cli/help.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"slices"
 	"strings"
+	"strconv"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -135,6 +136,15 @@ func ShowHelpInPager(text string) {
 	_ = pager.Run()
 }
 
+func getDeterministicTimestamp() time.Time {
+	if epochStr, exists := os.LookupEnv("SOURCE_DATE_EPOCH"); exists {
+			if epoch, err := strconv.ParseInt(epochStr, 10, 64); err == nil {
+					return time.Unix(epoch, 0).UTC()
+			}
+	}
+	return time.Now()
+}
+
 func (self *Command) GenerateManPages(level int, recurse bool) (err error) {
 	var names []string
 	p := self
@@ -149,7 +159,7 @@ func (self *Command) GenerateManPages(level int, recurse bool) (err error) {
 		return err
 	}
 	defer outf.Close()
-	fmt.Fprintf(outf, `.TH "%s" "1" "%s" "%s" "%s"`, name, time.Now().Format("Jan 02, 2006"), kitty.VersionString, "kitten Manual")
+	fmt.Fprintf(outf, `.TH "%s" "1" "%s" "%s" "%s"`, name, getDeterministicTimestamp().Format("Jan 02, 2006"), kitty.VersionString, "kitten Manual")
 	fmt.Fprintln(outf)
 	fmt.Fprintln(outf, ".SH Name")
 	fmt.Fprintln(outf, name, "\\-", escape_text_for_man(self.ShortDescription))


### PR DESCRIPTION
This patch aims to address two sources of build non-determinism in the kitty package:

1. It sorts fish completions to avoid nondeterministic ordering, which could lead to inconsistent builds.
2. It modifies the man page generation process to respect SOURCE_DATE_EPOCH instead of using time.Now() for timestamps, helping ensure consistent dates in the documentation.

These changes are intended to help with the issue of unreproducible builds for kitty, as mentioned in [Nixpkgs Issue #383872](https://github.com/NixOS/nixpkgs/issues/383872). If any further adjustments are needed or if there are better approaches, I'm happy to make changes based on feedback.