### PR TITLE
Fix mouse cursor unhiding logic to reset on mouse being hidden

### DIFF
--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -1938,6 +1938,7 @@ set_os_window_title(OSWindow *w, const char *title) {
 void
 hide_mouse(OSWindow *w) {
     glfwSetInputMode(w->handle, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
+    w->mouse_activate_deadline = -1;
 }
 
 bool


### PR DESCRIPTION
Previously, mouse unhiding time was not reset on mouse hides, which can lead to sooner than expected unhides.