### PR TITLE
fix: typos in documentation

### DIFF
--- a/docs/clipboard.rst
+++ b/docs/clipboard.rst
@@ -153,7 +153,7 @@ and human friendly name with ``type=write`` and ``type=read`` requests. The
 terminal can then ask the user to allow all future requests using that
 password. If the user agrees, future requests on the same tty will be
 automatically allowed by the terminal. The editor or other program using
-this facility should ideally use a password randomnly generated at startup,
+this facility should ideally use a password randomly generated at startup,
 such as a UUID4. However, terminals may implement permanent/stored passwords.
 Users can then configure terminal programs they trust to use these password.
 
@@ -218,15 +218,15 @@ other characters must be stripped out from the id by the terminal emulator
 before retransmitting it.
 
 Note that when using a terminal multiplexer it is possible for two different
-programs to overwrite each others clipboard requests. This is fundamentally
+programs to overwrite each other's clipboard requests. This is fundamentally
 unavoidable since the system clipboard is a single global shared resource.
-However, there is an additional complication where responses form this protocol
+However, there is an additional complication where responses from this protocol
 could get lost if, for instance, multiple write requests are received
 simultaneously. It is up to well designed multiplexers to ensure that only a
 single request is in flight at a time. The multiplexer can abort requests by
 sending back the ``EBUSY`` error code indicating some other window is trying
 to access the clipboard.
 
-When the terminal sends an unsolicited paste event beause the user triggerred
+When the terminal sends an unsolicited paste event because the user triggered
 a paste and the 5522 mode is enabled, there will be no associated id. In this
 case, the multiplexer must forward the event to the currently active window.

--- a/docs/color-stack.rst
+++ b/docs/color-stack.rst
@@ -103,7 +103,7 @@ This indicates that the foreground color is red and the cursor color is
 undefined (typically the cursor takes the color of the text under it and the
 text takes the color of the background).
 
-If the terminal does not know a field that a client send to it for a query it
+If the terminal does not know a field that a client sends to it for a query it
 must respond back with the ``field=?``, that is, it must send back a question
 mark as the value.
 

--- a/docs/desktop-notifications.rst
+++ b/docs/desktop-notifications.rst
@@ -25,7 +25,7 @@ the set :code:`a-zA-Z0-9-_/\+.,(){}[]*&^%$#@!`~`. The payload must be
 interpreted based on the metadata section. The two semi-colons *must* always be
 present even when no metadata is present.
 
-Before going into details, lets see how one can display a simple, single line
+Before going into details, let's see how one can display a simple, single line
 notification from a shell script::
 
     printf '\x1b]99;;Hello world\x1b\\'

--- a/docs/file-transfer-protocol.rst
+++ b/docs/file-transfer-protocol.rst
@@ -127,7 +127,7 @@ receiving::
 
 The client must then wait for responses from the terminal emulator. It
 is an error to send anymore commands to the terminal until an ``OK``
-response is received from the terminal. The terminal wait for the user to accept
+response is received from the terminal. The terminal waits for the user to accept
 the request. If accepted, it sends::
 
     ← action=status id=someid status=OK

--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -364,7 +364,7 @@ Here we tell the terminal emulator to read compressed image data from
 the specified shared memory object.
 
 The client can also specify a size and offset to tell the terminal emulator
-to only read a part of the specified file. The is done using the ``S`` and ``O``
+to only read a part of the specified file. This is done using the ``S`` and ``O``
 keys respectively. For example::
 
     <ESC>_Gs=10,v=2,t=s,S=80,O=10;<encoded /some-shared-memory-name><ESC>\

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -340,7 +340,7 @@ Allow injecting passwords from 1Password into kitty.
 `BitWarden <https://github.com/dnanhkhoa/kitty-password-manager>`__
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Inject passwords from ButWarden into kitty
+Inject passwords from BitWarden into kitty
 
 Miscellaneous
 ------------------

--- a/docs/launch.rst
+++ b/docs/launch.rst
@@ -130,7 +130,7 @@ create :file:`~/.config/kitty/mywatcher.py` and use :option:`launch --watcher` =
 
     def on_load(boss: Boss, data: dict[str, Any]) -> None:
         # This is a special function that is called just once when this watcher
-        # module is first loaded, can be used to perform any initializztion/one
+        # module is first loaded, can be used to perform any initialization/one
         # time setup. Any exceptions in this function are printed to kitty's
         # STDERR but otherwise ignored.
         ...

--- a/docs/mapping.rst
+++ b/docs/mapping.rst
@@ -194,7 +194,7 @@ running an editor::
 
     map --when-focus-on var:in_editor kitty_mod+c
 
-In order to make this work, you need to configure your editor as show below:
+In order to make this work, you need to configure your editor as shown below:
 
 .. tab:: vim
 

--- a/docs/misc-protocol.rst
+++ b/docs/misc-protocol.rst
@@ -35,7 +35,7 @@ Reporting when the mouse leaves the window
 ----------------------------------------------
 
 kitty extends the SGR Pixel mouse reporting protocol created by xterm to
-also report when the mouse leaves the window. This is event is delivered
+also report when the mouse leaves the window. This event is delivered
 encoded as a normal SGR pixel event except that the eight bit is set on the
 first number. Additionally, bit 5 is set to indicate this is a motion related event.
 The remaining bits 1-7 (except 5) are used to encode button and modifier information.

--- a/docs/sessions.rst
+++ b/docs/sessions.rst
@@ -319,7 +319,7 @@ documentation for them.
 
 ``layout name``
     Set the layout for the current tab to the specified layout, including any
-    specified options, see :doc:`layouts` for the available alyouts and
+    specified options, see :doc:`layouts` for the available layouts and
     options.
 
 ``new_os_window``

--- a/docs/text-sizing-protocol.rst
+++ b/docs/text-sizing-protocol.rst
@@ -440,7 +440,7 @@ described by the rules below, in order of decreasing priority:
 #. *Wide emoji*: Parse `emoji-sequences.txt
    <https://www.unicode.org/Public/emoji/latest/emoji-sequences.txt>`__ from
    the Unicode standard. All :code:`Basic_Emoji` have width two unless they are
-   followed by :code:`FE0F` in the file. The leading copdepoints in all
+   followed by :code:`FE0F` in the file. The leading codepoints in all
    :code:`RGI_Emoji_Modifier_Sequence` and :code:`RGI_Emoji_Tag_Sequence` have width two.
    All code points in :code:`RGI_Emoji_Flag_Sequence` have width two.
 


### PR DESCRIPTION
I was browsing through the documentation and noticed a handful of typos and small grammatical errors, so I went ahead and cleaned them up.