### PR TITLE
[IMP] choose-files: make ctrl+backspace delete a word

### DIFF
--- a/kittens/choose_files/search-bar.go
+++ b/kittens/choose_files/search-bar.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/kovidgoyal/kitty/tools/tui/loop"
 	"github.com/kovidgoyal/kitty/tools/utils"
@@ -117,6 +119,13 @@ func (h *Handler) draw_search_bar(y int) {
 
 func (h *Handler) handle_edit_keys(ev *loop.KeyEvent) bool {
 	switch {
+	case ev.MatchesPressOrRepeat("ctrl+backspace"):
+		if h.state.SearchText() == "" {
+			h.lp.Beep()
+		} else {
+			h.set_query(delete_last_word(h.state.search_text))
+			return true
+		}
 	case ev.MatchesPressOrRepeat("backspace"):
 		if h.state.SearchText() == "" {
 			h.lp.Beep()
@@ -127,4 +136,23 @@ func (h *Handler) handle_edit_keys(ev *loop.KeyEvent) bool {
 		}
 	}
 	return false
+}
+
+func delete_last_word(text string) string {
+	end := len(text)
+	for end > 0 {
+		r, size := utf8.DecodeLastRuneInString(text[:end])
+		if !unicode.IsSpace(r) {
+			break
+		}
+		end -= size
+	}
+	for end > 0 {
+		r, size := utf8.DecodeLastRuneInString(text[:end])
+		if unicode.IsSpace(r) {
+			break
+		}
+		end -= size
+	}
+	return text[:end]
 }

--- a/kittens/choose_files/search-bar_test.go
+++ b/kittens/choose_files/search-bar_test.go
@@ -1,0 +1,22 @@
+package choose_files
+
+import "testing"
+
+func TestDeleteLastWord(t *testing.T) {
+	for _, tc := range []struct {
+		text, expected string
+	}{
+		{"", ""},
+		{"one", ""},
+		{"one two", "one "},
+		{"one two  ", "one "},
+		{"one\ttwo", "one\t"},
+		{"one\u2003two", "one\u2003"},
+		{"one   ", ""},
+		{"你好 世界", "你好 "},
+	} {
+		if actual := delete_last_word(tc.text); actual != tc.expected {
+			t.Errorf("delete_last_word(%q): expected %q, got %q", tc.text, tc.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
At the moment, ctrl+backspace does nothing in choose-files. With the commit, ctrl+backspace will delete the previous word.