### PR TITLE
Honor background image overrides for single instance windows

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -977,8 +977,16 @@ class Boss:
                     override_title=args.title or None, window_state=wstate, x=pos_x, y=pos_y)
                 if session.focus_os_window:
                     focused_os_window = os_window_id
-                if opts.background_opacity != get_options().background_opacity:
+                global_opts = get_options()
+                if opts.background_opacity != global_opts.background_opacity:
                     self._set_os_window_background_opacity(os_window_id, opts.background_opacity)
+                if opts.background_image != global_opts.background_image:
+                    self.set_background_image(
+                        opts.background_image[0] if opts.background_image else None, (os_window_id,), False,
+                        layout=opts.background_image_layout,
+                        linear_interpolation=opts.background_image_linear,
+                        tint=opts.background_tint,
+                        tint_gaps=opts.background_tint_gaps)
                 if n := data.get('notify_on_os_window_death'):
                     self.os_window_death_actions[os_window_id] = partial(self.notify_on_os_window_death, n)
             if focused_os_window > 0:

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -1537,14 +1537,15 @@ static void
 draw_bg_image(OSWindow *os_window, Tab *tab) {
     BackgroundImage *bg = background_image_for_os_window(os_window);
     if (!bg) return;
+    BackgroundImageLayout layout = os_window->background_image.has_layout ? os_window->background_image.layout : OPT(background_image_layout);
     BackgroundImageRenderSettings s = {
         .os_window.width = os_window->viewport_width, .os_window.height = os_window->viewport_height,
-        .instance_id = bg->id, .layout=OPT(background_image_layout),
+        .instance_id = bg->id, .layout=layout,
         .linear=OPT(background_image_linear), .bgcolor=OPT(background), .opacity=effective_os_window_alpha(os_window),
     };
     GLfloat iwidth = bg->width, iheight = bg->height;
     GLfloat vwidth = s.os_window.width, vheight = s.os_window.height;
-    if (CENTER_SCALED == OPT(background_image_layout)) {
+    if (CENTER_SCALED == layout) {
         GLfloat ifrac = iwidth / iheight;
         if (ifrac > (vwidth / vheight)) {
             iheight = vheight;
@@ -1556,7 +1557,7 @@ draw_bg_image(OSWindow *os_window, Tab *tab) {
     }
     GLfloat tiled = 0.f;;
     GLfloat left = -1.0, top = 1.0, right = 1.0, bottom = -1.0;
-    switch (OPT(background_image_layout)) {
+    switch (layout) {
         case TILING: case MIRRORED: case CLAMPED:
             tiled = 1.f; break;
         case SCALED:

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -1440,6 +1440,8 @@ pyset_background_image(PyObject *self UNUSED, PyObject *args, PyObject *kw) {
             if (bgimage) {
                 if (!configured) {  // configured means we use the zero index global image
                     os_window->background_image.override = bgimage;
+                    os_window->background_image.layout = layout;
+                    os_window->background_image.has_layout = true;
                     bgimage->refcnt++;
                 }
             } else if (is_increment) {

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -419,7 +419,9 @@ typedef struct OSWindow {
     struct {
         size_t global_bg_images_idx;
         BackgroundImage *override;
+        BackgroundImageLayout layout;
         bool no_image;
+        bool has_layout;
     } background_image;
     struct {
         uint32_t framebuffer_id, attached_texture_generation;


### PR DESCRIPTION
When kitty is invoked with --single-instance and an existing instance handles the request, the new invocation's parsed options are used for sizing and background opacity, but background_image/background_image_layout overrides are ignored. The new OS window therefore inherits the running instance's configured background and callers have to repaint it after launch.\n\nThis applies an explicit background_image override to the newly created OS window during the single-instance handoff, without changing the configured background for existing or future windows. It also stores the requested background layout on per-window background overrides so a one-shot launch can honor e.g. background_image_layout=cscaled instead of depending on the process-global layout.