### PR TITLE
feat(rc): allow cscaled and centered in set-background-image layouts

### DIFF
--- a/kitty/rc/set_background_image.py
+++ b/kitty/rc/set_background_image.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from kitty.cli_stub import SetBackgroundImageRCOptions as CLIOptions
 
 
-layout_choices = 'tiled,scaled,mirror-tiled,clamped,configured'
+layout_choices = 'tiled,scaled,mirror-tiled,clamped,centered,cscaled,configured'
 
 
 class SetBackgroundImage(RemoteCommand):


### PR DESCRIPTION
## Summary
Allow `kitten @ set-background-image --layout` to accept `cscaled` and `centered` in addition to the existing choices.

These values are already valid in `kitty.conf`, but were rejected by remote-control validation.

## Why
This makes the remote-control API match the config surface more closely and removes an avoidable mismatch between:

- `background_image_layout` in config
- `kitten @ set-background-image --layout ...`

## Change
- add `centered` and `cscaled` to the allowed `layout_choices` in `kitty/rc/set_background_image.py`

## Verification
- Python syntax check passes
- patch is isolated to a single validation string

If this is the wrong place to fix the mismatch, or if these layouts should intentionally remain config-only, I would appreciate guidance.
