### PR TITLE
scrollbar: start drag after track click when jump_on_click is enabled

### DIFF
--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -645,6 +645,11 @@ handle_scrollbar_mouse(Window *w, int button, MouseAction action, int modifiers 
                 start_scrollbar_drag(w, mouse_y);
                 global_state.active_drag_in_window = w->id;
                 global_state.active_drag_button = button;
+            } else if (hit_type == SCROLLBAR_HIT_TRACK && OPT(scrollbar_jump_on_click)) {
+                handle_scrollbar_track_click(w, mouse_y);
+                start_scrollbar_drag(w, mouse_y);
+                global_state.active_drag_in_window = w->id;
+                global_state.active_drag_button = button;
             }
         }
     }


### PR DESCRIPTION
When scrollbar_jump_on_click is on and the user clicks the track, immediately jump to the clicked position and begin a drag so holding the button and moving the mouse continues scrolling. Matches the behavior of Firefox and GTK apps.

Relates to #10081

