### PR TITLE
Add paste_from_clipboard_as_file action

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -153,6 +153,10 @@ Detailed list of changes
 0.46.0 [future]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+- A new action :ac:`paste_from_clipboard_as_file` to paste clipboard image data
+  as a temporary file path, with fallback to normal text paste. Useful for CLI
+  tools that accept image file paths, such as Claude Code.
+
 - Pixel scrolling for the kitty scrollback buffer controlled via :opt:`pixel_scroll` (:pull:`9330`)
 
 - Linux: momentum scrolling in the kitty scrollback buffer for touchpads and touchscreens, see :opt:`momentum_scroll`

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -2544,6 +2544,31 @@ class Boss:
             if text:
                 w.paste_with_actions(text)
 
+    @ac('cp', '''
+        Paste clipboard image as a temp file path, or fall back to text paste
+
+        If the system clipboard contains image data (e.g. a screenshot),
+        save it to a temporary file and paste the file path into the active
+        window. If no image data is found, fall back to normal text paste.
+        Useful for CLI tools that accept image file paths, such as
+        Claude Code which supports pasting images for multimodal input.
+        Temp files are cleaned up when kitty exits.
+        ''')
+    def paste_from_clipboard_as_file(self) -> None:
+        w = self.window_for_dispatch or self.active_window
+        if w is not None:
+            from .clipboard import get_clipboard_image_as_file
+            path = get_clipboard_image_as_file()
+            if path:
+                self.atexit.unlink(path)
+                w.paste_with_actions(path)
+            else:
+                if w.send_paste_event():
+                    return
+                text = get_clipboard_string()
+                if text:
+                    w.paste_with_actions(text)
+
     def current_primary_selection(self) -> str:
         return get_primary_selection() if supports_primary_selection else ''
 

--- a/kitty/clipboard.py
+++ b/kitty/clipboard.py
@@ -176,6 +176,61 @@ def get_primary_selection() -> str:
     return get_boss().primary_selection.get_text()
 
 
+IMAGE_MIME_TYPES = ('image/png', 'image/tiff', 'image/jpeg', 'image/bmp', 'image/gif')
+IMAGE_MIME_EXTENSIONS = {
+    'image/png': '.png', 'image/tiff': '.tiff', 'image/jpeg': '.jpg',
+    'image/bmp': '.bmp', 'image/gif': '.gif',
+}
+
+
+def get_clipboard_image_as_file() -> str:
+    import subprocess
+    import tempfile
+
+    from .constants import kitten_exe
+
+    clipboard = get_boss().clipboard
+    mime_types = clipboard.get_available_mime_types_for_paste()
+    chosen_mime = ''
+    for preferred in IMAGE_MIME_TYPES:
+        if preferred in mime_types:
+            chosen_mime = preferred
+            break
+    if not chosen_mime:
+        for mt in mime_types:
+            if mt.startswith('image/'):
+                chosen_mime = mt
+                break
+    if not chosen_mime:
+        return ''
+    data = clipboard.get_mime_data(chosen_mime)
+    if not data:
+        return ''
+    if chosen_mime != 'image/png':
+        # Convert non-PNG images (e.g. TIFF from macOS screenshots) to PNG
+        # using kitty's built-in cross-platform image converter
+        fd, path = tempfile.mkstemp(suffix='.png', prefix='kitty-clipboard-image-')
+        try:
+            cp = subprocess.run(
+                [kitten_exe(), '__convert_image__', 'png'],
+                input=data, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            )
+            if cp.returncode != 0 or not cp.stdout:
+                os.close(fd)
+                os.unlink(path)
+                return ''
+            os.write(fd, cp.stdout)
+        finally:
+            os.close(fd)
+        return path
+    fd, path = tempfile.mkstemp(suffix='.png', prefix='kitty-clipboard-image-')
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)
+    return path
+
+
 def develop() -> tuple[Clipboard, Clipboard]:
     from .constants import detect_if_wayland_ok, is_macos
     from .fast_data_types import set_boss


### PR DESCRIPTION
Fixes #9565

## Summary

- New action `paste_from_clipboard_as_file` that pastes clipboard image data as a temp file path
- Falls back to normal text paste when no image is found (drop-in replacement for `paste_from_clipboard`)
- Converts non-PNG clipboard images (e.g. TIFF from macOS screenshots) to PNG using `kitten __convert_image__`
- Temp files cleaned up on kitty exit via `self.atexit.unlink()`

## Motivation

Claude Code and other CLI tools accept image file paths for multimodal input, but `paste_from_clipboard` only handles text. When the clipboard contains a screenshot, nothing gets pasted. Users currently have to manually save screenshots to files and type the path. This action bridges that gap.

## Implementation

Uses existing kitty infrastructure only — no new dependencies:
- `Clipboard.get_available_mime_types_for_paste()` and `Clipboard.get_mime_data()` for clipboard access
- `kitten __convert_image__ png` for cross-platform image format conversion
- `self.atexit.unlink()` for temp file cleanup

## Test plan

- [ ] Copy screenshot to clipboard → trigger action → file path pasted with `.png` extension
- [ ] `file /path/to/pasted.png` → confirms valid PNG image data
- [ ] In Claude Code inside kitty → paste shows `[Image #1]`
- [ ] Copy text to clipboard → trigger action → normal text paste (fallback works)
- [ ] Exit kitty → temp files cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)