### PR TITLE
Make first mouse clicks activate and pass through

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -1015,7 +1015,7 @@ static void _glfwUpdateNotchCover(_GLFWwindow*);
 - (BOOL)acceptsFirstMouse:(NSEvent *)event
 {
     (void)event;
-    return NO;  // changed by Kovid, to follow cocoa platform conventions
+    return YES;  // follow cocoa platform conventions
 }
 
 - (void)mouseDown:(NSEvent *)event


### PR DESCRIPTION
## Summary

Allow first mouse clicks to both activate/focus the target and pass through to the clicked element.

This applies to:
- inactive Cocoa OS windows via `acceptsFirstMouse:`
- inactive kitty windows inside an already focused OS window

## Details

The original Cocoa-only change would have made inactive OS windows pass first clicks through, while inactive kitty windows inside a focused OS window still treated the first click as focus-only.

This patch updates the kitty-internal behavior as well, so both levels now follow the same rule: the first click focuses the target and continues through the normal mouse handling path.

In particular, clicking an inactive kitty window inside a focused OS window still switches kitty focus to the clicked window, but no longer suppresses forwarding of the initial left click and matching release. This allows the click to be handled normally, including by kitty mouse mappings and mouse-tracking applications.

This change only adjusts Cocoa OS-window behavior and kitty's own internal window behavior.

## Testing

- `./dev.sh build`
- `./test.py --module mouse`
- `./test.py --module glfw`
- `./test.py --module layout`

Implemented with assistance from Codex.