### PR TITLE
Clear font caches on config reload for new font recognition

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -3200,6 +3200,8 @@ class Boss:
         opts = load_config(*paths, overrides=final_overrides or None, accumulate_bad_lines=bad_lines)
         if bad_lines:
             self.show_bad_config_lines(bad_lines)
+        from .fonts.render import clear_font_caches
+        clear_font_caches()
         self.apply_new_options(opts)
         from .open_actions import clear_caches
         clear_caches()

--- a/kitty/fonts/common.py
+++ b/kitty/fonts/common.py
@@ -65,6 +65,13 @@ else:
 
 
 cache_for_variable_data_by_path: dict[str, VariableData] = {}
+
+
+def clear_caches() -> None:
+    cache_for_variable_data_by_path.clear()
+    actually_variable_cache.clear()
+
+
 attr_map = {(False, False): 'font_family', (True, False): 'bold_font', (False, True): 'italic_font', (True, True): 'bold_italic_font'}
 
 

--- a/kitty/fonts/core_text.py
+++ b/kitty/fonts/core_text.py
@@ -49,6 +49,11 @@ def create_font_map(all_fonts: Iterable[CoreTextFont]) -> FontMap:
     return ans
 
 
+def clear_caches() -> None:
+    all_fonts_map.cache_clear()
+    weight_range_for_family.cache_clear()
+
+
 @lru_cache(maxsize=2)
 def all_fonts_map(monospaced: bool = True) -> FontMap:
     return create_font_map(coretext_all_fonts(monospaced))

--- a/kitty/fonts/fontconfig.py
+++ b/kitty/fonts/fontconfig.py
@@ -44,6 +44,12 @@ def create_font_map(all_fonts: tuple[FontConfigPattern, ...]) -> FontMap:
     return ans
 
 
+def clear_caches() -> None:
+    all_fonts_map.cache_clear()
+    fc_match.cache_clear()
+    weight_range_for_family.cache_clear()
+
+
 @lru_cache(maxsize=2)
 def all_fonts_map(monospaced: bool = True) -> FontMap:
     if monospaced:

--- a/kitty/fonts/render.py
+++ b/kitty/fonts/render.py
@@ -187,6 +187,16 @@ def dump_font_debug() -> None:
             log_error('  ' + s.identify_for_debug())
 
 
+def clear_font_caches() -> None:
+    from .common import clear_caches as clear_common_caches
+    clear_common_caches()
+    if is_macos:
+        from .core_text import clear_caches as clear_platform_caches
+    else:
+        from .fontconfig import clear_caches as clear_platform_caches
+    clear_platform_caches()
+
+
 def set_font_family(opts: Options | None = None, override_font_size: float | None = None, add_builtin_nerd_font: bool = False) -> None:
     global current_faces, builtin_nerd_font_descriptor
     opts = opts or defaults


### PR DESCRIPTION
## Summary
  - Clear font caches before applying new options in `load_config_file`, so newly installed fonts are picked up without restarting kitty.

  ## Problem
  When using `kitten choose-fonts` to select a font that was installed while kitty was running, the new font would not be applied even though choose-fonts patched the config and triggered a reload via SIGUSR1. The root cause was that `all_fonts_map()` (and other font-related caches) retained stale data from before the font was installed.

  ## Fix
  Added `clear_caches()` functions in each font module to invalidate LRU caches and dict caches:

  - `kitty/fonts/core_text.py` — clears `all_fonts_map` and `weight_range_for_family`
  - `kitty/fonts/fontconfig.py` — clears `all_fonts_map`, `fc_match`, and `weight_range_for_family`
  - `kitty/fonts/common.py` — clears `cache_for_variable_data_by_path` and `actually_variable_cache`
  - `kitty/fonts/render.py` — exposes `clear_font_caches()` that aggregates platform + common cache clearing

  `boss.py`'s `load_config_file` now calls `clear_font_caches()` before `apply_new_options`, so font enumeration always sees  the latest system font state.
