### PR TITLE
panel kitten: on Wayland, use app-id for the LayerShellV1 `namespace` parameter

### DIFF
--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -1144,7 +1144,7 @@ create_layer_shell_surface(_GLFWwindow *window) {
     struct wl_output *wl_output = find_output_by_name(window->wl.layer_shell.config.output_name);
 #define ls window->wl.layer_shell.zwlr_layer_surface_v1
     ls = zwlr_layer_shell_v1_get_layer_surface(
-            _glfw.wl.zwlr_layer_shell_v1, window->wl.surface, wl_output, get_layer_shell_layer(window), "kitty");
+            _glfw.wl.zwlr_layer_shell_v1, window->wl.surface, wl_output, get_layer_shell_layer(window), window->wl.appId[0] ? window->wl.appId : "kitty");
     if (!ls) {
         _glfwInputError(GLFW_PLATFORM_ERROR, "Wayland: layer-surface creation failed");
         return false;

--- a/kittens/quick_access_terminal/main.py
+++ b/kittens/quick_access_terminal/main.py
@@ -67,7 +67,8 @@ opt('+kitty_override', '', long_text='Override individual kitty configuration op
 )
 
 opt('app_id', f'{appname}-quick-access',
-    long_text='The WM_CLASS assigned to the quick access window (X11 only)')
+    long_text='On Wayland set the :italic:`namespace` parameter of the LayerShellV1 surface. On X11 set the WM_CLASS assigned'
+    ' to the quick access window. (Linux only)')
 
 
 opt('output_name', '', long_text='''

--- a/kitty/simple_cli_definitions.py
+++ b/kitty/simple_cli_definitions.py
@@ -375,7 +375,7 @@ def kitty_options_spec() -> str:
 dest=cls
 default={appname}
 condition=not is_macos
-Set the :italic:`application id` on Wayland. On X11 set the class part of the :italic:`WM_CLASS` window property.
+On Wayland set the :italic:`namespaces` parameter of the LayerShellV1 surface. On X11 set the class part of the :italic:`WM_CLASS` window property.
 
 
 --name --os-window-tag


### PR DESCRIPTION
The Wayland LayerShellV1 protocol doesn't allow setting window class/name/role/type/appId. Instead, it has a `namespace` parameter that we currently hardcode to `kitty`. It seems suitable to use app-id for this parameter.

Example use case:

kwin use the `namespace` parameter and an undocumented mapping to set window type for Layer Shell windows. E.g., "dock" maps to NET:Dock. So if we set `app_id dock` in quick_access_terminal.conf, the panel would be considered a dock, and won't have the normal scale in/out animation on shown/hidden.