### PR TITLE
Fix horizontal alignment shifting too much

### DIFF
--- a/kitty/fonts.c
+++ b/kitty/fonts.c
@@ -1132,17 +1132,17 @@ render_filled_sprite(pixel *buf, unsigned num_glyphs, FontCellMetrics scaled_met
 }
 
 static void
-apply_horizontal_alignment(pixel *canvas, RunFont rf, bool center_glyph, GlyphRenderInfo ri, unsigned canvas_height, unsigned num_cells, unsigned num_glyphs, bool was_colored) {
+apply_horizontal_alignment(pixel *canvas, RunFont rf, bool center_glyph, GlyphRenderInfo ri, unsigned max_render_width, unsigned canvas_height, unsigned num_cells, unsigned num_glyphs, bool was_colored) {
     int delta = 0;
     (void)was_colored;
 #ifdef __APPLE__
     if (num_cells == 2 && was_colored) center_glyph = true;
 #endif
     if (rf.subscale_n && rf.subscale_d && rf.align.horizontal) {
-        delta = ri.canvas_width - ri.rendered_width;
+        delta = max_render_width - ri.rendered_width;
         if (rf.align.horizontal == 2) delta /= 2;
-    } else if (center_glyph && num_glyphs && num_cells > 1 && ri.rendered_width < ri.canvas_width) {
-        unsigned half = (ri.canvas_width - ri.rendered_width) / 2;
+    } else if (center_glyph && num_glyphs && num_cells > 1 && ri.rendered_width < max_render_width) {
+        unsigned half = (max_render_width - ri.rendered_width) / 2;
         if (half > 1) delta = half;
     }
     delta -= ri.x;
@@ -1202,7 +1202,7 @@ render_group(
     } else {
         render_glyphs_in_cells(font->face, font->bold, font->italic, info, positions, num_glyphs, fg->canvas.buf, scaled_metrics.cell_width, scaled_metrics.cell_height, num_scaled_cells, scaled_metrics.baseline, &was_colored, (FONTS_DATA_HANDLE)fg, &ri);
     }
-    apply_horizontal_alignment(fg->canvas.buf, rf, center_glyph, ri, scaled_metrics.cell_height, num_scaled_cells, num_glyphs, was_colored);
+    apply_horizontal_alignment(fg->canvas.buf, rf, center_glyph, ri, num_cells * unscaled_metrics.cell_width, scaled_metrics.cell_height, num_scaled_cells, num_glyphs, was_colored);
     if (PyErr_Occurred()) PyErr_Print();
 
     fg->fcm = unscaled_metrics;  // needed for current_send_sprite_to_gpu()


### PR DESCRIPTION
This is the problem I mentioned I ran into in an earlier issue (it is unrelated to the cropping from that issue).

The delta that is used to calculate how far horizontally aligned symbols are shifted to the right is mistakenly scaled, which causes cropping.

Before and after this change:
<img width="528" height="972" alt="image" src="https://github.com/user-attachments/assets/c68c7bdc-6dc5-40bf-91b5-0a43342851e3" />