### PR TITLE
Fix bash integration when 'set -o nounset' is in effect

### DIFF
--- a/shell-integration/bash/kitty.bash
+++ b/shell-integration/bash/kitty.bash
@@ -85,7 +85,7 @@ if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
     builtin return
 fi
 
-if [[ "${_ksi_prompt[sourced]}" == "y" ]]; then
+if [ -v "_ksi_prompt[sourced]" ]; then
     # we have already run
     builtin unset KITTY_SHELL_INTEGRATION
     builtin return
@@ -318,7 +318,7 @@ _ksi_main() {
         builtin local venv="${VIRTUAL_ENV}/bin/activate"
         builtin local sourced=""
         _ksi_s_is_ok() {
-            [[ -z "${sourced:-}" && "$KITTY_CLONE_SOURCE_STRATEGIES" == *",$1,"* ]] && builtin return 0
+            [[ -z "$sourced" && "$KITTY_CLONE_SOURCE_STRATEGIES" == *",$1,"* ]] && builtin return 0
             builtin return 1
         }
 


### PR DESCRIPTION
If the user's bash profile contains 'set -u' / 'set -o nounset' (to protect against typos in variable names; think "rm -Rf $TMp/*"), starting a new kitty terminal resulted in a `bash: sourced: unbound variable` message.
Also, the error disabled kitty's shell integration.

This PR fixes/supersedes bba4ce22, which was based on an incorrect assumption and was submitted by mistake.