### PR TITLE
Fix segfault when dragging tab to detach with window title bars enabled

### DIFF
--- a/kitty/state.c
+++ b/kitty/state.c
@@ -865,12 +865,13 @@ PYWRAP1(set_tab_bar_render_data) {
 }
 
 PYWRAP1(set_window_title_bar_render_data) {
-    WindowGeometry g;
+    WindowGeometry g = {0};
     id_type os_window_id, tab_id, window_id;
     Screen *screen;
     PA("KKKOIIII", &os_window_id, &tab_id, &window_id, &screen, &g.left, &g.top, &g.right, &g.bottom);
     WITH_WINDOW(os_window_id, tab_id, window_id)
         init_window_render_data(&window->window_title_render_data, g, screen);
+        screen->reload_all_gpu_data = true;
     END_WITH_WINDOW
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
## Summary

Fixes a segfault when dragging a tab off-screen to detach it into a new OS window while `window_title_bar_min_windows 1` is set.

## Root cause

Two bugs in `set_window_title_bar_render_data` (`state.c`):

1. **Uninitialized `WindowGeometry.spaces`** — The local `WindowGeometry g` was declared without initialization. Only `left/top/right/bottom` are parsed from Python args; the `spaces` field contained stack garbage (observed values like `593040`, `11747456` vs expected single-digit padding values).

2. **Missing `reload_all_gpu_data` flag** — When a window is transferred between OS windows via tab detach, `attach_window` creates a new (empty) VAO for the title bar and clears `trd->screen`. Python's relayout then calls `set_window_title_bar_render_data` to reassign the screen, but without marking `screen->reload_all_gpu_data = true`, `send_cell_data_to_gpu` skips the upload (the screen's dirty flags reflect the old context). The render loop then calls `draw_cells` on an empty VAO buffer, causing a NULL deref in `gleRunVertexSubmitImmediate`. This matches the existing pattern for the main window screen in `attach_window` (line 450).

## Repro

```conf
window_title_bar top
window_title_bar_min_windows 1
```

1. Open kitty, create 2 tabs
2. Drag a tab outside the window to detach
3. Segfault

## Fix

- Zero-initialize `WindowGeometry g = {0}`
- Set `screen->reload_all_gpu_data = true` after `init_window_render_data`, matching the existing pattern in `attach_window`