### PR TITLE
macos: explicitly enable modern window corners on macOS 26

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -3918,6 +3918,18 @@ apply_titlebar_color_settings(_GLFWwindow *window) {
 #undef tc
 }
 
+static void
+apply_window_corner_curve(_GLFWwindow *window) {
+    if (!window || !window->decorated) return;
+    if (@available(macOS 26.0, *)) {
+        GLFWWindow *nsw = window->ns.object;
+        NSView *frame_view = nsw.contentView.superview;
+        CALayer *layer = frame_view.layer;
+        if (!layer) return;
+        layer.cornerCurve = kCACornerCurveContinuous;
+    }
+}
+
 
 
 GLFWAPI void glfwCocoaSetWindowChrome(GLFWwindow *w, unsigned int color, bool use_system_color, unsigned int system_color, int background_blur, unsigned int hide_window_decorations, bool show_text_in_titlebar, int color_space, float background_opacity, bool resizable) { @autoreleasepool {
@@ -4033,6 +4045,7 @@ GLFWAPI void glfwCocoaSetWindowChrome(GLFWwindow *w, unsigned int color, bool us
     }
 #undef tc
     apply_titlebar_color_settings(window);
+    apply_window_corner_curve(window);
 
     // HACK: Changing the style mask can cause the first responder to be cleared
     [nsw makeFirstResponder:window->ns.view];

--- a/glfw/glfw.py
+++ b/glfw/glfw.py
@@ -175,7 +175,7 @@ def init_env(
 
     elif module == 'cocoa':
         ans.cppflags.append('-DGL_SILENCE_DEPRECATION')
-        for f_ in 'Cocoa IOKit CoreFoundation CoreVideo UniformTypeIdentifiers'.split():
+        for f_ in 'Cocoa IOKit CoreFoundation CoreVideo QuartzCore UniformTypeIdentifiers'.split():
             ans.ldpaths.extend(('-framework', f_))
 
     elif module == 'wayland':


### PR DESCRIPTION
## Summary

This change explicitly enables the modern window corner style on macOS 26 while preserving the existing behavior on older macOS versions.

## Motivation

On newer macOS releases, the system can present updated window corner styling. However, builds targeting older SDKs or older deployment environments do not use the newer appearance automatically, even when running on macOS 26.

To keep compatibility with older macOS versions, this change applies the new corner styling explicitly only on macOS 26 and later, while leaving earlier versions unchanged.

## Changes

- Add a runtime macOS version check for macOS 26+
- Explicitly apply the newer window corner curve on supported systems
- Keep behavior unchanged on macOS versions below 26
- Link against `QuartzCore` for the required corner curve symbol

## Compatibility

This change is intentionally conservative:

- macOS 26 and later: use the modern corner style explicitly
- macOS 25 and earlier: no behavior change

This ensures we support the new appearance on macOS 26 without affecting users on older releases.


before:
<img width="542" height="424" alt="before" src="https://github.com/user-attachments/assets/4fc3bd6c-8947-4c69-9b7b-6aa650c305b8" />

after:
<img width="541" height="421" alt="after" src="https://github.com/user-attachments/assets/f74814e8-5f7f-43af-b93f-b2d4c1948208" />

diff:
<img width="630" height="481" alt="diff" src="https://github.com/user-attachments/assets/049144cb-1648-40fa-a231-9c6607b225c1" />

