### PR TITLE
fonts: attach synthetic-italic FC_MATRIX to found roman faces

### DIFF
--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -423,7 +423,7 @@ class FontConfigPattern(TypedDict):
     scalable: bool
     outline: bool
     color: bool
-    matrix: tuple[float, float, float, float]
+    matrix: NotRequired[tuple[float, float, float, float]]
     variable: bool
     named_instance: bool
 

--- a/kitty/fontconfig.c
+++ b/kitty/fontconfig.c
@@ -458,6 +458,10 @@ specialize_font_descriptor(PyObject *base_descriptor, double font_sz_in_pts, dou
     if (axes) {
         if (PyDict_SetItemString(ans, "axes", axes) != 0) return NULL;
     }
+    PyObject *matrix = PyDict_GetItemString(base_descriptor, "matrix");
+    if (matrix) {
+        if (PyDict_SetItemString(ans, "matrix", matrix) != 0) return NULL;
+    }
     PyObject *ff = PyDict_GetItemString(ans, "fontfeatures");
     if (ff && PyList_GET_SIZE(ff)) {
         for (Py_ssize_t i = 0; i < PyList_GET_SIZE(ff); i++) {

--- a/kitty/fonts/common.py
+++ b/kitty/fonts/common.py
@@ -401,7 +401,38 @@ def get_font_files(opts: Options) -> FontFiles:
             font = medium_font
         key = kd[(bold, italic)]
         ans[key] = font
-    return {'medium': ans['medium'], 'bold': ans['bold'], 'italic': ans['italic'], 'bi': ans['bi']}
+
+    def apply_synthetic_matrix(font: Descriptor, bold: bool, italic: bool) -> Descriptor:
+        # fontconfig's FcFontList (used by find_best_match) omits FC_MATRIX from
+        # its object set, so a roman font found there carries no synthetic-italic
+        # shear and its "italic" renders upright. Fira Code is the case (it ships
+        # no italic), in both its static and variable builds. The italic intent
+        # exists only here at selection finalize, not at face construction, so
+        # recover the matrix now: for an italic slot whose chosen face is upright
+        # (no slant) and has no matrix yet, ask fc_match what fontconfig would do.
+        # fc_match returns a synthetic matrix only when there is no real italic to
+        # use (no italic face and no slanted named instance or variable slant
+        # axis); when a real italic exists it returns no matrix, so a font that is
+        # already italic, static or variable, is never double-slanted. Face construction applies the matrix
+        # via FT_Set_Transform; specialize_font_descriptor preserves it when the
+        # descriptor is sized for rendering. Only the matrix is taken, so
+        # selection is unchanged. Covers the four configured faces; fc_match
+        # re-matches by family name (see commit message).
+        if (italic and font['descriptor_type'] == 'fontconfig'
+                and not font.get('matrix') and not font.get('slant')):
+            from kitty.fast_data_types import FC_MONO
+            from kitty.fonts.fontconfig import fc_match
+            mtx = fc_match(font['family'], bold, italic, FC_MONO if is_monospace(font) else -1).get('matrix')
+            if mtx:
+                new_font = font.copy()
+                new_font['matrix'] = mtx
+                return new_font
+        return font
+    return {
+        'medium': ans['medium'], 'bold': ans['bold'],
+        'italic': apply_synthetic_matrix(ans['italic'], False, True),
+        'bi': apply_synthetic_matrix(ans['bi'], True, True),
+    }
 
 
 def axis_values_are_equal(defaults: dict[str, float], a: dict[str, float], b: dict[str, float]) -> bool:

--- a/kitty_tests/fonts.py
+++ b/kitty_tests/fonts.py
@@ -173,6 +173,41 @@ class Selection(BaseTest):
             self.ae(face_from_descriptor(ff['medium']).applied_features(), {'dlig': 'dlig', 'test': 'test=3'})
             self.ae(face_from_descriptor(ff['bold']).applied_features(), {'dlig': 'dlig', 'test': 'test=3'})
 
+    def test_synthetic_italic_matrix(self):
+        # A roman-only font that find_best_match finds (e.g. Fira Code, which ships
+        # no italic face) must get fontconfig's synthetic-italic FC_MATRIX
+        # (90-synthetic.conf) attached, so its italic renders slanted rather than
+        # upright; real-italic faces must not. The shear value is fontconfig's, not
+        # ours, so assert the invariant (a non-identity matrix is present), not the
+        # exact tuple, for cross-config stability.
+        if is_macos:
+            self.skipTest('synthetic-italic FC_MATRIX is a fontconfig feature')
+        from kitty.fonts.fontconfig import FC_MONO, fc_match
+        names = set(all_fonts_map(True)['family_map']) | set(all_fonts_map(True)['variable_map'])
+        if family_name_to_key('fira code') not in names:
+            self.skipTest('Fira Code not installed')
+        # Probe fc_match directly so we can tell "environment lacks the rule" (skip)
+        # from "code did not attach the matrix" (fail).
+        if fc_match('Fira Code', False, True, FC_MONO).get('matrix') is None:
+            self.skipTest('fontconfig 90-synthetic.conf not active; no synthetic-italic matrix')
+        opts = Options()
+        opts.font_family = parse_font_spec('Fira Code')
+        ff = get_font_files(opts)
+        self.assertIsNone(ff['medium'].get('matrix'))      # upright stays upright
+        mi = ff['italic'].get('matrix')
+        self.assertIsNotNone(mi)                            # roman, no italic -> sheared
+        self.assertNotEqual(mi[1], 0.0)                     # actually slanted, not identity
+        # Faces are built from a size-specialized descriptor at render time; the
+        # matrix must survive specialize_font_descriptor or the glyphs render
+        # upright despite the descriptor above being correct.
+        from kitty.fast_data_types import specialize_font_descriptor
+        sd = specialize_font_descriptor(dict(ff['italic']), 12.0, 96.0, 96.0)
+        self.ae(sd.get('matrix'), mi)
+        if family_name_to_key('liberation mono') in names:  # real-italic control
+            opts.font_family = parse_font_spec('Liberation Mono')
+            self.assertIsNone(get_font_files(opts)['italic'].get('matrix'))
+
+
 def block_helpers(s, sprites, cell_width, cell_height):
     mr = {}
     actual = b''


### PR DESCRIPTION
Follow-up to #10007, applying the suggestion there (do the matching for rendering,
not during listing) but taking only the resulting matrix and only after selection,
so it cannot perturb font selection the way that PR did.

Now two commits. The first fixes the reason the original push of this branch did
not actually render slanted (caught by Kovid in review): the matrix was attached
to the descriptor but stripped again before the face was built.

### Problem

fontconfig's `90-synthetic.conf` applies a slant matrix to a roman-only font when
italic is requested. `b3e7c3e` reads that matrix and applies it via
`FT_Set_Transform`, but the matrix only exists after fontconfig substitution.
`find_best_match()` reads candidates from `FcFontList`, whose object set does not
include `FC_MATRIX`, so a roman-only font it finds carries no shear and its italic
renders upright. Fira Code is the common case: it is monospaced, in the exact-match
map, and ships no italic, so `font_family Fira Code` leaves italic text upright.

There is a second, independent gap. Faces are built at render size from a
descriptor that first goes through `specialize_font_descriptor()`. That re-match is
keyed on file, index, size and dpi with no slant request, so fontconfig cannot
re-derive the synthetic matrix, and the function copied back only `index`,
`named_style` and `axes` from the base descriptor. Any matrix on a descriptor was
lost on every sized face build. Runtime glyph-fallback faces are unaffected
(`create_fallback_face` -> `_fc_match` builds the face directly, no specialize
step), which is why b3e7c3e works for fallback glyphs but a matrix on a configured
face never reached the renderer.

### Change

Commit 1: `specialize_font_descriptor()` preserves `matrix` alongside the other
selection-derived fields the re-match cannot reproduce.

Commit 2: at the end of `get_font_files()`, for an italic or bold-italic slot whose
chosen face is roman and carries no matrix, fetch the synthetic matrix with
`fc_match()` and set it on a copy of the descriptor. Face construction applies it.

This is at selection finalize rather than inside `find_best_match` because running
render-prepare there mutates descriptors used for selection, which is what broke
font selection in #10007. It is not in `face_from_descriptor` because the italic
intent only exists during selection (a roman descriptor chosen for the italic slot
is identical to one chosen for the medium slot by the time it reaches face
construction). Only the matrix is taken, so selection is unchanged. fc_match returns
a matrix only when there is no real italic to use (no italic face and no slanted
named instance or variable slant axis), so a font that is already italic, static
or variable, gets none and is not double-slanted; already-slanted and
already-matrixed faces are skipped up front.

`FontConfigPattern` declared `matrix` as a required key, but `pattern_as_dict` sets
it only when the pattern has one, so it is `NotRequired` now. With that and
narrowing on `descriptor_type` the attach needs no `cast()`.

### Testing

- Verified at the pixel level through font group creation (the path a real terminal
  takes): with `font_family Fira Code`, an italic cell renders with a clear forward
  shear while the roman cell stays vertical. Without commit 1 both render vertical,
  which reproduces the review report.
- Selection is unchanged, re-checked on this exact tree: across 12 monospace
  families and both spec forms, master's selection code and this branch choose
  identical faces in all 96 slot checks; the only difference is the matrix key
  added on Fira Code's italic and bold-italic slots.
- The regression test, `test_synthetic_italic_matrix`: a roman no-italic font
  (Fira Code) gets a non-identity matrix on its italic slot, a real-italic control
  (Liberation Mono) gets none, and the matrix survives
  `specialize_font_descriptor()`. That last assertion fails without commit 1. The
  test asserts the invariant, not the exact shear (the value is fontconfig's and
  version-dependent), and skips when the synthetic rule is inactive.
- Since the shear also reaches harfbuzz via `hb_font_set_synthetic_slant` for
  configured faces, shaping is regression-checked: `test_shaping` passes.
- The fonts test module passes here, with two unrelated pre-existing failures: the
  Consolas package on my machine ships only three faces (no BoldItalic), so its
  bold-italic slot falls back to Consolas-Italic. Fails identically on master.
- mypy (strict, as in CI) and ruff: no findings for this change.

### Known limitation

`fc_match` re-matches by family name, so a user per-font `FC_MATRIX` rule keyed on
width or style could attach a matrix computed for a different face of a multi-face
family. The `90-synthetic` shear this targets is weight-independent and unaffected.
The precise fix re-matches the selected face by path, index and slant, which needs a
small C helper; I can do that instead if you prefer it over the family match.
