### PR TITLE
Fix timing, memory safety, and tar extraction vulnerabilities

### DIFF
--- a/glfw/ibus_glfw.c
+++ b/glfw/ibus_glfw.c
@@ -287,7 +287,9 @@ get_ibus_address_file_name(void) {
     addr = getenv("IBUS_ADDRESS");
     int offset = 0;
     if (addr && addr[0]) {
-        memcpy(ans, addr, GLFW_MIN(strlen(addr), sizeof(ans)));
+        size_t len = GLFW_MIN(strlen(addr), sizeof(ans) - 1);
+        memcpy(ans, addr, len);
+        ans[len] = '\0';
         return ans;
     }
     const char* disp_num = NULL;

--- a/glfw/x11_window.c
+++ b/glfw/x11_window.c
@@ -937,7 +937,9 @@ get_clipboard_data(const _GLFWClipboardData *cd, const char *mime, char **data) 
         if (!chunk.sz) break;
         if (cap < sz + chunk.sz) {
             cap = MAX(cap * 2, sz + 4 * chunk.sz);
-            buf = realloc(buf, cap * sizeof(buf[0]));
+            char *new_buf = realloc(buf, cap * sizeof(buf[0]));
+            if (!new_buf) { free(buf); *data = NULL; cd->get_data(NULL, iter, cd->ctype); return 0; }
+            buf = new_buf;
         }
         memcpy(buf + sz, chunk.data, chunk.sz);
         sz += chunk.sz;
@@ -3636,7 +3638,9 @@ write_chunk(void *object, const char *data, size_t sz) {
     if (data) {
         if (cw->cap < cw->sz + sz) {
             cw->cap = MAX(cw->cap * 2, cw->sz + 8*sz);
-            cw->buf = realloc(cw->buf, cw->cap * sizeof(cw->buf[0]));
+            char *new_buf = realloc(cw->buf, cw->cap * sizeof(cw->buf[0]));
+            if (!new_buf) return false;
+            cw->buf = new_buf;
         }
         memcpy(cw->buf + cw->sz, data, sz);
         cw->sz += sz;

--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -1940,7 +1940,7 @@ write_to_peer(Peer *peer) {
     else if (n < 0) {
         if (errno != EINTR) { log_error("write() to peer socket failed with error: %s", strerror(errno)); peer->write.used = 0; peer->write.failed = true; }
     } else {
-        if ((size_t)n > peer->write.used) memmove(peer->write.data, peer->write.data + n, peer->write.used - n);
+        if ((size_t)n < peer->write.used) memmove(peer->write.data, peer->write.data + n, peer->write.used - n);
         peer->write.used -= n;
     }
     talk_mutex(unlock);

--- a/kitty/crypto.c
+++ b/kitty/crypto.c
@@ -14,6 +14,7 @@
 #include <openssl/pem.h>
 #include <openssl/bio.h>
 #include <openssl/rand.h>
+#include <openssl/crypto.h>
 #include <sys/mman.h>
 #include <structmember.h>
 
@@ -72,8 +73,8 @@ dealloc_secret(Secret *self) {
 
 static int
 __eq__(Secret *a, Secret *b) {
-    const size_t l = a->secret_len < b->secret_len ? a->secret_len : b->secret_len;
-    return memcmp(a->secret, b->secret, l) == 0;
+    if (a->secret_len != b->secret_len) return 0;
+    return CRYPTO_memcmp(a->secret, b->secret, a->secret_len) == 0;
 }
 
 static Py_ssize_t

--- a/kitty/disk-cache.c
+++ b/kitty/disk-cache.c
@@ -16,6 +16,7 @@
 #include "cross-platform-random.h"
 #include <structmember.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <time.h>
@@ -40,7 +41,7 @@ static uint64_t key_hash(KEY_TY k);
 #define HASH_FN key_hash
 static bool keys_are_equal(CacheKey a, CacheKey b) { return a.hash_keylen == b.hash_keylen && memcmp(a.hash_key, b.hash_key, a.hash_keylen) == 0; }
 #define CMPR_FN keys_are_equal
-static void free_cache_value(CacheValue *cv) { free(cv->data); cv->data = NULL; free(cv); }
+static void free_cache_value(CacheValue *cv) { explicit_bzero(cv->encryption_key, sizeof(cv->encryption_key)); free(cv->data); cv->data = NULL; free(cv); }
 static void free_cache_key(CacheKey cv) { free(cv.hash_key); cv.hash_key = NULL; }
 #define KEY_DTOR_FN free_cache_key
 #define VAL_DTOR_FN free_cache_value

--- a/kitty/dnd.c
+++ b/kitty/dnd.c
@@ -308,11 +308,12 @@ drop_set_status(Window *w, int operation, const char *payload, size_t payload_sz
         }
     }
     if (payload_sz) {
-        w->drop.accepted_mimes = realloc(w->drop.accepted_mimes, w->drop.accepted_mimes_sz + payload_sz + 2);
-        if (w->drop.accepted_mimes) {
-            memcpy(w->drop.accepted_mimes + w->drop.accepted_mimes_sz, payload, payload_sz);
-            w->drop.accepted_mimes_sz += payload_sz;
-        }
+        if (w->drop.accepted_mimes_sz + payload_sz > 1024 * 1024) return;
+        char *new_buf = realloc(w->drop.accepted_mimes, w->drop.accepted_mimes_sz + payload_sz + 2);
+        if (!new_buf) return;
+        w->drop.accepted_mimes = new_buf;
+        memcpy(w->drop.accepted_mimes + w->drop.accepted_mimes_sz, payload, payload_sz);
+        w->drop.accepted_mimes_sz += payload_sz;
     }
     if (!more) {
         w->drop.accept_in_progress = false;

--- a/kitty/file_transmission.py
+++ b/kitty/file_transmission.py
@@ -2,6 +2,7 @@
 # License: GPLv3 Copyright: 2021, Kovid Goyal <kovid at kovidgoyal.net>
 
 import errno
+import hmac
 import inspect
 import io
 import json
@@ -572,12 +573,12 @@ def check_bypass(password: str, request_id: str, bypass_data: str) -> bool:
             delta = time_ns() - int(timestamp)
             if abs(delta) > 5 * 60 * 1e9:
                 return False
-            return payload == f'{request_id};{password}'
+            return hmac.compare_digest(payload, f'{request_id};{password}')
         except Exception as err:
             log_error(f'Invalid file transmission bypass data received: {err}')
             return False
     elif protocol == 'sha256':
-        return (encode_bypass(request_id, password) == bypass_data) if password else False
+        return hmac.compare_digest(encode_bypass(request_id, password), bypass_data) if password else False
     else:
         log_error(f'Invalid file transmission bypass data received with protocol: {protocol}')
     return False

--- a/kitty/png-reader.c
+++ b/kitty/png-reader.c
@@ -113,7 +113,7 @@ inflate_png_inner(png_read_data *d, const uint8_t *buf, size_t bufsz, int max_im
     png_read_update_info(png, info);
 
     png_uint_32 rowbytes = png_get_rowbytes(png, info);
-    d->sz = sizeof(png_byte) * rowbytes * d->height;
+    d->sz = (size_t)rowbytes * (size_t)d->height;
     d->decompressed = malloc(d->sz + 16);
     if (d->decompressed == NULL) ABRT(ENOMEM, "Out of memory allocating decompression buffer for PNG");
     d->row_pointers = malloc(d->height * sizeof(png_bytep));

--- a/kitty/remote_control.py
+++ b/kitty/remote_control.py
@@ -2,6 +2,7 @@
 # License: GPL v3 Copyright: 2018, Kovid Goyal <kovid at kovidgoyal.net>
 
 import base64
+import hmac
 import json
 import os
 import re
@@ -103,6 +104,14 @@ def fnmatch_pattern(pat: str) -> 're.Pattern[str]':
     return re.compile(translate(pat))
 
 
+def _ct_password_lookup(passwords: dict[str, Any], pw: str) -> Any:
+    result = None
+    for k, v in passwords.items():
+        if hmac.compare_digest(k, pw):
+            result = v
+    return result
+
+
 def remote_control_allowed(
     pcmd: dict[str, Any], remote_control_passwords: dict[str, Sequence[str]] | None,
     window: Optional['Window'], extra_data: dict[str, Any]
@@ -110,7 +119,7 @@ def remote_control_allowed(
     if not remote_control_passwords:
         return True
     pw = pcmd.get('password', '')
-    auth_items = remote_control_passwords.get(pw)
+    auth_items = _ct_password_lookup(remote_control_passwords, pw)
     if pw == '!':
         auth_items = None
     if auth_items is None:
@@ -185,10 +194,10 @@ def is_cmd_allowed(pcmd: dict[str, Any], window: Optional['Window'], from_socket
             return False
         pa = password_authorizer(auth_items)
         return pa.is_cmd_allowed(pcmd, window, from_socket, extra_data)
-    q = user_password_allowed.get(pw)
+    q = _ct_password_lookup(user_password_allowed, pw)
     if q is not None:
         return q
-    auth_items = get_options().remote_control_password.get(pw)
+    auth_items = _ct_password_lookup(get_options().remote_control_password, pw)
     if auth_items is None:
         return None
     pa = password_authorizer(auth_items)

--- a/tools/utils/tar.go
+++ b/tools/utils/tar.go
@@ -182,7 +182,7 @@ func ExtractAllFromTar(tr *tar.Reader, dest_path string, optss ...TarExtractOpti
 	dest_path = filepath.Clean(dest_path)
 
 	mode := func(hdr int64) fs.FileMode {
-		return fs.FileMode(hdr) & (fs.ModePerm | fs.ModeSetgid | fs.ModeSetuid | fs.ModeSticky)
+		return fs.FileMode(hdr) & fs.ModePerm
 	}
 
 	set_metadata := func(chmod func(mode fs.FileMode) error, hdr_mode int64) (err error) {
@@ -249,6 +249,12 @@ func ExtractAllFromTar(tr *tar.Reader, dest_path string, optss ...TarExtractOpti
 			link_target := hdr.Linkname
 			if !filepath.IsAbs(link_target) {
 				link_target = filepath.Join(filepath.Dir(dest), link_target)
+			}
+			if link_target, err = EvalSymlinksThatExist(link_target); err != nil {
+				return
+			}
+			if !strings.HasPrefix(link_target, needed_prefix) {
+				continue
 			}
 			if err = os.Link(link_target, dest); err != nil {
 				return


### PR DESCRIPTION
## Summary

Found and fixed several security issues across the C, Python, and Go code during a source audit. All changes are minimal and surgical.

### Timing-safe comparisons
- **crypto.c** — `Secret.__eq__` used `memcmp` (not constant-time) and compared only `min(len_a, len_b)` bytes, so secrets of different lengths with a shared prefix compared equal. Switched to `CRYPTO_memcmp` with a length-equality check first.
- **remote_control.py** — Remote control passwords were looked up via `dict.get()`, which leaks timing through Python's hash+compare. Replaced with a constant-time linear scan using `hmac.compare_digest`.
- **file_transmission.py** — Bypass token comparison in `check_bypass` used `==` for both the `kitty-1` and `sha256` protocols. Switched to `hmac.compare_digest`.

### Memory safety (C)
- **child-monitor.c** — `write_to_peer` had an inverted condition (`n > used` instead of `n < used`). Since `send()` never returns more than `used`, the `memmove` never fired, so partial writes resent stale data from the buffer head.
- **ibus_glfw.c** — `IBUS_ADDRESS` env var copied via `memcpy` without a null terminator. When `strlen(addr) >= PATH_MAX`, the static buffer was returned unterminated.
- **x11_window.c** — Two `realloc` calls (clipboard + DnD chunked writer) didn't check for `NULL`, leading to a use-after-free of the old pointer and a `memcpy` into `NULL + offset`.
- **dnd.c** — `accepted_mimes` buffer had no size cap (unlike `registered_mimes` which caps at 1MB) and the `realloc` pattern leaked the old pointer on failure. Added the same 1MB cap and safe realloc.
- **png-reader.c** — `rowbytes * height` was computed as `png_uint_32` arithmetic, which can overflow on 32-bit before assigning to `size_t`. Added explicit casts.

### Secrets hygiene
- **disk-cache.c** — `CacheValue` contains a 64-byte encryption key that was left in memory after `free()`. Added `explicit_bzero` before freeing.

### Tar extraction hardening
- **tar.go** — Hardlink targets were not validated against the destination prefix the way `dest` and symlinks were, allowing a malicious tar to hardlink outside the extraction directory then overwrite the target via a later entry. Also stripped setuid/setgid/sticky bits from extracted file modes.

## Test plan
- [x] Full build (`make`) passes with zero errors/warnings
- [x] Full test suite (`make test`) passes — 2 pre-existing font-name failures unrelated to these changes
- [x] Python files pass `py_compile` and `ast.parse`
- [x] Go files pass `gofmt -e`
- [ ] Upstream CI