### PR TITLE
Revert NotRequired to tuple fix choose-fonts crash

### DIFF
--- a/kitty/typing_compat.py
+++ b/kitty/typing_compat.py
@@ -21,5 +21,5 @@ PowerlineStyle = str
 MatchType = str
 Protocol = object
 OptionsProtocol = object
-NotRequired = object
+NotRequired = tuple
 CoreTextFont = FontConfigPattern = dict


### PR DESCRIPTION
Not sure if this is a WIP, but choose-fonts is crashing on this change in c4ed1d3, reverting NotRequired back to tuple fixes it.

```
Traceback (most recent call last):
  File "lib/python3.12/runpy.py", line 198, in _run_module_as_main
  File "lib/python3.12/runpy.py", line 88, in _run_code
  File "lib/python3.12/kitty_main.py", line 7, in <module>
  File "lib/python3.12/kitty/entry_points.py", line 142, in main
  File "lib/python3.12/kitty/entry_points.py", line 100, in namespaced
  File "lib/python3.12/kitty/entry_points.py", line 23, in runpy
  File "<string>", line 1, in <module>
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "bypy-importer.py", line 279, in exec_module
  File "lib/python3.12/kittens/choose_fonts/backend.py", line 98, in <module>
  File "lib/python3.12/kittens/choose_fonts/backend.py", line 100, in FD
TypeError: type 'object' is not subscriptable
Error: exit status 1
```
