### PR TITLE
Read FC_MATRIX from fontconfig

### DIFF
--- a/kitty/fontconfig.c
+++ b/kitty/fontconfig.c
@@ -41,6 +41,7 @@ static struct {PyObject *face, *descriptor;} builtin_nerd_font = {0};
 #define FcPatternAddInteger dynamically_loaded_fc_symbol.PatternAddInteger
 #define FcPatternCreate dynamically_loaded_fc_symbol.PatternCreate
 #define FcPatternGetBool dynamically_loaded_fc_symbol.PatternGetBool
+#define FcPatternGetMatrix dynamically_loaded_fc_symbol.PatternGetMatrix
 #define FcPatternAddCharSet dynamically_loaded_fc_symbol.PatternAddCharSet
 #define FcConfigAppFontAddFile dynamically_loaded_fc_symbol.ConfigAppFontAddFile
 
@@ -66,6 +67,7 @@ static struct {
     FcBool (*PatternAddInteger) (FcPattern *p, const char *object, int i);
     FcPattern * (*PatternCreate) (void);
     FcResult (*PatternGetBool) (const FcPattern *p, const char *object, int n, FcBool *b);
+    FcResult (*PatternGetMatrix) (const FcPattern *p, const char *object, int n, FcMatrix **m);
     FcBool (*PatternAddCharSet) (FcPattern *p, const char *object, const FcCharSet *c);
     FcBool (*ConfigAppFontAddFile) (FcConfig *config, const FcChar8 *file);
 } dynamically_loaded_fc_symbol = {0};
@@ -117,6 +119,7 @@ load_fontconfig_lib(void) {
         LOAD_FUNC(PatternAddInteger);
         LOAD_FUNC(PatternCreate);
         LOAD_FUNC(PatternGetBool);
+        LOAD_FUNC(PatternGetMatrix);
         LOAD_FUNC(PatternAddCharSet);
         LOAD_FUNC(ConfigAppFontAddFile);
 }
@@ -210,6 +213,13 @@ pattern_as_dict(FcPattern *pat) {
     B(FC_OUTLINE, outline);
     B(FC_COLOR, color);
     E(FC_SPACING, spacing, pyspacing);
+    {
+        FcMatrix *mtx = NULL;
+        if (FcPatternGetMatrix(pat, FC_MATRIX, 0, &mtx) == FcResultMatch && mtx) {
+            RAII_PyObject(t, Py_BuildValue("(dddd)", mtx->xx, mtx->xy, mtx->yx, mtx->yy));
+            if (!t || PyDict_SetItemString(ans, "matrix", t) != 0) return NULL;
+        }
+    }
 
     Py_INCREF(ans);
     return ans;

--- a/kitty/freetype.c
+++ b/kitty/freetype.c
@@ -66,6 +66,8 @@ typedef struct {
     PyObject *name_lookup_table;
     FontFeatures font_features;
     unsigned short dark_palette_index, light_palette_index, palettes_scanned;
+    FT_Matrix matrix;
+    bool has_matrix;
 } Face;
 PyTypeObject Face_Type;
 
@@ -284,6 +286,29 @@ set_load_error(const char *path, int error) {
     return NULL;
 }
 
+static bool
+read_matrix_from_descriptor(PyObject *descriptor, FT_Matrix *out, bool *out_has) {
+    *out_has = false;
+    PyObject *mt = PyDict_GetItemString(descriptor, "matrix");
+    if (!mt || !PyTuple_Check(mt) || PyTuple_GET_SIZE(mt) != 4) return true;
+    double v[4];
+    for (int i = 0; i < 4; i++) {
+        v[i] = PyFloat_AsDouble(PyTuple_GET_ITEM(mt, i));
+        if (PyErr_Occurred()) return false;
+        if (!isfinite(v[i])) {
+            PyErr_SetString(PyExc_ValueError, "matrix contains non-finite value");
+            return false;
+        }
+    }
+    if (v[0] == 1.0 && v[1] == 0.0 && v[2] == 0.0 && v[3] == 1.0) return true;
+    out->xx = (FT_Fixed)(v[0] * 0x10000);
+    out->xy = (FT_Fixed)(v[1] * 0x10000);
+    out->yx = (FT_Fixed)(v[2] * 0x10000);
+    out->yy = (FT_Fixed)(v[3] * 0x10000);
+    *out_has = true;
+    return true;
+}
+
 bool
 face_equals_descriptor(PyObject *face_, PyObject *descriptor) {
     Face *face = (Face*)face_;
@@ -292,6 +317,13 @@ face_equals_descriptor(PyObject *face_, PyObject *descriptor) {
     if (PyObject_RichCompareBool(face->path, t, Py_EQ) != 1) return false;
     t = PyDict_GetItemString(descriptor, "index");
     if (t && PyLong_AsLong(t) != face->face->face_index) return false;
+    FT_Matrix dmat = {0};
+    bool d_has = false;
+    if (!read_matrix_from_descriptor(descriptor, &dmat, &d_has)) { PyErr_Clear(); return false; }
+    if (d_has != face->has_matrix) return false;
+    if (d_has && (
+        face->matrix.xx != dmat.xx || face->matrix.xy != dmat.xy ||
+        face->matrix.yx != dmat.yx || face->matrix.yy != dmat.yy)) return false;
     return true;
 }
 
@@ -339,6 +371,29 @@ face_from_descriptor(PyObject *descriptor, FONTS_DATA_HANDLE fg) {
             if ((error = FT_Set_Var_Design_Coordinates(self->face, sz, coords))) return set_load_error(path, error);
         }
         if (!create_features_for_face(postscript_name_for_face((PyObject*)self), PyDict_GetItemString(descriptor, "features"), &self->font_features)) return NULL;
+        if (!read_matrix_from_descriptor(descriptor, &self->matrix, &self->has_matrix)) return NULL;
+        if (self->has_matrix) {
+            FT_Set_Transform(self->face, &self->matrix, NULL);
+            if (self->harfbuzz_font) {
+#if HB_VERSION_ATLEAST(4,0,0)
+                // Inform HarfBuzz so shaping (mark positioning, cluster
+                // boundaries) matches the slanted rendering. The HB API
+                // models a horizontal shear ratio, which equals xy/xx for
+                // matrix [[xx,xy],[yx,yy]]. Both operands are FT_Fixed at
+                // the same 16.16 scale so the factor cancels in the
+                // division. Guard against xx==0 (degenerate transform).
+                // Pure scales (s,0,0,s) yield slant=0, which is correct.
+                // Rotations and shear+rotation composites produce a slant
+                // value HB can't represent faithfully, but stock fontconfig
+                // only ever emits horizontal shear here.
+                if (self->matrix.xx != 0) {
+                    float slant = (float)self->matrix.xy / (float)self->matrix.xx;
+                    hb_font_set_synthetic_slant(self->harfbuzz_font, slant);
+                }
+#endif
+                hb_ft_font_changed(self->harfbuzz_font);
+            }
+        }
     }
     Py_XINCREF(retval);
     return retval;


### PR DESCRIPTION
Refs #9857, #9700.

## What

`pattern_as_dict()` in `kitty/fontconfig.c` extracts file path, family,
weight, slant, hinting, and so on, but never called
`FcPatternGetMatrix`. Any per-font matrix set by a user's fontconfig
rule was silently dropped before reaching FreeType.

Most users hit this without realising it. fontconfig ships
`/etc/fonts/conf.d/90-synthetic.conf` (default-enabled in every distro)
that applies a slant matrix `(1, 0.2, 0, 1)` to any roman-only font
when italic is requested. So italic Chinese, Japanese, Korean, and any
other language with no italic-style font files has been rendering
upright in kitty for as long as kitty has supported CJK.

## Changes

1. **`kitty/fontconfig.c`**: read `FC_MATRIX` and add it to the
   descriptor dict as `(xx, xy, yx, yy)`. The key is only present when
   fontconfig actually sets a matrix.
2. **`kitty/freetype.c`**: in `face_from_descriptor()`, read the tuple,
   convert to 16.16 fixed point, store on `Face`, call
   `FT_Set_Transform` once if non-identity. Identity is filtered out so
   faces without a transform incur no extra work.
3. **`kitty/freetype.c`**: also call `hb_font_set_synthetic_slant`
   (slant = `xy/xx`) and `hb_ft_font_changed` so HarfBuzz shaping (mark
   positioning, cluster boundaries) reflects the slanted rendering. The
   `synthetic_slant` call is gated on `HB_VERSION_ATLEAST(4,0,0)` since
   `setup.py` allows down to 1.5.0.
4. **`kitty/freetype.c`**: extend `face_equals_descriptor()` to compare
   the matrix. Without this, the per-FontGroup fallback cache returns
   an unmatrixed face for a matrixed descriptor (or vice versa)
   whenever upright and italic share a font file - the common case for
   CJK, where one .ttc serves both slants and only the matrix differs.

A small `read_matrix_from_descriptor` helper is shared between
`face_from_descriptor` and `face_equals_descriptor` so the
identity-skip, tuple-parsing, and `isfinite()` validation stay in one
place.

## Why this is safe

`FT_Set_Transform` is sticky on the FT face: set once at init,
inherited by every later `FT_Load_Glyph`, no per-call overhead. The
per-`Face` glyph atlas cache stays correct because the matrix never
changes after init.

`FT_Set_Transform` only affects per-glyph outline transforms before
rasterization. Face-level metrics from `FT_Set_Char_Size` are
untouched, so cell width and height calculation is unchanged. For pure
shears (`xx=1, yy=1`) horizontal advance is preserved and monospace
layout is intact.

## Verification

Built and tested locally on Arch with `noto-fonts-cjk` installed and
default fontconfig (no custom rule):

- `kitty.fonts.fontconfig.fc_match('Noto Sans CJK SC', italic=True)`
  returns a descriptor containing `'matrix': (1.0, 0.2, 0.0, 1.0)`,
  applied by the stock 90-synthetic rule.
- Same query for upright leaves matrix unset.
- Rendering U+4E2D (中) from the resolved face: 23 px wide upright, 25
  px wide italic. Both descriptors point at the same `.ttc` file,
  exercising the `face_equals_descriptor` cache equality path.
- All 329 existing kitty tests pass.

## Caveats

- Underline and strikethrough position come from face-level metrics
  (`face->size->metrics`) and are not affected by `FT_Set_Transform`,
  so a synthetic-italic glyph keeps an upright underline. This matches
  per-cell underline rendering in every terminal.
- Matrix is honoured on the fallback path (which goes through
  `FcFontMatch` and runs `target="font"` rules) but not on the primary
  `font_family` resolution path (`find_best_match` walks the
  `FcFontList` cache which does not). Affects users who set
  `font_family` directly to a CJK font; doesn't affect the asker's use
  case in #9700 (CJK as fallback in italic context). The fix is
  Python-side: run `FcConfigSubstitute(FcMatchFont)` on font-map
  results in `kitty/fonts/fontconfig.py`. Worth a follow-up issue.
- Color glyph rendering (COLR/CBDT/SVG) goes through cairo, which
  unconditionally calls `FT_Set_Transform` on the FT face from its own
  scale matrix on every render
  (`_cairo_ft_unscaled_font_set_scale` in `cairo-ft-font.c`), so the
  matrix is not honoured on that path. Stock fontconfig rules don't
  apply `FC_MATRIX` to color fonts, so this is a hand-built config
  edge case. A correct fix would route the matrix through cairo via
  `cairo_set_font_matrix` instead of `cairo_set_font_size`.
- `get_glyph_width` uses `FT_LOAD_DEFAULT` (no rasterization) and
  returns `M.width` from the glyph metrics, which `FT_Set_Transform`
  does not update. For pure shears (`xx=1`) this is the unsheared bbox
  width and equals the unsheared advance, which is the right answer
  for monospace cell-counting. Non-shear matrices on monospace fonts
  are out of scope.

## Scope

Linux only. macOS kitty uses CoreText, not fontconfig, so there is no
`FC_MATRIX` to read on that platform.