### PR TITLE
Cache process_group_map() to fix high CPU when tab_title_template uses active_exe

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -185,6 +185,8 @@ Detailed list of changes
 
 - Allow optionally dragging URLs with the mouse, see :sc:`start_simple_selection` (:pull:`9804`)
 
+- Reduce CPU usage when ``tab_title_template`` uses ``active_exe`` by caching ``/proc`` scans during tab bar rendering (:iss:`9862`)
+
 - Change :opt:`focus_follows_mouse` to switch the active window only when the mouse crosses into a different window, instead of on every mouse motion event. Prevents accidental mouse bumps from undoing a keyboard-driven window switch.
 
 - Wayland: Use hold gestures to cancel momentum scrolling when fingers are placed on the trackpad, for a more natural kinetic scrolling experience (:iss:`9863`)

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1926,7 +1926,8 @@ class Boss:
     def update_tab_bar_data(self, os_window_id: int) -> None:
         tm = self.os_window_map.get(os_window_id)
         if tm is not None:
-            tm.update_tab_bar_data()
+            with cached_process_data(ttl=1.0):
+                tm.update_tab_bar_data()
 
     def on_drop_move(self, os_window_id: int, x: int, y: int, from_self: bool, is_leave: bool) -> None:
         if (tm := self.os_window_map.get(os_window_id)) is None:

--- a/kitty/child.py
+++ b/kitty/child.py
@@ -4,6 +4,7 @@
 import os
 import sys
 import termios
+import time
 from collections import defaultdict
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager, suppress
@@ -96,27 +97,58 @@ def checked_terminfo_dir() -> str | None:
     return terminfo_dir if os.path.isdir(terminfo_dir) else None
 
 
+_pgmap_cache: DefaultDict[int, list[int]] | None = None
+_pgmap_cache_at: float = 0.0
+_pgmap_ttl: float = 0.0
+_pgmap_depth: int = 0
+
+
+def _refresh_pgmap_cache() -> DefaultDict[int, list[int]]:
+    global _pgmap_cache, _pgmap_cache_at
+    try:
+        _pgmap_cache = process_group_map()
+    except Exception:
+        _pgmap_cache = defaultdict(list)
+    _pgmap_cache_at = time.monotonic()
+    return _pgmap_cache
+
+
 def processes_in_group(grp: int) -> list[int]:
-    gmap: DefaultDict[int, list[int]] | None = getattr(process_group_map, 'cached_map', None)
-    if gmap is None:
-        try:
-            gmap = process_group_map()
-        except Exception:
-            gmap = defaultdict(list)
+    if _pgmap_depth > 0 and _pgmap_cache is not None:
+        if _pgmap_ttl <= 0 or (time.monotonic() - _pgmap_cache_at) < _pgmap_ttl:
+            return _pgmap_cache.get(grp, [])
+    try:
+        gmap = process_group_map()
+    except Exception:
+        gmap = defaultdict(list)
     return gmap.get(grp, [])
 
 
 @contextmanager
-def cached_process_data() -> Generator[None, None, None]:
-    try:
-        cm = process_group_map()
-    except Exception:
-        cm = defaultdict(list)
-    setattr(process_group_map, 'cached_map', cm)
+def cached_process_data(ttl: float = 0.0) -> Generator[None, None, None]:
+    """Cache process_group_map() results within this context.
+
+    With ttl=0 (default), a fresh snapshot is taken on entry and cleared
+    on exit. Suitable for short-lived operations like listing windows.
+    With ttl>0, the snapshot is reused across calls if still within the
+    TTL window. Suitable for high-frequency callers like tab bar rendering.
+    """
+    global _pgmap_cache, _pgmap_cache_at, _pgmap_ttl, _pgmap_depth
+    prev_cache, prev_at, prev_ttl = _pgmap_cache, _pgmap_cache_at, _pgmap_ttl
+    _pgmap_ttl = ttl
+    if ttl > 0 and _pgmap_cache is not None and (time.monotonic() - _pgmap_cache_at) < ttl:
+        pass  # reuse existing cache
+    else:
+        _refresh_pgmap_cache()
+    _pgmap_depth += 1
     try:
         yield
     finally:
-        delattr(process_group_map, 'cached_map')
+        _pgmap_depth -= 1
+        if _pgmap_depth == 0:
+            _pgmap_cache, _pgmap_cache_at, _pgmap_ttl = prev_cache, prev_at, prev_ttl
+        else:
+            _pgmap_ttl = prev_ttl
 
 
 def session_id(pids: Iterable[int]) -> int:


### PR DESCRIPTION
Fixes #9862

Adds a `ttl` parameter to `cached_process_data()`:
- `ttl=0` (default): existing behavior, snapshot on entry, cleared on exit
- `ttl=1.0`: reuses cached results within the TTL window across calls

`update_tab_bar_data()` in `boss.py` now wraps with `cached_process_data(ttl=1.0)` so the `/proc` scan happens at most once per second across all OS windows and tabs.

`process_group_map()` is unchanged and continues to return live results.

Kept `cached_process_data()` with a `ttl` parameter rather than replacing it. Default `ttl=0` preserves existing snapshot behavior for `list_os_windows`/`close_windows_with_confirmation_msg`. Let me know if you'd prefer a different default or want the old codepath removed entirely.