### PR TITLE
fix(background): fix background image opacity

### DIFF
--- a/kitty/bgimage_fragment.glsl
+++ b/kitty/bgimage_fragment.glsl
@@ -1,11 +1,15 @@
 #pragma kitty_include_shader <alpha_blend.glsl>
+#pragma kitty_include_shader <utils.glsl>
 
 uniform sampler2D image;
 uniform vec4 background;
 in vec2 texcoord;
-out vec4 premult_color;
+out vec4 color;
 
 void main() {
-    vec4 color = texture(image, texcoord);
-    premult_color = alpha_blend(color, background);
+    color = texture(image, texcoord);
+    float alpha = color.a * background.a;
+    vec4 premult_color = vec4_premul(color.rgb, alpha);
+    color = vec4(color.rgb, alpha);
+    color = alpha_blend(color, premult_color);
 }


### PR DESCRIPTION
A patch to resolve issue #9046, where certain parts of the background image fragment shader were deleted, mistakenly removing the ability to make background images transparent. This PR adds the functionality back while respecting the v0.43 changes to the background processing pipeline.

Specifically, d52f2e7's change to `kitty/bgimage_fragment.glsl` [here](https://github.com/kovidgoyal/kitty/commit/d52f2e798164c2f2800eb28d227bead4f1b913a4#diff-03fb9497cd8ad20c20cb9a6d8a0fb0ad107cf06cea5ee6d6604316a38a3363e9L10) seems to have introduced the bug.

See issue #9046 for bug details.