### PR TITLE
Escape inputs in zsh integration's _ksi_preexec

### DIFF
--- a/kitty_tests/shell_integration.py
+++ b/kitty_tests/shell_integration.py
@@ -161,6 +161,9 @@ RPS1="{rps1}"
             pty.write_to_child('\x04')
             pty.wait_till(lambda: pty.screen.cursor.shape == CURSOR_BEAM)
             self.assert_command(pty)
+            # Check escaping of inputs
+            pty.send_cmd_to_child("-f-this-command-must-not-exist")
+            self.assert_command(pty, exit_status=127)
         with self.run_shell(rc=f'''PS1="{ps1}"''') as pty:
             pty.callbacks.clear()
             pty.send_cmd_to_child('printf "%s\x16\a%s" "a" "b"')
@@ -273,7 +276,7 @@ function _set_status_prompt; function fish_prompt; echo -n "$pipestatus $status 
 
     def assert_command(self, pty, cmd='', exit_status=0):
         cmd = cmd or pty.last_cmd
-        pty.wait_till(lambda: pty.callbacks.last_cmd_exit_status == 0, timeout_msg=lambda: f'{pty.callbacks.last_cmd_exit_status=} != {exit_status}')
+        pty.wait_till(lambda: pty.callbacks.last_cmd_exit_status == exit_status, timeout_msg=lambda: f'{pty.callbacks.last_cmd_exit_status=} != {exit_status}')
         pty.wait_till(lambda: pty.callbacks.last_cmd_cmdline == cmd, timeout_msg=lambda: f'{pty.callbacks.last_cmd_cmdline=!r} != {cmd!r}')
 
     @unittest.skipUnless(bash_ok(), 'bash not installed, too old, or debug build')

--- a/shell-integration/zsh/kitty-integration
+++ b/shell-integration/zsh/kitty-integration
@@ -222,7 +222,7 @@ _ksi_deferred_init() {
             # its preexec hook before us, we'll incorrectly mark its output as
             # belonging to the command (as if the user typed it into zle) rather
             # than command output.
-            builtin print -nu "$_ksi_fd" -f '\e]133;C;cmdline=%q\a' "$1"
+            builtin print -nu "$_ksi_fd" -f '\e]133;C;cmdline=%q\a' -- "$1"
             (( _ksi_state = 1 ))
         }
 


### PR DESCRIPTION
I noticed that the zsh integration sometimes emits errors or extraneous text when you start a command line with `-`, because `_ksi_preexec` treats those input lines as arguments.

```console
% -f(not-a-command)
(not-a-command)zsh: command not found: -fabc
% - sh -c 'echo $0'
_ksi_preexec:print:4: bad option: - 
-sh
```

I fixed it by adding the option-terminating `--`, added a test, and fixed a bug in the test function I used.