### PR TITLE
fontconfig: apply target="font" rules to primary font_family path

### DIFF
--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -457,6 +457,13 @@ def fc_match_postscript_name(
 
 def add_font_file(path: str) -> bool: ...
 def set_builtin_nerd_font(path: str) -> Union[CoreTextFont, FontConfigPattern]: ...
+def fc_render_prepare(
+    family: str,
+    bold: bool,
+    italic: bool,
+    spacing: int,
+    candidate: FontConfigPattern,
+) -> FontConfigPattern: ...
 
 
 class FeatureData(TypedDict):

--- a/kitty/fontconfig.c
+++ b/kitty/fontconfig.c
@@ -44,6 +44,7 @@ static struct {PyObject *face, *descriptor;} builtin_nerd_font = {0};
 #define FcPatternGetMatrix dynamically_loaded_fc_symbol.PatternGetMatrix
 #define FcPatternAddCharSet dynamically_loaded_fc_symbol.PatternAddCharSet
 #define FcConfigAppFontAddFile dynamically_loaded_fc_symbol.ConfigAppFontAddFile
+#define FcFontRenderPrepare dynamically_loaded_fc_symbol.FontRenderPrepare
 
 static struct {
     FcBool(*Init)(void);
@@ -70,6 +71,7 @@ static struct {
     FcResult (*PatternGetMatrix) (const FcPattern *p, const char *object, int n, FcMatrix **m);
     FcBool (*PatternAddCharSet) (FcPattern *p, const char *object, const FcCharSet *c);
     FcBool (*ConfigAppFontAddFile) (FcConfig *config, const FcChar8 *file);
+    FcPattern * (*FontRenderPrepare) (FcConfig *config, FcPattern *pat, FcPattern *font);
 } dynamically_loaded_fc_symbol = {0};
 #define LOAD_FUNC(name) {\
     *(void **) (&dynamically_loaded_fc_symbol.name) = dlsym(libfontconfig_handle, "Fc" #name); \
@@ -122,6 +124,7 @@ load_fontconfig_lib(void) {
         LOAD_FUNC(PatternGetMatrix);
         LOAD_FUNC(PatternAddCharSet);
         LOAD_FUNC(ConfigAppFontAddFile);
+        LOAD_FUNC(FontRenderPrepare);
 }
 #undef LOAD_FUNC
 
@@ -614,6 +617,104 @@ add_font_file(PyObject UNUSED *self, PyObject *args) {
 }
 
 
+static FcPattern*
+dict_to_font_pattern(PyObject *d) {
+    // Rebuild an FcPattern from a descriptor dict produced by pattern_as_dict().
+    // Only intrinsic file-level properties are reattached. User-config fields
+    // (hinting, hint_style, subpixel, lcdfilter) are omitted on purpose:
+    // pattern_as_dict() defaults missing booleans to False and missing ints
+    // to 0, so we cannot distinguish "fontconfig set this" from "the default
+    // leaked through." Forwarding them would let stale defaults preempt
+    // MatchFont substitution for rules using mode="add" or mode="append".
+    FcPattern *pat = FcPatternCreate();
+    if (!pat) { PyErr_NoMemory(); return NULL; }
+#define ADD_S(key, prop) do { \
+    PyObject *_v = PyDict_GetItemString(d, key); \
+    if (_v && PyUnicode_Check(_v)) { \
+        const char *_s = PyUnicode_AsUTF8(_v); \
+        if (_s && *_s) FcPatternAddString(pat, prop, (const FcChar8*)_s); \
+    } \
+} while (0)
+#define ADD_I(key, prop) do { \
+    PyObject *_v = PyDict_GetItemString(d, key); \
+    if (_v && PyLong_Check(_v)) FcPatternAddInteger(pat, prop, (int)PyLong_AsLong(_v)); \
+} while (0)
+#define ADD_B(key, prop) do { \
+    PyObject *_v = PyDict_GetItemString(d, key); \
+    if (_v) FcPatternAddBool(pat, prop, PyObject_IsTrue(_v) ? FcTrue : FcFalse); \
+} while (0)
+    ADD_S("path", FC_FILE);
+    ADD_S("family", FC_FAMILY);
+    ADD_S("full_name", FC_FULLNAME);
+    ADD_S("postscript_name", FC_POSTSCRIPT_NAME);
+    ADD_S("style", FC_STYLE);
+    ADD_I("weight", FC_WEIGHT);
+    ADD_I("width", FC_WIDTH);
+    ADD_I("slant", FC_SLANT);
+    ADD_I("index", FC_INDEX);
+    ADD_B("scalable", FC_SCALABLE);
+    ADD_B("outline", FC_OUTLINE);
+    ADD_B("color", FC_COLOR);
+    {
+        PyObject *sp = PyDict_GetItemString(d, "spacing");
+        if (sp && PyUnicode_Check(sp)) {
+            const char *s = PyUnicode_AsUTF8(sp);
+            int spacing = -1;
+            if (s) {
+                if (strcmp(s, "MONO") == 0) spacing = FC_MONO;
+                else if (strcmp(s, "DUAL") == 0) spacing = FC_DUAL;
+                else if (strcmp(s, "PROPORTIONAL") == 0) spacing = FC_PROPORTIONAL;
+                else if (strcmp(s, "CHARCELL") == 0) spacing = FC_CHARCELL;
+            }
+            if (spacing >= 0) FcPatternAddInteger(pat, FC_SPACING, spacing);
+        }
+    }
+#undef ADD_S
+#undef ADD_I
+#undef ADD_B
+    return pat;
+}
+
+
+static PyObject*
+fc_render_prepare(PyObject UNUSED *self, PyObject *args) {
+    // Apply fontconfig's target="font" substitution to a candidate already
+    // picked from the FcFontList cache. FcFontList skips both substitution
+    // phases, so users selecting a font via font_family= never see per-font
+    // edits (notably FC_MATRIX from 90-synthetic.conf). FcFontRenderPrepare()
+    // is the same call FcFontMatch() makes internally to combine a request
+    // pattern with a font pattern, including the MatchFont substitution pass.
+    ensure_initialized();
+    const char *family = NULL;
+    int bold = 0, italic = 0, spacing = -1;
+    PyObject *candidate = NULL;
+    if (!PyArg_ParseTuple(args, "sppiO!", &family, &bold, &italic, &spacing, &PyDict_Type, &candidate)) return NULL;
+
+    FcPattern *req = FcPatternCreate();
+    FcPattern *font = NULL, *prep = NULL;
+    PyObject *ans = NULL;
+    if (!req) return PyErr_NoMemory();
+    if (family && family[0]) FcPatternAddString(req, FC_FAMILY, (const FcChar8*)family);
+    if (bold) FcPatternAddInteger(req, FC_WEIGHT, FC_WEIGHT_BOLD);
+    if (italic) FcPatternAddInteger(req, FC_SLANT, FC_SLANT_ITALIC);
+    if (spacing >= 0) FcPatternAddInteger(req, FC_SPACING, spacing);
+    FcConfigSubstitute(NULL, req, FcMatchPattern);
+    FcDefaultSubstitute(req);
+
+    font = dict_to_font_pattern(candidate);
+    if (!font) goto end;
+
+    prep = FcFontRenderPrepare(NULL, req, font);
+    if (!prep) { PyErr_SetString(PyExc_RuntimeError, "FcFontRenderPrepare() failed"); goto end; }
+    ans = pattern_as_dict(prep);
+end:
+    if (req) FcPatternDestroy(req);
+    if (font) FcPatternDestroy(font);
+    if (prep) FcPatternDestroy(prep);
+    return ans;
+}
+
+
 #undef AP
 
 static PyMethodDef module_methods[] = {
@@ -622,6 +723,7 @@ static PyMethodDef module_methods[] = {
     METHODB(fc_match_postscript_name, METH_VARARGS),
     METHODB(add_font_file, METH_VARARGS),
     METHODB(set_builtin_nerd_font, METH_O),
+    METHODB(fc_render_prepare, METH_VARARGS),
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/kitty/fonts/fontconfig.py
+++ b/kitty/fonts/fontconfig.py
@@ -15,6 +15,7 @@ from kitty.fast_data_types import (
     FC_WIDTH_NORMAL,
     Face,
     fc_list,
+    fc_render_prepare,
 )
 from kitty.fast_data_types import (
     FC_WEIGHT_SEMIBOLD as FC_WEIGHT_BOLD,
@@ -181,6 +182,12 @@ def find_best_match(
     font_map = all_fonts_map(monospaced)
     scorer = create_scorer(bold, italic, monospaced, prefer_variable=prefer_variable)
     is_medium_face = not bold and not italic
+    spacing = FC_MONO if monospaced else -1
+    # candidates come from FcFontList, which skips fontconfig's MatchFont
+    # substitution pass. Run FcFontRenderPrepare so target="font" rules
+    # (notably 90-synthetic.conf's FC_MATRIX) attach to the chosen descriptor.
+    def prepare(p: FontConfigPattern) -> FontConfigPattern:
+        return fc_render_prepare(family, bold, italic, spacing, p)
     # First look for an exact match
     groups: tuple[FontCollectionMapType, ...] = ('ps_map', 'full_map', 'family_map')
     for which in groups:
@@ -191,7 +198,7 @@ def find_best_match(
                 continue  # IBM Plex Mono has fullname of regular face == family_name under fontconfig
             exact_match = find_best_match_in_candidates(cq, scorer, is_medium_face, ignore_face=ignore_face)
             if exact_match:
-                return exact_match
+                return prepare(exact_match)
 
     # Use fc-match to see if we can find a monospaced font that matches family
     # When aliases are defined, spacing can cause the incorrect font to be
@@ -214,7 +221,7 @@ def find_best_match(
                         family_name_candidates = font_map['family_map'].get(family_name_to_key(candidates[0]['family']))
                         if family_name_candidates and len(family_name_candidates) > 1:
                             candidates = family_name_candidates
-                    return scorer.sorted_candidates(candidates)[0]
+                    return prepare(scorer.sorted_candidates(candidates)[0])
     return find_last_resort_text_font(bold, italic, monospaced)
 
 


### PR DESCRIPTION
`find_best_match()` picks candidates from the `FcFontList` cache populated by `fc_list()`. `FcFontList` skips both `fontconfig` substitution phases, so `target="font"` rules never run and per-font edits like `FC_MATRIX` never attach to the chosen descriptor. The fallback path in the same module goes through `fc_match() -> FcFontMatch()`, which does run `MatchFont`, so `fontconfig.fc_match()` in #9990 returned the matrix correctly. The two paths diverged for any user setting font_family directly to a CJK font.

Bind `FcFontRenderPrepare` and expose `fc_render_prepare(family, bold, italic, spacing, candidate)` at the Python boundary. It is the same call `FcFontMatch` makes internally to combine a request pattern with a listed font, including the `MatchFont` substitution pass.

Wrap the three `FcFontList`-derived returns in `find_best_match()` with `fc_render_prepare()` so the descriptor that reaches Face construction carries the matrix.

`dict_to_font_pattern` forwards only intrinsic file-level properties. User-config fields (hinting, hint_style, subpixel, lcdfilter) are omitted on purpose: `pattern_as_dict` defaults missing booleans to False and missing ints to 0, so we cannot distinguish "fontconfig set this" from "the default leaked through." Forwarding them would let stale defaults preempt `MatchFont` substitution for rules using `mode="add"` or `mode="append"`. The `fc_match` fallback path leaves them alone too.

Verified locally on Arch with stock fontconfig and noto-fonts-cjk:

  >>> from kitty.fast_data_types import fc_list, fc_render_prepare
  >>> cjk = [c for c in fc_list(allow_bitmapped_fonts=True)
  ...        if c.get('family') == 'Noto Sans CJK SC']
  >>> for c in cjk[:2]:
  ...     p = fc_render_prepare('Noto Sans CJK SC', False, True, -1, c)
  ...     assert c.get('spacing') == p.get('spacing')  # no field regressed
  >>> from kitty.fonts.fontconfig import find_best_match
  >>> find_best_match('Noto Sans CJK SC', italic=True, monospaced=False)
  ... .get('matrix')
  (1.0, 0.2, 0.0, 1.0)
  >>> find_best_match('Noto Sans CJK SC', italic=False, monospaced=False)
  ... .get('matrix')
  None

Refs: #9857, #9990