### PR TITLE
Change momentum_scroll value from 0.96 to 0.35

### DIFF
--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -619,7 +619,7 @@ class Options:
     mark2_foreground: Color = Color(0, 0, 0)
     mark3_background: Color = Color(242, 116, 188)
     mark3_foreground: Color = Color(0, 0, 0)
-    momentum_scroll: float = 0.96
+    momentum_scroll: float = 0.5
     mouse_hide_wait: MouseHideWait = MouseHideWait(hide_wait=0.0, show_wait=0.0, show_threshold=40, scroll_show=True) if is_macos else MouseHideWait(hide_wait=3.0, show_wait=0.0, show_threshold=40, scroll_show=True)
     notify_on_cmd_finish: NotifyOnCmdFinish = NotifyOnCmdFinish(when='never', duration=5.0, action='notify', cmdline=(), clear_on=('focus', 'next'))
     open_url_with: list[str] = ['default']


### PR DESCRIPTION
I made this pull request because by default, I think that 0.96 is far too high for momentum_scroll and a smaller value would be a more sane default for all users. Initially I though this was a bug. What happens is that when you scroll it keeps on going long after touchpad scrolling stops. Im not sure what the reasoning for such a high value is because a commit titled ... changed it from 0.04 (good) to 0.94.  I decided to move it to 0.35 because its still there but it does not make using a text editor in the terminal difficult. Since conf.rst does not have any of the configuration code I am assuming its autogenerated and excluded a documentation update from this commit, however I did not test that.

Im don't want to test this, but: This is happening on xorg, so the momentum might have a higher effect on xorg compared to wayland? since it is high enough it seems to be a bug and not a feature. 

Generally I think that momentum scrolling is only really desirable on the web, and not the terminal since it is mainly UI polish and not a good feature for text editors.