### PR TITLE
docs: Remove outdated note

### DIFF
--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -62,10 +62,6 @@ by running a program using :code:`geninclude`. For example::
      geninclude dynamic.py
 
 
-.. note:: Syntax highlighting for :file:`kitty.conf` in vim is available via
-   `vim-kitty <https://github.com/fladson/vim-kitty>`__.
-
-
 .. include:: /generated/conf-kitty.rst
 
 


### PR DESCRIPTION
Syntax highlighting for kitty filetype is now native in vim/nvim, with the ftplugin in a PR. 3rd party repo is considered deprecated.

https://github.com/fladson/vim-kitty/commit/cd72f2d9cfee8d6aba5a180a5ac3ca265b5d3a46