### PR TITLE
Fix `kitten choose-files` panic

### DIFF
--- a/kittens/choose_files/scan.go
+++ b/kittens/choose_files/scan.go
@@ -447,8 +447,8 @@ func (fss *FileSystemScorer) Start() {
 		}
 		if fss.global_gitignore != nil {
 			sc.global_gitignore = fss.global_gitignore
-		} else {
-			sc.global_gitignore = ignorefiles.GlobalGitignore()
+		} else if ignore := ignorefiles.GlobalGitignore(); ignore != nil {
+			sc.global_gitignore = ignore
 		}
 		if fss.global_ignore != nil {
 			sc.global_ignore = fss.global_ignore


### PR DESCRIPTION
```
Error: Panicked: runtime error: invalid memory address or nil pointer
dereference
Panicked with error: runtime error: invalid memory address or nil
pointer dereference
Stacktrace (most recent call first):
github.com/kovidgoyal/kitty/kittens/choose_files.(*FileSystemScanner).worker
        kitty/kittens/choose_files/scan.go:351
```
