### PR TITLE
Clear macOS dock badge on keypress and mouse click

### DIFF
--- a/kitty/cocoa_window.h
+++ b/kitty/cocoa_window.h
@@ -67,3 +67,4 @@ void get_cocoa_key_equivalent(uint32_t, int, char *key, size_t key_sz, int*);
 void set_cocoa_pending_action(CocoaPendingAction action, const char*);
 void cocoa_report_live_notifications(const char* ident);
 void cocoa_set_dock_badge(const char *label);
+void cocoa_clear_dock_badge_if_set(void);

--- a/kitty/cocoa_window.m
+++ b/kitty/cocoa_window.m
@@ -1341,13 +1341,21 @@ cocoa_show_progress_bar_on_dock_icon(PyObject *self UNUSED, PyObject *args) {
 
 // Dock badge {{{
 
+static bool dock_badge_is_set = false;
+
 void
 cocoa_set_dock_badge(const char *label) {
     @autoreleasepool {
         NSDockTile *dockTile = [NSApp dockTile];
         [dockTile setBadgeLabel:label ? @(label) : nil];
         [dockTile display];
+        dock_badge_is_set = (label != NULL);
     }
+}
+
+void
+cocoa_clear_dock_badge_if_set(void) {
+    if (dock_badge_is_set) cocoa_set_dock_badge(NULL);
 }
 
 // }}}

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -518,6 +518,9 @@ update_modifier_state_on_modifier_key_event(GLFWkeyevent *ev, int key_modifier, 
 static void
 key_callback(GLFWwindow *w, GLFWkeyevent *ev) {
     if (!set_callback_window(w)) return;
+#ifdef __APPLE__
+    cocoa_clear_dock_badge_if_set();
+#endif
 #ifndef __APPLE__
     bool is_left;
     int key_modifier = key_to_modifier(ev->key, &is_left);
@@ -554,6 +557,9 @@ cursor_enter_callback(GLFWwindow *w, int entered) {
 static void
 mouse_button_callback(GLFWwindow *w, int button, int action, int mods) {
     if (!set_callback_window(w)) return;
+#ifdef __APPLE__
+    cocoa_clear_dock_badge_if_set();
+#endif
     monotonic_t now = monotonic();
     cursor_active_callback(now);
     mods_at_last_key_or_button_event = mods;


### PR DESCRIPTION
## Summary

Fixes #9639

The `macos_dock_badge_on_bell` dock badge is currently only cleared via `NSApplicationDidBecomeActiveNotification`, which fires when kitty transitions from inactive to active. This leaves the badge stuck when a bell occurs while kitty is already the active app (e.g. bell in a background tmux pane or non-focused kitty tab) — a common real-world scenario for users who rely on bell notifications for long-running commands.

This PR clears the badge on any user interaction (keypress or mouse click), so it dismisses as soon as the user engages with kitty, regardless of whether kitty was already active.

## Changes

- **`kitty/cocoa_window.m`**: Added a `static bool dock_badge_is_set` flag to track badge state. Updated `cocoa_set_dock_badge()` to maintain the flag. Added `cocoa_clear_dock_badge_if_set()` which only calls `cocoa_set_dock_badge(NULL)` when a badge is actually set, avoiding unnecessary Cocoa calls on every keystroke/click.
- **`kitty/cocoa_window.h`**: Declared `cocoa_clear_dock_badge_if_set()`.
- **`kitty/glfw.c`**: Call `cocoa_clear_dock_badge_if_set()` in `key_callback()` and `mouse_button_callback()`, guarded by `#ifdef __APPLE__`.

The existing `NSApplicationDidBecomeActiveNotification` clearing is preserved for the app-switch case.

## Design notes

- The `dock_badge_is_set` bool check ensures zero overhead in the common case (no badge set) — just a single branch on a static bool, no Cocoa/ObjC calls.
- Clearing on both keypress and mouse click covers all direct user interaction. Mouse movement alone does not clear the badge, which is intentional — the user should actively engage, not just hover.