### PR TITLE
resize-os-window: fix '--incremental' option of 'os-panel' action

### DIFF
--- a/kittens/panel/main.py
+++ b/kittens/panel/main.py
@@ -5,7 +5,7 @@ import os
 import sys
 from contextlib import suppress
 from functools import partial
-from typing import Iterable, Mapping, Sequence
+from typing import Any, Iterable, Mapping, Sequence
 
 from kitty.cli import parse_args
 from kitty.cli_stub import PanelCLIOptions
@@ -46,7 +46,7 @@ def panel_kitten_options_spec() -> str:
     return ans
 
 
-def parse_panel_args(args: list[str], track_seen_options: set[str] | None = None) -> tuple[PanelCLIOptions, list[str]]:
+def parse_panel_args(args: list[str], track_seen_options: dict[str, Any] | None = None) -> tuple[PanelCLIOptions, list[str]]:
     return parse_args(
         args, panel_kitten_options_spec, usage, help_text, 'kitty +kitten panel',
         result_class=PanelCLIOptions, track_seen_options=track_seen_options)

--- a/kitty/cli.py
+++ b/kitty/cli.py
@@ -593,7 +593,7 @@ PreparsedCLIFlags = tuple[dict[str, tuple[Any, bool]], list[str]]
 
 def apply_preparsed_cli_flags(
     preparsed_from_c: PreparsedCLIFlags, ans: Any, create_oc: Callable[[], Options],
-    track_seen_options: set[str] | None = None
+    track_seen_options: dict[str, Any] | None = None
 ) -> list[str]:
     for key, (val, is_seen) in preparsed_from_c[0].items():
         if key == 'help' and is_seen and val:
@@ -601,14 +601,14 @@ def apply_preparsed_cli_flags(
         elif key == 'version' and is_seen and val:
             create_oc().handle_version()
         if is_seen and track_seen_options is not None:
-            track_seen_options.add(key)
+            track_seen_options[key] = val
         setattr(ans, key, val)
     return preparsed_from_c[1]
 
 
 def parse_cmdline_inner(
         args: list[str], oc: Options, disabled: OptionSpecSeq, names_map: dict[str, OptionDict],
-        values_map: dict[str, OptionDict], ans: Any, track_seen_options: set[str] | None = None
+        values_map: dict[str, OptionDict], ans: Any, track_seen_options: dict[str, Any] | None = None
 ) -> list[str]:
     preparsed = parse_cli_from_spec(args, names_map, values_map)
     leftover_args = apply_preparsed_cli_flags(preparsed, ans, lambda: oc, track_seen_options)
@@ -620,7 +620,7 @@ def parse_cmdline_inner(
 
 def parse_cmdline(
     oc: Options, disabled: OptionSpecSeq, ans: Any, args: list[str] | None = None,
-    track_seen_options: set[str] | None = None
+    track_seen_options: dict[str, Any] | None = None
 ) -> list[str]:
     names_map = oc.names_map.copy()
     values_map = oc.values_map.copy()
@@ -677,7 +677,7 @@ def parse_args(
     appname: str | None = None,
     result_class: type[T] | None = None,
     preparsed_from_c: PreparsedCLIFlags | None = None,
-    track_seen_options: set[str] | None = None,
+    track_seen_options: dict[str, Any] | None = None,
 ) -> tuple[T, list[str]]:
     if result_class is not None:
         ans = result_class()

--- a/kitty/launch.py
+++ b/kitty/launch.py
@@ -443,7 +443,7 @@ def get_env(opts: LaunchCLIOptions, active_child: Child | None = None, base_env:
     return env
 
 
-def layer_shell_config_from_panel_opts(panel_opts: Iterable[str], track_seen_options: set[str] | None = None) -> LayerShellConfig:
+def layer_shell_config_from_panel_opts(panel_opts: Iterable[str], track_seen_options: dict[str, Any] | None = None) -> LayerShellConfig:
     from kittens.panel.main import layer_shell_config, parse_panel_args
     args = [('' if x.startswith('--') else '--') + x for x in panel_opts]
     try:


### PR DESCRIPTION
This commit addresses a few issues with the implementation of '--incremental':
    - Unspecified settings are reset to their default value, which defeats the purpose of the option.
    - It is assumed that the names of options in 'LayerCLIOptions' map one to one with the names of fields in 'LayerShellConfig' but this isn't true. For example: The 'margin_top' cli option sets the 'requested_top_margin' layer shell config.
    - When some options are set to a certain value, they force other options to be some value. The current implementation doesn't account for this.
    - The documentation is contradictory.