### PR TITLE
add special value listjson in panel output-name option

### DIFF
--- a/kitty/simple_cli_definitions.py
+++ b/kitty/simple_cli_definitions.py
@@ -660,7 +660,8 @@ Syntax: :italic:`name=value`. For example: :option:`kitty +kitten panel -o` font
 The panel can only be displayed on a single monitor (output) at a time. This allows
 you to specify which output is used, by name. If not specified the compositor will choose an
 output automatically, typically the last output the user interacted with or the primary monitor.
-Use the special value :code:`list` to get a list of available outputs.
+Use the special value :code:`list` to get a list of available outputs. Use :code:`listjson` for
+a json encoded output.
 
 
 --class --app-id


### PR DESCRIPTION
adds a special value `listjson` for panel `--output-name` for a json encoded output instead.

<img width="957" height="267" alt="image" src="https://github.com/user-attachments/assets/96657e0b-0800-4296-a3d3-47f3f5e792fd" />
