### PR TITLE
Fix new_os_window_with_cwd in presence of defunct processes

### DIFF
--- a/kitty/child.py
+++ b/kitty/child.py
@@ -30,10 +30,10 @@ if is_macos:
     def cwd_of_process(pid: int) -> str:
         # The underlying code on macos returns a path with symlinks resolved
         # anyway but we use realpath for extra safety.
-        return os.path.realpath(_cwd(pid))
+        return os.path.realpath(_cwd(pid), strict=True)
 
     def abspath_of_exe(pid: int) -> str:
-        return os.path.realpath(_abspath_of_process(pid))
+        return os.path.realpath(_abspath_of_process(pid), strict=True)
 
     def process_group_map() -> DefaultDict[int, list[int]]:
         ans: DefaultDict[int, list[int]] = defaultdict(list)
@@ -56,13 +56,13 @@ else:
             if cp.returncode != 0:
                 raise ValueError(f'Failed to find cwd of process with pid: {pid}')
             ans = cp.stdout.decode('utf-8', 'replace').split()[1]
-            return os.path.realpath(ans)
+            return os.path.realpath(ans, strict=True)
     else:
         def cwd_of_process(pid: int) -> str:
             # We use realpath instead of readlink to match macOS behavior where
             # the underlying OS API returns real paths.
             ans = f'/proc/{pid}/cwd'
-            return os.path.realpath(ans)
+            return os.path.realpath(ans, strict=True)
 
     def _environ_of_process(pid: int) -> str:
         with open(f'/proc/{pid}/environ', 'rb') as f:
@@ -88,7 +88,7 @@ else:
         return ans
 
     def abspath_of_exe(pid: int) -> str:
-        return os.path.realpath(f'/proc/{pid}/exe')
+        return os.path.realpath(f'/proc/{pid}/exe', strict=True)
 
 
 @run_once


### PR DESCRIPTION
This is a hilariously specific problem, but: right now, if you have a defunct process as some descendant of your shell and the PID of that process is the highest of any PID in your session, then `new_os_window_with_cwd` will fail to determine the current working directory and instead put you in `~` (or wherever you launched kitty from).

For example, this happens for me when `less` invokes a streaming input preprocessor ($LESSOPEN starts with `|`): once I have scrolled to the end of the file, the preprocessor process remains defunct until less exits, and `new_os_window_with_cwd` starts putting me in my home directory until I quit less.

This is ultimately due to a behaviour change in Python 3.13 (https://github.com/python/cpython/commit/7407267ce47d95d41acd2e7e6a5cc9c0e70d2ccd, a backport of https://github.com/python/cpython/pull/118489), so it is not reproducible on 3.12 and previous versions. The `strict` parameter was added to `os.path.realpath` in 3.10, which appears (looking at pyproject.toml) to be the earliest version kitty supports, so I think adding that is the best solution and should revert to the pre-3.13 behaviour: if the cwd of a process is unreadable, it's probably best to skip it and try a different process.

Strictly speaking, I only tested the change on line 65 (the Linux version of `cwd_of_process`) – I don't know if this situation is actually possible on macOS/FreeBSD, and I don't have machines available to check easily. I also don't know if the same problem could occur with `abspath_of_exe`, but for consistency's sake I changed the `realpath` invocation there in the same way, since the only callsite has a `with suppress(Exception)` already so is presumably expecting an exception to be raised if the symlink is unreadable.

Some repro steps for the bug this fixes:

1. Have [lesspipe](https://github.com/wofr06/lesspipe) or similar installed (`export LESSOPEN="|lesspipe.sh %s"`)
2. `cd` to some directory other than your home directory/the directory kitty opens in
3. Use less to open a file which lesspipe will process, e.g. a tar file
4. Scroll to the end of the file (<kbd>G</kbd>)
5. Invoke `new_os_window_with_cwd` and observe that you end up in your home directory, not the current directory