### PR TITLE
tests: regression for apply_selection with paused-rendering + scrollback selection

### DIFF
--- a/kitty_tests/screen.py
+++ b/kitty_tests/screen.py
@@ -741,6 +741,35 @@ class TestScreen(BaseTest):
         self.ae(s.text_for_selection(False, True), ('1234 ', '5'))
         self.ae(s.text_for_selection(True, True), ('1234 ', '5', ''))
 
+    def test_apply_selection_with_paused_rendering_and_scrollback(self):
+        # Regression test: in 0.46.2 the paused-rendering branch of
+        # apply_selection passed the (possibly negative) loop variable y
+        # directly to linebuf_init_line, which interprets it as an unsigned
+        # index_type and reads ~4GB out of bounds in line_attrs[idx]. The fix
+        # translates to paused_y = y + scrolled_by and guards paused_y < 0.
+        # Real-world trigger: a TUI sending DCS =1s (DEC synchronized output)
+        # while the user has scrolled back and has an active scrollback
+        # selection.
+        s = self.create_screen(cols=10, lines=3, scrollback=50)
+        for i in range(40):
+            s.draw(f"row{i:03d}")
+            s.carriage_return()
+            s.linefeed()
+        s.scroll(20, True)
+        self.assertGreater(s.scrolled_by, 0)
+        # Selection that crosses the top of the visible area into scrollback,
+        # so the inner loop iterates with negative y.
+        s.start_selection(0, 0)
+        s.update_selection(2, 1)
+        self.assertTrue(s.has_selection())
+        self.assertTrue(s.pause_rendering(True, 5000))
+        # Must not crash and must return the visible-area buffer.
+        result = s.current_selections()
+        self.ae(len(result), s.lines * s.columns)
+        # The visible portion of the selection must have at least one byte
+        # marked (set_mask = 1 for plain selections).
+        self.assertIn(1, result)
+
     def test_soft_hyphen(self):
         s = self.create_screen()
         s.draw('a\u00adb')


### PR DESCRIPTION
## Summary

Adds a regression test exercising the `apply_selection` code path that crashed in v0.46.2 (#10017) — paused-rendering active + selection extending into scrollback. The fix itself already landed on master; this test guards against regression.

The bug: in v0.46.2 the paused-rendering branch of `apply_selection` passed the (signed, possibly negative) loop variable `y` directly to `linebuf_init_line`, which interprets it as `index_type` (unsigned int). Negative `y` became a ~4 GB unsigned offset, and `line_attrs[idx]` read into the macOS `commpage (reserved)` VM region, causing `SIGBUS`.

Master fixed this with `paused_y = y + scrolled_by` plus a `paused_y < 0` guard, and added a `scrolled_by` parameter to `apply_selection`.

## Test plan

- [x] New test passes on current master (with the fix): `setup.py test` reports `test_apply_selection_with_paused_rendering_and_scrollback ... ok`.
- [x] Same test logic (the body of the test) reliably crashes a stock v0.46.2 build with `Fatal Python error: Bus error` at `apply_selection+0x67b20`, confirming the test would have caught the bug.
- [x] No other tests in `kitty_tests/screen.py` are affected by this change.

Full root-cause analysis and crash reproduction are in #10017.