### PR TITLE
Add wayland_scale_override config option

### DIFF
--- a/glfw/glfw3.h
+++ b/glfw/glfw3.h
@@ -1204,6 +1204,7 @@ typedef enum {
  */
 #define GLFW_COCOA_MENUBAR          0x00051002
 #define GLFW_WAYLAND_IME            0x00051003
+#define GLFW_WAYLAND_SCALE_OVERRIDE 0x00051004
 /*! @} */
 
 #define GLFW_DONT_CARE              -1

--- a/glfw/init.c
+++ b/glfw/init.c
@@ -303,6 +303,9 @@ GLFWAPI void glfwInitHint(int hint, int value)
         case GLFW_WAYLAND_IME:
             _glfwInitHints.wl.ime = value;
             return;
+        case GLFW_WAYLAND_SCALE_OVERRIDE:
+            _glfwInitHints.wl.scale_override = value;
+            return;
     }
 
     _glfwInputError(GLFW_INVALID_ENUM,

--- a/glfw/internal.h
+++ b/glfw/internal.h
@@ -295,6 +295,7 @@ struct _GLFWinitconfig
     } ns;
     struct {
         bool ime;
+        int scale_override;
     } wl;
 };
 

--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -381,6 +381,7 @@ update_regions(_GLFWwindow* window) {
 
 int
 _glfwWaylandIntegerWindowScale(_GLFWwindow *window) {
+    if (_glfwInitHints.wl.scale_override > 0) return _glfwInitHints.wl.scale_override;
     int ans = (window->wl.integer_scale.preferred) ? window->wl.integer_scale.preferred : window->wl.integer_scale.deduced;
     if (ans < 1) ans = 1;
     return ans;
@@ -388,6 +389,7 @@ _glfwWaylandIntegerWindowScale(_GLFWwindow *window) {
 
 double
 _glfwWaylandWindowScale(_GLFWwindow *window) {
+    if (_glfwInitHints.wl.scale_override > 0) return (double)_glfwInitHints.wl.scale_override;
     double ans = _glfwWaylandIntegerWindowScale(window);
     if (window->wl.fractional_scale) ans = window->wl.fractional_scale / 120.;
     return ans;

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -1883,9 +1883,9 @@ dbus_user_notification_activated(uint32_t notification_id, int type, const char*
 static PyObject*
 glfw_init(PyObject UNUSED *self, PyObject *args) {
     const char* path;
-    int debug_keyboard = 0, debug_rendering = 0, wayland_enable_ime = 0;
+    int debug_keyboard = 0, debug_rendering = 0, wayland_enable_ime = 0, wayland_scale_override = 0;
     PyObject *edge_sf;
-    if (!PyArg_ParseTuple(args, "sO|ppp", &path, &edge_sf, &debug_keyboard, &debug_rendering, &wayland_enable_ime)) return NULL;
+    if (!PyArg_ParseTuple(args, "sO|pppi", &path, &edge_sf, &debug_keyboard, &debug_rendering, &wayland_enable_ime, &wayland_scale_override)) return NULL;
     if (!PyCallable_Check(edge_sf)) { PyErr_SetString(PyExc_TypeError, "edge_spacing_func must be a callable"); return NULL; }
     Py_CLEAR(edge_spacing_func);
 #ifdef __APPLE__
@@ -1898,6 +1898,7 @@ glfw_init(PyObject UNUSED *self, PyObject *args) {
     glfwInitHint(GLFW_DEBUG_RENDERING, debug_rendering);
     OPT(debug_keyboard) = debug_keyboard != 0;
     glfwInitHint(GLFW_WAYLAND_IME, wayland_enable_ime != 0);
+    glfwInitHint(GLFW_WAYLAND_SCALE_OVERRIDE, wayland_scale_override);
 #ifdef __APPLE__
     glfwInitHint(GLFW_COCOA_CHDIR_RESOURCES, 0);
     glfwInitHint(GLFW_COCOA_MENUBAR, 0);

--- a/kitty/main.py
+++ b/kitty/main.py
@@ -96,8 +96,8 @@ def load_all_shaders() -> None:
         raise SystemExit(err)
 
 
-def init_glfw_module(glfw_module: str = 'wayland', debug_keyboard: bool = False, debug_rendering: bool = False, wayland_enable_ime: bool = True) -> None:
-    ok, swo = glfw_init(glfw_path(glfw_module), edge_spacing, debug_keyboard, debug_rendering, wayland_enable_ime)
+def init_glfw_module(glfw_module: str = 'wayland', debug_keyboard: bool = False, debug_rendering: bool = False, wayland_enable_ime: bool = True, wayland_scale_override: int = 0) -> None:
+    ok, swo = glfw_init(glfw_path(glfw_module), edge_spacing, debug_keyboard, debug_rendering, wayland_enable_ime, wayland_scale_override)
     if not ok:
         raise SystemExit('GLFW initialization failed')
     supports_window_occlusion(swo)
@@ -105,7 +105,7 @@ def init_glfw_module(glfw_module: str = 'wayland', debug_keyboard: bool = False,
 
 def init_glfw(opts: Options, debug_keyboard: bool = False, debug_rendering: bool = False) -> str:
     glfw_module = 'cocoa' if is_macos else ('wayland' if is_wayland(opts) else 'x11')
-    init_glfw_module(glfw_module, debug_keyboard, debug_rendering, wayland_enable_ime=opts.wayland_enable_ime)
+    init_glfw_module(glfw_module, debug_keyboard, debug_rendering, wayland_enable_ime=opts.wayland_enable_ime, wayland_scale_override=opts.wayland_scale_override)
     return glfw_module
 
 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -3803,6 +3803,15 @@ config is not supported.
 '''
     )
 
+opt('wayland_scale_override', '0', option_type='positive_int', ctype='int', long_text='''
+Override the compositor-provided scale factor on Wayland. Set to :code:`0`
+to use the compositor scale (default). Set to :code:`1` to force 1x scaling
+even when the compositor uses a higher scale, or any other positive integer
+to force that scale. This is useful when you want your terminal to render at
+a different scale than other applications. Changing this option by reloading
+the config is not supported.
+''')
+
 opt('wayland_enable_ime', 'yes', option_type='to_bool', ctype='bool', long_text='''
 Enable Input Method Extension on Wayland. This is typically used for
 inputting text in East Asian languages. However, its implementation in


### PR DESCRIPTION
## Summary
- Add `wayland_scale_override` config option to override compositor-provided Wayland scale factor
- Defaults to `0` (use compositor scale). Set to `1` to force 1x rendering, or any positive integer to force that scale
- Useful when the compositor is set to 2x but the user wants kitty at 1x (e.g. terminal already has large fonts, or user prefers native pixel rendering)

## Motivation
On Wayland, apps cannot opt out of compositor scaling. Other terminals like Alacritty support this via `WINIT_X11_SCALE_FACTOR`. Kitty currently has no equivalent, forcing users to choose between scaling all apps or none.

## Changes
- `glfw/glfw3.h` — new `GLFW_WAYLAND_SCALE_OVERRIDE` init hint
- `glfw/internal.h` — add `scale_override` field to `_GLFWinitconfig.wl`
- `glfw/init.c` — handle the new hint
- `glfw/wl_window.c` — use override in `_glfwWaylandIntegerWindowScale()` and `_glfwWaylandWindowScale()`
- `kitty/glfw.c` — pass option from Python to GLFW
- `kitty/main.py` — thread option through `init_glfw_module()`
- `kitty/options/definition.py` — define the new config option

## Usage
```conf
# kitty.conf
wayland_scale_override 1
```