### PR TITLE
Fix MX Master scrolling on XWayland

### DIFF
--- a/glfw/x11_window.c
+++ b/glfw/x11_window.c
@@ -1487,6 +1487,13 @@ handle_xi_motion_event(_GLFWwindow *window, XIDeviceEvent *de) {
             }
             if (d->offset_type == GLFW_SCROLL_OFFSET_LINES) {
                 if (v->increment != 0) *off /= v->increment;
+            } else if (d->offset_type == GLFW_SCROLL_OFFEST_V120 && v->increment != 0 && v->increment != 120.) {
+                // On XWayland, scroll deltas are in scroll-increment units (typically
+                // where increment=1.0 means one line), but the heuristic may classify
+                // them as V120. Since the V120 code path downstream divides by 120,
+                // we must normalize to actual V120 units here to avoid ~120x reduction
+                // in scroll speed. For real V120 devices (increment=120), this is a no-op.
+                *off *= 120. / v->increment;
             }
         }
         type = d->offset_type;


### PR DESCRIPTION
This fixes the bug I described in https://github.com/kovidgoyal/kitty/issues/9649#issuecomment-4147760397, I have tested it on my end with Logitech MX Master and can confirm scrolling now works as expected.

Debugging of the issue was done with OpenCode and Opus 4.6, this is very much out of my depth so I appologize in advance for the waste of time if the fix makes no sense.

Find below a log file showcasing the issue prior to the fix.

[kitty-scroll-debug.log](https://github.com/user-attachments/files/26326244/kitty-scroll-debug.log)
