### PR TITLE
regenerate palette on theme change

### DIFF
--- a/kitty/colors.c
+++ b/kitty/colors.c
@@ -382,6 +382,16 @@ patch_color_profiles(PyObject *module UNUSED, PyObject *args) {
     if (!PyArg_ParseTuple(args, "O!O!O!p", &PyDict_Type, &spec, &PyTuple_Type, &transparent_background_colors, &PyTuple_Type, &profiles, &change_configured)) return NULL;
     char key[32] = {0};
     bool has_null_values = false;
+    bool semantic, dynamic = palette_generation_is_dynamic(global_state.options_object, &semantic);
+    if (dynamic) {
+        for (Py_ssize_t j = 0; j < PyTuple_GET_SIZE(profiles); j++) {
+            ColorProfile *self = (ColorProfile*)PyTuple_GET_ITEM(profiles, j);
+            for (size_t i = 16; i < arraysz(FG_BG_256); i++) {
+                self->color_table[i] = NULL_COLOR_VALUE;
+                if (change_configured) self->orig_color_table[i] = NULL_COLOR_VALUE;
+            }
+        }
+    }
     for (size_t i = 0; i < arraysz(FG_BG_256); i++) {
         snprintf(key, sizeof(key) - 1, "color%zu", i);
         patch_color_table(key, profiles, spec, i, change_configured, &has_null_values);
@@ -420,8 +430,7 @@ patch_color_profiles(PyObject *module UNUSED, PyObject *args) {
         if (change_configured) set_transparent_background_colors(self->configured_transparent_colors, transparent_background_colors);
     }
 
-    if (has_null_values) {
-        bool semantic, dynamic = palette_generation_is_dynamic(global_state.options_object, &semantic);
+    if (dynamic || has_null_values) {
         for (Py_ssize_t j = 0; j < PyTuple_GET_SIZE(profiles); j++) {
             ColorProfile *self = (ColorProfile*)PyTuple_GET_ITEM(profiles, j);
             if (dynamic) {


### PR DESCRIPTION
#9426

`set-colors` is not causing palette regeneration because it is attempting to
replace `NULL_COLOR_VALUE` values in the already-generated palette that has
none.

This fix simply sets colors 16-255 to `NULL_COLOR_VALUE` so that they can be
regenerated.

This will replace user-defined 256-color entries. But I think this is
acceptable since they are loading a whole new theme. It makes sense for their
colors to be cleared and generated from scratch.

This PR only affects runtime color changes. For example:

```
map ctrl+0 set_colors ~/.config/kitty/dark.conf
```
