### PR TITLE
drag window without titlebar on macOS

### DIFF
--- a/glfw/cocoa_platform.h
+++ b/glfw/cocoa_platform.h
@@ -133,6 +133,15 @@ typedef struct _GLFWwindowNS
     bool            titlebar_hidden;
     unsigned long   pre_full_screen_style_mask;
 
+    // Tab bar region for draggable area when titlebar is hidden
+    struct {
+        int left;
+        int top;
+        int right;
+        int bottom;
+        bool valid;
+    } tab_bar_region;
+
     // Cached window properties to filter out duplicate events
     int             width, height;
     int             fbWidth, fbHeight;

--- a/glfw/glfw.py
+++ b/glfw/glfw.py
@@ -315,6 +315,7 @@ def generate_wrappers(glfw_header: str) -> None:
     void glfwSetPrimarySelectionString(GLFWwindow* window, const char* string)
     void glfwCocoaSetWindowChrome(GLFWwindow* window, unsigned int color, bool use_system_color, unsigned int system_color,\
     int background_blur, unsigned int hide_window_decorations, bool show_text_in_titlebar, int color_space, float background_opacity, bool resizable)
+    void glfwSetTabBarRegion(GLFWwindow* window, int left, int top, int right, int bottom)
     const char* glfwGetPrimarySelectionString(GLFWwindow* window, void)
     int glfwGetNativeKeyForName(const char* key_name, int case_sensitive)
     void glfwRequestWaylandFrameEvent(GLFWwindow *handle, unsigned long long id, GLFWwaylandframecallbackfunc callback)

--- a/kitty/glfw-wrapper.c
+++ b/kitty/glfw-wrapper.c
@@ -476,6 +476,9 @@ load_glfw(const char* path) {
     *(void **) (&glfwCocoaSetWindowChrome_impl) = dlsym(handle, "glfwCocoaSetWindowChrome");
     if (glfwCocoaSetWindowChrome_impl == NULL) dlerror(); // clear error indicator
 
+    *(void **) (&glfwSetTabBarRegion_impl) = dlsym(handle, "glfwSetTabBarRegion");
+    if (glfwSetTabBarRegion_impl == NULL) dlerror(); // clear error indicator
+
     *(void **) (&glfwGetPrimarySelectionString_impl) = dlsym(handle, "glfwGetPrimarySelectionString");
     if (glfwGetPrimarySelectionString_impl == NULL) dlerror(); // clear error indicator
 

--- a/kitty/glfw-wrapper.h
+++ b/kitty/glfw-wrapper.h
@@ -2334,6 +2334,10 @@ typedef void (*glfwCocoaSetWindowChrome_func)(GLFWwindow*, unsigned int, bool, u
 GFW_EXTERN glfwCocoaSetWindowChrome_func glfwCocoaSetWindowChrome_impl;
 #define glfwCocoaSetWindowChrome glfwCocoaSetWindowChrome_impl
 
+typedef void (*glfwSetTabBarRegion_func)(GLFWwindow*, int, int, int, int);
+GFW_EXTERN glfwSetTabBarRegion_func glfwSetTabBarRegion_impl;
+#define glfwSetTabBarRegion glfwSetTabBarRegion_impl
+
 typedef const char* (*glfwGetPrimarySelectionString_func)(GLFWwindow*);
 GFW_EXTERN glfwGetPrimarySelectionString_func glfwGetPrimarySelectionString_impl;
 #define glfwGetPrimarySelectionString glfwGetPrimarySelectionString_impl


### PR DESCRIPTION
Add the ability to drag windows on macOS without using the title bar.