### PR TITLE
Update `symbol_map` setting for nerd fonts

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -280,8 +280,7 @@ fonts to be freely resizable, so it does not support bitmapped fonts.
    add the following line to :file:`kitty.conf`::
 
         # Nerd Fonts v3.3.0
-
-        symbol_map U+e000-U+e00a,U+ea60-U+ebeb,U+e0a0-U+e0c8,U+e0ca,U+e0cc-U+e0d7,U+e200-U+e2a9,U+e300-U+e3e3,U+e5fa-U+e6b7,U+e700-U+e8ef,U+ed00-U+efc1,U+f000-U+f2ff,U+f000-U+f2e0,U+f300-U+f381,U+f400-U+f533,U+f0001-U+f1af0 Symbols Nerd Font Mono
+        symbol_map U+23fb-U+23fe,U+2500-U+259f,U+2630,U+2665,U+26a1,U+276c-U+2771,U+2b58,U+e000-U+e00a,U+e0a0-U+e0a2,U+e0a3,U+e0b0-U+e0b3,U+e0b4-U+e0c8,U+e0ca,U+e0cc-U+e0d7,U+e200-U+e2a9,U+e300-U+e3e3,U+e5fa-U+e6b7,U+e700-U+e8ef,U+ea60-U+ec1e,U+ed00-U+efce,U+ee00-U+ee0b,U+f000-U+f2ff,U+f300-U+f381,U+f400-U+f533,U+f0001-U+f1af0 Symbols Nerd Font Mono
 
    Those Unicode symbols not in the `Unicode private use areas
    <https://en.wikipedia.org/wiki/Private_Use_Areas>`__ are


### PR DESCRIPTION
Updates Nerd Font codepoints from https://github.com/ryanoasis/nerd-fonts/wiki/Glyph-Sets-and-Code-Points.