### PR TITLE
docs: panel: update river compatibility information

### DIFF
--- a/docs/kittens/panel.rst
+++ b/docs/kittens/panel.rst
@@ -153,6 +153,9 @@ Compatibility with various platforms
         🟢 **niri**
            Fully working, no known issues
 
+        🟢 **river**
+           Fully working, no known issues
+
         🟢 **Xfce**
            Fully working, no known issues
 
@@ -162,13 +165,6 @@ Compatibility with various platforms
         🟠 **Sway**
            Renders its configured background over the background window instead of
            under it. This is because it uses the wlr protocol for backgrounds itself.
-
-        🟠 **river**
-           Breaks when hiding (unmapping) layer shell windows. This means the quick
-           access terminal is non-functional, but background and dock panels work.
-           More technically, when unmapping the surface (attaching a NULL buffer to
-           it) river continues to send configure events to the unmapped surface,
-           leading to Wayland protocol errors.
 
         🔴 **GNOME** (mutter)
            Does not implement the wlr protocol at all, nothing works.


### PR DESCRIPTION
The panel kitten now works as expected under river.

https://codeberg.org/river/river/issues/1311

https://codeberg.org/river/river/commit/39b11b1d130681ac1f3c5a415510f590c37a215d
https://codeberg.org/river/river-classic/commit/df131f9a9d454ca60fa58e85edda5bd1eff16956