### PR TITLE
Preserve copy_or_noop passthrough result

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -3737,6 +3737,6 @@ class Boss:
         if w := self.active_window:
             w.search_scrollback()
 
-    def copy_or_noop(self) -> None:
+    def copy_or_noop(self) -> bool | None:
         if w := self.active_window:
-            w.copy_or_noop()
+            return w.copy_or_noop()

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -3740,3 +3740,4 @@ class Boss:
     def copy_or_noop(self) -> bool | None:
         if w := self.active_window:
             return w.copy_or_noop()
+        return None

--- a/kitty_tests/keys.py
+++ b/kitty_tests/keys.py
@@ -2,6 +2,7 @@
 # License: GPL v3 Copyright: 2016, Kovid Goyal <kovid at kovidgoyal.net>
 
 from functools import partial
+from types import SimpleNamespace
 
 import kitty.fast_data_types as defines
 from kitty.key_encoding import EventType, KeyEvent, decode_key_event, encode_key_event
@@ -655,6 +656,42 @@ class TestKeys(BaseTest):
         self.ae(tm('m', 'a'), [True, True])
         self.ae(tm.actions, ['push_keyboard_mode mw', 'new_window'])
         af(tm.ignore_os_keyboard_processing)
+
+    def test_copy_or_noop_passthrough(self):
+        from kitty.boss import Boss
+        from kitty.conf.utils import KeyAction
+
+        class Window:
+            def __init__(self, passthrough: bool):
+                self.passthrough = passthrough
+                self.calls = 0
+
+            def copy_or_noop(self) -> bool:
+                self.calls += 1
+                return self.passthrough
+
+        class TestBoss(Boss):
+            window: Window
+
+            @property
+            def active_window(self):
+                return self.window
+
+            @property
+            def active_tab(self):
+                return None
+
+        boss = TestBoss.__new__(TestBoss)
+        boss.args = SimpleNamespace(debug_keyboard=False)
+        boss.window_for_dispatch = None
+
+        boss.window = Window(True)
+        self.assertFalse(boss.dispatch_action(KeyAction('copy_or_noop')))
+        self.ae(boss.window.calls, 1)
+
+        boss.window = Window(False)
+        self.assertTrue(boss.dispatch_action(KeyAction('copy_or_noop')))
+        self.ae(boss.window.calls, 1)
 
     def test_match_physical_keys_removed(self):
         # match_physical_keys global option has been removed in favor of per-mapping --allow-fallback


### PR DESCRIPTION
This fixes a regression where copy_or_noop no longer passed the mapped key through when there was no active selection.

Window.copy_or_noop() already returns True in the no-selection case, and Boss.dispatch_action() uses exactly True to mean “do not consume this key”. The Boss.copy_or_noop() wrapper was calling the window method but not returning its result, so the True became None and the key was consumed.

I added a focused regression test for both paths: passthrough when the window returns True, and consumed when it returns False. The test is a little longer than the fix because it exercises the dispatcher behavior rather than just calling the wrapper directly. Happy to trim or reshape it if you prefer a smaller test.

Tested with:
./test.py --module keys
python3 -m py_compile kitty/boss.py kitty_tests/keys.py