### PR TITLE
Drop the mutable default in as_conf

### DIFF
--- a/kitty/conf/types.py
+++ b/kitty/conf/types.py
@@ -244,7 +244,9 @@ class Option:
     def is_color_table_color(self) -> bool:
         return self.name.startswith('color') and self.name[5:].isdigit()
 
-    def as_conf(self, commented: bool = False, level: int = 0, option_group: list['Option'] = []) -> list[str]:
+    def as_conf(self, commented: bool = False, level: int = 0, option_group: list['Option'] = None) -> list[str]:
+        if option_group is None:
+            option_group = []
         ans: list[str] = []
         a = ans.append
         if not self.documented:
@@ -264,8 +266,10 @@ class Option:
 
     def as_rst(
         self, conf_name: str, shortcut_slugs: dict[str, tuple[str, str]],
-        kitty_mod: str, level: int = 0, option_group: list['Option'] = []
+        kitty_mod: str, level: int = 0, option_group: list['Option'] = None
     ) -> list[str]:
+        if option_group is None:
+            option_group = []
         ans: list[str] = []
         a = ans.append
         if not self.documented:


### PR DESCRIPTION
One-liner fix for a shared mutable default in kitty/conf/types.py.

Mutable defaults are shared across calls and usually turn into state leaks.

Ran: `/Users/tejasattarde/Downloads/gh-patchbot/.venv/bin/python3.14 -m py_compile kitty/conf/types.py`.

`conf/types.py` line 247.