### PR TITLE
Fix --wait-for-child-to-exit not working with overlay windows

### DIFF
--- a/kitty/rc/launch.py
+++ b/kitty/rc/launch.py
@@ -132,6 +132,11 @@ instead of the active tab
         if tabs and tabs[0]:
             target_tab = tabs[0]
 
+        # Create responder before defining callback to avoid closure issue
+        responder = None
+        if payload_get('wait_for_child_to_exit') and not payload_get('no_response'):
+            responder = self.create_async_responder(payload_get, window)
+
         def on_child_death(exit_status: int, exc: Exception | None) -> None:
             code = os.waitstatus_to_exitcode(exit_status)
             ans = str(code)
@@ -141,7 +146,8 @@ instead of the active tab
                     ans = Signals(-code).name
                 except ValueError:
                     pass
-            responder.send_data(ans)
+            if responder is not None:
+                responder.send_data(ans)
 
         w = do_launch(
             boss, opts, payload_get('args') or [], target_tab=target_tab, rc_from_window=window, base_env=base_env,
@@ -152,7 +158,6 @@ instead of the active tab
         if not payload_get('wait_for_child_to_exit'):
             return str(0 if w is None else w.id)
 
-        responder = self.create_async_responder(payload_get, window)
         return AsyncResponse()
 
     def cancel_async_request(self, boss: 'Boss', window: Window | None, payload_get: PayloadGetType) -> None:


### PR DESCRIPTION
## Summary
Fixes the issue where `--wait-for-child-to-exit` flag doesn't work with overlay windows.

## Problem
When using commands like:
```bash
kitten @ launch --type=overlay --wait-for-child-to-exit bash -c "echo 'test'"
```
The overlay window would not exit immediately as expected, instead hanging indefinitely.

## Root Cause
The issue was a closure problem in `kitty/rc/launch.py`:
- The `on_child_death` callback referenced a `responder` variable
- However, `responder` was created AFTER `do_launch()` was called with the callback
- When the child process exited, the callback failed because `responder` didn't exist in its closure

## Solution
- Create the `responder` before defining the `on_child_death` callback
- Add a null check in the callback before using `responder.send_data()`
- This ensures the callback has access to the responder object when needed

## Test Plan
- [x] Build kitty with `./dev.sh build`
- [x] Test overlay with wait: `kitty/launcher/kitty kitten @ launch --type=overlay --wait-for-child-to-exit bash -c "echo 'test'"`
- [x] Verify it exits immediately and returns exit code 0
- [x] Test with regular windows to ensure no regression