### PR TITLE
Add macos_dock_badge_on_bell config option

### DIFF
--- a/kitty/cocoa_window.h
+++ b/kitty/cocoa_window.h
@@ -66,3 +66,5 @@ extern uint8_t* render_single_ascii_char_as_mask(const char ch, size_t *result_w
 void get_cocoa_key_equivalent(uint32_t, int, char *key, size_t key_sz, int*);
 void set_cocoa_pending_action(CocoaPendingAction action, const char*);
 void cocoa_report_live_notifications(const char* ident);
+void cocoa_set_dock_badge(const char *label);
+void cocoa_clear_dock_badge(void);

--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -1339,6 +1339,28 @@ cocoa_show_progress_bar_on_dock_icon(PyObject *self UNUSED, PyObject *args) {
 }
 // }}}
 
+// Dock badge {{{
+
+void
+cocoa_set_dock_badge(const char *label) {
+    @autoreleasepool {
+        NSDockTile *dockTile = [NSApp dockTile];
+        [dockTile setBadgeLabel:@(label)];
+        [dockTile display];
+    }
+}
+
+void
+cocoa_clear_dock_badge(void) {
+    @autoreleasepool {
+        NSDockTile *dockTile = [NSApp dockTile];
+        [dockTile setBadgeLabel:nil];
+        [dockTile display];
+    }
+}
+
+// }}}
+
 static PyMethodDef module_methods[] = {
     {"cocoa_play_system_sound_by_id_async", play_system_sound_by_id_async, METH_O, ""},
     {"cocoa_get_lang", (PyCFunction)cocoa_get_lang, METH_NOARGS, ""},
@@ -1360,5 +1382,12 @@ init_cocoa(PyObject *module) {
     cocoa_clear_global_shortcuts();
     if (PyModule_AddFunctions(module, module_methods) != 0) return false;
     register_at_exit_cleanup_func(COCOA_CLEANUP_FUNC, cleanup);
+    [[NSNotificationCenter defaultCenter]
+        addObserverForName:NSApplicationDidBecomeActiveNotification
+        object:nil
+        queue:[NSOperationQueue mainQueue]
+        usingBlock:^(NSNotification *note __attribute__((unused))) {
+            cocoa_clear_dock_badge();
+        }];
     return true;
 }

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -2201,6 +2201,9 @@ request_window_attention(id_type kitty_window_id, bool audio_bell) {
     if (w) {
         if (audio_bell) ring_audio_bell(w);
         if (OPT(window_alert_on_bell)) glfwRequestWindowAttention(w->handle);
+#ifdef __APPLE__
+        if (OPT(macos_dock_badge_on_bell)) cocoa_set_dock_badge("!");
+#endif
         glfwPostEmptyEvent();
     }
 }

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -1129,6 +1129,15 @@ window in which the bell occurred.
 '''
     )
 
+opt('macos_dock_badge_on_bell', 'yes',
+    option_type='to_bool', ctype='bool',
+    long_text='''
+Show a badge on kitty's dock icon when a bell occurs and kitty is not the
+active application (macOS only). The badge is automatically cleared when kitty
+regains focus.
+'''
+    )
+
 opt('bell_path', 'none',
     option_type='config_or_absolute_path', ctype='!bell_path',
     long_text='''

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -379,6 +379,7 @@ option_names = (
     'listen_on',
     'macos_colorspace',
     'macos_custom_beam_cursor',
+    'macos_dock_badge_on_bell',
     'macos_hide_from_tasks',
     'macos_menubar_title_max_length',
     'macos_option_as_alt',
@@ -575,6 +576,7 @@ class Options:
     listen_on: str = 'none'
     macos_colorspace: choices_for_macos_colorspace = 'srgb'
     macos_custom_beam_cursor: bool = False
+    macos_dock_badge_on_bell: bool = True
     macos_hide_from_tasks: bool = False
     macos_menubar_title_max_length: int = 0
     macos_option_as_alt: int = 0

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -98,6 +98,7 @@ typedef struct Options {
     bool sync_to_monitor;
     bool close_on_child_death;
     bool window_alert_on_bell;
+    bool macos_dock_badge_on_bell;
     bool debug_keyboard;
     bool allow_hyperlinks;
     struct { monotonic_t on_end, on_pause; } resize_debounce_time;


### PR DESCRIPTION
## Summary
- Add `macos_dock_badge_on_bell` config option (default `yes`) that sets a "!" badge on kitty's dock icon when a bell fires and kitty is not focused
- Badge is automatically cleared when kitty regains focus via `NSApplicationDidBecomeActiveNotification`
- Provides a persistent visual indicator complementing the existing `window_alert_on_bell` dock bounce

Closes #9528