### PR TITLE
docs: panel: update niri compatibility information

### DIFF
--- a/docs/kittens/panel.rst
+++ b/docs/kittens/panel.rst
@@ -160,8 +160,8 @@ Compatibility with various platforms
         🟠 **niri**
            Breaks when hiding (unmapping) layer shell windows. This means the quick
            access terminal is non-functional, but background and dock panels work.
-           More technically, keyboard focus gets stuck in the hidden window and when trying
-           to remap the hidden window niri never sends configure events for the remapped surface.
+           More technically, when trying to remap the hidden window niri never sends
+           configure events for the remapped surface.
 
         🟠 **labwc**
            Breaks when hiding (unmapping) layer shell windows. This means the quick


### PR DESCRIPTION
As of the latest niri release, more specifically https://github.com/YaLTeR/niri/commit/3e31c134a602dd876f2b446071e5802fa4a0c3ec, focus no longer gets stuck on an unmapped layer surface.