### PR TITLE
Allow accessibility selectors needed for external window management tools

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -1884,6 +1884,17 @@ void _glfwPlatformUpdateIMEState(_GLFWwindow *w, const GLFWIMEUpdateEvent *ev) {
         selector == @selector(accessibilityInsertionPointLineNumber) ||
         selector == @selector(accessibilityValue) ||
         selector == @selector(setAccessibilityValue:)) return YES;
+
+    // Allow accessibility selectors needed for external window management tools
+    // (e.g. Easy Move+Resize) to find and manipulate the window.
+    // See https://github.com/kovidgoyal/kitty/issues/5561
+    if (selector == @selector(accessibilityWindow) ||
+        selector == @selector(accessibilityParent) ||
+        selector == @selector(accessibilityPosition) ||
+        selector == @selector(setAccessibilityPosition:) ||
+        selector == @selector(accessibilitySize) ||
+        selector == @selector(setAccessibilitySize:)) return YES;
+
     return NO;
 }
 


### PR DESCRIPTION
Tools like Easy Move+Resize use the macOS Accessibility API to find and move/resize windows. They call AXUIElementCopyElementAtPosition to get the content view, then use kAXWindowAttribute to navigate to the parent window.

The isAccessibilitySelectorAllowed: whitelist was blocking these selectors, preventing external window management tools from working with kitty.

Fixes #5561