### PR TITLE
Fix inner_corner

### DIFF
--- a/kitty/decorations.c
+++ b/kitty/decorations.c
@@ -890,7 +890,9 @@ inner_corner(Canvas *self, uint level, Corner corner) {
     uint vthick = thickness(self, level, true) / 2;
     uint x1 = 0, x2 = self->width, y1 = 0, y2 = self->height; int xd = 1, yd = 1;
     if (corner & LEFT_EDGE) {
-        x2 = minus(self->width / 2 + vthick + 1, hgap); xd = -1;
+        xd = -1;
+        Range vlinelimit = vline_limits(self, self->width / 2 + (xd * hgap), level);
+        x2 = vlinelimit.end;
     } else x1 = minus(self->width / 2 + hgap, vthick);
     if (corner & TOP_EDGE) {
         y2 = minus(self->height / 2, vgap); yd = -1;


### PR DESCRIPTION
Fixed an issue where the rendering of inner_corner was misaligned with the vertical line at certain DPI settings.

- before

<img width="249" height="168" alt="image" src="https://github.com/user-attachments/assets/1d4bdd83-0289-4484-808d-5fd9f93d09ed" />

- after

<img width="234" height="160" alt="image" src="https://github.com/user-attachments/assets/f09087fe-20bb-4e47-8d04-28c1a4dd79fa" />
