### PR TITLE
Fix the background color rendering

### DIFF
--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -987,11 +987,19 @@ do_toggle_fullscreen(OSWindow *w, unsigned int flags, bool restore_sizes) {
     glfwGetWindowSize(w->handle, &width, &height);
     if (!global_state.is_wayland) glfwGetWindowPos(w->handle, &x, &y);
     bool was_maximized = glfwGetWindowAttrib(w->handle, GLFW_MAXIMIZED);
+    float background_opacity = w->background_opacity;
+    if (flags) {
+        w->background_opacity = 1.0;
+    }
     if (glfwToggleFullscreen(w->handle, flags)) {
         w->before_fullscreen.is_set = true;
+        w->before_fullscreen.background_opacity = background_opacity;
         w->before_fullscreen.w = width; w->before_fullscreen.h = height; w->before_fullscreen.x = x; w->before_fullscreen.y = y;
         w->before_fullscreen.was_maximized = was_maximized;
         return true;
+    }
+    if (w->before_fullscreen.is_set && flags) {
+        w->background_opacity = w->before_fullscreen.background_opacity;
     }
     if (w->before_fullscreen.is_set && restore_sizes) {
         glfwSetWindowSize(w->handle, w->before_fullscreen.w, w->before_fullscreen.h);

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -284,6 +284,7 @@ typedef struct {
     monotonic_t created_at;
     struct {
         int x, y, w, h;
+        float background_opacity;
         bool is_set, was_maximized;
     } before_fullscreen;
     int viewport_width, viewport_height, window_width, window_height;


### PR DESCRIPTION
Currently, when background_opacity < 1.0 and macos_traditional_fullscreen = no, switching to fullscreen with Cmd+Ctrl+F causes the window’s background color to differ from the specified background.
After the fix, the behavior with macos_traditional_fullscreen = yes remains unaffected.