### PR TITLE
Fix font detection command on linux in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -949,7 +949,7 @@ def add_builtin_fonts(args: Options) -> None:
                     break
         else:
             lines = subprocess.check_output([
-                'fc-match', '--format', '%{file}\n%{postscriptname}', f'term:postscriptname={psname}', 'file', 'postscriptname']).decode().splitlines()
+                'fc-list', '--format', '%{file}\n%{postscriptname}', f':postscriptname={psname}']).decode().splitlines()
             if len(lines) != 2:
                 raise SystemExit(f'fc-match returned unexpected output: {lines}')
             if lines[1] != psname:


### PR DESCRIPTION
The previous check used `fc-match`, but `fc-match` is affected by both user and system font configuration.
These configurations may pre-process the font matching pattern to prepend multiple default fonts and set language to current system locale. The modification can be quite large if you have many fonts installed in the system.

```bash
$ fc-pattern -cd -f 'family=%{family}\npostscriptname=%{postscriptname}\nlang=%{lang}\n' ':postscriptname=SymbolsNFM'
family=Inter,MiSans VF,STIX Two Math,Noto Color Emoji,Noto Sans,DejaVu Sans,Verdana,Arial,Albany AMT,Luxi Sans,Nimbus Sans L,Nimbus Sans,Nimbus Sans,Helvetica,Nimbus Sans,Nimbus Sans L,Lucida Sans Unicode,BPG Glaho International,Tahoma,Nachlieli,Lucida Sans Unicode,Yudit Unicode,Kerkis,ArmNet Helvetica,Artsounk,BPG UTF8 M,Waree,Loma,Garuda,Umpush,Saysettha Unicode,JG Lao Old Arial,GF Zemen Unicode,Pigiarniq,B Davat,B Compset,Kacst-Qr,Urdu Nastaliq Unicode,Raghindi,Mukti Narrow,malayalam,Sampige,padmaa,Hapax Berbère,MS Gothic,UmePlus P Gothic,Microsoft YaHei,Microsoft JhengHei,WenQuanYi Zen Hei,WenQuanYi Bitmap Song,AR PL ShanHeiSun Uni,AR PL New Sung,Hiragino Sans,PingFang SC,PingFang TC,PingFang HK,Hiragino Sans CNS,Hiragino Sans GB,MgOpen Modata,VL Gothic,IPAMonaGothic,IPAGothic,Sazanami Gothic,Kochi Gothic,AR PL KaitiM GB,AR PL KaitiM Big5,AR PL ShanHeiSun Uni,AR PL SungtiL GB,AR PL Mingti2L Big5,ＭＳ ゴシック,ZYSong18030,TSCu_Paranar,NanumGothic,UnDotum,Baekmuk Dotum,Baekmuk Gulim,Apple SD Gothic Neo,KacstQura,Lohit Bengali,Lohit Gujarati,Lohit Hindi,Lohit Marathi,Lohit Maithili,Lohit Kashmiri,Lohit Konkani,Lohit Nepali,Lohit Sindhi,Lohit Punjabi,Lohit Tamil,Meera,Lohit Malayalam,Lohit Kannada,Lohit Telugu,Lohit Odia,LKLUG,DejaVu Sans,Bitstream Vera Sans,WenQuanYi Zen Hei,Input Sans,Noto Sans,FreeSans,Arial Unicode MS,Arial Unicode,Code2000,Code2001,URW Gothic,Nimbus Sans,Nimbus Sans Narrow,sans-serif,Roya,Koodak,Terafik,Helvetica,sans-serif,ITC Avant Garde Gothic,URW Gothic,sans-serif,sans-serif,Helvetica,Helvetica Narrow,Nimbus Sans Narrow
postscriptname=SymbolsNFM
lang=zh-CN
```

This causes my default sans-serif fonts to rank ahead of SymbolsNFM, producing a false “font not found” failure.

Switching to `fc-list` with an exact postscriptname filter makes detection deterministic and correctly finds the installed Symbols Nerd Font.