### PR TITLE
Guard line buffer copy bounds

### DIFF
--- a/kitty/line-buf.c
+++ b/kitty/line-buf.c
@@ -292,6 +292,7 @@ copy_line_to(LineBuf *self, PyObject *args) {
     unsigned int y;
     Line src, *dest;
     if (!PyArg_ParseTuple(args, "IO!", &y, &Line_Type, &dest)) return NULL;
+    if (y >= self->ynum) { PyErr_SetString(PyExc_ValueError, "Out of bounds"); return NULL; }
     src.xnum = self->xnum; dest->xnum = self->xnum;
     dest->ynum = y;
     dest->attrs = self->line_attrs[y];

--- a/kitty_tests/datatypes.py
+++ b/kitty_tests/datatypes.py
@@ -279,6 +279,8 @@ class TestDataTypes(BaseTest):
         l2 = lb.create_line_copy(2)
         lb.copy_line_to(1, l2)
         self.ae(l2, lb2.line(2))
+        with self.assertRaises(ValueError):
+            lb.copy_line_to(lb.ynum, l2)
         lb.clear_line(0)
         self.ae(lb.line(0), LineBuf(1, lb.xnum).create_line_copy(0))
         lb = filled_line_buf(5, 5, filled_cursor())


### PR DESCRIPTION
## Summary
- reject out-of-range `LineBuf.copy_line_to()` row indices before indexing line buffer storage
- add regression coverage for the Python-facing out-of-bounds copy path

## Motivation / Bug
`LineBuf.copy_line_to()` accepts a row index from Python and previously used it directly to index `line_attrs`, `line_map`, and the backing cell storage. If a caller passed `y >= self->ynum`, the C extension could read past the allocated line buffer arrays.

This mirrors the bounds behavior already present in `create_line_copy()`, which rejects an out-of-range row before accessing the same line buffer storage.

A minimal reproducer for the unsafe path is:

```python
from kitty.fast_data_types import LineBuf

lb = LineBuf(2, 3)
line = lb.line(0)
lb.copy_line_to(99, line)
```

Before this change, that call reached the C indexing path with an invalid row. After this change, it raises `ValueError: Out of bounds` before touching the backing arrays.

While I originally found this while investigating a local Kitty 0.46.2 crash in `kitty.fast_data_types.so`, I checked the call sites after review feedback and `LineBuf.copy_line_to()` appears to be used only by tests. So this PR is not meant to claim it fixes that runtime crash; it is a narrow bounds fix for the exposed helper path.

## Validation
- `PATH=$HOME/.local/opt/go1.26.2/bin:$PATH PYTHONNOUSERSITE=1 python3 setup.py build --skip-building-kitten`
- `PATH=$HOME/.local/opt/go1.26.2/bin:$PATH PYTHONNOUSERSITE=1 PYTHONPATH=$PWD python3 -m unittest kitty_tests.datatypes`
- manual reproducer now raises `ValueError: Out of bounds`