### PR TITLE
Add macos_fullscreen_ignore_safe_area_insets option

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -3419,6 +3419,7 @@ bool _glfwPlatformToggleFullscreen(_GLFWwindow* w, unsigned int flags) {
     NSWindow *window = w->ns.object;
     bool made_fullscreen = true;
     bool traditional = !(flags & 1);
+    bool ignore_safe_area_insets = flags & 2;
     NSWindowStyleMask sm = [window styleMask];
     if (traditional) {
         if (@available(macOS 10.15.7, *)) {
@@ -3438,12 +3439,14 @@ bool _glfwPlatformToggleFullscreen(_GLFWwindow* w, unsigned int flags) {
                 [window setStyleMask: NSWindowStyleMaskBorderless];
                 [[NSApplication sharedApplication] setPresentationOptions: NSApplicationPresentationAutoHideMenuBar | NSApplicationPresentationAutoHideDock];
                 NSRect screenFrame = [window.screen frame];
-                if (@available(macOS 12.0, *)) {
-                    screenFrame.size.height -= window.screen.safeAreaInsets.top;
+                if (!ignore_safe_area_insets) {
+                    if (@available(macOS 12.0, *)) {
+                        screenFrame.size.height -= window.screen.safeAreaInsets.top;
+                    }
                 }
                 [window setFrame:screenFrame display:YES];
                 w->ns.in_traditional_fullscreen = true;
-                _glfwUpdateNotchCover(w);
+                if (!ignore_safe_area_insets) _glfwUpdateNotchCover(w);
             } else {
                 made_fullscreen = false;
                 if (sm & NSWindowStyleMaskFullScreen) {

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -1502,6 +1502,8 @@ toggle_fullscreen_for_os_window(OSWindow *w) {
     if (!w->is_layer_shell) {
 #ifdef __APPLE__
         if (!OPT(macos_traditional_fullscreen)) return do_toggle_fullscreen(w, 1, false);
+        unsigned int flags = OPT(macos_fullscreen_ignore_safe_area_insets) ? 2u : 0u;
+        return do_toggle_fullscreen(w, flags, true);
 #endif
         return do_toggle_fullscreen(w, 0, true);
     }

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -2695,6 +2695,15 @@ pretty.
 '''
     )
 
+opt('macos_fullscreen_ignore_safe_area_insets', 'no',
+    option_type='to_bool', ctype='bool',
+    long_text='''
+When using :opt:`macos_traditional_fullscreen`, ignore the safe area insets on
+displays such as MacBook screens with a notch. This allows kitty to use the
+full display frame instead of leaving space for the notch area.
+'''
+    )
+
 opt('macos_show_window_title_in', 'all',
     choices=('all', 'menubar', 'none', 'window'), ctype='window_title_in',
     long_text='''

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -1094,6 +1094,9 @@ class Parser:
     def macos_dock_badge_on_bell(self, val: str, ans: dict[str, typing.Any]) -> None:
         ans['macos_dock_badge_on_bell'] = to_bool(val)
 
+    def macos_fullscreen_ignore_safe_area_insets(self, val: str, ans: dict[str, typing.Any]) -> None:
+        ans['macos_fullscreen_ignore_safe_area_insets'] = to_bool(val)
+
     def macos_hide_from_tasks(self, val: str, ans: dict[str, typing.Any]) -> None:
         ans['macos_hide_from_tasks'] = to_bool(val)
 

--- a/kitty/options/to-c-generated.h
+++ b/kitty/options/to-c-generated.h
@@ -1397,6 +1397,19 @@ convert_from_opts_macos_thicken_font(PyObject *py_opts, Options *opts) {
 }
 
 static void
+convert_from_python_macos_fullscreen_ignore_safe_area_insets(PyObject *val, Options *opts) {
+    opts->macos_fullscreen_ignore_safe_area_insets = PyObject_IsTrue(val);
+}
+
+static void
+convert_from_opts_macos_fullscreen_ignore_safe_area_insets(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "macos_fullscreen_ignore_safe_area_insets");
+    if (ret == NULL) return;
+    convert_from_python_macos_fullscreen_ignore_safe_area_insets(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
 convert_from_python_macos_traditional_fullscreen(PyObject *val, Options *opts) {
     opts->macos_traditional_fullscreen = PyObject_IsTrue(val);
 }
@@ -1670,6 +1683,8 @@ convert_opts_from_python_opts(PyObject *py_opts, Options *opts) {
     convert_from_opts_macos_option_as_alt(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_macos_hide_from_tasks(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_macos_fullscreen_ignore_safe_area_insets(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_macos_quit_when_last_window_closed(py_opts, opts);
     if (PyErr_Occurred()) return false;

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -386,6 +386,7 @@ option_names = (
     'macos_colorspace',
     'macos_custom_beam_cursor',
     'macos_dock_badge_on_bell',
+    'macos_fullscreen_ignore_safe_area_insets',
     'macos_hide_from_tasks',
     'macos_menubar_title_max_length',
     'macos_option_as_alt',
@@ -598,6 +599,7 @@ class Options:
     macos_colorspace: choices_for_macos_colorspace = 'srgb'
     macos_custom_beam_cursor: bool = False
     macos_dock_badge_on_bell: bool = True
+    macos_fullscreen_ignore_safe_area_insets: bool = False
     macos_hide_from_tasks: bool = False
     macos_menubar_title_max_length: int = 0
     macos_option_as_alt: int = 0

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -76,7 +76,7 @@ typedef struct Options {
     monotonic_t repaint_delay, input_delay;
     bool focus_follows_mouse;
     unsigned int hide_window_decorations;
-    bool macos_hide_from_tasks, macos_quit_when_last_window_closed, macos_window_resizable, macos_traditional_fullscreen;
+    bool macos_hide_from_tasks, macos_quit_when_last_window_closed, macos_window_resizable, macos_traditional_fullscreen, macos_fullscreen_ignore_safe_area_insets;
     unsigned int macos_option_as_alt;
     float macos_thicken_font;
     WindowTitleIn macos_show_window_title_in;


### PR DESCRIPTION
Adds a configuration option `macos_fullscreen_ignore_safe_area_insets` to allow ignoring the safe area insets when running in traditional full-screen mode on MacOS.

The motivation for this is that I personally run Kitty as my terminal emulator on Mac primarily because of its full-screen mode. A recent change in https://github.com/kovidgoyal/kitty/pull/9678 introduced respecting the safe area insets by shifting the window down, so the macbook notch doesn't overlap content in the terminal, which is a very reasonable default. I personally prefer to have the full-screen mode fill the entire screen and use all of the available screen real estate and accept that the notch will cover part of the tab bar. I think the proper handling of the notch should be content-aware (i.e. the content in the terminal to be shifted, so that the notch doesn't overlap it, but still have it be full screen), however that's a lot more work, so I added an option to opt out of that behavior.

I've tried to keep the diff minimal and most of the changes are just piping the configuration option to the cocoa window.

Not sure if there's appetite for such a feature, but maybe other folks also have this preference, so I thought I'd open a PR. If not, happy to run this as a personal fork, too.