### PR TITLE
Fix goto_session not recreating a closed startup_session

### DIFF
--- a/kitty/session.py
+++ b/kitty/session.py
@@ -379,9 +379,6 @@ def window_for_session_name(boss: BossType, session_name: str) -> WindowType | N
     if not windows:
         tabs = (t for t in boss.all_tabs if t.created_in_session_name == session_name)
         windows = [t.active_window for t in tabs if t.active_window]
-        if not windows:
-            os_windows = (tm for tm in boss.all_tab_managers if tm.created_in_session_name == session_name)
-            windows = [tm.active_window for tm in os_windows if tm.active_window]
     if windows:
         def skey(w: WindowType) -> float:
             return w.last_focused_at


### PR DESCRIPTION
## Summary

Fixes a bug where goto_session cannot recreate a session that was initially loaded via startup_session after that session has been closed.

Reproduction

With config:
```  
startup_session ~/.config/kitty/sessions/home.conf
tab_bar_filter session:~ or session:^$
map ctrl+b>h goto_session ~/.config/kitty/sessions/home.conf
map ctrl+b>b goto_session ~/.config/kitty/sessions/home1.conf
```

1. Launch kitty — home is loaded as the startup session.
2. ctrl+b>b creates home1 (its tabs are added to the same OS window, filtered by tab_bar_filter).
3. ctrl+b>h switches back to home.
4. Close the home session.
5. ctrl+b>h — nothing happens; home is not recreated.

## Cause

TabManager.created_in_session_name is set once at TM construction from startup_session.session_name (tabs.py:1185) and never updated.

The third-level fallback in window_for_session_name returned the active_window of any TabManager whose label matched the requested session — regardless of whether that OS window currently contained any tabs or windows belonging to the session.

After closing home, the original OS window's TM is still labeled home, so switch_to_session('home') returned its (now home1) active window. switch_to_session reported success and create_session never ran.

Sessions created purely via goto_session aren't affected because their OS windows' TMs are constructed with startup_session=None, so the label is '' and the fallback can't false-match.

## Fix

Drop the third-level fallback from window_for_session_name. A window is now only returned if a real window or tab carries the matching session name. When that fails, goto_session falls through to create_session, which adds the new session's tabs to the current active_tab_manager — the same behavior as for sessions that have never been loaded.