### PR TITLE
Highlight full extent of hint matches, not just the prefix label

### DIFF
--- a/kittens/hints/main.go
+++ b/kittens/hints/main.go
@@ -189,7 +189,7 @@ func main(_ *cli.Command, o *Options, args []string) (rc int, err error) {
 	fctx := style.Context{AllowEscapeCodes: true}
 	faint := fctx.SprintFunc("dim")
 	hint_style := fctx.SprintFunc(fmt.Sprintf("fg=%s bg=%s bold", o.HintsForegroundColor, o.HintsBackgroundColor))
-	text_style := fctx.SprintFunc(fmt.Sprintf("fg=%s bold", o.HintsTextColor))
+	text_style := fctx.SprintFunc(fmt.Sprintf("fg=%s bg=%s bold", o.HintsTextColor, o.HintsTextBackgroundColor))
 
 	highlight_mark := func(m *Mark, mark_text string) string {
 		hint := encode_hint(m.Index, alphabet)

--- a/kittens/hints/main.py
+++ b/kittens/hints/main.py
@@ -234,9 +234,19 @@ color.
 --hints-text-color
 default=auto
 type=str
-The foreground color for text pointed to by the hints. You can use color names or hex values. For the eight basic
-named terminal colors you can also use the :code:`bright-` prefix to get the bright variant of the
-color. The default is to pick a suitable color automatically.
+The foreground color for text pointed to by the hints (excluding the hint label itself). You can use
+color names or hex values. For the eight basic named terminal colors you can also use the
+:code:`bright-` prefix to get the bright variant of the color. The default is to pick a suitable
+color automatically.
+
+
+--hints-text-background-color
+default=auto
+type=str
+The background color for text pointed to by the hints (excluding the hint label itself). You can use
+color names or hex values. For the eight basic named terminal colors you can also use the
+:code:`bright-` prefix to get the bright variant of the color. The default is to pick a suitable
+color automatically.
 
 
 --customize-processing


### PR DESCRIPTION
Add `--hints-text-background-color` option (default: auto) that can apply a background color to the matched text after the hint label. This makes it more clear exactly which text each hint covers.