### PR TITLE
debug_config: redact potentially sensitive information

### DIFF
--- a/kitty/debug_config.py
+++ b/kitty/debug_config.py
@@ -94,6 +94,8 @@ def compare_opts(opts: KittyOpts, global_shortcuts: dict[str, SingleKey] | None,
             elif f == 'modify_font':
                 for k in sorted(val):
                     print('   ', val[k])
+            elif f == 'remote_control_password':
+                print({"REDACTED": value for _, value in val.items()})
             else:
                 print(pformat(val))
         else:


### PR DESCRIPTION
When a user creates a bug report following the issue template they can potentially leak their remote control passwords.