### PR TITLE
dnd: eagerly stage remote drags so non-promise apps accept them

### DIFF
--- a/docs/dnd-protocol.rst
+++ b/docs/dnd-protocol.rst
@@ -438,6 +438,51 @@ inform the client of it with::
 The error code for too many resources is ``EMFILE``,
 for IO errors is ``EIO`` and so on.
 
+Eager staging for platforms without lazy file transfer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+On some platforms (notably macOS) the native drag and drop machinery requires
+that, by the time a drop happens, the dragged files already exist on the local
+filesystem (it hands the receiving application a real ``file://`` URL that is
+read synchronously). Lazy, on-demand transfer of remote files at drop time
+(as used on X11/Wayland) is therefore not possible for applications that do not
+implement file promises. To make remote drags work with such applications, the
+data must be downloaded (*staged*) into a local temporary directory **before**
+the drag is started.
+
+To request this, the client sends, after building the drag offer (sending the
+MIME types, pre-sending the ``text/uri-list`` data and any drag images) but
+**before** starting the drag::
+
+    OSC _dnd_code ; t=P:x=-2 ST
+
+The terminal then downloads all the ``file://`` entries from the
+``text/uri-list`` into a local temporary directory using the ``t=k`` requests
+described above, exactly as it would at drop time. As staging progresses the
+terminal reports its status to the client using the ``t=s`` escape code:
+
+.. list-table:: Staging status
+
+   * - Code
+     - Description
+   * - ``t=s : x=0 : y=0``
+     - Staging has started; the data is being downloaded.
+   * - ``t=s : x=0 : y=1``
+     - Staging is complete; the data is local and the drag may now be started.
+   * - ``t=s : x=0 : y=2``
+     - An error occurred while staging; the optional payload is a POSIX error name.
+
+A terminal that does not need to stage the data (for example a local drag, or a
+platform that supports lazy transfer) **must** reply with ``t=s : x=0 : y=1``
+immediately so that the client can start the drag without delay. Once the client
+receives the ready status it starts the drag normally with ``t=P:x=-1``. If the
+user has released the mouse button by then the terminal responds with the ready
+status again (rather than ``t=E ; EPERM``) and keeps the staged data, so that a
+subsequent ``t=P:x=-1`` can start the drag without re-downloading.
+
+The ``t=P:x=-2`` step is optional; a client that does not send it gets the
+previous behaviour (lazy transfer where supported, file promises otherwise).
+
 Detecting support for this protocol
 -------------------------------------
 

--- a/kittens/dnd/drag.go
+++ b/kittens/dnd/drag.go
@@ -40,6 +40,8 @@ type remote_data_item struct {
 
 type drag_status struct {
 	active                 bool
+	preparing              bool // waiting for the terminal to finish staging (downloading) remote data before the OS drag can start
+	staged                 bool // staging finished; data is local and the OS drag can be started safely
 	terminal_accepted_drag bool
 	offered_mimes          []string
 	accepted_mime          int
@@ -155,8 +157,16 @@ func (dnd *dnd) set_drag_image() (err error) {
 }
 
 func (dnd *dnd) on_potential_drag_start(cell_x, cell_y int) (err error) {
-	if !dnd.allow_drags || dnd.drag_status.active {
+	if !dnd.allow_drags || dnd.drag_status.active || dnd.drag_status.preparing {
 		return
+	}
+	// The data has already been staged (e.g. on a previous attempt where the mouse
+	// button was released while files were still transferring). Start the OS drag
+	// immediately using the already-local files.
+	if dnd.drag_status.staged {
+		dnd.lp.QueueDnDData(DC{Type: 'P', X: -1}) // start drag
+		dnd.drag_status.active = true
+		return dnd.render_screen()
 	}
 	mimes := slices.Collect(maps.Keys(dnd.drag_sources))
 	actions := 3
@@ -181,9 +191,48 @@ func (dnd *dnd) on_potential_drag_start(cell_x, cell_y int) (err error) {
 		dnd.finish_drag("EIO")
 		return err
 	}
-	dnd.lp.QueueDnDData(DC{Type: 'P', X: -1}) // start drag
-	dnd.drag_status.active = true
+	// Ask the terminal to stage (download) the data locally before the OS drag is
+	// started. The terminal replies with a staging-status message; only once it
+	// reports "ready" do we actually start the drag (see on_staging_status). This is
+	// what lets remote drags be accepted by apps that do not support file promises
+	// (Firefox, Telegram, ...). For local/non-macOS drags the terminal reports ready
+	// immediately, so the drag starts with no perceptible delay.
+	dnd.lp.QueueDnDData(DC{Type: 'P', X: -2}) // prepare/stage
+	dnd.drag_status.preparing = true
 
+	return dnd.render_screen()
+}
+
+// staging states reported by the terminal via the t=s message
+const (
+	staging_preparing = 0
+	staging_ready     = 1
+	staging_error     = 2
+)
+
+func (dnd *dnd) on_staging_status(uri_idx, state int) (err error) {
+	switch state {
+	case staging_ready:
+		if dnd.drag_status.preparing {
+			// Data is local now: start the OS drag. If the user is still holding the
+			// mouse button this begins the drag immediately; if they released it the
+			// terminal keeps the staged data and reports ready again, and we wait for
+			// the user to drag once more (handled by drag_status.staged).
+			dnd.drag_status.preparing = false
+			dnd.drag_status.staged = true
+			dnd.drag_status.active = true
+			dnd.lp.QueueDnDData(DC{Type: 'P', X: -1})
+		} else {
+			// Ready after the OS drag could not be started (button released). Keep the
+			// staged flag so the next drag attempt starts instantly.
+			dnd.drag_status.staged = true
+			dnd.drag_status.active = false
+		}
+	case staging_error:
+		dnd.finish_drag("EIO")
+		dnd.drag_status.preparing = false
+		dnd.drag_status.staged = false
+	}
 	return dnd.render_screen()
 }
 

--- a/kittens/dnd/main.go
+++ b/kittens/dnd/main.go
@@ -282,6 +282,8 @@ func (dnd *dnd) run_loop() (err error) {
 			return dnd.on_drag_error(cmd)
 		case 'e':
 			return dnd.on_drag_event(cmd.X, cmd.Y, cmd.Operation)
+		case 's':
+			return dnd.on_staging_status(cmd.X, cmd.Y)
 		case 'k':
 			return dnd.on_drag_remote_data_request(cmd.X - 1)
 		}

--- a/kittens/dnd/render.go
+++ b/kittens/dnd/render.go
@@ -60,6 +60,11 @@ func (dnd *dnd) render_screen() error {
 		lp.Println()
 		y++
 	}
+	if dnd.drag_status.preparing {
+		lp.Println("\x1b[33mTransferring files, please wait…\x1b[39m")
+		render_paragraph("The files are being downloaded locally so they can be dropped into any application. Keep the mouse button held down; the drag will begin automatically once the transfer completes.")
+		return nil
+	}
 	if dnd.drag_status.active {
 		lp.Println("Dragging data...")
 		if dnd.drag_status.dropped {
@@ -67,6 +72,11 @@ func (dnd *dnd) render_screen() error {
 		} else if dnd.drag_status.accepted_operation > 0 {
 			render_paragraph("Another window is willing to accept the dragged data")
 		}
+		return nil
+	}
+	if dnd.drag_status.staged {
+		lp.Println("\x1b[32m✓ OK to drag\x1b[39m")
+		render_paragraph("The files are ready. Start dragging again to drop them into another application.")
 		return nil
 	}
 

--- a/kitty/dnd.c
+++ b/kitty/dnd.c
@@ -1325,6 +1325,7 @@ drag_free_offer(Window *w, bool remove_remote_items) {
     free_pending(&ds.pending);
     ds.allowed_operations = 0;
     ds.state = DRAG_SOURCE_NONE;
+    ds.prefetching = false;
     ds.pre_sent_total_sz = 0;
     ds.images_sent_total_sz = 0;
     if (ds.file_promises) {
@@ -1354,6 +1355,21 @@ cancel_drag(Window *w, int error_code, const char *details) {
     if (error_code) drag_send_error(w, error_code, details);
     if (global_state.drag_source.is_active && global_state.drag_source.from_window == w->id) cancel_current_drag_source();
     if (error_code) drag_free_offer(w, true);
+}
+
+// Eager staging (prefetch) status reported back to the client kitten so it can
+// show the user when a remote drag is safe to start (i.e. the data has been
+// downloaded locally and promise-incapable apps like Firefox/Telegram will accept
+// the drop). state: 0 = preparing, 1 = ready, 2 = error.
+typedef enum { STAGING_PREPARING = 0, STAGING_READY = 1, STAGING_ERROR = 2 } StagingState;
+
+static void
+drag_send_staging_status(Window *w, StagingState state, int uri_idx, const char *details) {
+    char buf[256];
+    int header_size = snprintf(buf, sizeof(buf), "\x1b]%d;t=s:x=%d:y=%d", DND_CODE, uri_idx, (int)state);
+    size_t n = details ? strlen(details) : 0;
+    queue_payload_to_child(
+        w->id, w->drag_source.client_id, &w->drag_source.pending, buf, header_size, details, n, false);
 }
 
 #define abrt(code, details) { cancel_drag(w, code, details); return; }
@@ -1553,7 +1569,8 @@ parse_uri_list(Window *w, char *data, const ssize_t sz, size_t *num_uris_out) {
 void
 drag_start(Window *w) {
     if (ds.state != DRAG_SOURCE_BEING_BUILT) abrt(EINVAL, "cannot start drag as drag source is not being built");
-    delete_basedir_for_remote_items(w);
+    // Preserve any eagerly-staged items (their data lives under base_dir_for_remote_items).
+    if (!ds.prefetching) delete_basedir_for_remote_items(w);
     size_t total_size = 0;
     for (size_t idx = 0; idx < arraysz(ds.images); idx++) {
         if (img.sz) {
@@ -1623,13 +1640,24 @@ drag_start(Window *w) {
     last_total_image_size = total_size;
     int err = start_window_drag(w, dnd_is_test_mode());
     if (err != 0) {
-        if (err == EPERM) abrt(err, "permission to start drag denied, this can happen if the user has already released the drag or if the mouse has moved out of the window");
+        if (err == EPERM) {
+            // The user released the button (or moved out of the window) before the OS
+            // drag could be started. If we have already staged the data, keep the offer
+            // intact and tell the client it is ready, so the next drag attempt starts
+            // immediately instead of re-downloading everything.
+            bool have_staged = false;
+            for (size_t i = 0; i < ds.num_mimes; i++) if (ds.items[i].staged) { have_staged = true; break; }
+            if (have_staged) { drag_send_staging_status(w, STAGING_READY, 0, NULL); return; }
+            abrt(err, "permission to start drag denied, this can happen if the user has already released the drag or if the mouse has moved out of the window");
+        }
         abrt(err, "failed to start drag in OS");
     } else {
         // Free images and optional_data but keep the items array for later
         // data requests from the drop target
         for (size_t i = 0; i < ds.num_mimes; i++) {
-            if (ds.is_remote_client && ds.items[i].is_uri_list) {
+            // Staged items already hold local file:// URLs in optional_data and need
+            // no remote parsing; the OS backend was told to use real URLs for them.
+            if (ds.is_remote_client && ds.items[i].is_uri_list && !ds.items[i].staged) {
                 if (ds.items[i].optional_data && ds.items[i].data_size) {
                     ds.items[i].uri_list = parse_uri_list(
                             w, (char*)ds.items[i].optional_data, ds.items[i].data_size, &ds.items[i].num_uris);
@@ -1754,6 +1782,38 @@ request_remote_files(Window *w, size_t i) {
     }
     return true;
 #undef mi
+}
+
+void
+drag_prepare(Window *w) {
+    // Called when the client offers a remote drag, before the OS drag is started.
+    // On macOS we eagerly download (stage) the remote uri-list items into a local
+    // temp dir so that, when the user actually drags, real local file:// URLs can be
+    // placed on the pasteboard and promise-incapable apps (Firefox, Telegram, etc.)
+    // accept the drop. On other platforms the OS streams the data lazily at drop
+    // time which already works everywhere, so we just report ready immediately.
+    if (!ds.can_offer || ds.state != DRAG_SOURCE_BEING_BUILT) return;
+    if (!ds.is_remote_client) { drag_send_staging_status(w, STAGING_READY, 0, NULL); return; }
+#ifndef __APPLE__
+    drag_send_staging_status(w, STAGING_READY, 0, NULL);
+#else
+    for (size_t i = 0; i < ds.num_mimes; i++) {
+        if (ds.items[i].is_uri_list && ds.items[i].optional_data && ds.items[i].data_size) {
+            if (ds.items[i].staged) { drag_send_staging_status(w, STAGING_READY, 0, NULL); return; }
+            if (ds.items[i].requested_remote_files) return;  // staging already in progress
+            ds.items[i].uri_list = parse_uri_list(
+                w, (char*)ds.items[i].optional_data, ds.items[i].data_size, &ds.items[i].num_uris);
+            if (!ds.items[i].uri_list) return;  // parse_uri_list cancelled the drag on error
+            ds.prefetching = true;
+            ds.items[i].requested_remote_files = true;
+            drag_send_staging_status(w, STAGING_PREPARING, 0, NULL);
+            if (!request_remote_files(w, i)) abrt(ENOMEM, "out of memory starting drag prefetch");
+            return;
+        }
+    }
+    // Nothing remote to stage (e.g. only in-memory mimes): ready right away.
+    drag_send_staging_status(w, STAGING_READY, 0, NULL);
+#endif
 }
 
 const char*
@@ -1969,7 +2029,41 @@ write_all(int fd, const void *buf, size_t sz) {
 }
 
 static void
+finish_prefetch_staging(Window *w, size_t item_idx) {
+    // All remote items for this uri-list have been downloaded into
+    // base_dir_for_remote_items and ds.items[item_idx].uri_list now holds local
+    // file:// URLs. Re-assemble them into optional_data so that when the OS drag is
+    // started later, the macOS backend emits real public.file-url drag items
+    // (instead of file promises) and the readiness can be reported to the client.
+#define it ds.items[item_idx]
+    size_t total = 1;
+    for (size_t i = 0; i < it.num_uris; i++) total += (it.uri_list[i] ? strlen(it.uri_list[i]) : 0) + 2;
+    char *buf = malloc(total);
+    if (!buf) abrt(ENOMEM, "out of memory finalizing drag prefetch");
+    size_t pos = 0;
+    for (size_t i = 0; i < it.num_uris; i++) {
+        if (it.uri_list[i]) {
+            size_t l = strlen(it.uri_list[i]);
+            memcpy(buf + pos, it.uri_list[i], l); pos += l;
+            buf[pos++] = '\r'; buf[pos++] = '\n';
+        }
+        free(it.uri_list[i]); it.uri_list[i] = NULL;
+    }
+    buf[pos] = 0;
+    free(it.uri_list); it.uri_list = NULL; it.num_uris = 0;
+    free(it.optional_data);
+    it.optional_data = (uint8_t*)buf;
+    it.data_size = pos;
+    it.data_capacity = pos;
+    it.requested_remote_files = false;
+    it.staged = true;
+    drag_send_staging_status(w, STAGING_READY, 0, NULL);
+#undef it
+}
+
+static void
 finish_remote_data(Window *w, size_t item_idx) {
+    if (ds.prefetching && ds.state < DRAG_SOURCE_STARTED) { finish_prefetch_staging(w, item_idx); return; }
     if (!ds.items[item_idx].fd_plus_one) {
         int fd = open_item_tmpfile();
         if (fd < 0) abrt(EIO, "failed to open temp file to store modified uri list");

--- a/kitty/dnd.h
+++ b/kitty/dnd.h
@@ -35,6 +35,7 @@ int drag_free_data(Window *w, const char *mime_type, const char* data, size_t sz
 const char* drag_get_data(Window *w, const char *mime_type, size_t *sz, int *err_code);
 void drag_process_item_data(Window *w, size_t idx, int has_more, const uint8_t *payload, size_t payload_sz);
 void drag_remote_file_data(Window *w, int32_t x, int32_t y, int32_t X, int32_t Y, bool has_more, const uint8_t *payload, size_t payload_sz);
+void drag_prepare(Window *w);
 void drag_start_offerring(Window *w, const char *client_machine_id, size_t sz);
 void drag_stop_offerring(Window *w);
 void drag_offer_start_to_child(Window *w, int32_t cell_x, int32_t cell_y, int32_t pixel_x, int32_t pixel_y);

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -3095,11 +3095,14 @@ start_window_drag(Window *w, bool in_test_mode) {
     if (!items) return ENOMEM;
     for (size_t i = 0; i < w->drag_source.num_mimes; i++) {
         items[i].mime_type = w->drag_source.items[i].mime_type;
-        items[i].is_remote_client = w->drag_source.is_remote_client;
+        // Staged uri-list items have already been downloaded locally and optional_data
+        // holds local file:// URLs, so they are treated as a non-remote (real URL) drag
+        // on macOS instead of using lazy file promises.
+        items[i].is_remote_client = w->drag_source.is_remote_client && !w->drag_source.items[i].staged;
         items[i].optional_data = (char*)w->drag_source.items[i].optional_data;
         items[i].data_size = w->drag_source.items[i].data_size;
 #ifndef __APPLE__
-        if (w->drag_source.is_remote_client && w->drag_source.items[i].is_uri_list) {
+        if (w->drag_source.is_remote_client && !w->drag_source.items[i].staged && w->drag_source.items[i].is_uri_list) {
             // On platforms other than macOS we treat the request for data for
             // this MIME type as a trigger to start remote download. On macOS
             // requests for individual items from this list will come in.

--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -1576,6 +1576,7 @@ screen_handle_dnd_command(Screen *self, const DnDCommand *cmd_, const uint8_t *p
         } break;
         case 'P': {
             if (cmd->cell_x >= 0) drag_change_image(w, cmd->cell_x);
+            else if (cmd->cell_x == -2) drag_prepare(w);
             else drag_start(w);
         } break;
         case 'e': {

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -325,6 +325,7 @@ typedef struct Window {
         struct {
             const char *mime_type; uint8_t *optional_data; size_t data_size, data_capacity; base64_state base64_state;
             bool data_decode_initialized, is_uri_list, requested_remote_files, data_requested_from_client;
+            bool staged;  // remote uri-list item has been fully pre-fetched to base_dir_for_remote_items and uri-list rewritten to local paths
             int fd_plus_one;
             char** uri_list; size_t num_uris;
             DragRemoteItem *remote_items; size_t num_remote_items;
@@ -337,6 +338,7 @@ typedef struct Window {
         unsigned img_idx;
         int allowed_operations;
         DragSourceState state;
+        bool prefetching;  // eager staging of remote items requested before the OS drag is started (macOS, so promise-incapable apps get real file:// URLs)
         PendingData pending;
         uint32_t client_id;
         char *base_dir_for_remote_items;

--- a/kitty_tests/dnd.py
+++ b/kitty_tests/dnd.py
@@ -4,6 +4,7 @@
 import errno
 import os
 import re
+import sys
 from base64 import standard_b64encode
 from contextlib import contextmanager
 from functools import partial
@@ -2772,6 +2773,42 @@ class TestDnDProtocol(BaseTest):
     def assert_drag_data_complete(self, cap) -> None:
         first_incomplete_entry = dnd_test_probe_state(cap.window_id, 'drag_remote_data_complete')
         self.assertIsNone(first_incomplete_entry)
+
+    def test_remote_drag_prefetch_eager_staging(self) -> None:
+        """drag_prepare (t=P:x=-2) eagerly downloads remote files before the drag.
+
+        On macOS, this is what lets promise-incapable apps (Firefox, Telegram, ...)
+        accept a remote drag: the files are staged locally first, then the OS drag is
+        started with real file:// URLs. Verifies the preparing/ready status messages
+        and that the remote-file requests are issued and complete without error.
+        """
+        if sys.platform != 'darwin':
+            self.skipTest('eager staging prefetch is only active on macOS')
+        mimes = 'text/plain text/uri-list'
+        uri_list = b'file:///home/user/hello.txt\r\n'
+        file_content = b'Hello, eager prefetch world!'
+        with dnd_test_window() as (screen, cap):
+            parse_bytes(screen, _osc(f'{DND_CODE};t=o:x=1;different-machine-id'))
+            parse_bytes(screen, client_drag_offer_mimes(1, mimes))
+            uri_idx = mimes.split().index('text/uri-list')
+            parse_bytes(screen, client_drag_pre_send(uri_idx, standard_b64encode(uri_list).decode()))
+            cap.consume()
+            # Request eager staging
+            parse_bytes(screen, _osc(f'{DND_CODE};t=P:x=-2'))
+            events = self._get_events(cap)
+            s_events = [e for e in events if e['type'] == 's']
+            k_events = [e for e in events if e['type'] == 'k']
+            self.assertTrue(
+                any(e['meta'].get('y') == '0' for e in s_events), f'no preparing status emitted: {events}')
+            self.assertEqual(1, len(k_events), f'expected one remote-file request, got: {events}')
+            # Stream the file content from the (simulated) remote client
+            parse_bytes(screen, client_remote_file(1, standard_b64encode(file_content).decode(), item_type=0))
+            parse_bytes(screen, client_remote_file(1, '', item_type=0))
+            events = self._get_events(cap)
+            s_events = [e for e in events if e['type'] == 's']
+            self.assertTrue(
+                any(e['meta'].get('y') == '1' for e in s_events), f'no ready status emitted: {events}')
+            self.assert_drag_data_complete(cap)
 
     def test_remote_drag_three_level_tree_with_verification(self) -> None:
         """Transfer a 3-level directory tree and verify no errors occur.


### PR DESCRIPTION
On macOS the native drag and drop hands the receiving application a real file:// URL that is read synchronously at drop time. Apps that do not implement file promises (Firefox, Telegram, most Chromium/Qt/Electron apps) therefore could not accept remote drags from the dnd kitten, which relied on lazy file promises. Finder, which does support promises, worked.

Make remote drags work everywhere by downloading (staging) the remote files into a local temp dir before the OS drag is started, then placing real file:// URLs on the pasteboard instead of promises.

The staging is triggered by the drag gesture (not proactively): on mouse-down the kitten builds the offer and sends a new t=P:x=-2 "prepare" request; the terminal stages all uri-list entries via the existing t=k machinery and reports progress with a new t=s status message. The kitten shows "Transferring files, please wait..." until staging completes, then starts the drag with real URLs. If the button is released mid-transfer the staged data is kept and "OK to drag" is shown so the retry is instant.

Local drags and non-macOS platforms report ready immediately, so there is no perceptible delay and lazy transfer behaviour is unchanged there.

See #10161.