### PR TITLE
Fix nvim SetUsrVar autocmd for --remote-ui

### DIFF
--- a/docs/mapping.rst
+++ b/docs/mapping.rst
@@ -210,17 +210,25 @@ In order to make this work, you need to configure your editor as show below:
 
     .. code-block:: lua
 
-        vim.api.nvim_create_autocmd({ "VimEnter", "VimResume" }, {
+        vim.api.nvim_create_autocmd({ "VimEnter", "VimResume", "UIEnter" }, {
             group = vim.api.nvim_create_augroup("KittySetVarVimEnter", { clear = true }),
             callback = function()
-                io.stdout:write("\x1b]1337;SetUserVar=in_editor=MQo\007")
+                if vim.api.nvim_ui_send then
+                    vim.api.nvim_ui_send("\x1b]1337;SetUserVar=in_editor=MQo\007")
+                else
+                    io.stdout:write("\x1b]1337;SetUserVar=in_editor=MQo\007")
+                end
             end,
         })
 
         vim.api.nvim_create_autocmd({ "VimLeave", "VimSuspend" }, {
             group = vim.api.nvim_create_augroup("KittyUnsetVarVimLeave", { clear = true }),
             callback = function()
-                io.stdout:write("\x1b]1337;SetUserVar=in_editor\007")
+                if vim.api.nvim_ui_send then
+                    vim.api.nvim_ui_send("\x1b]1337;SetUserVar=in_editor=MQo\007")
+                else
+                    io.stdout:write("\x1b]1337;SetUserVar=in_editor\007")
+                end
             end,
         })
 


### PR DESCRIPTION
* Current autocmd in document don't work when you attach new ui client to existing instance.
* Use `vim.api.nvim_ui_send` if possible, since `io.stdout:write` don't seem write to new ui when old ui is still alive.
