### PR TITLE
Add copy_last_command_output_or_clipboard action

### DIFF
--- a/kitty/window.py
+++ b/kitty/window.py
@@ -2234,6 +2234,16 @@ class Window:
         self.copy_or_interrupt()
         self.screen.clear_selection()
 
+    @ac('cp', 'Copy the selected text from the active window to the clipboard, if no selection, copy the last command output')
+    def copy_last_command_output_or_clipboard(self) -> None:
+        text = self.text_for_selection()
+        if text:
+            set_clipboard_string(text)
+        else:
+            text = self.cmd_output(CommandOutput.last_non_empty, as_ansi=False, add_wrap_markers=False)
+            if text:
+                set_clipboard_string(text)
+
     @ac('cp', 'Pass the selected text from the active window to the specified program')
     def pass_selection_to_program(self, *args: str) -> None:
         cwd = self.cwd_of_child


### PR DESCRIPTION
Adds a new keyboard action that copies the selected text to clipboard,
or if no selection exists, copies the last command output. This follows
the pattern of existing actions like copy_or_interrupt.

resolves https://github.com/kovidgoyal/kitty/issues/9511
