### PR TITLE
Double-click tab to rename

### DIFF
--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -1725,6 +1725,19 @@ class TabManager:  # {{{
                 else:
                     drag_started = get_tab_being_dragged()[1]
                     if not drag_started:
+                        if len(self.recent_mouse_events) > 2:
+                            ci = get_click_interval()
+                            prev, prev2 = self.recent_mouse_events[-1], self.recent_mouse_events[-2]
+                            if (
+                                prev.button == button and prev2.button == button and
+                                prev.action == GLFW_PRESS and prev2.action == GLFW_RELEASE and
+                                prev.tab_id == tab.id and prev2.tab_id == tab.id and
+                                now - prev.at <= ci and now - prev2.at <= 2 * ci
+                            ):  # double click on tab
+                                get_boss().set_tab_title()
+                                self.recent_mouse_events.clear()
+                                set_tab_being_dragged()
+                                return
                         self.set_active_tab(tab)
                         set_tab_being_dragged()
             elif button == GLFW_MOUSE_BUTTON_MIDDLE:


### PR DESCRIPTION
  ## Summary                                                                                                                                                        

  - Double-clicking a tab in the tab bar opens the rename overlay (`set_tab_title()`) pre-filled with the current title
  - Mirrors the existing double-click-on-empty-space pattern (which creates a new tab)
  - Single-click tab switching and all other mouse behavior unchanged

 ## Implementation

  In `TabManager.handle_tab_bar_mouse()`, the `else` branch (tab is not None, left-click release, no drag) now checks for a double-click before falling through to `set_active_tab()`. The detection logic reuses the existing `recent_mouse_events` deque and `get_click_interval()`, matching the same event pattern as the empty-space double-click.

  ## Follow-up

  - Double-click-to-rename for window title bars can be added in this PR or a separate one, whichever you prefer
  - Draggable window reordering via title bars will be a separate PR

  Ref: #9448