### PR TITLE
mouse suppress split focus-transfer clicks

### DIFF
--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -832,10 +832,21 @@ HANDLER(handle_button_event) {
     Tab *t = osw->tabs + osw->active_tab;
     bool is_release = !osw->mouse_button_pressed[button];
 
+    if (button == GLFW_MOUSE_BUTTON_LEFT && is_release && osw->suppress_left_mouse_release) {
+        osw->suppress_left_mouse_release = false;
+        return;
+    }
+
     if (handle_scrollbar_mouse(w, button, is_release ? RELEASE : PRESS, modifiers)) return;
 
-    if (window_idx != t->active_window && !is_release) {
+    if (osw->is_focused && window_idx != t->active_window && !is_release) {
         call_boss(switch_focus_to_in_active_tab, "K", t->windows[window_idx].id);
+        if (button == GLFW_MOUSE_BUTTON_LEFT) {
+            // Treat split-focus transfer clicks as focus-only and suppress
+            // the matching release to avoid release-without-press reports.
+            osw->suppress_left_mouse_release = true;
+            return;
+        }
     }
 
     Screen *screen = w->render_data.screen;

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -329,6 +329,7 @@ typedef struct OSWindow {
     double mouse_x, mouse_y;
     bool mouse_button_pressed[32];
     bool has_too_few_tabs;
+    bool suppress_left_mouse_release;
     PyObject *window_title;
     bool disallow_title_changes, title_is_overriden;
     bool viewport_size_dirty, viewport_updated_at_least_once;


### PR DESCRIPTION
Treat left clicks that only transfer split focus as focus-only events. Suppress forwarding the left press and matching release to the child so applications do not see release-without-press sequences.

Previously, the behavior differed depending on the focus state of the window. If the window was unfocused, clicking to transfer focus to the window only delivered a focus event. Clicking from to an unfocused pane would deliver a focus event *and* a mouse event. This PR unifies that into only delivering a focus event when clicking onto an unfocused terminal pane, regardless of window focus state.

Related: https://github.com/ghostty-org/ghostty/pull/11167
Amp-Thread-ID: https://ampcode.com/threads/T-019cba50-5f2e-763b-ab5f-aa8c96a45747