### PR TITLE
Accumulate VALUE120 high-res discrete scrolling events

### DIFF
--- a/glfw/wl_init.c
+++ b/glfw/wl_init.c
@@ -202,21 +202,23 @@ pointer_handle_frame(void *data UNUSED, struct wl_pointer *pointer UNUSED) {
     _GLFWwindow* window = _glfw.wl.pointerFocus;
     if (!window) return;
     float x = 0, y = 0;
-    int highres = 0;
+    const int HIGHRES = 1;
+    const int VALUE120 = 1 << 4;
+    int flags = 0;
 
     if (info.discrete.y_axis_type != AXIS_EVENT_UNKNOWN) {
         y = info.discrete.y;
-        if (info.discrete.y_axis_type == AXIS_EVENT_VALUE120) y /= 120.f;
+        if (info.discrete.y_axis_type == AXIS_EVENT_VALUE120) flags |= VALUE120;
     } else if (info.continuous.y_axis_type != AXIS_EVENT_UNKNOWN) {
-        highres = 1;
+        flags |= HIGHRES;
         y = info.continuous.y;
     }
 
     if (info.discrete.x_axis_type != AXIS_EVENT_UNKNOWN) {
         x = info.discrete.x;
-        if (info.discrete.x_axis_type == AXIS_EVENT_VALUE120) x /= 120.f;
+        if (info.discrete.x_axis_type == AXIS_EVENT_VALUE120) flags |= VALUE120;
     } else if (info.continuous.x_axis_type != AXIS_EVENT_UNKNOWN) {
-        highres = 1;
+        flags |= HIGHRES;
         x = info.continuous.x;
     }
     /* clear pointer_curr_axis_info for next frame */
@@ -225,7 +227,7 @@ pointer_handle_frame(void *data UNUSED, struct wl_pointer *pointer UNUSED) {
     if (x != 0.0f || y != 0.0f) {
         float scale = (float)_glfwWaylandWindowScale(window);
         y *= scale; x *= scale;
-        _glfwInputScroll(window, -x, y, highres, _glfw.wl.xkb.states.modifiers);
+        _glfwInputScroll(window, -x, y, flags, _glfw.wl.xkb.states.modifiers);
     }
 }
 


### PR DESCRIPTION
Fixes a bug where VALUE120 scroll events with value < 1 line would always scroll a full line, leading to strange-feeling scrolling behavior on smooth-scrolling input devices.

Explanation:

```
        // VALUE120 events are "discrete" in that they scroll lines, not pixels.
        // But each VALUE120 event of value `v` represents a fraction of a
        // line, specifically `v` 120ths of a line.

        // GLFWscrollfun does not handle non-highres scroll events with
        // non-integer value. We could use `highres` for VALUE120 events, but
        // that would be wrong since the units should be interpreted as
        // fractional lines, not pixels.

        // So instead, we accumulate discrete events until we have at least one
        // full line to scroll, and then call the GLFWscrollfun to scroll entire
        // lines.
```