### PR TITLE
Expose window activity state in the `kitty @ ls`

### DIFF
--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -129,6 +129,8 @@ class TabDict(TypedDict):
     is_active: bool
     title: str
     title_overridden: bool
+    needs_attention: bool
+    has_activity_since_last_focus: bool
     layout: str
     layout_state: dict[str, Any]
     layout_opts: dict[str, Any]
@@ -1444,6 +1446,8 @@ class TabManager:  # {{{
                         'is_active': tab is active_tab,
                         'title': tab.name or tab.title,
                         'title_overridden': bool(tab.name),
+                        'needs_attention': any(w.needs_attention for w in tab),
+                        'has_activity_since_last_focus': any(w.has_activity_since_last_focus for w in tab),
                         'layout': str(tab.current_layout.name),
                         'layout_state': tab.current_layout.serialize(tab.windows),
                         'layout_opts': tab.current_layout.layout_opts.serialized(),

--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -129,8 +129,6 @@ class TabDict(TypedDict):
     is_active: bool
     title: str
     title_overridden: bool
-    needs_attention: bool
-    has_activity_since_last_focus: bool
     layout: str
     layout_state: dict[str, Any]
     layout_opts: dict[str, Any]
@@ -1446,8 +1444,6 @@ class TabManager:  # {{{
                         'is_active': tab is active_tab,
                         'title': tab.name or tab.title,
                         'title_overridden': bool(tab.name),
-                        'needs_attention': any(w.needs_attention for w in tab),
-                        'has_activity_since_last_focus': any(w.has_activity_since_last_focus for w in tab),
                         'layout': str(tab.current_layout.name),
                         'layout_state': tab.current_layout.serialize(tab.windows),
                         'layout_opts': tab.current_layout.layout_opts.serialized(),

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -271,6 +271,8 @@ class WindowDict(TypedDict):
     in_alternate_screen: bool
     neighbors: NeighborsMap
     session_name: str
+    needs_attention: bool
+    has_activity_since_last_focus: bool
 
 
 class PipeData(TypedDict):
@@ -2160,6 +2162,8 @@ class Window:
             'in_alternate_screen': self.screen.is_using_alternate_linebuf(),
             'neighbors': neighbors_map,
             'session_name': self.created_in_session_name,
+            'needs_attention': self.needs_attention,
+            'has_activity_since_last_focus': self.has_activity_since_last_focus,
         }
 
     def serialize_state(self) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Adds two new fields to the kitty @ ls output at ~both~ the window ~and tab~ level:
- `needs_attention`
- `has_activity_since_last_focus`

~At the tab level, these are aggregated from all child windows.~

## Motivation

The `kitty @ ls` command currently provides no way to determine which windows or tabs have unseen activity. This information is already tracked internally (used for tab bar rendering, bell handling, etc.) but is not exposed to remote control consumers. Scripts and extensions that build custom UIs or status lines need this data to highlight tabs/windows that need attention.