### PR TITLE
Wayland: Fix crash hiding titlebar on layer-shell windows

### DIFF
--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -476,7 +476,9 @@ inform_compositor_of_window_geometry(_GLFWwindow *window, const char *event) {
 #define geometry window->wl.decorations.geometry
     debug("Setting window %llu \"visible area\" geometry in %s event: x=%d y=%d %dx%d viewport: %dx%d\n",
             window->id, event, geometry.x, geometry.y, geometry.width, geometry.height, window->wl.width, window->wl.height);
-    xdg_surface_set_window_geometry(window->wl.xdg.surface, geometry.x, geometry.y, geometry.width, geometry.height);
+    // Layer-shell surfaces have no xdg_surface; geometry is managed via the
+    // layer surface, so skip the xdg call to avoid a NULL proxy dereference.
+    if (window->wl.xdg.surface) xdg_surface_set_window_geometry(window->wl.xdg.surface, geometry.x, geometry.y, geometry.width, geometry.height);
     if (window->wl.wp_viewport) wp_viewport_set_destination(window->wl.wp_viewport, window->wl.width, window->wl.height);
 #undef geometry
 }


### PR DESCRIPTION
inform_compositor_of_window_geometry() calls xdg_surface_set_window_geometry() unconditionally, but layer-shell surfaces (e.g. those from `kitten panel`) have no xdg_surface. With hide_window_decorations set to titlebar-only, the panel hits this geometry call during creation and dereferences the NULL proxy, crashing in wl_proxy_get_version() with SIGSEGV.

Guard on window->wl.xdg.surface: layer-shell surfaces manage geometry via the layer surface, so the xdg call is skipped. Normal toplevels are unaffected.

Repro: set hide_window_decorations titlebar-only and launch a layer-shell window