### PR TITLE
Fix outdated check in paste confirmation

### DIFF
--- a/kitty/window.py
+++ b/kitty/window.py
@@ -2018,7 +2018,7 @@ class Window:
     def handle_dangerous_paste_confirmation(self, unsanitized: bytes, sanitized: bytes, choice: str) -> None:
         if choice == 's':
             self.paste_text(sanitized)
-        elif choice == 'p':
+        elif choice == 'a':
             self.paste_text(unsanitized)
 
     def handle_large_paste_confirmation(self, btext: bytes, confirmed: bool) -> None:


### PR DESCRIPTION
Really short fix

"Paste/drop anyway"'s key was changed from p to a in 0.46.0 but handle_dangerous_paste_confirmation wasn't updated accordingly 