### PR TITLE
options: add copy_or_noop, make default

### DIFF
--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -3725,10 +3725,12 @@ There is also a :ac:`copy_or_interrupt` action that can be optionally mapped
 to :kbd:`Ctrl+C`. It will copy only if there is a selection and send an
 interrupt otherwise. Similarly, :ac:`copy_and_clear_or_interrupt` will copy
 and clear the selection or send an interrupt if there is no selection.
+The :ac:`copy_or_noop` action will copy if there is a selection and pass
+the key through to the application if there is no selection.
 '''
     )
-map('Copy to clipboard',
-    'copy_to_clipboard cmd+c copy_to_clipboard',
+map('Copy to clipboard or pass through',
+    'copy_or_noop cmd+c copy_or_noop',
     only='macos',
     )
 

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -2142,6 +2142,15 @@ class Window:
             self.scroll_end()
             self.write_to_child(self.encoded_key(KeyEvent(key=ord('c'), mods=GLFW_MOD_CONTROL)))
 
+    @ac('cp', 'Copy the selected text from the active window to the clipboard, if no selection, pass the key through to the application')
+    def copy_or_noop(self) -> bool:
+        text = self.text_for_selection()
+        if text:
+            set_clipboard_string(text)
+            return False
+        else:
+            return True
+
     @ac('cp', 'Copy the selected text from the active window to the clipboard and clear selection, if no selection, send SIGINT (aka :kbd:`ctrl+c`)')
     def copy_and_clear_or_interrupt(self) -> None:
         self.copy_or_interrupt()


### PR DESCRIPTION
Add a "copy_or_noop" option which copies the text, and if there is no
selected text passes through the key. This allows applications to
implement native text selection but also have cmd+c still function as a
copy key since they can now receive it.

Make this the default on macos. This should have very little impact on
users because when no text is selected, the application can
(potentially) handle the key.
