### PR TITLE
Fix prompt click event flags reset on OSC 133 A

### DIFF
--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -3106,6 +3106,8 @@ shell_prompt_marking(Screen *self, char *buf) {
                 PromptKind pk = PROMPT_START;
                 self->prompt_settings.redraws_prompts_at_all = 1;
                 self->prompt_settings.uses_special_keys_for_cursor_movement = 0;
+                self->prompt_settings.supports_click_events = 0;
+                self->prompt_settings.relative_click_events = 0;
                 parse_prompt_mark(self, buf+1, &pk);
                 self->linebuf->line_attrs[self->cursor->y].prompt_kind = pk;
                 if (pk == PROMPT_START) CALLBACK("cmd_output_marking", "O", Py_False);


### PR DESCRIPTION
**Summary**
- Reset click-event support flags on each prompt start to avoid leaking prior settings
- Prevent unintended click event escape sequences in shells that do not enable click events

before:

https://github.com/user-attachments/assets/f7323cae-7e24-4532-9567-60156c30730c

after:

https://github.com/user-attachments/assets/ae2abcd3-f552-42e8-9431-0ddeeceadc0e


