### PR TITLE
Fix GPU texture leak in free_sprite_data()

### DIFF
--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -118,7 +118,7 @@ free_sprite_data(FONTS_DATA_HANDLE fg) {
     SpriteMap *sprite_map = (SpriteMap*)fg->sprite_map;
     if (sprite_map) {
         if (sprite_map->texture_id) free_texture(&sprite_map->texture_id);
-        if (sprite_map->decorations_map.texture_id) free_texture(&sprite_map->texture_id);
+        if (sprite_map->decorations_map.texture_id) free_texture(&sprite_map->decorations_map.texture_id);
         free(sprite_map);
         fg->sprite_map = NULL;
     }


### PR DESCRIPTION
The decorations_map texture was never freed due to a typo - the code checked decorations_map.texture_id but then freed sprite_map.texture_id (which was already freed on the previous line).

This leaked ~1-4 MB of GPU memory each time a font group was deleted, which occurs when changing font size or reloading font configuration.

A typo in `kitty/shaders.c` causes the sprite decoration texture to leak when font groups are freed.

The Bug is here:

```c
void
free_sprite_data(FONTS_DATA_HANDLE fg) {
    SpriteMap *sprite_map = (SpriteMap*)fg->sprite_map;
    if (sprite_map) {
        if (sprite_map->texture_id) free_texture(&sprite_map->texture_id);
        if (sprite_map->decorations_map.texture_id) free_texture(&sprite_map->texture_id);  // BUG
        free(sprite_map);
        fg->sprite_map = NULL;
    }
}
```

Code checks if `decorations_map.texture_id` is non-zero, but then incorrectly frees `sprite_map->texture_id` instead of `sprite_map->decorations_map.texture_id`.

Since `sprite_map->texture_id` was already freed (and zeroed) on line 120, this second call to `free_texture` is a no-op, and the decoration texture is never freed.

## What is happenning

- **Memory leaked per font group deletion:** ~1-4 MB (depends on number of glyphs rendered)
- **When it occurs:** Each time a font group is deleted, which happens when:
  - The user changes font size (Ctrl+Shift+Plus/Minus)
  - Font configuration is reloaded
  - OS window with unique DPI is closed

For a typical user who changes font size a few times per session, this results in ~10-20 MB of leaked GPU texture memory.

