### PR TITLE
fix #9017

### DIFF
--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -1666,7 +1666,7 @@ dbus_set_notification_callback(PyObject *self UNUSED, PyObject *callback) {
 #define send_dbus_notification_event_to_python(event_type, a, b) { \
     if (dbus_notification_callback) { \
         const char call_args_fmt[] = {'s', \
-            _Generic((a), unsigned long : 'k', unsigned long long : 'K'), _Generic((b), unsigned long : 'k', const char* : 's') }; \
+            _Generic((a), unsigned long : 'k', unsigned long long : 'K'), _Generic((b), unsigned long : 'k', const char* : 's'), '\0' }; \
         RAII_PyObject(ret, PyObject_CallFunction(dbus_notification_callback, call_args_fmt, event_type, a, b)); \
         if (!ret) PyErr_Print(); \
     } \


### PR DESCRIPTION
With this patch

```
❯ python3 setup.py build && ./kitty/launcher/kitty
[1/1] Compiling kitty/data-types.c ... done
[1/1] Linking kitty/fast_data_types ... done
github.com/kovidgoyal/kitty/tools/cmd
```

without this patch

```
❯ python3 setup.py build && ./kitty/launcher/kitty
[2/2] Compiling kitty/data-types.c ... done
[1/1] Linking kitty/fast_data_types ... done
SystemError: bad format char passed to Py_BuildValue
```

This is on:

```
❯ uname -a
Linux natural-judge 6.17.12-400.asahi.fc42.aarch64+16k #1 SMP PREEMPT_DYNAMIC Sun Dec 14 02:20:03 UTC 2025 aarch64 GNU/Linux
```