### PR TITLE
fix(show_key): fix typo in python exit message

### DIFF
--- a/kittens/show_key/main.py
+++ b/kittens/show_key/main.py
@@ -18,7 +18,7 @@ usage = ''
 
 
 def main(args: list[str]) -> None:
-    raise SystemExit('This should be reun as kitten show_key')
+    raise SystemExit('This should be run as kitten show_key')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix a small typo in the exit message I spotted after making my own typo trying to run `show_key`!