### PR TITLE
[IMP] choose-files: allow selecting files and directories

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -200,6 +200,8 @@ Detailed list of changes
 
 - Fix superfluous margin visible to the left and right of the tab bar when :opt:`background_opacity` is less than one and the window width is not a multiple of the cell width (:iss:`10212`)
 
+- choose-files kitten: Add an ``all`` mode to select either an existing file or directory (:iss:`10208`)
+
 
 0.47.4 [2026-06-15]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/kittens/choose-files.rst
+++ b/docs/kittens/choose-files.rst
@@ -120,6 +120,16 @@ directory you can select a descendant directory by pressing :kbd:`Enter`, the
 same as you would for selecting a file to open.
 
 
+Selecting files or directories
+--------------------------------
+
+To select any existing path, whether it is a file or a directory, use
+:option:`--mode <kitty +kitten choose_files --mode>`:code:`=all`. Press
+:kbd:`Enter` to select the highlighted path. You can still use :kbd:`Tab` to
+change into a highlighted directory and :kbd:`Ctrl+Enter` to select the
+current directory itself.
+
+
 Configuration
 ------------------------
 

--- a/kittens/choose_files/main.go
+++ b/kittens/choose_files/main.go
@@ -44,6 +44,7 @@ const (
 	SELECT_SAVE_DIR
 	SELECT_SINGLE_DIR
 	SELECT_MULTIPLE_DIRS
+	SELECT_ANY
 )
 
 func (m Mode) CanSelectNonExistent() bool {
@@ -94,6 +95,8 @@ func (m Mode) WindowTitle() string {
 		return "Choose one or more directories"
 	case SELECT_SAVE_FILES:
 		return "Choose files to save"
+	case SELECT_ANY:
+		return "Choose an existing file or directory"
 	}
 	return ""
 }
@@ -391,6 +394,9 @@ func (h *Handler) current_abspath() string {
 }
 
 func (s *State) CanSelect(r *ResultItem) bool {
+	if s.mode == SELECT_ANY {
+		return true
+	}
 	return utils.IfElse(s.OnlyDirs(), r.ftype.IsDir(), !r.ftype.IsDir())
 }
 
@@ -585,7 +591,7 @@ func (h *Handler) dispatch_action(name, args string) (err error) {
 		}
 	case "typename":
 		if !h.state.mode.CanSelectNonExistent() {
-			if h.state.mode.OnlyDirs() {
+			if h.state.mode.OnlyDirs() || h.state.mode == SELECT_ANY {
 				h.state.AddSelection(h.state.CurrentDir())
 				return h.finish_selection()
 			}
@@ -730,6 +736,8 @@ func (h *Handler) set_state_from_config(conf *Config, opts *Options) (err error)
 		h.state.mode = SELECT_SINGLE_FILE
 	case "files":
 		h.state.mode = SELECT_MULTIPLE_FILES
+	case "all":
+		h.state.mode = SELECT_ANY
 	case "save-file":
 		h.state.mode = SELECT_SAVE_FILE
 	case "dir":

--- a/kittens/choose_files/main.py
+++ b/kittens/choose_files/main.py
@@ -214,7 +214,7 @@ usage = '[directory to start choosing files in]'
 OPTIONS = """
 --mode
 type=choices
-choices=file,files,save-file,dir,save-dir,dirs,save-files
+choices=file,files,all,save-file,dir,save-dir,dirs,save-files
 default=file
 The type of object(s) to select
 


### PR DESCRIPTION
Add a new mode `all` to select either a file or a directory.

For reference: https://github.com/kovidgoyal/kitty/issues/10208