### PR TITLE
fix crash when macos_titlebar_color=background with transparent background

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -3711,7 +3711,6 @@ apply_titlebar_color_settings(_GLFWwindow *window) {
     if (!window->ns.titlebar_hidden && window->decorated && tc.was_set && window->ns.last_applied_titlebar_settings.transparent) {
         NSColor *titlebar_color = [NSColor colorWithSRGBRed:tc.red green:tc.green blue:tc.blue alpha:tc.alpha];
         set_title_bar_background(nsw, titlebar_color);
-        [titlebar_color release];
     } else clear_title_bar_background_views(nsw);
 #undef tc
 }
@@ -4239,4 +4238,3 @@ _glfwPlatformDragDataReady(const char *mime_type) {
     }
     return 0;
 }
-


### PR DESCRIPTION
This fixes a crash in the macOS titlebar color path caused by over-releasing an autoreleased NSColor in apply_titlebar_color_settings().

When macos_titlebar_color is enabled (for example background) and the window is transparent, that code path is hit and can trigger EXC_BAD_ACCESS.

The fix removes the incorrect manual [titlebar_color release].

### Repro

```./kitty/launcher/kitty --debug-rendering --config=NONE -o macos_titlebar_color=background -o background_opacity=0.9```

### Expected result after this change
kitty starts and renders normally without crashing.

---
Generated with AI: Codex (GPT-5).