### PR TITLE
macOS: fix menus getting stuck when window title updates during menu tracking

### DIFF
--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -885,14 +885,16 @@ cocoa_update_menu_bar_title(PyObject *pytitle) {
         title = @(PyUnicode_AsUTF8(pytitle));
     }
     if (!title) return;
-    NSMenu *bar = [NSApp mainMenu];
+    NSString *menuTitle = [NSString stringWithFormat:@" :: %@", title];
     if (title_menu != NULL) {
-        [bar removeItem:title_menu];
+        [[title_menu submenu] setTitle:menuTitle];
+    } else {
+        NSMenu *bar = [NSApp mainMenu];
+        title_menu = [bar addItemWithTitle:@"" action:NULL keyEquivalent:@""];
+        NSMenu *m = [[NSMenu alloc] initWithTitle:menuTitle];
+        [title_menu setSubmenu:m];
+        [m release];
     }
-    title_menu = [bar addItemWithTitle:@"" action:NULL keyEquivalent:@""];
-    NSMenu *m = [[NSMenu alloc] initWithTitle:[NSString stringWithFormat:@" :: %@", title]];
-    [title_menu setSubmenu:m];
-    [m release];
 }
 
 void


### PR DESCRIPTION
## Summary

- Fix menus (e.g. Help) getting stuck open on macOS when the window title changes while a menu is being tracked
- `cocoa_update_menu_bar_title()` was removing and re-adding the title menu item to `[NSApp mainMenu]` on every title change, which corrupted macOS's menu tracking state
- Now reuses the existing menu item and updates only its submenu title via `setTitle:`

Fixes #9489

## Test plan

- [ ] Open kitty with `macos_show_window_title_in` set to `menubar` or `all`
- [ ] Click the Help menu in the menu bar
- [ ] While the menu is open, trigger a window title change (e.g. switch tabs, run a command that updates the title)
- [ ] Verify the menu dismisses normally and does not get stuck on screen