### PR TITLE
Splits layout: Fix variable shadowing in layout_pair causing corrupted pane positions

### DIFF
--- a/kitty/layout/splits.py
+++ b/kitty/layout/splits.py
@@ -272,8 +272,8 @@ class Pair:
             if isinstance(self.one, Pair):
                 self.one.layout_pair(left, top, w1, height, id_window_map, layout_object)
                 if bw:
-                    for top, bottom, window_id in self.one.edge_border(RIGHT_EDGE, id_window_map):
-                        one.append(BorderLine(Edges(bleft, top, bleft + bw, bottom), window_id=window_id))
+                    for etop, ebottom, window_id in self.one.edge_border(RIGHT_EDGE, id_window_map):
+                        one.append(BorderLine(Edges(bleft, etop, bleft + bw, ebottom), window_id=window_id))
             else:
                 wg = id_window_map[self.one]
                 yl = next(layout_object.ylayout(iter((wg,)), start=top, size=height, border_mult=border_mult))
@@ -287,8 +287,8 @@ class Pair:
             if isinstance(self.two, Pair):
                 self.two.layout_pair(left, top, w2, height, id_window_map, layout_object)
                 if bw:
-                    for top, bottom, window_id in self.two.edge_border(LEFT_EDGE, id_window_map):
-                        two.append(BorderLine(Edges(left - bw, top, left, bottom), window_id=window_id))
+                    for etop, ebottom, window_id in self.two.edge_border(LEFT_EDGE, id_window_map):
+                        two.append(BorderLine(Edges(left - bw, etop, left, ebottom), window_id=window_id))
             else:
                 wg = id_window_map[self.two]
                 if bw:
@@ -310,8 +310,8 @@ class Pair:
             if isinstance(self.one, Pair):
                 self.one.layout_pair(left, top, width, h1, id_window_map, layout_object)
                 if bw:
-                    for left, right, window_id in self.one.edge_border(BOTTOM_EDGE, id_window_map):
-                        one.append(BorderLine(Edges(left, btop, right, btop + bw), window_id=window_id))
+                    for eleft, eright, window_id in self.one.edge_border(BOTTOM_EDGE, id_window_map):
+                        one.append(BorderLine(Edges(eleft, btop, eright, btop + bw), window_id=window_id))
             else:
                 wg = id_window_map[self.one]
                 xl = next(layout_object.xlayout(iter((wg,)), start=left, size=width, border_mult=border_mult))
@@ -325,8 +325,8 @@ class Pair:
             if isinstance(self.two, Pair):
                 self.two.layout_pair(left, top, width, h2, id_window_map, layout_object)
                 if bw:
-                    for left, right, window_id in self.two.edge_border(TOP_EDGE, id_window_map):
-                        two.append(BorderLine(Edges(left, top - bw, right, top), window_id=window_id))
+                    for eleft, eright, window_id in self.two.edge_border(TOP_EDGE, id_window_map):
+                        two.append(BorderLine(Edges(eleft, top - bw, eright, top), window_id=window_id))
             else:
                 wg = id_window_map[self.two]
                 if bw:


### PR DESCRIPTION
## Summary

- Fix variable shadowing bug in `Pair.layout_pair()` where `for` loop variables (`top`, `bottom`, `left`, `right`) overwrote the function's local position-tracking variables, causing sibling panes to be positioned at incorrect offsets
- When splitting a pane that is a nested Pair (e.g. horizontally splitting the left pane of a vertical split), the sibling pane would shift down/over by roughly half the screen
- Renamed loop variables to `etop`, `ebottom`, `eleft`, `eright` to avoid shadowing

## Bug Description

When you have two panes side-by-side (horizontal split) and then split the **left** pane horizontally (top/bottom), the **right** pane shifts down to approximately the vertical midpoint of the screen. Splitting the **right** pane does not exhibit this issue.

The bug was introduced in commit 6b54c201e ("Track window ids on border rects"), where `edge_border()` iteration loops used `top`/`left` as loop variable names, which shadowed the local `top`/`left` variables used to position subsequent panes in `layout_pair()`.

## Testing

- `./test.py --module layout` passes (test_splits, test_layout_operations, test_overlay_layout_operations)
- Manual testing confirms the fix resolves the pane displacement issue