### PR TITLE
macOS: Fix ctypes freeze in signed builds

### DIFF
--- a/bypy/macos/__main__.py
+++ b/bypy/macos/__main__.py
@@ -125,6 +125,7 @@ def sign_app(app_dir, notarize):
     create_entitlements_file({
         'com.apple.security.automation.apple-events': True,
         'com.apple.security.cs.allow-jit': True,
+        'com.apple.security.cs.disable-executable-page-protection': True,
         'com.apple.security.device.audio-input': True,
         'com.apple.security.device.camera': True,
         'com.apple.security.personal-information.addressbook': True,


### PR DESCRIPTION
This fixes a macOS freeze when kitty first imports `ctypes` in a signed build.

On macOS 26.5, marker actions such as `toggle_marker` and `create_marker` can freeze kitty permanently. The marker path imports `ctypes` from `kitty/marks.py`:

```python
from ctypes import POINTER, c_uint, c_void_p, cast
```

A minimal `kitty +launch` script reproduces the same hang before marker scanning:

```python
#!/usr/bin/env python3
import ctypes
print(ctypes.__file__, flush=True)
```

Run it with:

```sh
timeout 10s kitty +launch ./demo-ctypes-import.py
```

The process hangs in the `import ctypes` statement and times out.

Sampling the frozen process shows:

```text
_ctypes.so
  ffi_closure_alloc  (in libffi.dylib)
    dlmmap
      dlmmap_locked
        open_temp_exec_file_dir
          mkostemp
            openat$NOCANCEL
```

CPython 3.14 initializes `_ctypes` by calling:

```c
Py_ffi_closure_alloc(sizeof(void *), &codeloc);
```

On Apple OS libffi this reaches `ffi_closure_alloc()`. In a macOS app signed with Hardened Runtime, this closure allocation path needs `com.apple.security.cs.disable-executable-page-protection`. kitty already has `com.apple.security.cs.allow-jit`, but local testing shows `allow-jit` alone is not sufficient for this path.

This PR adds the missing entitlement to the generated macOS entitlements used when signing kitty.app.

No separate issue was opened because this is a small, localized signing change with a minimal fix and local validation. I can open a tracking issue if you prefer.

## Validation

- Installed kitty 0.47.0 with bundled Python 3.14.5 hangs with the minimal `ctypes` reproduction.
- kitty nightly 0.47.4 with bundled Python 3.14.6 still hangs, so this does not track Python patch version alone.
- Homebrew Python 3.14.6 succeeds, but it is unsigned, so Hardened Runtime entitlements do not apply.
- python.org CPython 3.14.5 succeeds; it is signed with Hardened Runtime and includes `com.apple.security.cs.disable-executable-page-protection`.
- A standalone C probe calling `ffi_closure_alloc()` succeeds unsigned, hangs when signed with Hardened Runtime and kitty-like `allow-jit` only, and succeeds when `disable-executable-page-protection` is added.
- Adding only `disable-library-validation` does not fix the C probe.
- A local copy of `kitty.app` re-signed with `disable-executable-page-protection` successfully imports `ctypes` and allocates a `ctypes.CFUNCTYPE` callback. The local ad-hoc test also needed `disable-library-validation` only because the copied app bundle had mixed signing identities; that is not part of this PR.

## Minimal patch

```diff
diff --git a/bypy/macos/__main__.py b/bypy/macos/__main__.py
@@
     create_entitlements_file({
         'com.apple.security.automation.apple-events': True,
         'com.apple.security.cs.allow-jit': True,
+        'com.apple.security.cs.disable-executable-page-protection': True,
         'com.apple.security.device.audio-input': True,
```

## Risk and scope

`disable-executable-page-protection` weakens one Hardened Runtime protection for the process. The scope is limited to the signed macOS app entitlement set, and the entitlement matches the behavior required by Apple libffi closure allocation. python.org's signed CPython macOS build also uses this entitlement.

This does not add `disable-library-validation`; that was only needed in local ad-hoc testing after re-signing a copied app bundle with a different identity.

## Changelog note

I did not include a changelog entry in this commit since this is release-signing metadata and the final wording may be better handled during release notes. If you want it in this PR, I can add:

```text
- macOS: Fix a freeze when marker actions first import ctypes in signed builds.
```

> The investigation was prepared with AI assistance; the one-line entitlement change was reviewed locally and validated with the checks above.
