### PR TITLE
Fix `kitty +open` use non-tokenized `$EDITOR`

### DIFF
--- a/kitty/open_actions.py
+++ b/kitty/open_actions.py
@@ -265,7 +265,7 @@ action launch --hold --type=os-window -- kitten __confirm_and_run_exe__ $FILE_PA
 # Open text files without fragments in the editor
 protocol file
 mime text/*
-action launch --type=os-window -- $EDITOR -- $FILE_PATH
+action launch --type=os-window -- $SHELL -c "$EDITOR -- $FILE_PATH"
 
 # Open image files with icat
 protocol file

--- a/kitty_tests/open_actions.py
+++ b/kitty_tests/open_actions.py
@@ -32,7 +32,7 @@ class TestOpenActions(BaseTest):
 protocol file
 mime text/*
 fragment_matches .
-AcTion launch $EDITOR $FILE_PATH $FRAGMENT
+AcTion launch $SHELL -c "$EDITOR $FILE_PATH $FRAGMENT"
 action
 
 protocol file


### PR DESCRIPTION
```sh
EDITOR='nvim --clean' kitty +open README.asciidoc
```

```
Failed to launch child: /usr/bin/nvim --clean
With error: No such file or directory
Press Enter or Esc to exit
```
