### PR TITLE
Don't complain about unset 'sourced'

### DIFF
--- a/shell-integration/bash/kitty.bash
+++ b/shell-integration/bash/kitty.bash
@@ -318,7 +318,7 @@ _ksi_main() {
         builtin local venv="${VIRTUAL_ENV}/bin/activate"
         builtin local sourced=""
         _ksi_s_is_ok() {
-            [[ -z "$sourced" && "$KITTY_CLONE_SOURCE_STRATEGIES" == *",$1,"* ]] && builtin return 0
+            [[ -z "${sourced:-}" && "$KITTY_CLONE_SOURCE_STRATEGIES" == *",$1,"* ]] && builtin return 0
             builtin return 1
         }
 


### PR DESCRIPTION
If the user's bash profile contains 'set -u' (to protect against typos in variable names; think "rm -Rf $TMp/*"), starting a new kitty terminal resulted in a spurious `bash: sourced: unbound variable` message.