### PR TITLE
Update graphics-protocol.rst: typo fix

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -1003,8 +1003,8 @@ take, and the default value they take when missing. All integers are 32-bit.
 Key      Value                 Default    Description
 =======  ====================  =========  =================
 ``a``    Single character.     ``t``      The overall action this graphics command is performing.
-         ``(a, c, d, f, ``                ``t`` - transmit data, ``T`` - transmit data and display image,
-         ``p, q, t, T)``                  ``q`` - query terminal, ``p`` - put (display) previous transmitted image,
+         ``(a, c, d, f,                   ``t`` - transmit data, ``T`` - transmit data and display image,
+         p, q, t, T)``                    ``q`` - query terminal, ``p`` - put (display) previous transmitted image,
                                           ``d`` - delete image, ``f`` - transmit data for animation frames,
                                           ``a`` - control animation, ``c`` - compose animation frames
 


### PR DESCRIPTION
Those ticks are not neccessary.

|Before|After|
|-|-|
|![Screenshot From 2025-04-29 00-10-37](https://github.com/user-attachments/assets/ef1ae106-3817-4f3d-b302-66a5a66b5693)|![Screenshot From 2025-04-29 00-10-24](https://github.com/user-attachments/assets/feef98c2-9865-4d36-907d-92686c2c5496)|

It will work the same way this thing does:

|![image](https://github.com/user-attachments/assets/dc1aca2b-7bdb-4bd9-94e1-1c864aba4721)|![image](https://github.com/user-attachments/assets/c2df26f6-1354-450a-b20b-88d6b95f877d)|
|-|-|