### PR TITLE
Add `active-only` option  to the  `goto_session` command

### DIFF
--- a/docs/sessions.rst
+++ b/docs/sessions.rst
@@ -55,6 +55,8 @@ easily swap between them, kitty has you covered. You can use the
    map f7>h goto_session ~/path/to/hot/hot.kitty-session
    # Browse and select from the list of known projects defined via goto_session commands
    map f7>/ goto_session
+   # Browse and select from the list of active projects defined via goto_session commands
+   map f7>/ goto_session --active-only [=no]
    # Same as above, but the sessions are listed alphabetically instead of by most recent
    map f7>/ goto_session --sort-by=alphabetical
    # Browse session files inside a directory and pick one

--- a/kitty/session.py
+++ b/kitty/session.py
@@ -538,6 +538,9 @@ def choose_session_from_map(
 
 def choose_session(boss: BossType, opts: GotoSessionOptions) -> None:
     all_known_sessions = get_all_known_sessions()
+    if opts.active_only:
+        all_active_sessions = boss.all_loaded_session_names
+        all_known_sessions = {name: all_known_sessions[name] for name in all_active_sessions if name in all_known_sessions}
     choose_session_from_map(boss, opts, all_known_sessions, _('Select a session to activate'))
 
 
@@ -575,6 +578,11 @@ def goto_session_options() -> str:
 choices=recent,alphabetical
 default=recent
 When interactively choosing sessions from a list, how to sort the list.
+
+
+--active-only
+type=bool-set
+Only consider active sessions.
 '''
 
 


### PR DESCRIPTION
Solves https://github.com/kovidgoyal/kitty/discussions/9386
Allows to specify whether or not to switch only to an active session.

I have tested this locally and it works, but I have not found any tests for sessions in general in `kitty_tests` so I skipped writing any.
Ordering should be preserved from the original dictionary.