### PR TITLE
docs: add kitty-search kitten to integrations page

### DIFF
--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -322,6 +322,13 @@ Various image viewing plugins for editors
 Scrollback manipulation
 -------------------------
 
+.. tool_kitty_search_incremental:
+
+`kitty-search <https://github.com/Mobinshahidi/kitty-search>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Incremental scrollback search with live results, regex and literal modes,
+case-sensitivity toggle, match counter, and auto-scroll to the matching line.
+
 .. tool_kitty_scrollback_nvim:
 
 `kitty-scrollback.nvim <https://github.com/mikesmithgh/kitty-scrollback.nvim>`_


### PR DESCRIPTION
As suggested by @kovidgoyal in #10093. Adding my incremental scrollback search kitten to the integrations page.