### PR TITLE
hints: make default regex ignore trailing whitespace

### DIFF
--- a/kittens/hints/main.py
+++ b/kittens/hints/main.py
@@ -15,7 +15,7 @@ from kitty.utils import get_editor, resolve_custom_file
 
 from ..tui.handler import result_handler
 
-DEFAULT_REGEX = r'(?m)^\s*(.+)\s*$'
+DEFAULT_REGEX = r'(?m)^\s*(.+?)\s*$'
 
 def load_custom_processor(customize_processing: str) -> Any:
     if customize_processing.startswith('::import::'):


### PR DESCRIPTION
For `hints --type regex` the captured part of the default regex is greedy so if your vim has the following text:
```
+---------------------------------------------------+
|foo                                                |
|     I want to capture this line!                  |
|bar                                                |
+---------------------------------------------------+
```
and you then select the second line with `kitten hints --type regex --program @`, the capture texted will be:
`I want to capture this line!                  ` (notice the trailing whitespace)
I believe the intent is for the kitten to capture:
`I want to capture this line!`

Making the capture part of the regex non-greedy results in the desired behavior.