### PR TITLE
feat: respawn_window

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -168,6 +168,8 @@ Detailed list of changes
 0.47.0 [future]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+- A new action :ac:`respawn_window` to restart the shell in the currently active window without changing its position in the layout. Supports ``--cwd``, ``--env``, ``--hold``, and command arguments.
+
 - A new option :opt:`palette_generate` to automatically generate the 256 color palette from the first 16 colors (:pull:`9426`)
 
 - For builtin key mappings automatically :ref:`fallback <mapping-fallback>` to matching the US-PC layout key when the pressed key has no matches and is a non-English character (:pull:`9671`)

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -3085,6 +3085,53 @@ class Boss:
             opts.next_to = opts.next_to or f'id:{self.window_for_dispatch.id}'
         launch(self, opts, args_)
 
+    @ac('win', '''
+Respawn the currently active window
+
+Restart the shell in the currently active window without changing its position
+in the layout. The terminal screen will be cleared and a new shell will start.
+Supports :code:`--cwd`, :code:`--env`, :code:`--hold`, and command arguments::
+
+    map f5 respawn_window
+    map ctrl+f5 respawn_window --cwd current
+    map shift+f5 respawn_window --cwd /some/path
+    map alt+f5 respawn_window --env FOO=bar /bin/zsh
+''')
+    def respawn_window(self, *args: str) -> None:
+        from kitty.launch import get_env, parse_launch_args
+        from kitty.window import CwdRequest, CwdRequestType
+
+        window = self.window_for_dispatch or self.active_window
+        if not window:
+            return
+
+        try:
+            opts, cmd_args = parse_launch_args(args)
+        except ValueError as e:
+            self.show_error(_('Invalid arguments'), str(e))
+            return
+
+        cwd: str | None = None
+        cwd_from: CwdRequest | None = None
+        if opts.cwd:
+            if opts.cwd == 'current':
+                cwd_from = CwdRequest(window)
+            elif opts.cwd == 'last_reported':
+                cwd_from = CwdRequest(window, CwdRequestType.last_reported)
+            elif opts.cwd == 'oldest':
+                cwd_from = CwdRequest(window, CwdRequestType.oldest)
+            elif opts.cwd == 'root':
+                cwd_from = CwdRequest(window, CwdRequestType.root)
+            else:
+                cwd = opts.cwd
+
+        env = get_env(opts, window.child) or None
+        argv = cmd_args or None
+
+        if not window.respawn_child(cwd=cwd, argv=argv, env=env, cwd_from=cwd_from,
+                                    hold=opts.hold, hold_after_ssh=opts.hold_after_ssh):
+            self.show_error(_('Respawn failed'), _('Failed to respawn window'))
+
     @ac('tab', 'Move the active tab forward. You can also use drag and drop to re-arrange tabs.')
     def move_tab_forward(self) -> None:
         tm = self.active_tab_manager

--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -321,6 +321,49 @@ add_child(ChildMonitor *self, PyObject *args) {
     Py_RETURN_NONE;
 }
 
+static PyObject *
+replace_child(ChildMonitor *self, PyObject *args) {
+#define replace_child_doc "replace_child(id, pid, fd, screen) -> Replace the child process for a window, updating pid/fd/screen. Used by respawn_window."
+    id_type id;
+    int pid, fd;
+    PyObject *screen;
+    if (!PyArg_ParseTuple(args, "kiiO", &id, &pid, &fd, &screen)) {
+        return NULL;
+    }
+    children_mutex(lock);
+    bool found = false;
+    for (size_t i = 0; i < self->count; i++) {
+        if (children[i].id == id) {
+            // Drain old screen's write buffer so stale input is not sent to new child
+            {
+                Screen *screen = children[i].screen;
+                screen_mutex(lock, write);
+                screen->write_buf_used = 0;
+                screen_mutex(unlock, write);
+            }
+
+            children[i].pid = pid;
+            children[i].fd = fd;
+            children_fds[EXTRA_FDS + i].fd = fd;
+            Py_DECREF(children[i].screen);
+            children[i].screen = (Screen*)screen;
+            Py_INCREF(screen);
+            // Clear removal flag: if the old child died before this call,
+            // needs_removal may already be set. Reset it so the window survives.
+            children[i].needs_removal = false;
+            found = true;
+            break;
+        }
+    }
+    children_mutex(unlock);
+    if (!found) {
+        PyErr_SetString(PyExc_KeyError, "Child with given id not found");
+        return NULL;
+    }
+    wakeup_io_loop(self, false);
+    Py_RETURN_NONE;
+}
+
 static const unsigned write_buf_limit = 100 * 1024 * 1024;
 
 #define schedule_write_to_child_generic(id, num, va_start, get_next_arg, va_end, found, too_much_data) \
@@ -2115,6 +2158,7 @@ send_response_to_peer(id_type peer_id, const char *msg, size_t msg_sz, bool is_a
 // Boilerplate {{{
 static PyMethodDef methods[] = {
     METHOD(add_child, METH_VARARGS)
+    METHOD(replace_child, METH_VARARGS)
     METHOD(inject_peer, METH_O)
     METHOD(needs_write, METH_VARARGS)
     METHOD(start, METH_NOARGS)

--- a/kitty/child.py
+++ b/kitty/child.py
@@ -261,6 +261,7 @@ class Child:
         self.id = next(child_counter)
         self.add_listen_on_env_var = add_listen_on_env_var
         self.argv = list(argv)
+        self.argv_before_cwd_rewrite = list(argv)
         self.pass_fds = pass_fds
         self.remote_control_fd = remote_control_fd
         if cwd_from:
@@ -421,6 +422,71 @@ class Child:
             except OSError as err:
                 log_error("Could not move child process into a systemd scope: " + str(err))
         return pid
+
+    def respawn(
+        self, cwd: str | None = None, argv: list[str] | None = None,
+        env: dict[str, str] | None = None, cwd_from: 'CwdRequest | None' = None,
+        hold: bool = False, hold_after_ssh: bool = False,
+    ) -> tuple[int, int] | None:
+        """Respawn the child process with a new shell.
+
+        Args:
+            cwd: Working directory for the new process. If None, keeps previous cwd.
+            argv: Optional command to run (defaults to original argv)
+            env: Additional environment variables to merge into child env.
+            cwd_from: CwdRequest for resolving cwd. May rewrite argv for ssh kitten sessions.
+            hold: Keep window open after child exits.
+            hold_after_ssh: Keep window open after ssh session ends.
+
+        Returns:
+            A tuple of (old_pid, old_fd) on success, or None if failed.
+            The new child is blocked on terminal_ready_fd, so the caller
+            can safely dup2 and swap the screen before it produces output.
+        """
+        if not self.forked:
+            return None
+
+        old_pid = self.pid
+        old_fd = self.child_fd
+        old_id = self.id
+        self.forked = False
+
+        # Get a new id like a new Child would, so systemd scope name is unique
+        self.id = next(child_counter)
+
+        if argv is not None:
+            self.argv = list(argv)
+            self.argv_before_cwd_rewrite = list(argv)
+        else:
+            # Reset to pre-rewrite argv so modify_argv_for_launch_with_cwd
+            # starts from the original command, not a previously rewritten one
+            self.argv = list(self.argv_before_cwd_rewrite)
+        if env is not None:
+            self.env.update(env)
+        self.hold = hold
+
+        # Resolve cwd, rewriting argv for ssh sessions if needed
+        # (mirrors the logic in Child.__init__).
+        if cwd_from:
+            try:
+                resolved = cwd_from.modify_argv_for_launch_with_cwd(self.argv, self.env, hold_after_ssh=hold_after_ssh) or cwd or self.cwd
+            except Exception as err:
+                log_error(f'Failed to read cwd of {cwd_from} with error: {err}')
+                resolved = cwd or self.cwd
+            self.cwd = os.path.abspath(resolved)
+        else:
+            self.cwd = os.path.expandvars(os.path.expanduser(cwd or self.cwd))
+
+        new_pid = self.fork()
+        if new_pid is None:
+            # fork failed, restore state so the old child remains functional
+            self.forked = True
+            self.pid = old_pid
+            self.child_fd = old_fd
+            self.id = old_id
+            return None
+
+        return old_pid, old_fd
 
     def __del__(self) -> None:
         fd = getattr(self, 'terminal_ready_fd', -1)

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -78,7 +78,7 @@ class InvalidMods(ValueError):
     'pass_selection_to_program', 'new_window', 'new_tab', 'new_os_window',
     'new_window_with_cwd', 'new_tab_with_cwd', 'new_os_window_with_cwd',
     'launch', 'mouse_handle_click', 'show_error', 'goto_session', 'save_as_session',
-    'close_session',
+    'close_session', 'respawn_window',
     )
 def shlex_parse(func: str, rest: str) -> FuncArgsType:
     return func, to_cmdline(rest)

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -1918,6 +1918,65 @@ class Window:
                 import traceback
                 traceback.print_exc()
 
+    def respawn_child(
+        self, cwd: str | None = None, argv: list[str] | None = None,
+        env: dict[str, str] | None = None, cwd_from: 'CwdRequest | None' = None,
+        hold: bool = False, hold_after_ssh: bool = False,
+    ) -> bool:
+        import signal
+
+        if not self.child or self.destroyed:
+            return False
+
+        # Fork new child process. The new child is blocked on
+        # terminal_ready_fd until mark_terminal_ready() is called during
+        # relayout, so it cannot produce output yet.
+        result = self.child.respawn(cwd=cwd, argv=argv, env=env, cwd_from=cwd_from,
+                                    hold=hold, hold_after_ssh=hold_after_ssh)
+        if result is None:
+            return False
+        old_pid, old_fd = result
+
+        # Redirect old_fd to the new child's pty via dup2.
+        # Safe because the new child is still blocked on terminal_ready_fd.
+        new_fd = self.child.child_fd
+        if new_fd != old_fd:
+            os.dup2(new_fd, old_fd)
+            os.close(new_fd)
+            self.child.child_fd = old_fd
+
+        # Now swap the screen in the child monitor.
+        cell_width, cell_height = cell_size_for_window(self.os_window_id)
+        opts = get_options()
+        self.screen = Screen(self, 24, 80, opts.scrollback_lines, cell_width, cell_height, self.id)
+        get_boss().child_monitor.replace_child(self.id, self.child.pid, old_fd, self.screen)
+
+        # Kill the old process group — matching the normal close path
+        # (hangup() in child-monitor.c uses killpg). Safe because
+        # replace_child already updated the pid, so mark_child_for_removal
+        # won't match.
+        with suppress(ProcessLookupError, OSError):
+            pgid = os.getpgid(old_pid)
+            os.killpg(pgid, signal.SIGHUP)
+
+        # Reset state so set_geometry will initialize the new child properly
+        self.needs_layout = True
+        self.child_is_launched = False
+        self.last_reported_pty_size = (-1, -1, -1, -1)
+        self._pause_resize_notifications_to_child = None
+        self.finish_scroll_animation()
+        self.kitten_result = None
+        self.kitten_result_processors = []
+        if hasattr(self, '_file_transmission'):
+            del self._file_transmission
+
+        # Trigger relayout to connect new screen to renderer
+        tab = self.tabref()
+        if tab is not None:
+            tab.relayout()
+
+        return True
+
     def destroy(self) -> None:
         self.call_watchers(self.watchers.on_close, {})
         self.destroyed = True

--- a/kitty_tests/respawn.py
+++ b/kitty_tests/respawn.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+# License: GPLv3 Copyright: 2026, Kovid Goyal <kovid at kovidgoyal.net>
+
+import os
+import signal
+import tempfile
+import time
+from contextlib import suppress
+
+from . import BaseTest
+
+
+class FakeBoss:
+    encryption_public_key = 'test_key'
+    listening_on = ''
+
+
+class TestRespawn(BaseTest):
+
+    def setUp(self):
+        super().setUp()
+        from kitty.fast_data_types import get_boss, set_boss
+        self.set_options()
+        self._old_boss = get_boss()
+        set_boss(FakeBoss())
+        self._pids: list[int] = []
+        self._fds: set[int] = set()
+        self._tmpdirs: list[str] = []
+
+    def tearDown(self):
+        from kitty.fast_data_types import set_boss
+        for pid in self._pids:
+            with suppress(ProcessLookupError):
+                os.kill(pid, signal.SIGTERM)
+        for fd in self._fds:
+            with suppress(OSError):
+                os.close(fd)
+        for d in self._tmpdirs:
+            with suppress(OSError):
+                os.rmdir(d)
+        set_boss(self._old_boss)
+        super().tearDown()
+
+    def _tmpdir(self) -> str:
+        d = tempfile.mkdtemp()
+        self._tmpdirs.append(d)
+        return d
+
+    def _make_child(self, code: str = 'import time; time.sleep(100)', cwd: str | None = None):
+        from kitty.child import Child
+        if cwd is None:
+            cwd = self._tmpdir()
+        child = Child(self.cmd_to_run_python_code(code), cwd)
+        child.fork()
+        child.mark_terminal_ready()
+        self._pids.append(child.pid)
+        self._fds.add(child.child_fd)
+        return child
+
+    def _respawn(self, child, **kwargs):
+        result = child.respawn(**kwargs)
+        self.assertIsNotNone(result)
+        child.mark_terminal_ready()
+        old_pid, old_fd = result
+        self._pids.append(child.pid)
+        self._fds.add(child.child_fd)
+        return old_pid, old_fd
+
+    def _read_child_output(self, fd: int, timeout: float = 0.3) -> bytes:
+        os.set_blocking(fd, False)
+        time.sleep(timeout)
+        with suppress(BlockingIOError):
+            return os.read(fd, 4096)
+        return b''
+
+    def test_child_respawn_basic(self):
+        """Test that Child.respawn() creates a new process and returns old pid/fd."""
+        child = self._make_child()
+        old_pid, old_fd = child.pid, child.child_fd
+
+        new_cwd = self._tmpdir()
+        returned_old_pid, returned_old_fd = self._respawn(
+            child, cwd=new_cwd,
+            argv=self.cmd_to_run_python_code('print("respawned", flush=True); import time; time.sleep(100)'),
+        )
+
+        self.assertEqual(returned_old_pid, old_pid)
+        self.assertEqual(returned_old_fd, old_fd)
+        self.assertNotEqual(child.pid, old_pid)
+        self.assertIn(b'respawned', self._read_child_output(child.child_fd))
+
+        proc_cwd = os.readlink(f'/proc/{child.pid}/cwd')
+        self.assertEqual(os.path.realpath(proc_cwd), os.path.realpath(new_cwd))
+
+    def test_child_respawn_env(self):
+        """Test that respawn merges new env vars."""
+        child = self._make_child()
+        self._respawn(
+            child,
+            env={'KITTY_TEST_RESPAWN_VAR': 'test_value'},
+            argv=self.cmd_to_run_python_code(
+                'import os; print(os.environ["KITTY_TEST_RESPAWN_VAR"], flush=True); import time; time.sleep(100)'
+            ),
+        )
+        self.assertIn(b'test_value', self._read_child_output(child.child_fd))
+
+    def test_child_respawn_hold(self):
+        """Test that respawn with hold=True sets the hold flag."""
+        child = self._make_child()
+        self.assertFalse(child.hold)
+        old_pid = child.pid
+
+        self._respawn(child, hold=True)
+
+        self.assertTrue(child.hold)
+        self.assertNotEqual(child.pid, old_pid)
+        os.kill(child.pid, 0)  # verify process is alive
+
+    def test_child_respawn_repeated(self):
+        """Test that respawning multiple times doesn't corrupt argv."""
+        child = self._make_child()
+        original_argv = list(child.argv)
+
+        for i in range(2):
+            self._respawn(child)
+            self.assertEqual(child.argv_before_cwd_rewrite, original_argv,
+                             f'argv corrupted after respawn #{i+1}')
+
+    def test_child_respawn_not_forked(self):
+        """Test that respawn returns None if child was never forked."""
+        from kitty.child import Child
+        child = Child(self.cmd_to_run_python_code('pass'), '/tmp')
+        self.assertIsNone(child.respawn())
+
+    def test_dup2_fd_reuse(self):
+        """Test the dup2 trick: after dup2(new_fd, old_fd), reading old_fd gives new child's output."""
+        import pty
+        old_master, old_slave = pty.openpty()
+        new_master, new_slave = pty.openpty()
+
+        pid = os.fork()
+        if pid == 0:
+            os.close(old_master)
+            os.close(old_slave)
+            os.close(new_master)
+            os.dup2(new_slave, 1)
+            os.close(new_slave)
+            os.write(1, b'from_new_child\n')
+            os._exit(0)
+
+        os.close(old_slave)
+        os.close(new_slave)
+        os.dup2(new_master, old_master)
+        os.close(new_master)
+
+        self.assertIn(b'from_new_child', self._read_child_output(old_master, timeout=0.2))
+        os.close(old_master)
+        os.waitpid(pid, 0)


### PR DESCRIPTION
Add a `respawn_window` action that restarts the shell (or any child process) in the currently active window without changing its position in the layout.

### Usage

```conf
map f5 respawn_window
map ctrl+f5 respawn_window --cwd current
map shift+f5 respawn_window --cwd /some/path
map alt+f5 respawn_window --env FOO=bar /bin/zsh
```

Supports `--cwd` (including `current`, `last_reported`, `oldest`, `root`), `--env`, `--copy-env`, `--hold`, `--hold-after-ssh`, and positional command arguments. Works correctly in ssh kitten sessions — `respawn_window --cwd current` in an ssh window will re-establish the ssh connection with the remote cwd preserved.

### Motivation

Sometimes a terminal window becomes unresponsive — a hung process, a broken pipe, or a stale ssh session. Currently the only option is to close the window and open a new one, which loses the window's position in the layout and requires navigating back to the desired working directory. `respawn_window` solves this by replacing the child process in-place: the window, its layout position, and its id all remain unchanged. Tmux has a `respawn-pane` action that does exact this thing.

### Implementation notes

The core challenge is that kitty's io_thread continuously `poll()`s on child file descriptors in a separate thread. Normal launch/kill operations update the fd list safely because the changes happen inside the io_loop itself (via `add_queue`/`remove_children`), before the next `poll()` call. But for respawn, using `remove_children` + `add_children` would trigger `death_notify`, which runs the normal window close flow — exactly what we want to avoid. Adding a new "replace queue" would require more invasive changes to the io_loop. Instead, we use `dup2` to swap the underlying pty while keeping the fd number unchanged, so the io_thread transitions seamlessly without any queue mechanism:

1. **Fork a new child process**, which creates a new pty pair. The new child is blocked on `terminal_ready_fd` — it cannot produce output until `mark_terminal_ready()` is called during relayout.
2. **`dup2(new_fd, old_fd)`** — redirect the old fd (which the io_thread is polling) to the new pty. The fd number stays the same, so the io_thread transitions seamlessly. Safe because the new child is still blocked.
3. **`replace_child()` in C** — atomically swap the pid, screen, and clear `needs_removal` in the child monitor.
4. **Relayout** triggers `mark_terminal_ready()`, unblocking the new child. Output goes directly into the new screen.
5. **`killpg(old_pgid, SIGHUP)`** — kill the old process group, matching the normal window close path (`hangup()` in `child-monitor.c`).

The `terminal_ready_fd` mechanism guarantees the new child cannot produce output before the screen swap, so there is no race between dup2 and replace_child.

**Argv preservation for ssh sessions:** When a window is launched with `--cwd=current` from an ssh kitten session, `Child.__init__` rewrites `self.argv` from the original shell (e.g., `['/bin/zsh']`) to the ssh kitten command line via `modify_argv_for_launch_with_cwd`. This rewrite is in-place and destructive. Without care, `respawn()` would pass the already-rewritten ssh command line back to `modify_argv_for_launch_with_cwd`, causing double-rewriting and a corrupted command. To prevent this, `Child` saves `argv_before_cwd_rewrite` before the rewrite in `__init__`, and `respawn()` always resets `self.argv` from it before calling `modify_argv_for_launch_with_cwd` again.

**Files changed:**

| File | Purpose |
|------|---------|
| `kitty/boss.py` | `respawn_window` action, argument parsing consistent with `launch` |
| `kitty/child.py` | `Child.respawn()` — forks new process, supports cwd/argv/env/cwd_from/hold; restores state on fork failure |
| `kitty/child-monitor.c` | `replace_child()` — atomically swaps pid/screen/fd in the child monitor |
| `kitty/window.py` | `Window.respawn_child()` — orchestrates dup2, replace_child, and cleanup |
| `kitty/options/utils.py` | Register `respawn_window` for `shlex_parse` argument handling |
| `docs/changelog.rst` | Changelog entry under 0.47.0 |
| `kitty_tests/respawn.py` | Tests: basic respawn, env propagation, hold, repeated respawn, not-forked guard, dup2 fd reuse |
