### PR TITLE
Fix crash in overlay line drawing on uninitialized linebuf view

### DIFF
--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -4283,6 +4283,11 @@ screen_update_overlay_text(Screen *self, const char *utf8_text) {
 static void
 screen_draw_overlay_line(Screen *self) {
     if (!self->overlay_line.overlay_text) return;
+    // self->linebuf->line is a shared view that callers may not have pointed
+    // at the overlay row (e.g. render_line_for_virtual_y inits a stack-local
+    // Line instead). Without this, line->cpu_cells can be NULL or stale,
+    // crashing the cell loops below.
+    linebuf_init_line(self->linebuf, self->overlay_line.ynum);
     // Right-align the overlay to ensure that the pre-edit text just entered is visible when the cursor is near the end of the line.
     index_type xstart = self->overlay_line.text_len <= self->columns ? self->columns - self->overlay_line.text_len : 0;
     if (self->overlay_line.xstart < xstart) xstart = self->overlay_line.xstart;
@@ -6067,6 +6072,26 @@ test_create_write_buffer(Screen *screen UNUSED, PyObject *args UNUSED) {
 }
 
 static PyObject*
+test_draw_overlay_line(Screen *self, PyObject *args) {
+    PyObject *text;
+    unsigned int xstart, ynum;
+    if (!PyArg_ParseTuple(args, "UII", &text, &xstart, &ynum)) return NULL;
+    if (ynum >= self->lines || xstart >= self->columns) {
+        PyErr_SetString(PyExc_IndexError, "ynum or xstart out of range");
+        return NULL;
+    }
+    Py_INCREF(text);
+    Py_XDECREF(self->overlay_line.overlay_text);
+    self->overlay_line.overlay_text = text;
+    self->overlay_line.text_len = (index_type)PyUnicode_GET_LENGTH(text);
+    self->overlay_line.xstart = xstart;
+    self->overlay_line.ynum = ynum;
+    self->overlay_line.is_active = true;
+    screen_draw_overlay_line(self);
+    Py_RETURN_NONE;
+}
+
+static PyObject*
 test_commit_write_buffer(Screen *screen, PyObject *args) {
     RAII_PY_BUFFER(srcbuf); RAII_PY_BUFFER(destbuf);
     if (!PyArg_ParseTuple(args, "y*y*", &srcbuf, &destbuf)) return NULL;
@@ -6153,6 +6178,7 @@ static PyMethodDef methods[] = {
     METHODB(test_create_write_buffer, METH_NOARGS),
     METHODB(test_commit_write_buffer, METH_VARARGS),
     METHODB(test_parse_written_data, METH_VARARGS),
+    METHODB(test_draw_overlay_line, METH_VARARGS),
     MND(line_edge_colors, METH_NOARGS)
     MND(line, METH_O)
     MND(dump_lines_with_attrs, METH_VARARGS)

--- a/kitty_tests/multicell.py
+++ b/kitty_tests/multicell.py
@@ -14,6 +14,18 @@ class TestMulticell(BaseTest):
     def test_multicell(self):
         test_multicell(self)
 
+    def test_overlay_line_does_not_crash_on_uninit_linebuf_view(self):
+        # Regression: screen_draw_overlay_line accessed self->linebuf->line->cpu_cells
+        # without ever calling linebuf_init_line, so on render paths that
+        # initialize a stack-local Line (render_line_for_virtual_y) the shared
+        # view's cpu_cells stayed NULL and the multicell-trim loop dereferenced
+        # NULL + xstart * sizeof(CPUCell). Reproduces by placing a wide cell at
+        # xstart>0 and triggering the overlay draw directly.
+        for xstart in (1, 2, 3):
+            s = self.create_screen(cols=10, lines=5)
+            s.draw('好好')  # two 2-cell wide chars covering columns 0..3
+            s.test_draw_overlay_line('xy', xstart, 0)  # would SIGSEGV without fix
+
 
 def test_multicell(self: TestMulticell) -> None:
     from kitty.tab_bar import as_rgb


### PR DESCRIPTION
## Bug

`screen_draw_overlay_line` accesses `self->linebuf->line->cpu_cells` to trim multicell characters that intersect the overlay's left boundary, but never calls `linebuf_init_line` to point that shared view at the overlay row. On render paths that initialize a stack-local `Line` via `render_line_for_virtual_y` instead (the common path through `update_line_data`), `self->linebuf->line` keeps whatever state it had from an unrelated earlier call — and on a freshly allocated `LineBuf` that is `cpu_cells == NULL` (set by `alloc_line` via `PyType_GenericAlloc`).

When the user types into an IME pre-edit overlay with the cursor not in column 0 and a multicell glyph at the boundary, the trim loop dereferences `NULL + xstart * sizeof(CPUCell)` — SIGSEGV at a small address (`0x1e` for `xstart=2`, `0x2a` for `xstart=3`, etc.).

I have observed this in the wild on kitty-git under niri/Wayland with fcitx5 — two long-running kitty instances crashed within one second of each other, both with identical register state (`rbp = NULL`, `rcx = 0x18`, faulting on `testb \$0x2,0x6(%rcx)`). Verified the offsets `0x250 → 0x40 → 0x18` map exactly to `Screen->linebuf->line->cpu_cells` via `pahole` on a debug build.

## Repro

A 4-line script reliably crashes master (exit 139):

\`\`\`python
from kitty.fast_data_types import Screen
s = Screen(None, 5, 10, 5, 10, 20, 0, None)
s.draw('好好')                            # multicell wide chars at cols 0..3
s.test_draw_overlay_line('xy', 2, 0)      # SIGSEGV — NULL + 2*sizeof(CPUCell)
\`\`\`

(`test_draw_overlay_line` is the small test helper added in this PR.)

## Fix

Call `linebuf_init_line(self->linebuf, self->overlay_line.ynum)` at the top of `screen_draw_overlay_line`. Idempotent on the path that already initializes it (line 3653 in screen.c), and removes the hidden assumption everywhere else.

## Test

`kitty_tests/multicell.py::TestMulticell::test_overlay_line_does_not_crash_on_uninit_linebuf_view` exercises the crash directly via the new helper. Verified red→green: removing the one-line fix makes the test SIGSEGV; with the fix the full suite (312 tests) passes.