### PR TITLE
Kitten: Avoid doing dash/underscore replace if the provided path exists

### DIFF
--- a/kittens/runner.py
+++ b/kittens/runner.py
@@ -24,6 +24,9 @@ else:
 
 def resolved_kitten(k: str) -> str:
     ans = aliases.get(k, k)
+    if os.path.exists(ans):
+        return ans
+
     head, tail = os.path.split(ans)
     tail = tail.replace('-', '_')
     return os.path.join(head, tail)


### PR DESCRIPTION
## Motivation

When looking up kitten scripts, all dashes in the filename are replaced with underscores.

This causes problems for anyone who wishes to use a kitten script whose filename includes a dash.

Concretely, the `.replace('-', '_')` causes issues for nixos / home-manager users who include nix-managed kitten scripts in their configuration, since the /nix/store path will include a dash.

I get an error like this:

```
Key action failed

kitten /nix/store/v2v0dbwcsdrfzi23fg998xsxzng21bvz-emocli_kitten.py
[Errno 2] No such file or directory: '/nix/store/v2v0dbwcsdrfzi23fg998xsxzng21bvz_emocli_kitten.py'
```

This causes people to do [interesting workarounds](https://gitlab.com/kofoednielsen/nixos-laptop/-/commit/f6bbb03ed5cd619d12ad9372e3d22d32145dbfde)

## The Fix

I suggest not replacing dashes with underscores, if there already exists a file at the unmodified path.

I'm not sure why this character replacement was added in the first place. It seems like it was introduced in [commit ec0edd6](https://github.com/kovidgoyal/kitty/commit/ec0edd6f458cced8867641da5c91319163437c0b) without much explanation.

A [later commit](https://github.com/kovidgoyal/kitty/commit/3dee3aba5916dcdb21d9312717fcf7efb32bbd87) restricts the scope of this replacement to just the filename, since it caused problems with files inside directories whose name include a dash.

The cleanest solution would probably be to not do the dash/underscore replacement in the first place, but since this behavior has been around for almost seven years now, it might break a lot of existing configurations that rely on it.