### PR TITLE
Support combined notify and bell on command finish

### DIFF
--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -3482,6 +3482,10 @@ Second, the action to perform. The default is :code:`notify`. The possible value
 :code:`bell`
     Ring the terminal bell.
 
+:code:`notify-bell`
+    Send a desktop notification and ring the terminal bell.
+    The arguments are the same as for `notify`.
+
 :code:`command`
     Run a custom command. All subsequent arguments are the cmdline to run.
 

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -803,10 +803,10 @@ def notify_on_cmd_finish(x: str) -> NotifyOnCmdFinish:
     cmdline: tuple[str, ...] = ()
     clear_on = default_clear_on
     if len(parts) > 2:
-        if parts[2] not in ('notify', 'bell', 'command'):
+        if parts[2] not in ('notify', 'bell', 'notify-bell', 'command'):
             raise ValueError(f'Unknown notify_on_cmd_finish action: {parts[2]}')
         action = parts[2]
-        if action == 'notify':
+        if action.startswith('notify'):
             if len(parts) > 3:
                 con: list[ClearOn] = []
                 for x in parts[3].split():


### PR DESCRIPTION
This adds a `notify-bell` action to the `notify_on_cmd_finish` option that combines the `notify` and `bell` actions. In principle you could use the `command` action to do something similar, but you wouldn't be able to replicate some things like dismissing the notification when the window gains focus, and everyone would have to implement it separately. So this seemed like a simple solution.

I considered a more flexible solution for combining arbitrary actions, but that seemed like it would make things unnecessarily complicated.