### PR TITLE
Add branch drawing symbols for compact graphs

### DIFF
--- a/kitty/fonts.c
+++ b/kitty/fonts.c
@@ -608,7 +608,7 @@ START_ALLOW_CASE_RANGE
         case 0xe0b0 ... 0xe0bf: case 0xe0d6 ... 0xe0d7:    // powerline box drawing
         case 0xee00 ... 0xee0b:    // fira code progress bar/spinner
         case 0x1fb00 ... 0x1fbae:  // symbols for legacy computing
-        case 0xf5d0 ... 0xf5fb:    // branch drawing characters
+        case 0xf5d0 ... 0xf605:    // branch drawing characters
             return BOX_FONT;
         default:
             *is_emoji_presentation = has_emoji_presentation(cpu_cell, gpu_cell);
@@ -649,7 +649,7 @@ START_ALLOW_CASE_RANGE
             return 0xf00 + ch - 0x2800; // IDs from 0xf00 to 0xfff
         case 0x1fb00 ... 0x1fbae:
             return 0x1000 + ch - 0x1fb00; // IDs from 0x1000 to 0x10ae
-        case 0xf5d0 ... 0xf5fb:
+        case 0xf5d0 ... 0xf605:
             return 0x2000 + ch - 0xf5d0; // IDs from 0x2000 to 0x202b
         default:
             return 0xffff;

--- a/kitty/fonts/box_drawing.py
+++ b/kitty/fonts/box_drawing.py
@@ -595,20 +595,20 @@ def draw_circle(buf: SSByteArray, width: int, height: int, scale: float = 1.0, g
 
 
 @supersampled()
-def commit(buf: SSByteArray, width: int, height: int, level: int = 1, scale: float = 0.75, line: str = 'none', solid: bool = True) -> None:
+def commit(buf: SSByteArray, width: int, height: int, level: int = 1, scale: float = 0.75, lines: tuple[Literal['l', 'r', 't', 'b'], ...] = (), solid: bool = True) -> None:
     ' Draw a circular commit with the given scale. Commits can either be solid or hollow and can have vertical, horizontal, up, down, left, or right line(s) '
 
     factor = buf.supersample_factor
     # Round half width/height to supersample factor to avoid misalignment with non-supersampled lines
     hwidth, hheight = factor * (width // 2 // factor), factor * (height // 2 // factor)
 
-    if line == 'horizontal' or line == 'right':
+    if 'r' in lines:
         draw_hline(buf, width, hwidth, width, hheight, level, supersample_factor=factor)
-    if line == 'horizontal' or line == 'left':
+    if 'l' in lines:
         draw_hline(buf, width, 0, hwidth, hheight, level, supersample_factor=factor)
-    if line == 'vertical' or line == 'down':
+    if 'b' in lines:
         draw_vline(buf, width, hheight, height, hwidth, level, supersample_factor=factor)
-    if line == 'vertical' or line == 'up':
+    if 't' in lines:
         draw_vline(buf, width, 0, hheight, hwidth, level, supersample_factor=factor)
 
     draw_circle(buf, width, height, scale=scale)
@@ -1332,18 +1332,28 @@ box_chars: dict[str, list[Callable[[BufType, int, int], Any]]] = {
     '': [hline, p(rounded_corner, which='╮'), p(rounded_corner, which='╰')],
     '': [commit],
     '': [p(commit, solid=False)],
-    '': [p(commit, line='right')],
-    '': [p(commit, solid=False, line='right')],
-    '': [p(commit, line='left')],
-    '': [p(commit, solid=False, line='left')],
-    '': [p(commit, line='horizontal')],
-    '': [p(commit, solid=False, line='horizontal')],
-    '': [p(commit, line='down')],
-    '': [p(commit, solid=False, line='down')],
-    '': [p(commit, line='up')],
-    '': [p(commit, solid=False, line='up')],
-    '': [p(commit, line='vertical')],
-    '': [p(commit, solid=False, line='vertical')],
+    '': [p(commit, lines=('r',))],
+    '': [p(commit, solid=False, lines=('r',))],
+    '': [p(commit, lines=('l',))],
+    '': [p(commit, solid=False, lines=('l',))],
+    '': [p(commit, lines=('r', 'l'))],
+    '': [p(commit, solid=False, lines=('r', 'l'))],
+    '': [p(commit, lines=('b',))],
+    '': [p(commit, solid=False, lines=('b',))],
+    '': [p(commit, lines=('t',))],
+    '': [p(commit, solid=False, lines=('t',))],
+    '': [p(commit, lines=('b', 't'))],
+    '': [p(commit, solid=False, lines=('b', 't'))],
+    '': [p(commit, lines=('r', 'b', 't'))],
+    '': [p(commit, solid=False, lines=('r', 'b', 't'))],
+    '': [p(commit, lines=('l', 'b', 't'))],
+    '': [p(commit, solid=False, lines=('l', 'b', 't'))],
+    '': [p(commit, lines=('r', 'l', 'b'))],
+    '': [p(commit, solid=False, lines=('r', 'l', 'b'))],
+    '': [p(commit, lines=('r', 'l', 't'))],
+    '': [p(commit, solid=False, lines=('r', 'l', 't'))],
+    '': [p(commit, lines=('r', 'l', 'b', 't'))],
+    '': [p(commit, solid=False, lines=('r', 'l', 'b', 't'))],
 }
 
 t, f = 1, 3


### PR DESCRIPTION
## Summary

This includes 10 new branch drawing symbols for [drawing compact graphs](https://github.com/rbong/vim-flog/issues/163).
Commit drawing code has been slightly updated to allow for slightly more complex lines.

Here is a screenshot of how commit symbols appear with the new branch drawing code and new symbols:

<img width="328" height="906" alt="new_flog_commit_symbols" src="https://github.com/user-attachments/assets/48fda249-6166-4ac8-b915-722b249d15f8" />

## Consistency

The order is consistent with other branch drawing and box drawing symbols.
I've tried to make the new code consistent with other box drawing functions.

These symbols are a logical extension of branch drawing symbols and are exactly where we would want to put them in the symbol table.
They're just commits with 3/4 way connections instead of just 1/2 way connections, which is all we had before.

## Future-proofing

The only reason these weren't included before was that I believe no one asked for them even after I reached out for feedback, and I couldn't think of a use case myself.
In retrospect, it would have been better to include them before for future-proofing, but I think it's fairly low-impact to include them now as no one else has extended branch drawing symbols yet.
The [use case for adding them makes sense to me](https://github.com/rbong/vim-flog/issues/163).

There's no other combinations of symbols we could reasonably add: fade-out symbols don't make sense combined with anything else, curved lines would just be obscured by commit symbols if we combined them, every other combination exists.

I say this so I hope it's obvious I won't just keep adding symbols.
This should be the last updates unless if someone comes up with a good case for something essentially new, and we can weigh the number of new symbols against the usefulness.

## Next steps

I'm submitting it here first because this was the first terminal to accept a PR for these symbols.

I plan to reach out to other terminals that have already implemented these symbols to let them know about this development.
If you'd like me to do that first, let me know.

In the interest of more standardization, I think it's also time to submit these symbols to Nerd Fonts.
I'm not confident in my ability to create these as font symbols, but since no one else has done it yet I will give it a shot.
Again, if you'd like to see this happen first, let me know.