### PR TITLE
fix: add missing pkgs and manually add font for nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -15,6 +15,7 @@ in
           xxHash
           simde
           go_1_23
+          matplotlib
         ]
         ++ optionals stdenv.isDarwin [
           Cocoa
@@ -25,7 +26,6 @@ in
           OpenGL
           UniformTypeIdentifiers
           libpng
-          python3
           zlib
         ]
         ++ lib.optionals (stdenv.isDarwin && (builtins.hasAttr "UserNotifications" darwin.apple_sdk.frameworks)) [
@@ -46,6 +46,10 @@ in
           wayland
           openssl
           dbus
+          cairo #
+        ]
+        ++ lib.optionals stdenv.hostPlatform.isLinux [
+          wayland-scanner
         ]
         ++ checkInputs;
 
@@ -77,10 +81,21 @@ in
         if stdenv.isDarwin
         then ''
           export KITTY_NO_LTO=
+          # Add fonts by hand
+
+          if [ ! -e ./fonts/SymbolsNerdFontMono-Regular.ttf ]; then
+            cp "${nerd-fonts.symbols-only}/share/fonts/truetype/NerdFonts/Symbols/SymbolsNerdFontMono-Regular.ttf" ./fonts/
+          fi
         ''
         else ''
           export KITTY_EGL_LIBRARY='${lib.getLib libGL}/lib/libEGL.so.1'
           export KITTY_STARTUP_NOTIFICATION_LIBRARY='${libstartup_notification}/lib/libstartup-notification-1.so'
           export KITTY_CANBERRA_LIBRARY='${libcanberra}/lib/libcanberra.so'
+          export KITTY_FONTCONFIG_LIBRARY='${fontconfig.lib}/lib/libfontconfig.so'
+
+          # Add fonts by hand
+          if [ ! -e ./fonts/SymbolsNerdFontMono-Regular.ttf ]; then
+            cp "${nerd-fonts.symbols-only}/share/fonts/truetype/NerdFonts/Symbols/SymbolsNerdFontMono-Regular.ttf" ./fonts/
+          fi
         '';
     }


### PR DESCRIPTION
I added three missing packages to the shell environment provided by the *Nix* shell (two of them are only needed on Linux). Also, I manually copy the needed font to *./fonts* using *shellHook*.

The provided *Nix Shell* now allows for successful builds (tested on x86_64-linux and x86_64-darwin).