### PR TITLE
Add multi key overlay

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1606,6 +1606,9 @@ class Boss:
         self.mappings.push_keyboard_mode(new_mode)
 
     def dispatch_possible_special_key(self, ev: KeyEvent) -> bool:
+        w = self.active_window
+        if w is not None and w.overlay_parent is not None:
+            return False
         return self.mappings.dispatch_possible_special_key(ev)
 
     def cancel_current_visual_select(self) -> None:

--- a/kitty/keys.py
+++ b/kitty/keys.py
@@ -15,15 +15,19 @@ from .fast_data_types import (
     GLFW_MOD_SUPER,
     KeyEvent,
     SingleKey,
+    add_timer,
     get_boss,
     get_options,
+    glfw_get_key_name,
     grab_keyboard,
     is_modifier_key,
+    remove_timer,
     ring_bell,
     set_ignore_os_keyboard_processing,
 )
 from .options.types import Options
 from .options.utils import KeyboardMode, KeyDefinition, KeyMap
+from .types import Shortcut, human_repr_of_single_key
 from .typing_compat import ScreenType
 
 if TYPE_CHECKING:
@@ -87,6 +91,8 @@ class Mappings:
 
     def clear_keyboard_modes(self) -> None:
         had_mode = bool(self.keyboard_mode_stack)
+        for mode in self.keyboard_mode_stack:
+            self.cancel_sequence_hint(mode)
         self.keyboard_mode_stack = []
         self.set_ignore_os_keyboard_processing(False)
         if had_mode:
@@ -95,7 +101,8 @@ class Mappings:
     def pop_keyboard_mode(self) -> bool:
         passthrough = True
         if self.keyboard_mode_stack:
-            self.keyboard_mode_stack.pop()
+            mode = self.keyboard_mode_stack.pop()
+            self.cancel_sequence_hint(mode)
             if not self.keyboard_mode_stack:
                 self.set_ignore_os_keyboard_processing(False)
             passthrough = False
@@ -153,6 +160,135 @@ class Mappings:
             matches = [matches[-1]]
         return matches
 
+    def single_key_from_event(self, ev: KeyEvent) -> SingleKey:
+        mods = ev.mods & mod_mask
+        if ev.key:
+            return SingleKey(mods, False, ev.key)
+        return SingleKey(mods, True, ev.native_key)
+
+    def cancel_sequence_hint(self, mode: KeyboardMode) -> None:
+        timer_id = getattr(mode, 'sequence_hint_timer_id', 0)
+        if timer_id:
+            remove_timer(timer_id)
+            mode.sequence_hint_timer_id = 0
+
+    def schedule_sequence_hint(self, mode: KeyboardMode, actions: list[KeyDefinition]) -> None:
+        delay_ms = self.get_options().multi_key_hint_delay
+        if delay_ms < 0:
+            return
+        delay = delay_ms / 1000.0
+        self.cancel_sequence_hint(mode)
+        if delay <= 0:
+            self.clear_keyboard_modes()
+            self.show_sequence_choices(actions, mode.sequence_hint_prefix)
+            return
+
+        def show_hint(timer_id: int | None) -> None:
+            if timer_id is None or getattr(mode, 'sequence_hint_timer_id', 0) != timer_id:
+                return
+            if not self.keyboard_mode_stack or self.keyboard_mode_stack[-1] is not mode:
+                return
+            mode.sequence_hint_timer_id = 0
+            self.clear_keyboard_modes()
+            self.show_sequence_choices(actions, mode.sequence_hint_prefix)
+
+        mode.sequence_hint_timer_id = add_timer(show_hint, delay, False)
+
+    def show_sequence_choices(self, actions: list[KeyDefinition], prefix: tuple[SingleKey, ...]) -> None:
+        boss = get_boss()
+        opts = self.get_options()
+        kitty_mod = opts.kitty_mod
+        grouped: dict[SingleKey, list[KeyDefinition]] = {}
+        order: list[SingleKey] = []
+        for fa in actions:
+            if not fa.rest:
+                continue
+            k = fa.rest[0]
+            if k not in grouped:
+                grouped[k] = []
+                order.append(k)
+            grouped[k].append(fa)
+
+        if not order:
+            return
+
+        entries: list[tuple[int, str]] = []
+        entry_data: list[tuple[SingleKey, list[KeyDefinition]]] = []
+        alphabet_chars: list[str] = []
+        used_hint_chars: set[str] = set()
+        fallback_chars = '1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+
+        def hint_char_for_key(k: SingleKey) -> str | None:
+            resolved = k.resolve_kitty_mod(kitty_mod)
+            name = (glfw_get_key_name(0, resolved.key) if resolved.is_native else glfw_get_key_name(resolved.key, 0)) or ''
+            if name == ' ' or len(name) != 1:
+                return None
+            if resolved.mods & GLFW_MOD_SHIFT and name.isalpha():
+                name = name.upper()
+            if not name.isprintable() or ord(name) >= 128:
+                return None
+            return name
+
+        entry_infos: list[tuple[int, SingleKey, list[KeyDefinition], str | None, int]] = []
+
+        def mod_weight(mods: int) -> int:
+            return bin(mods).count('1')
+
+        for idx, k in enumerate(order):
+            group = grouped[k]
+            key_name = human_repr_of_single_key(k, kitty_mod)
+            desc = group[0].human_repr()
+            if len(group) > 1 or len(group[0].rest) > 1:
+                desc = f'{desc} (more)'
+            entries.append((idx, f'{key_name} - {desc}'))
+            entry_data.append((k, group))
+            resolved = k.resolve_kitty_mod(kitty_mod)
+            entry_infos.append((idx, k, group, hint_char_for_key(k), mod_weight(resolved.mods)))
+
+        preferred_owner: dict[str, int] = {}
+        for idx, _k, _group, hint_char, weight in sorted(entry_infos, key=lambda x: (x[4], x[0])):
+            if hint_char and hint_char not in preferred_owner:
+                preferred_owner[hint_char] = idx
+
+        for idx, _k, _group, hint_char, _weight in entry_infos:
+            if hint_char is not None and preferred_owner.get(hint_char) == idx and hint_char not in used_hint_chars:
+                alphabet_chars.append(hint_char)
+                used_hint_chars.add(hint_char)
+                continue
+            for fc in fallback_chars:
+                if fc not in used_hint_chars:
+                    alphabet_chars.append(fc)
+                    used_hint_chars.add(fc)
+                    break
+
+        hints_args_list: list[str] = []
+        if len(alphabet_chars) == len(order):
+            hints_args_list.extend(['--alphabet', ''.join(alphabet_chars), '--hints-offset=0'])
+        hints_args: tuple[str, ...] | None = tuple(hints_args_list) if hints_args_list else None
+
+        title = f'Key sequence: {Shortcut(prefix).human_repr(kitty_mod)}'
+
+        chooser_window: Window | None = None
+
+        def chosen(ans: None | str | int) -> None:
+            if chooser_window is not None:
+                chooser_window.close()
+            if not isinstance(ans, int):
+                return
+            if ans < 0 or ans >= len(entry_data):
+                return
+            next_key, group = entry_data[ans]
+            if len(group) == 1 and len(group[0].rest) == 1:
+                self.combine(group[0].definition)
+                return
+            next_actions = [fa.shift_sequence_and_copy() for fa in group if len(fa.rest) > 1]
+            if not next_actions:
+                self.combine(group[0].definition)
+                return
+            self.show_sequence_choices(next_actions, prefix + (next_key,))
+
+        chooser_window = boss.choose_entry(title, entries, chosen, hints_args=hints_args)
+
     def dispatch_possible_special_key(self, ev: KeyEvent) -> bool:
         # Handles shortcuts, return True if the key was consumed
         is_root_mode = not self.keyboard_mode_stack
@@ -169,6 +305,7 @@ class Mappings:
                 return False
             if not is_root_mode:
                 if mode.sequence_keys is not None:
+                    self.cancel_sequence_hint(mode)
                     self.pop_keyboard_mode()
                     w = self.get_active_window()
                     if w is not None:
@@ -192,11 +329,14 @@ class Mappings:
                         sm = KeyboardMode('__sequence__')
                         sm.on_action = 'end'
                         sm.sequence_keys = [ev]
+                        sm.sequence_hint_prefix = (self.single_key_from_event(ev),)
                         for fa in final_actions:
                             sm.keymap[fa.rest[0]].append(fa.shift_sequence_and_copy())
                         self._push_keyboard_mode(sm)
                         self.debug_print('\n\x1b[35mKeyPress\x1b[m matched sequence prefix, ', end='')
+                        self.schedule_sequence_hint(sm, final_actions)
                     else:
+                        self.cancel_sequence_hint(mode)
                         if len(final_actions) == 1 and not final_actions[0].rest:
                             self.pop_keyboard_mode()
                             consumed = self.combine(final_actions[0].definition)
@@ -206,10 +346,12 @@ class Mappings:
                                     w.send_key_sequence(*mode.sequence_keys)
                             return consumed
                         mode.sequence_keys.append(ev)
+                        mode.sequence_hint_prefix = tuple(self.single_key_from_event(x) for x in mode.sequence_keys)
                         self.debug_print('\n\x1b[35mKeyPress\x1b[m matched sequence prefix, ', end='')
                         mode.keymap.clear()
                         for fa in final_actions:
                             mode.keymap[fa.rest[0]].append(fa.shift_sequence_and_copy())
+                        self.schedule_sequence_hint(mode, final_actions)
                     return True
                 final_action = final_actions[0]
                 consumed = self.combine(final_action.definition)

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -3785,6 +3785,15 @@ remove the default shortcuts.
 '''
     )
 
+opt('multi_key_hint_delay', '-1',
+    option_type='int', ctype='time-ms',
+    long_text='''
+Delay before showing the multi-key hint popup (in milliseconds). Set to a
+negative value to disable the popup entirely. A value of zero shows it
+immediately.
+'''
+    )
+
 opt('+action_alias', 'launch_tab launch --type=tab --cwd=current',
     option_type='action_alias',
     add_to_default=False,

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -120,6 +120,9 @@ class Parser:
     def clear_all_shortcuts(self, val: str, ans: dict[str, typing.Any]) -> None:
         clear_all_shortcuts(val, ans)
 
+    def multi_key_hint_delay(self, val: str, ans: dict[str, typing.Any]) -> None:
+        ans['multi_key_hint_delay'] = int(val)
+
     def clear_selection_on_clipboard_loss(self, val: str, ans: dict[str, typing.Any]) -> None:
         ans['clear_selection_on_clipboard_loss'] = to_bool(val)
 

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -64,6 +64,7 @@ option_names = (
     'box_drawing_scale',
     'clear_all_mouse_actions',
     'clear_all_shortcuts',
+    'multi_key_hint_delay',
     'clear_selection_on_clipboard_loss',
     'click_interval',
     'clipboard_control',
@@ -519,6 +520,7 @@ class Options:
     box_drawing_scale: tuple[float, float, float, float] = (0.001, 1.0, 1.5, 2.0)
     clear_all_mouse_actions: bool = False
     clear_all_shortcuts: bool = False
+    multi_key_hint_delay: int = -1
     clear_selection_on_clipboard_loss: bool = False
     click_interval: float = -1.0
     clipboard_control: tuple[str, ...] = ('write-clipboard', 'write-primary', 'read-clipboard-ask', 'read-primary-ask')


### PR DESCRIPTION
Just exploring the idea for now, wondering what you think?

Similar to `which-key` in Emacs and other editors, this helps to navigate and discover multi-key mappings. Basically when you press first part of the multi-key sequence, it'll show a hints overlay with available follow-ups. Requires quite a bit of hacking on the `boss.py` level, so not sure how you feel about it? Don't think it is possible to do via a kitten, it can't really handle keys that well as far as understand. 

Here is a little demo

https://github.com/user-attachments/assets/9ad670d4-d6d2-43c8-af20-cc4b9aaf4fc4

PSA: not going to lie, I've used AI agents to draft the idea and navigate codebase. Obviously if you like the idea, happy to hand-polish the AI slop before merging.

Example (kitty.conf):
```
map ctrl+h>a <action a>
map ctrl+h>b <action b>
multi_key_hint_delay 600
```

When you hit ctrl+h and hesitate for 600ms, hints overlay will appear showing what's available:
```
a <action a>
b <action b>
```

Pressing a or b will activate the mapped action.

Modifiers are supported as well, i.e.
```
map ctrl+h>a <action a>
map ctrl+h>ctrl+a <action b>
map ctrl+h>shift+a <action c>
```

Will display:
```
a a <action a>
1 ctrl+a <action b>
A shift+a <action c>
```

1 here is because hints overlay requires a key, but there is nothing exactly matching ctrl, so it's a compromise.

Nested mappings are supported as well:
```
map ctrl+h>a>1 <action 1>
map ctrl+h>a>2 <action 2>
```

Will display two hints sequentially.