### PR TITLE
gl: drop GL_MAP_INVALIDATE_RANGE_BIT from partial UBO maps

### DIFF
--- a/kitty/gl.c
+++ b/kitty/gl.c
@@ -509,7 +509,14 @@ void*
 map_vao_buffer_for_write_only(ssize_t vao_idx, size_t bufnum, int offset, unsigned size) {
     ssize_t buf_idx = vaos[vao_idx].buffers[bufnum];
     bind_buffer(buf_idx);
-    return map_buffer_range(buf_idx, GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_RANGE_BIT, offset, size);
+    // Workaround for https://github.com/kovidgoyal/kitty/issues/9844: callers may map only a
+    // sub-range of a buffer and rely on bytes outside the range persisting from a previous
+    // upload. The OpenGL spec says GL_MAP_INVALIDATE_RANGE_BIT only authorizes discarding
+    // the mapped range, but some drivers (notably after GPU state transitions like system
+    // suspend/resume) discard or fail to preserve the unmapped tail, producing visual
+    // corruption in the color table. Omitting the flag forces the driver to preserve the
+    // entire buffer.
+    return map_buffer_range(buf_idx, GL_MAP_WRITE_BIT, offset, size);
 }
 
 void*


### PR DESCRIPTION
The cell uniform block is mapped with GL_MAP_INVALIDATE_RANGE_BIT covering only the per-frame prefix when the color table is clean, relying on the unmapped color_table tail surviving from a prior upload. Per spec, INVALIDATE_RANGE_BIT only authorizes discarding the mapped range, but in practice some drivers fail to preserve the unmapped tail across GPU state transitions like system suspend/resume.

Fixes https://github.com/kovidgoyal/kitty/issues/9844

(we could also split this into two UBOs, I guess, lmk if you'd prefer that)