### PR TITLE
[FIX] edit-in-kitty: support sublime text for edit-in-kitty

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -212,6 +212,8 @@ Detailed list of changes
 
 - choose-files kitten: Add a ``--mode=all`` to select either an existing file or directory (:iss:`10208`)
 
+- ``edit-in-kitty``: Fix line number not working when the editor is Sublime Text or Zed
+
 
 0.47.4 [2026-06-15]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/kitty/utils.py
+++ b/kitty/utils.py
@@ -588,6 +588,8 @@ def get_editor(opts: Options | None = None, path_to_edit: str = '', line_number:
             if eq in ('code', 'code.exe'):
                 path_to_edit += f':{line_number}'
                 ans.append('--goto')
+            elif eq in ('subl', 'subl.exe', 'sublime_text', 'sublime_text.exe', 'zed', 'zed.exe', 'zeditor'):
+                path_to_edit += f':{line_number}'
             else:
                 ans.append(f'+{line_number}')
         ans.append(path_to_edit)


### PR DESCRIPTION
Currently, only vs-code is supported for line jump in the file.

Running `kitten edit-in-kitty +10 test` with sublime text will open 2 files, "+10" and "test", and won't jump to the line 10.