### PR TITLE
Support hide_window_decorations titlebar-only on Wayland

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -214,6 +214,11 @@ Detailed list of changes
 
 - edit-in-kitty: Handle connection drop more gracefully (:pull:`9480`)
 
+- Wayland: Add support for :code:`titlebar-only` in
+  :opt:`hide_window_decorations` to hide the titlebar while keeping shadow
+  borders for resizing. On compositors that use server-side decorations (such as
+  GNOME), this forces client-side decoration mode (:pull:`9486`)
+
 
 0.45.0 [2025-12-24]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/glfw/glfw.py
+++ b/glfw/glfw.py
@@ -323,6 +323,7 @@ def generate_wrappers(glfw_header: str) -> None:
     const char* glfwWaylandMissingCapabilities(void)
     void glfwWaylandRunWithActivationToken(GLFWwindow *handle, GLFWactivationcallback cb, void *cb_data)
     bool glfwWaylandSetTitlebarColor(GLFWwindow *handle, uint32_t color, bool use_system_color)
+    void glfwWaylandSetTitlebarHidden(GLFWwindow *handle, bool hidden)
     void glfwWaylandRedrawCSDWindowTitle(GLFWwindow *handle)
     bool glfwWaylandIsWindowFullyCreated(GLFWwindow *handle)
     bool glfwWaylandBeep(GLFWwindow *handle)

--- a/glfw/wl_platform.h
+++ b/glfw/wl_platform.h
@@ -231,7 +231,7 @@ typedef struct _GLFWwindowWayland
     } pointerLock;
 
     struct {
-        bool serverSide, buffer_destroyed, titlebar_needs_update, dragging;
+        bool serverSide, buffer_destroyed, titlebar_needs_update, dragging, titlebar_hidden;
         _GLFWCSDSurface focus;
 
         _GLFWWaylandCSDSurface titlebar, shadow_left, shadow_right, shadow_top, shadow_bottom, shadow_upper_left, shadow_upper_right, shadow_lower_left, shadow_lower_right;

--- a/kitty/glfw-wrapper.c
+++ b/kitty/glfw-wrapper.c
@@ -515,6 +515,9 @@ load_glfw(const char* path) {
     *(void **) (&glfwWaylandSetTitlebarColor_impl) = dlsym(handle, "glfwWaylandSetTitlebarColor");
     if (glfwWaylandSetTitlebarColor_impl == NULL) dlerror(); // clear error indicator
 
+    *(void **) (&glfwWaylandSetTitlebarHidden_impl) = dlsym(handle, "glfwWaylandSetTitlebarHidden");
+    if (glfwWaylandSetTitlebarHidden_impl == NULL) dlerror(); // clear error indicator
+
     *(void **) (&glfwWaylandRedrawCSDWindowTitle_impl) = dlsym(handle, "glfwWaylandRedrawCSDWindowTitle");
     if (glfwWaylandRedrawCSDWindowTitle_impl == NULL) dlerror(); // clear error indicator
 

--- a/kitty/glfw-wrapper.h
+++ b/kitty/glfw-wrapper.h
@@ -2516,6 +2516,10 @@ typedef bool (*glfwWaylandSetTitlebarColor_func)(GLFWwindow*, uint32_t, bool);
 GFW_EXTERN glfwWaylandSetTitlebarColor_func glfwWaylandSetTitlebarColor_impl;
 #define glfwWaylandSetTitlebarColor glfwWaylandSetTitlebarColor_impl
 
+typedef void (*glfwWaylandSetTitlebarHidden_func)(GLFWwindow*, bool);
+GFW_EXTERN glfwWaylandSetTitlebarHidden_func glfwWaylandSetTitlebarHidden_impl;
+#define glfwWaylandSetTitlebarHidden glfwWaylandSetTitlebarHidden_impl
+
 typedef void (*glfwWaylandRedrawCSDWindowTitle_func)(GLFWwindow*);
 GFW_EXTERN glfwWaylandRedrawCSDWindowTitle_func glfwWaylandRedrawCSDWindowTitle_impl;
 #define glfwWaylandRedrawCSDWindowTitle glfwWaylandRedrawCSDWindowTitle_impl

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -1308,6 +1308,10 @@ apply_window_chrome_state(GLFWwindow *w, WindowChromeState new_state, int width,
     // Need to resize the window again after hiding decorations or title bar to take up screen space
     if (window_decorations_changed) glfwSetWindowSize(w, width, height);
 #else
+        if (global_state.is_wayland && glfwWaylandSetTitlebarHidden) {
+            bool titlebar_only = (new_state.hide_window_decorations & 2) != 0;
+            glfwWaylandSetTitlebarHidden(w, titlebar_only);
+        }
         if (window_decorations_changed) {
             bool hide_window_decorations = new_state.hide_window_decorations & 1;
             glfwSetWindowAttrib(w, GLFW_DECORATED, !hide_window_decorations);
@@ -1587,6 +1591,10 @@ create_os_window(PyObject UNUSED *self, PyObject *args, PyObject *kw) {
     if (temp_window) { glfwDestroyWindow(temp_window); temp_window = NULL; }
     if (glfw_window == NULL) glfw_failure;
 #undef glfw_failure
+    // Set titlebar-only mode before the window becomes visible
+    if (global_state.is_wayland && (OPT(hide_window_decorations) & 2) && glfwWaylandSetTitlebarHidden) {
+        glfwWaylandSetTitlebarHidden(glfw_window, true);
+    }
     glfwMakeContextCurrent(glfw_window);
     if (is_first_window) gl_init();
     bool is_semi_transparent = glfwGetWindowAttrib(glfw_window, GLFW_TRANSPARENT_FRAMEBUFFER);

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -1341,9 +1341,13 @@ opt('hide_window_decorations', 'no',
     long_text='''
 Hide the window decorations (title-bar and window borders) with :code:`yes`. On
 macOS, :code:`titlebar-only` and :code:`titlebar-and-corners` can be used to only hide the titlebar and the rounded corners.
+On Wayland, :code:`titlebar-only` can be used to hide the titlebar while keeping
+the window shadow borders for resizing. On compositors that use server-side
+decorations (such as GNOME), both :code:`yes` and :code:`titlebar-only` force
+client-side decoration mode.
 Whether this works and exactly what effect it has depends on the window manager/operating
 system. Note that the effects of changing this option when reloading config
-are undefined. When using :code:`titlebar-only`, it is useful to also set
+are undefined. When using :code:`titlebar-only` on macOS, it is useful to also set
 :opt:`window_margin_width` and :opt:`placement_strategy` to prevent the rounded
 corners from clipping text. Or use :code:`titlebar-and-corners`.
 '''


### PR DESCRIPTION
Hide the CSD titlebar subsurface while keeping shadow borders for resizing. On SSD compositors (GNOME), forces CSD mode to draw kitty's own shadows without a titlebar.

Manually tested on the following:
   - GNOME Shell: 49.3
   - Wayland: 1.24.0 (libwayland-client)

This PR was authored by GitHub Copilot  / Opus 4.6. I'm not familiar with the kitty code base nor wayland window compositing but reading through the changes they feel reasonable. If you feel this is garbage, please let me know :)