### PR TITLE
Add new toggle_background_opacity mappable action

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1534,6 +1534,34 @@ class Boss:
             fin_opacity = float(opacity)
         self._set_os_window_background_opacity(os_window_id, fin_opacity)
 
+    @ac('win', '''
+        Toggles between the default and specified active OS window background opacities
+
+        Sets the active OS Window between the current value or restores it to
+        the default if it already has the specified background opacity. For example::
+
+            map f1 toggle_background_opacity 0.85
+        ''')
+    def toggle_background_opacity(self, opacity: str) -> None:
+        window = self.window_for_dispatch or self.active_window
+        if window is None or not opacity:
+            return
+        if not get_options().dynamic_background_opacity:
+            self.show_error(
+                    _('Cannot change background opacity'),
+                    _('You must set the dynamic_background_opacity option in kitty.conf to be able to change background opacity'))
+            return
+        os_window_id = window.os_window_id
+        current_opacity = background_opacity_of(os_window_id)
+        target_opacity = float(opacity)
+        # GLFW represents opacity as a float internally, so opacity values
+        # don't precisely roundtrip when set
+        if abs(current_opacity - target_opacity) <= 0.001:
+            fin_opacity = get_options().background_opacity
+        else:
+            fin_opacity = target_opacity
+        self._set_os_window_background_opacity(os_window_id, fin_opacity)
+
     @property
     def active_tab_manager(self) -> TabManager | None:
         os_window_id = current_focused_os_window_id()

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -165,7 +165,7 @@ def detach_tab_parse(func: str, rest: str) -> FuncArgsType:
 
 
 @func_with_args(
-    'set_background_opacity', 'goto_layout', 'toggle_layout', 'toggle_tab', 'kitty_shell', 'show_kitty_doc',
+    'set_background_opacity', 'toggle_background_opacity', 'goto_layout', 'toggle_layout', 'toggle_tab', 'kitty_shell', 'show_kitty_doc',
     'set_tab_title', 'push_keyboard_mode', 'dump_lines_with_attrs', 'set_window_title', 'simulate_color_scheme_preference_change',
 )
 def simple_parse(func: str, rest: str) -> FuncArgsType:


### PR DESCRIPTION
## Description
I want to be able to have a single key binding that toggles between my default opacity (opaque) and a specified background opacity. I in particular am using `map command+u toggle_background_opacity 0.8`.

This adds a new mappable action that performs this conversion.

## Verification steps
See this video. I'm successfully able to press command+u and have the opacity turn transparent and then press it again to turn it opaque.
<video src=https://github.com/user-attachments/assets/300500af-eb87-4300-9a26-b2a7a1809808 />



The compiled docs also look updated appropriately.
<img width="760" height="205" alt="Screenshot 2025-09-21 at 14 45 28" src="https://github.com/user-attachments/assets/35788764-cefb-4821-8c43-8ae8b0eb6d8c" />
