### PR TITLE
Fix hints kitten breaking multi-byte UTF-8 characters

### DIFF
--- a/kittens/hints/main.go
+++ b/kittens/hints/main.go
@@ -200,10 +200,12 @@ func main(_ *cli.Command, o *Options, args []string) (rc int, err error) {
 		if hint == "" {
 			hint = " "
 		}
-		if len(mark_text) <= len(hint) {
+		hint_runes := len(hint)
+		runes := []rune(mark_text)
+		if len(runes) <= hint_runes {
 			mark_text = ""
 		} else {
-			replaced_text := mark_text[:len(hint)]
+			replaced_text := string(runes[:hint_runes])
 			replaced_text = strings.ReplaceAll(replaced_text, "\r", "\n")
 			if strings.Contains(replaced_text, "\n") {
 				buf := strings.Builder{}
@@ -224,7 +226,7 @@ func main(_ *cli.Command, o *Options, args []string) (rc int, err error) {
 				}
 				hint = buf.String()
 			}
-			mark_text = mark_text[len(hint):]
+			mark_text = string(runes[hint_runes:])
 		}
 		ans := hint_style(hint) + text_style(mark_text)
 		return fmt.Sprintf("\x1b]8;;mark:%d\a%s\x1b]8;;\a", m.Index, ans)


### PR DESCRIPTION
## Summary

The hints kitten's `highlight_mark()` function uses byte-based string slicing (`mark_text[:len(hint)]` and `mark_text[len(hint):]`) to replace matched text with hint labels. Since `len(hint)` equals the rune count (hint is always ASCII from `encode_hint`), but `len(mark_text)` is a byte count, this can slice in the middle of a multi-byte UTF-8 sequence (e.g. CJK characters), producing an invalid byte sequence rendered as the Unicode replacement character (�).

**Example**: For matched text `"关键区别："` with hint `"da"`, `mark_text[:2]` slices the 3-byte UTF-8 sequence of `关` (`e5 85 b3`) at byte 2, leaving `e5` — an incomplete sequence displayed as `�`.

## Fix

Convert `mark_text` to `[]rune` before slicing, ensuring cuts always fall on rune boundaries. The hint is ASCII so `len(hint)` already equals its rune count — no conversion needed on the hint side.
<img width="955" height="166" alt="image" src="https://github.com/user-attachments/assets/b3959370-8b20-4071-a246-43fc41a1824d" />

### Before

<img width="954" height="206" alt="image" src="https://github.com/user-attachments/assets/c4f1794b-4d4f-4d02-b28b-a6f1b04a3848" />

### After

<img width="958" height="205" alt="image" src="https://github.com/user-attachments/assets/477d956f-f64c-42bb-8414-4a63c4d04f66" />


## Changes

- `kittens/hints/main.go`: 3 lines changed in `highlight_mark()`:
  - `len(mark_text) <= len(hint)` → `len(runes) <= hint_runes` (compare rune counts)
  - `mark_text[:len(hint)]` → `string(runes[:hint_runes])` (slice at rune boundary)
  - `mark_text[len(hint):]` → `string(runes[hint_runes:])` (slice at rune boundary)

## Test plan

- [x] Build kitty with the fix and verify hints overlay works correctly with multi-byte text (CJK, emoji, etc.)
- [x] Verify ASCII-only matches still render identically to before
- [ ] Confirm no regression in hint wrapping across line boundaries (the `\r` handling path)