### PR TITLE
Add focus_follows_drop option to focus window on drop done

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -1998,6 +1998,8 @@ class Boss:
                     if window.is_visible_in_layout:
                         g = window.geometry
                         if g.left <= x < g.right and g.top <= y < g.bottom:
+                            if get_options().focus_follows_drop and window is not tab.active_window:
+                                tab.set_active_window(window)
                             window.on_drop(drop)
                             break
         elif tab_bar.left <= x < tab_bar.right and tab_bar.top <= y < tab_bar.bottom:

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -866,6 +866,15 @@ mouse enters it, as long as the kitty application is the active application.
 '''
     )
 
+opt('focus_follows_drop', 'no',
+    option_type='to_bool',
+    long_text='''
+When something is dropped onto a window, automatically focus that window. If
+disabled (the default), the drop content is delivered to the target window but
+keyboard focus remains on the previously active window.
+'''
+    )
+
 opt('pointer_shape_when_grabbed', 'arrow',
     choices=pointer_shape_names, ctype='pointer_shape',
     long_text='''

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -362,6 +362,7 @@ option_names = (
     'exe_search_path',
     'file_transfer_confirmation_bypass',
     'filter_notification',
+    'focus_follows_drop',
     'focus_follows_mouse',
     'font_family',
     'font_features',
@@ -578,6 +579,7 @@ class Options:
     enable_audio_bell: bool = True
     enabled_layouts: list[str] = ['fat', 'grid', 'horizontal', 'splits', 'stack', 'tall', 'vertical']
     file_transfer_confirmation_bypass: str = ''
+    focus_follows_drop: bool = False
     focus_follows_mouse: bool = False
     font_family: FontSpec = FontSpec(family=None, style=None, postscript_name=None, full_name=None, system='monospace', axes=(), variable_name=None, features=(), created_from_string='monospace')
     font_size: float = 11.0


### PR DESCRIPTION
Add a new `focus_follows_drop` option (default: `no`) that, when enabled, automatically focuses the window that receives a drop.

### The problem

When using splits, dropping something onto a non-active window delivers the drop content correctly (via `window.on_drop()`), but keyboard focus remains on the previously active window. The user has to manually click the target window after every drag-and-drop to continue working in it.

### The fix

A new boolean option `focus_follows_drop` (default: `no`). When enabled, `tab.set_active_window(window)` is called before `window.on_drop(drop)` in `Boss.on_drop()`, so the window that receives the drop also receives keyboard focus.

### What's changed

- `kitty/options/definition.py` — new `focus_follows_drop` option
- `kitty/options/types.py` — generated type entry
- `kitty/boss.py` — guard `set_active_window` behind `get_options().focus_follows_drop`

### What's NOT affected

- Tab dragging (`application/net.kovidgoyal.kitty-tab-*` path) — unchanged
- Window dragging (`application/net.kovidgoyal.kitty-window-*` path) — unchanged
- Tab bar drops — unchanged
- Single-window tabs — the guard `window is not tab.active_window` makes this a no-op
- Default behavior — unchanged (`focus_follows_drop` defaults to `no`)

### Testing

1. Add `focus_follows_drop yes` to `kitty.conf`
2. Open kitty with splits layout
3. Focus the left split
4. Drag something onto the right split
5. **Before**: drop content arrives in right split, but keyboard focus stays on left split
6. **After**: right split receives both the drop and keyboard focus