### PR TITLE
Fix KeyError when using --incremental flag with resize-os-window panel control

### DIFF
--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -1278,6 +1278,7 @@ layer_shell_config_to_python(const GLFWLayerShellConfig *c) {
     A(requested_bottom_margin, fl);
     A(requested_right_margin, fl);
     A(requested_exclusive_zone, fl);
+    A(hide_on_focus_loss, b)
     A(override_exclusive_zone, b);
 #undef A
 #undef fl


### PR DESCRIPTION

When using `resize-os-window` with `--incremental` flag to modify panel kittens, a `KeyError: 'hide_on_focus_loss'` occurs:

```
Traceback (most recent call last):
  File "/usr/bin/../lib/kitty/kitty/boss.py", line 751, in _execute_remote_command
    response = handle_cmd(self, window, pcmd, peer_id, self_window)
  File "/usr/bin/../lib/kitty/kitty/remote_control.py", line 240, in handle_cmd
    ans = c.response_from_kitty(boss, self_window or window, PayloadGetter(c, payload))
  File "/usr/bin/../lib/kitty/kitty/rc/resize_os_window.py", line 137, in response_from_kitty
    replacements[x] = existing[x]
                      ~~~~~~~~^^^
KeyError: 'hide_on_focus_loss'

Error: 'hide_on_focus_loss'
```


The `layer_shell_config_to_python()` function was missing the `hide_on_focus_loss` field.
