### PR TITLE
Update documentation for kitty_override kitten quick_access_terminal

### DIFF
--- a/kittens/quick_access_terminal/main.py
+++ b/kittens/quick_access_terminal/main.py
@@ -67,7 +67,7 @@ opt('+kitty_conf', '',
 )
 
 opt('+kitty_override', '', long_text='Override individual kitty configuration options, can be specified multiple times.'
-    ' Syntax: :italic:`name=value`. For example: :code:`font_size=20`.'
+    ' Syntax: :italic:`kitty_override name=value`. For example: :code:`kitty_override font_size=20`.'
 )
 
 opt('app_id', f'{appname}-quick-access',


### PR DESCRIPTION
First off, love the terminal! Simple and elegant. 🚀 

I noticed while setting up the Kitten `quick-access-terminal` that the kitty overrides weren't working. Searching through the codebase I quickly realized that each of them needed to have `kitty_override` preceding that actual override key <-> value pairing. I've updated the documentation in a minimal way to highlight the example syntax for this configuration. 