### PR TITLE
feat(borders): add optional border ring behavior across kitty OS windows

### DIFF
--- a/kitty/border_vertex.glsl
+++ b/kitty/border_vertex.glsl
@@ -9,7 +9,9 @@
 #define TAB_BAR_MARGIN_COLOR 6
 #define TAB_BAR_EDGE_LEFT_COLOR 7
 #define TAB_BAR_EDGE_RIGHT_COLOR 8
-uniform uint colors[9];
+#define UNFOCUSED_ACTIVE_BORDER_COLOR 9
+#define UNFOCUSED_INACTIVE_BORDER_COLOR 10
+uniform uint colors[11];
 uniform float background_opacity;
 uniform float gamma_lut[256];
 

--- a/kitty/borders.py
+++ b/kitty/borders.py
@@ -6,7 +6,7 @@ from enum import IntFlag
 from functools import partial
 from typing import NamedTuple
 
-from .fast_data_types import BORDERS_PROGRAM, current_focused_os_window_id, get_options, init_borders_program, set_borders_rects
+from .fast_data_types import BORDERS_PROGRAM, current_focused_os_window_id, get_options, init_borders_program, last_focused_os_window_id, num_os_windows, set_borders_rects
 from .shaders import program_for
 from .typing_compat import LayoutType
 from .utils import color_as_int
@@ -15,7 +15,7 @@ from .window_list import WindowGroup, WindowList
 
 class BorderColor(IntFlag):
     # These are indices into the array of colors in the border vertex shader
-    default_bg, active, inactive, window_bg, bell, tab_bar_bg, tab_bar_margin_color, tab_bar_left_edge_color, tab_bar_right_edge_color = range(9)
+    default_bg, active, inactive, window_bg, bell, tab_bar_bg, tab_bar_margin_color, tab_bar_left_edge_color, tab_bar_right_edge_color, unfocused_active, unfocused_inactive = range(11)
 
 
 class Border(NamedTuple):
@@ -108,21 +108,38 @@ class Borders:
         else:
             draw_minimal_borders = opts.draw_minimal_borders and max(opts.window_margin_width) < 1
 
-        # For single window with the option enabled, check OS window focus state
-        # When unfocused, the border should appear inactive
-        os_window_focused = True
-        if opts.draw_window_borders_for_single_window and num_visible_groups == 1:
-            os_window_focused = current_focused_os_window_id() == self.os_window_id
+        # Determine OS window focus state for ring behavior
+        current_focused = current_focused_os_window_id()
+        os_window_focused = (current_focused == self.os_window_id)
+        is_ring_holder = False
+
+        if opts.border_ring_behavior:
+            if current_focused == 0 and num_os_windows() > 1:
+                # No kitty focused, multiple windows - check if we're the ring holder
+                is_ring_holder = (last_focused_os_window_id() == self.os_window_id)
+        elif opts.draw_window_borders_for_single_window and num_visible_groups == 1:
+            # Legacy single-window behavior
+            pass  # os_window_focused already set correctly
 
         if draw_borders and not draw_minimal_borders:
             for i, wg in enumerate(groups):
                 window_bg = color_as_int(wg.default_bg)
                 window_bg = (window_bg << 8) | BorderColor.window_bg
                 # Draw the border rectangles
-                if wg is active_group and draw_active_borders and os_window_focused:
-                    color = BorderColor.active
+                if wg is active_group and draw_active_borders:
+                    if os_window_focused:
+                        color = BorderColor.active
+                    elif is_ring_holder:
+                        color = BorderColor.unfocused_active
+                    else:
+                        color = BorderColor.unfocused_inactive
                 else:
-                    color = BorderColor.bell if wg.needs_attention else BorderColor.inactive
+                    if wg.needs_attention:
+                        color = BorderColor.bell
+                    elif os_window_focused:
+                        color = BorderColor.inactive
+                    else:
+                        color = BorderColor.unfocused_inactive
                 add_borders(rects, color, wg)
 
         if draw_minimal_borders:

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1911,10 +1911,15 @@ class Boss:
                 if is_macos and focused:
                     cocoa_set_menubar_title(w.title or '')
             tm.mark_tab_bar_dirty()
-            # Redraw borders when focus changes if draw_window_borders_for_single_window is enabled
-            # and there's only a single window (to show inactive border when OS window loses focus)
-            opts = get_options()
-            if opts.draw_window_borders_for_single_window and (tab := tm.active_tab) is not None and not tab.windows.has_more_than_one_visible_group:
+
+        # Ring border: redraw borders on ALL OS windows when focus changes
+        opts = get_options()
+        if opts.border_ring_behavior:
+            for other_tm in self.os_window_map.values():
+                if (tab := other_tm.active_tab) is not None:
+                    tab.relayout_borders()
+        elif opts.draw_window_borders_for_single_window and tm is not None:
+            if (tab := tm.active_tab) is not None and not tab.windows.has_more_than_one_visible_group:
                 tab.relayout_borders()
 
     def on_activity_since_last_focus(self, window: Window) -> None:

--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -989,6 +989,10 @@ def current_focused_os_window_id() -> int:
     pass
 
 
+def num_os_windows() -> int:
+    pass
+
+
 def cocoa_set_menubar_title(title: str) -> None:
     pass
 

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -1387,6 +1387,42 @@ opt('bell_border_color', '#ff5a00',
     long_text='The color for the border of inactive windows in which a bell has occurred.'
     )
 
+opt('border_ring_behavior', 'no',
+    option_type='to_bool', ctype='bool',
+    long_text='''
+When enabled, the last-focused kitty OS window retains an active border on its
+active pane even when focus moves to a non-kitty application, but only when
+multiple kitty OS windows exist. With a single OS window, borders go inactive
+when losing focus.
+'''
+)
+
+opt('unfocused_active_border_color', 'none',
+    option_type='to_color_or_none', ctype='color_or_none_as_int',
+    long_text='''
+Border color for the active pane when the OS window does NOT have desktop focus.
+Used with border_ring_behavior. If set to "none", falls back to brightening the
+background color by unfocused_border_brighten_factor.
+'''
+)
+
+opt('unfocused_inactive_border_color', 'none',
+    option_type='to_color_or_none', ctype='color_or_none_as_int',
+    long_text='''
+Border color for inactive panes when the OS window does NOT have desktop focus.
+Used with border_ring_behavior. If set to "none", falls back to brightening the
+background color by unfocused_border_brighten_factor.
+'''
+)
+
+opt('unfocused_border_brighten_factor', '0.15',
+    option_type='unit_float', ctype='float',
+    long_text='''
+When unfocused border colors are "none", compute the color by brightening the
+background color by this factor (0.0-1.0). 0.0 = same as background, 1.0 = white.
+'''
+)
+
 opt('inactive_text_alpha', '1.0',
     option_type='unit_float', ctype='float',
     long_text='''

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -114,6 +114,9 @@ class Parser:
     def bold_italic_font(self, val: str, ans: dict[str, typing.Any]) -> None:
         ans['bold_italic_font'] = parse_font_spec(val)
 
+    def border_ring_behavior(self, val: str, ans: dict[str, typing.Any]) -> None:
+        ans['border_ring_behavior'] = to_bool(val)
+
     def box_drawing_scale(self, val: str, ans: dict[str, typing.Any]) -> None:
         ans['box_drawing_scale'] = box_drawing_scale(val)
 
@@ -1447,6 +1450,15 @@ class Parser:
         ans["underline_hyperlinks"] = val
 
     choices_for_underline_hyperlinks = frozenset(('hover', 'always', 'never'))
+
+    def unfocused_active_border_color(self, val: str, ans: dict[str, typing.Any]) -> None:
+        ans['unfocused_active_border_color'] = to_color_or_none(val)
+
+    def unfocused_border_brighten_factor(self, val: str, ans: dict[str, typing.Any]) -> None:
+        ans['unfocused_border_brighten_factor'] = unit_float(val)
+
+    def unfocused_inactive_border_color(self, val: str, ans: dict[str, typing.Any]) -> None:
+        ans['unfocused_inactive_border_color'] = to_color_or_none(val)
 
     def update_check_interval(self, val: str, ans: dict[str, typing.Any]) -> None:
         ans['update_check_interval'] = float(val)

--- a/kitty/options/to-c-generated.h
+++ b/kitty/options/to-c-generated.h
@@ -890,6 +890,58 @@ convert_from_opts_bell_border_color(PyObject *py_opts, Options *opts) {
 }
 
 static void
+convert_from_python_border_ring_behavior(PyObject *val, Options *opts) {
+    opts->border_ring_behavior = PyObject_IsTrue(val);
+}
+
+static void
+convert_from_opts_border_ring_behavior(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "border_ring_behavior");
+    if (ret == NULL) return;
+    convert_from_python_border_ring_behavior(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
+convert_from_python_unfocused_active_border_color(PyObject *val, Options *opts) {
+    opts->unfocused_active_border_color = color_or_none_as_int(val);
+}
+
+static void
+convert_from_opts_unfocused_active_border_color(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "unfocused_active_border_color");
+    if (ret == NULL) return;
+    convert_from_python_unfocused_active_border_color(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
+convert_from_python_unfocused_inactive_border_color(PyObject *val, Options *opts) {
+    opts->unfocused_inactive_border_color = color_or_none_as_int(val);
+}
+
+static void
+convert_from_opts_unfocused_inactive_border_color(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "unfocused_inactive_border_color");
+    if (ret == NULL) return;
+    convert_from_python_unfocused_inactive_border_color(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
+convert_from_python_unfocused_border_brighten_factor(PyObject *val, Options *opts) {
+    opts->unfocused_border_brighten_factor = PyFloat_AsFloat(val);
+}
+
+static void
+convert_from_opts_unfocused_border_brighten_factor(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "unfocused_border_brighten_factor");
+    if (ret == NULL) return;
+    convert_from_python_unfocused_border_brighten_factor(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
 convert_from_python_inactive_text_alpha(PyObject *val, Options *opts) {
     opts->inactive_text_alpha = PyFloat_AsFloat(val);
 }
@@ -1598,6 +1650,14 @@ convert_opts_from_python_opts(PyObject *py_opts, Options *opts) {
     convert_from_opts_inactive_border_color(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_bell_border_color(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_border_ring_behavior(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_unfocused_active_border_color(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_unfocused_inactive_border_color(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_unfocused_border_brighten_factor(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_inactive_text_alpha(py_opts, opts);
     if (PyErr_Occurred()) return false;

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -66,6 +66,7 @@ option_names = (
     'bell_path',
     'bold_font',
     'bold_italic_font',
+    'border_ring_behavior',
     'box_drawing_scale',
     'clear_all_mouse_actions',
     'clear_all_shortcuts',
@@ -481,6 +482,9 @@ option_names = (
     'undercurl_style',
     'underline_exclusion',
     'underline_hyperlinks',
+    'unfocused_active_border_color',
+    'unfocused_border_brighten_factor',
+    'unfocused_inactive_border_color',
     'update_check_interval',
     'url_color',
     'url_excluded_characters',
@@ -539,6 +543,7 @@ class Options:
     bell_path: str | None = None
     bold_font: FontSpec = FontSpec(family=None, style=None, postscript_name=None, full_name=None, system='auto', axes=(), variable_name=None, features=(), created_from_string='auto')
     bold_italic_font: FontSpec = FontSpec(family=None, style=None, postscript_name=None, full_name=None, system='auto', axes=(), variable_name=None, features=(), created_from_string='auto')
+    border_ring_behavior: bool = False
     box_drawing_scale: tuple[float, float, float, float] = (0.001, 1.0, 1.5, 2.0)
     clear_all_mouse_actions: bool = False
     clear_all_shortcuts: bool = False
@@ -686,6 +691,9 @@ class Options:
     undercurl_style: choices_for_undercurl_style = 'thin-sparse'
     underline_exclusion: tuple[float, typing.Literal['', 'px', 'pt']] = (1.0, '')
     underline_hyperlinks: choices_for_underline_hyperlinks = 'hover'
+    unfocused_active_border_color: kitty.fast_data_types.Color | None = None
+    unfocused_border_brighten_factor: float = 0.15
+    unfocused_inactive_border_color: kitty.fast_data_types.Color | None = None
     update_check_interval: float = 24.0
     url_color: Color = Color(0, 135, 189)
     url_excluded_characters: str = ''

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -1467,6 +1467,17 @@ create_border_vao(void) {
     return vao_idx;
 }
 
+static color_type
+brighten_color(color_type color, float factor) {
+    uint8_t r = (color >> 16) & 0xFF;
+    uint8_t g = (color >> 8) & 0xFF;
+    uint8_t b = color & 0xFF;
+    r = (uint8_t)(r + (255 - r) * factor);
+    g = (uint8_t)(g + (255 - g) * factor);
+    b = (uint8_t)(b + (255 - b) * factor);
+    return (r << 16) | (g << 8) | b;
+}
+
 void
 draw_borders(ssize_t vao_idx, unsigned int num_border_rects, BorderRect *rect_buf, bool rect_data_is_dirty, color_type active_window_bg, unsigned int num_visible_windows, bool all_windows_have_same_bg, OSWindow *w) {
     float background_opacity = effective_os_window_alpha(w);
@@ -1481,10 +1492,22 @@ draw_borders(ssize_t vao_idx, unsigned int num_border_rects, BorderRect *rect_bu
         unmap_vao_buffer(vao_idx, 0);
     }
     color_type default_bg = (num_visible_windows > 1 && !all_windows_have_same_bg) ? OPT(background) : active_window_bg;
-    GLuint colors[9] = {
+
+    // Compute unfocused colors with brighten fallback
+    color_type unfocused_active = OPT(unfocused_active_border_color);
+    if (unfocused_active == 0) {
+        unfocused_active = brighten_color(default_bg, OPT(unfocused_border_brighten_factor));
+    }
+    color_type unfocused_inactive = OPT(unfocused_inactive_border_color);
+    if (unfocused_inactive == 0) {
+        unfocused_inactive = brighten_color(default_bg, OPT(unfocused_border_brighten_factor));
+    }
+
+    GLuint colors[11] = {
         default_bg, OPT(active_border_color), OPT(inactive_border_color), 0,
         OPT(bell_border_color), OPT(tab_bar_background), OPT(tab_bar_margin_color),
-        w->tab_bar_edge_color.left, w->tab_bar_edge_color.right
+        w->tab_bar_edge_color.left, w->tab_bar_edge_color.right,
+        unfocused_active, unfocused_inactive
     };
     glUniform1uiv(border_program_layout.uniforms.colors, arraysz(colors), colors);
     glUniform1f(border_program_layout.uniforms.background_opacity, background_opacity);

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -801,6 +801,10 @@ PYWRAP0(current_focused_os_window_id) {
     return PyLong_FromUnsignedLongLong(current_focused_os_window_id());
 }
 
+PYWRAP0(num_os_windows) {
+    return PyLong_FromUnsignedLongLong(global_state.num_os_windows);
+}
+
 
 PYWRAP1(handle_for_window_id) {
     id_type os_window_id;
@@ -1622,6 +1626,7 @@ static PyMethodDef module_methods[] = {
     MW(next_window_id, METH_NOARGS),
     MW(last_focused_os_window_id, METH_NOARGS),
     MW(current_focused_os_window_id, METH_NOARGS),
+    MW(num_os_windows, METH_NOARGS),
     MW(set_options, METH_VARARGS),
     MW(get_options, METH_NOARGS),
     MW(click_mouse_url, METH_VARARGS),

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -73,6 +73,9 @@ typedef struct Options {
     char_type *select_by_word_characters_forward;
     color_type url_color, background, foreground, active_border_color, inactive_border_color, bell_border_color, tab_bar_background, tab_bar_margin_color,
         window_title_bar_active_foreground, window_title_bar_active_background, window_title_bar_inactive_foreground, window_title_bar_inactive_background;
+    bool border_ring_behavior;
+    color_type unfocused_active_border_color, unfocused_inactive_border_color;
+    float unfocused_border_brighten_factor;
     monotonic_t repaint_delay, input_delay;
     bool focus_follows_mouse;
     unsigned int hide_window_decorations;


### PR DESCRIPTION
## Summary
Add an optional "border ring" behavior for multi-window focus retention.

When enabled and multiple kitty OS windows exist, the last-focused kitty OS window keeps its active border styling even after focus moves to a non-kitty application. This makes it easier to visually track the actual active pane across a single-instance kitty session spread over multiple top-level windows.

## New options
- `border_ring_behavior`
- `unfocused_active_border_color`
- `unfocused_inactive_border_color`
- `unfocused_border_brighten_factor`

## Behavior
- focus moves between kitty windows: normal active/inactive border behavior
- focus moves from kitty to a non-kitty app, with multiple kitty OS windows open:
  the last-focused kitty OS window keeps the active ring
- focus moves away with only a single kitty OS window open:
  borders behave as inactive as before

## Implementation notes
- expose `num_os_windows()` from C state
- use `last_focused_os_window_id()` plus `current_focused_os_window_id()` to decide the ring holder
- redraw borders across OS windows when focus changes
- add fallback unfocused border styling in shader/color plumbing

## Verification
- Python syntax checks pass for the touched Python modules
- patch rebased cleanly onto current `upstream/master`

I am not a C developer, so I would especially value critique on the implementation shape here. If the feature is useful but the plumbing is wrong, guidance on the preferred architecture would be very helpful.
