### PR TITLE
Add title_overridden field to kitty @ ls output

### DIFF
--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -93,6 +93,7 @@ class TabDict(TypedDict):
     is_focused: bool
     is_active: bool
     title: str
+    title_overridden: bool
     layout: str
     layout_state: dict[str, Any]
     layout_opts: dict[str, Any]
@@ -1388,6 +1389,7 @@ class TabManager:  # {{{
                         'is_focused': tab is active_tab and tab.os_window_id == current_focused_os_window_id(),
                         'is_active': tab is active_tab,
                         'title': tab.name or tab.title,
+                        'title_overridden': bool(tab.name),
                         'layout': str(tab.current_layout.name),
                         'layout_state': tab.current_layout.serialize(tab.windows),
                         'layout_opts': tab.current_layout.layout_opts.serialized(),

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -238,6 +238,7 @@ class WindowDict(TypedDict):
     is_focused: bool
     is_active: bool
     title: str
+    title_overridden: bool
     pid: int | None
     cwd: str
     cmdline: list[str]
@@ -2088,6 +2089,7 @@ class Window:
             'is_focused': is_focused,
             'is_active': is_active,
             'title': self.title,
+            'title_overridden': self.override_title is not None,
             'pid': self.child.pid,
             'cwd': self.child.current_cwd or self.child.cwd,
             'cmdline': self.child.cmdline,


### PR DESCRIPTION
## Summary
- Add `title_overridden` boolean to window and tab entries in `kitty @ ls` JSON output
- Indicates whether the title was manually set by the user (via `set-window-title` / `set-tab-title`) versus inherited from the running process or tab state
- Useful for session management tools that need to know which titles to restore when recreating a session

## Test plan
- Run `kitty @ ls` and verify `title_overridden: false` on windows/tabs
- Set a window title via `kitty @ set-window-title "test"`, verify `title_overridden: true`
- Set a tab title via `kitty @ set-tab-title "test"`, verify `title_overridden: true`