### PR TITLE
unicode-input: fix race condition causing incorrect results

### DIFF
--- a/tools/unicode_names/query.go
+++ b/tools/unicode_names/query.go
@@ -99,6 +99,9 @@ func find_matching_codepoints(prefix string) (ans mark_set) {
 			ans.AddItems(marks...)
 		}
 	}
+	if ans == nil {
+		ans = utils.NewSet[uint16](0)
+	}
 	return ans
 }
 


### PR DESCRIPTION
In the `unicode-input` kitten, if a word in your query matches no codepoints, codepoints matching other words in your query will still be shown if the result of `find_matching_codepoints` for the word with no matches is considered first. The order in which the words are considered is not defined since `find_matching_codepoints` is parallelized for each word.

Here you can see that even though `foobar` doesn't match any codepoints, sometimes results matching `face` and `fac` are still shown:

https://github.com/user-attachments/assets/3cd37819-235b-46c1-8ff4-558d063d2edc