### PR TITLE
Fix silent failure when pager (less) is not installed

### DIFF
--- a/tools/cli/help.go
+++ b/tools/cli/help.go
@@ -131,7 +131,9 @@ func ShowHelpInPager(text string) {
 	pager.Stdin = strings.NewReader(text)
 	pager.Stdout = os.Stdout
 	pager.Stderr = os.Stderr
-	_ = pager.Run()
+	if err := pager.Run(); err != nil {
+		os.Stdout.WriteString(text)
+	}
 }
 
 func getDeterministicTimestamp() time.Time {


### PR DESCRIPTION
When kitten --help is run in a terminal and less is not available, ShowHelpInPager silently discards the error from pager.Run(), resulting in no output and a zero exit code. Fall back to writing help text directly to stdout when the pager fails, matching the behavior of the Python equivalent in kitty/cli.py which catches FileNotFoundError and prints the text as a fallback.