### PR TITLE
Fix `background_image` type when calling `set_background_image`

### DIFF
--- a/kitty/colors.py
+++ b/kitty/colors.py
@@ -292,8 +292,11 @@ def patch_colors(
     notify_bg = notify_on_bg_change and default_bg_changed
     boss = get_boss()
     if background_image_options is not None:
+        bg = background_image_options.get('background_image')
+        if isinstance(bg, (tuple, list)):
+            bg = bg[0] if bg else None
         boss.set_background_image(
-            background_image_options.get('background_image'), tuple(os_window_ids), configured,
+            bg, tuple(os_window_ids), configured,
             layout=background_image_options.get('background_image_layout'),
             linear_interpolation=background_image_options.get('background_image_linear'), tint=background_image_options.get('background_tint'),
             tint_gaps=background_image_options.get('background_tint_gaps'))


### PR DESCRIPTION
**Bugfix**

Commit 2c9541cf2 changed the `background_image` option type from `str` to `tuple[str, ...]` to support multiple preloaded background images. However, `colors.py:patch_colors()` reads `background_image` from `background_image_options` and passes it directly to the C function `set_background_image`, which expects `str | None` (parsed via `PyArg_ParseTupleAndKeywords` with `z` format).

When a color scheme change triggers `patch_colors` (e.g., via `auto_color_scheme` on macOS), the tuple is passed to C, causing a TypeError. This exception aborts `patch_colors` before `w.refresh()` / `default_bg_changed_for`, so the `\033[?997;n` escape code notifying the color scheme change is not sent.

Closes https://github.com/kovidgoyal/kitty/issues/10058 (see issue for a practical, reproducible symptom of this when using automatic color theme changes on macOS)