### PR TITLE
Fix bug #9215 cmd+` now cycles windows properly on MacOS Tahoe

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -4088,6 +4088,9 @@ glfwCocoaCycleThroughOSWindows(bool backwards) {
         ) [filteredWindows addObject:window];
     }
     if (filteredWindows.count < 2) return;
+    [filteredWindows sortUsingComparator:^NSComparisonResult(NSWindow *a, NSWindow *b) {
+        return [@(a.windowNumber) compare:@(b.windowNumber)];
+    }];
     NSWindow *keyWindow = [NSApp keyWindow];
     NSUInteger index = [filteredWindows indexOfObject:keyWindow];
     NSUInteger nextIndex = 0;


### PR DESCRIPTION
## Fix macOS window cycling skipping windows due to z-order mutation

Fixes #9215.

### Root cause

1. `[NSApp windows]` returns windows in z-order (frontmost first): [A, B, C]
2. Key window is A (index 0), so next is B (index 1)
3. `makeKeyAndOrderFront:` is called on B — this reorders the windows, B is now front: [B, A, C]
4. Next cycle: key is B (index 0), so next is A (index 1)
5. A is brought to front: [A, B, C] — right back to step 1
6. C is never visited

### Fix

The fix was to sort `filteredWindows` by a stable identifier (`windowNumber`) instead of relying on
the z-order from `[NSApp windows]`, so the cycling order doesn't change when
`makeKeyAndOrderFront`: reorders windows.