### PR TITLE
docs: panel: added xfce to compatibility matrix

### DIFF
--- a/docs/kittens/panel.rst
+++ b/docs/kittens/panel.rst
@@ -153,6 +153,9 @@ Compatibility with various platforms
         🟢 **niri**
            Fully working, no known issues
 
+        🟢 **Xfce**
+           Fully working, no known issues
+
         🟠 **KDE** (kwin)
            Mostly working, except that clicks outside background panels cause kwin to :iss:`erroneously hide the panel <8715>`. KDE uses an `undocumented mapping <https://invent.kde.org/plasma/kwin/-/blob/3dc5cee6b34792486b343098e55e7f2b90dfcd00/src/layershellv1window.cpp#L24>`__ under Wayland to set the window type from the :code:`kitten panel --app-id` flag. You might want to use :code:`--app-id=dock` so that KDE treats the window as a dock panel, and disables window appearing/disappearing animations for it.
 


### PR DESCRIPTION
Verified that the panel test script works as expected.
Verified `--edge=center-sized` works as expected.
Verified unmapping layer surfaces doesn't result in crash.
Verified exclusive space is reclaimed after unmapping layer surfaces.