### PR TITLE
macOS: Implement dictation support

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -1400,7 +1400,11 @@ is_modifier_pressed(NSUInteger flags, NSUInteger target_mask, NSUInteger other_m
 
 - (NSRange)selectedRange
 {
-    return kEmptyRange;
+    // Return position 0 with no selection to indicate text can be inserted.
+    // This is required for macOS dictation to work - returning kEmptyRange
+    // (NSNotFound, 0) causes dictation to fail because the system doesn't
+    // know where to insert text. See https://github.com/kovidgoyal/kitty/issues/3732
+    return NSMakeRange(0, 0);
 }
 
 - (void)setMarkedText:(id)string
@@ -1545,7 +1549,15 @@ void _glfwPlatformUpdateIMEState(_GLFWwindow *w, const GLFWIMEUpdateEvent *ev) {
 
 - (BOOL)isAccessibilitySelectorAllowed:(SEL)selector
 {
-    if (selector == @selector(accessibilityRole) || selector == @selector(accessibilitySelectedText)) return YES;
+    // Allow accessibility selectors needed for dictation and other accessibility features
+    // See https://github.com/kovidgoyal/kitty/issues/3732
+    if (selector == @selector(accessibilityRole) ||
+        selector == @selector(accessibilitySelectedText) ||
+        selector == @selector(accessibilitySelectedTextRange) ||
+        selector == @selector(accessibilityNumberOfCharacters) ||
+        selector == @selector(accessibilityInsertionPointLineNumber) ||
+        selector == @selector(accessibilityValue) ||
+        selector == @selector(setAccessibilityValue:)) return YES;
     return NO;
 }
 
@@ -1569,6 +1581,44 @@ void _glfwPlatformUpdateIMEState(_GLFWwindow *w, const GLFWIMEUpdateEvent *ev) {
         }
     }
     return text;
+}
+
+// Accessibility methods required for dictation support
+// See https://github.com/kovidgoyal/kitty/issues/3732
+
+- (NSRange)accessibilitySelectedTextRange
+{
+    // Return position 0 with no selection for dictation support
+    return NSMakeRange(0, 0);
+}
+
+- (NSInteger)accessibilityNumberOfCharacters
+{
+    // Terminal doesn't have a fixed text buffer, return 0
+    return 0;
+}
+
+- (NSInteger)accessibilityInsertionPointLineNumber
+{
+    // Return line 0 as the insertion point
+    return 0;
+}
+
+- (NSString *)accessibilityValue
+{
+    // Terminal doesn't expose its buffer as an accessibility value
+    return @"";
+}
+
+- (void)setAccessibilityValue:(NSString *)value
+{
+    // When dictation or other accessibility features set text, insert it as keyboard input
+    if (value && [value length] > 0 && window) {
+        const char *utf8 = [value UTF8String];
+        debug_key("Inserting text via setAccessibilityValue: %s\n", utf8);
+        GLFWkeyevent glfw_keyevent = {.text=utf8, .ime_state=GLFW_IME_COMMIT_TEXT};
+        _glfwInputKeyboard(window, &glfw_keyevent);
+    }
 }
 
 // <https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/SysServices/Articles/using.html>


### PR DESCRIPTION
## Summary

This PR enables macOS dictation (triggered by pressing Fn twice) to work in kitty by implementing the necessary accessibility methods in `glfw/cocoa_window.m`.

- Fix `selectedRange` to return `NSMakeRange(0, 0)` instead of `kEmptyRange` - this is the key fix
- Add accessibility methods required for dictation: `accessibilitySelectedTextRange`, `accessibilityNumberOfCharacters`, `accessibilityInsertionPointLineNumber`, `accessibilityValue`, `setAccessibilityValue:`

## Background

The root cause was that `selectedRange` returned `kEmptyRange` (which is `{NSNotFound, 0}`), telling the macOS text input system there was no valid insertion point. This caused dictation to fail silently.

This fix is inspired by the [similar fix in Emacs v30](https://xenodium.com/macos-dictation-returns-to-emacs-fix-merged) which restored dictation by implementing `selectedRange` properly after migrating to NSTextInputClient.

## Test plan

- [x] Build kitty on macOS
- [x] Open kitty terminal
- [x] Press Fn twice to start dictation
- [x] Speak and verify text is inserted into the terminal

Fixes #3732