### PR TITLE
feat(vt): add support for DECST8C escape sequence

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -176,6 +176,8 @@ Detailed list of changes
 0.47.1 [future]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+- Preserve user-set tab stops across window resizes (previously they were reset to every 8 columns on every resize)
+
 - Fix a regression in the previous release that caused :ac:`copy_or_noop` to stop working correctly (:pull:`10041`)
 
 - macOS: Fix a regression in the previous release that caused URLs to be quoted when dropping into shells (:iss:`10054`)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -176,6 +176,8 @@ Detailed list of changes
 0.47.1 [future]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+- Add support for the DECST8C escape sequence (``CSI ? 5 W``) to reset tab stops to every 8 columns
+
 - Preserve user-set tab stops across window resizes (previously they were reset to every 8 columns on every resize)
 
 - Fix a regression in the previous release that caused :ac:`copy_or_noop` to stop working correctly (:pull:`10041`)

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -2076,6 +2076,11 @@ screen_set_tab_stop(Screen *self) {
 }
 
 void
+screen_reset_tab_stops(Screen *self) {
+    init_tabstops(self->tabstops, self->columns);
+}
+
+void
 screen_cursor_move(Screen *self, unsigned int count/*=1*/, int move_direction/*=-1*/, bool allow_move_to_previous_line) {
     if (count == 0) count = 1;
     bool in_margins = cursor_within_margins(self);
@@ -4978,6 +4983,7 @@ WRAP0(reverse_index)
 WRAP0(reset)
 WRAP0(set_tab_stop)
 WRAP1(clear_tab_stop, 0)
+WRAP0(reset_tab_stops)
 WRAP0(backspace)
 WRAP0(tab)
 WRAP0(linefeed)
@@ -6260,6 +6266,7 @@ static PyMethodDef methods[] = {
     MND(carriage_return, METH_NOARGS)
     MND(set_tab_stop, METH_NOARGS)
     MND(clear_tab_stop, METH_VARARGS)
+    MND(reset_tab_stops, METH_NOARGS)
     MND(start_selection, METH_VARARGS)
     MND(update_selection, METH_VARARGS)
     {"clear_selection", (PyCFunction)clear_selection_, METH_NOARGS, ""},

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -575,16 +575,26 @@ screen_resize(Screen *self, unsigned int lines, unsigned int columns) {
     grman_resize(self->alt_grman, self->lines, lines, self->columns, columns, num_content_lines_before, num_content_lines_after);
 #undef setup_cursor
     /* printf("\nold_size: (%u, %u) new_size: (%u, %u)\n", self->columns, self->lines, columns, lines); */
+    index_type old_columns_for_tabs = self->columns;
     self->lines = lines; self->columns = columns;
     self->margin_top = 0; self->margin_bottom = self->lines - 1;
 
-    PyMem_Free(self->main_tabstops);
-    self->main_tabstops = PyMem_Calloc(2*self->columns, sizeof(bool));
-    if (self->main_tabstops == NULL) { PyErr_NoMemory(); return false; }
-    self->alt_tabstops = self->main_tabstops + self->columns;
-    self->tabstops = self->main_tabstops;
-    init_tabstops(self->main_tabstops, self->columns);
-    init_tabstops(self->alt_tabstops, self->columns);
+    bool *old_tabstops = self->main_tabstops;
+    bool *new_tabstops = PyMem_Calloc(2 * self->columns, sizeof(bool));
+    if (new_tabstops == NULL) { PyErr_NoMemory(); return false; }
+    bool *new_main = new_tabstops;
+    bool *new_alt = new_tabstops + self->columns;
+    init_tabstops(new_main, self->columns);
+    init_tabstops(new_alt, self->columns);
+    if (old_tabstops && old_columns_for_tabs) {
+        index_type to_copy = MIN(old_columns_for_tabs, self->columns);
+        memcpy(new_main, old_tabstops, to_copy * sizeof(bool));
+        memcpy(new_alt, old_tabstops + old_columns_for_tabs, to_copy * sizeof(bool));
+    }
+    PyMem_Free(old_tabstops);
+    self->main_tabstops = new_main;
+    self->alt_tabstops = new_alt;
+    self->tabstops = is_main ? self->main_tabstops : self->alt_tabstops;
     self->is_dirty = true;
     clear_all_selections(self);
     self->last_visited_prompt.is_set = false;

--- a/kitty/screen.h
+++ b/kitty/screen.h
@@ -245,6 +245,7 @@ void screen_set_tab_stop(Screen *self);
 void screen_tab(Screen *self);
 void screen_backtab(Screen *self, unsigned int);
 void screen_clear_tab_stop(Screen *self, unsigned int how);
+void screen_reset_tab_stops(Screen *self);
 void screen_set_mode(Screen *self, unsigned int mode);
 void screen_reset_mode(Screen *self, unsigned int mode);
 void screen_decsace(Screen *self, unsigned int);

--- a/kitty/vt-parser.c
+++ b/kitty/vt-parser.c
@@ -1246,6 +1246,14 @@ dispatch_csi(PS *self) {
             }
             REPORT_ERROR("Unknown CSI R sequence with start and end modifiers: '%c' '%c' and %u parameters", start_modifier, end_modifier, num_params);
             break;
+        case 'W':
+            if (start_modifier == '?' && !end_modifier && num_params == 1 && params[0] == 5) {
+                REPORT_COMMAND(screen_reset_tab_stops);
+                screen_reset_tab_stops(self->screen);
+                break;
+            }
+            REPORT_ERROR("Unknown CSI W sequence with start and end modifiers: '%c' '%c' and %u parameters", start_modifier, end_modifier, num_params);
+            break;
         case ECH:
             CALL_CSI_HANDLER1(screen_erase_characters, 1);
         case DA:

--- a/kitty_tests/screen.py
+++ b/kitty_tests/screen.py
@@ -530,6 +530,22 @@ class TestScreen(BaseTest):
         s = self.create_screen(cols=4, lines=2)
         s.draw('aaaX\tbbbb')
         self.ae(str(s.line(0)) + str(s.line(1)), 'aaaXbbbb')
+        # DECST8C: reset tab stops to every 8 columns
+        s = self.create_screen(cols=20, lines=2)
+        s.clear_tab_stop(3)
+        s.reset_tab_stops()
+        s.cursor_position(1, 1)
+        s.tab()
+        self.ae(s.cursor.x, 8)
+        s.tab()
+        self.ae(s.cursor.x, 16)
+        # Verify the DECST8C escape sequence
+        s = self.create_screen(cols=20, lines=2)
+        s.clear_tab_stop(3)
+        parse_bytes(s, b'\x1b[?5W')
+        s.cursor_position(1, 1)
+        s.tab()
+        self.ae(s.cursor.x, 8)
 
         # Custom tab stops survive a window resize
         s = self.create_screen(cols=20, lines=2)

--- a/kitty_tests/screen.py
+++ b/kitty_tests/screen.py
@@ -531,6 +531,34 @@ class TestScreen(BaseTest):
         s.draw('aaaX\tbbbb')
         self.ae(str(s.line(0)) + str(s.line(1)), 'aaaXbbbb')
 
+        # Custom tab stops survive a window resize
+        s = self.create_screen(cols=20, lines=2)
+        s.clear_tab_stop(3)  # clear all
+        s.cursor_position(1, 5)
+        s.set_tab_stop()  # stop at column index 4
+        s.cursor_position(1, 13)
+        s.set_tab_stop()  # stop at column index 12
+        # Grow: existing stops preserved, new columns get default every-8 stops
+        s.resize(s.lines, 30)
+        s.cursor_position(1, 1)
+        s.tab(); self.ae(s.cursor.x, 4)
+        s.tab(); self.ae(s.cursor.x, 12)
+        s.tab(); self.ae(s.cursor.x, 24)  # default stop in newly added columns
+        # Shrink: stops within new width are preserved
+        s.resize(s.lines, 15)
+        s.cursor_position(1, 1)
+        s.tab(); self.ae(s.cursor.x, 4)
+        s.tab(); self.ae(s.cursor.x, 12)
+        # Resize on alt screen also preserves alt-screen tab stops
+        s = self.create_screen(cols=20, lines=2)
+        parse_bytes(s, b'\x1b[?1049h')  # switch to alt screen
+        s.clear_tab_stop(3)
+        s.cursor_position(1, 5)
+        s.set_tab_stop()
+        s.resize(s.lines, 30)
+        s.cursor_position(1, 1)
+        s.tab(); self.ae(s.cursor.x, 4)
+
     def test_backspace(self):
         s = self.create_screen()
         q = 'a'*s.columns


### PR DESCRIPTION
Recognize CSI ? 5 W as DECST8C, which resets the active screen's tab
stops to the default of every 8 columns. Other CSI W variants continue
to produce a parse error.

Note this is AI generated and reviewed by me and tested on WSL.

Depends on: https://github.com/kovidgoyal/kitty/pull/10073
Related: https://github.com/kovidgoyal/kitty/issues/10072