### PR TITLE
Add k-nine plotting tool to the integrations documentation

### DIFF
--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -209,6 +209,20 @@ Add this to bashrc and then to plot a function, simply do:
 
     iplot 'sin(x*3)*exp(x*.2)'
 
+.. _tool_k-nine:
+
+`k-nine <https://github.com/talwrii/kitty-plotnine>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A wrapper around the :code:`plotnine` library which lets you plot data from the command-line with bash one-liners by reading data from stdin in CSV, JSONL, or space-separated formats. :code:`plotnine` implements the Graphics of Grammar.
+
+The following bash command plots the number of downloads of the PyPI library :code:`kitkat` over time:
+
+.. code-block:: sh
+
+    curl https://pypistats.org/api/packages/kitcat/python_major | jq '.data | .[]' -rc | k-nine 'aes(x="date", y="downloads", group="category", color="category") + geom_line()'
+
+
 .. tool_tgutui:
 
 `tgutui <https://github.com/tgu-ltd/tgutui>`_

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -214,14 +214,7 @@ Add this to bashrc and then to plot a function, simply do:
 `k-nine <https://github.com/talwrii/kitty-plotnine>`_
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A wrapper around the :code:`plotnine` library which lets you plot data from the command-line with bash one-liners by reading data from stdin in CSV, JSONL, or space-separated formats. :code:`plotnine` implements the Graphics of Grammar.
-
-The following bash command plots the number of downloads of the PyPI library :code:`kitkat` over time:
-
-.. code-block:: sh
-
-    curl https://pypistats.org/api/packages/kitcat/python_major | jq '.data | .[]' -rc | k-nine 'aes(x="date", y="downloads", group="category", color="category") + geom_line()'
-
+A wrapper around the :code:`plotnine` library which lets you plot data from the command-line with bash one-liners.
 
 .. tool_tgutui:
 


### PR DESCRIPTION
I made a small tool called k-nine (kitty-plotnine) to do quick-and-dirty plotting within kitty-compatible terminals with bash one-liners. 

See this [reddit post](https://www.reddit.com/r/KittyTerminal/comments/1k7u34z/knine_a_tool_for_plotting_in_the_shell_with_bash/). It was suggested that I add this tool to the kitty documentation so I am creating a pull request to do so. 

Thanks,
readwithai