### PR TITLE
Fix Wayland drag source startup on FreeBSD

### DIFF
--- a/glfw/backend_utils.c
+++ b/glfw/backend_utils.c
@@ -17,6 +17,7 @@
 #include <errno.h>
 #include <time.h>
 #include <stdio.h>
+#include <sys/mman.h>
 
 #ifdef __NetBSD__
 #define ppoll pollts

--- a/glfw/wl_client_side_decorations.c
+++ b/glfw/wl_client_side_decorations.c
@@ -12,6 +12,16 @@
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
+// Needed for the BTN_* defines
+#ifdef __has_include
+#if __has_include(<linux/input.h>)
+#include <linux/input.h>
+#elif __has_include(<dev/evdev/input.h>)
+#include <dev/evdev/input.h>
+#endif
+#else
+#include <linux/input.h>
+#endif
 
 #define decs window->wl.decorations
 #define debug debug_rendering

--- a/kitty/colors.c
+++ b/kitty/colors.c
@@ -9,8 +9,8 @@
 #include <structmember.h>
 #include "colors.h"
 #include "color-names.h"
-#ifdef __APPLE__
-// Needed for strod_l
+#if defined(__APPLE__) || defined(__FreeBSD__)
+// Needed for strtod_l
 #include <xlocale.h>
 #endif
 


### PR DESCRIPTION
Follow-up to #10230, which tracked `kitten dnd` failing to start a drag source on FreeBSD/Hyprland native Wayland.

This fixes native Wayland drag source startup on FreeBSD.

This PR also includes two FreeBSD build fixes needed to build the current tree:

- include `<xlocale.h>` for `strtod_l`
- include FreeBSD's evdev input header fallback for `BTN_LEFT` / `BTN_RIGHT`, matching the existing fallback pattern in `glfw/wl_init.c`

The runtime fix is the missing `<sys/mman.h>` include.

On FreeBSD, `SHM_ANON` is defined by `<sys/mman.h>`. `glfw/backend_utils.c` checked `SHM_ANON` without including that header, so the intended FreeBSD anonymous shm path was skipped.

As a result, Wayland drag buffer creation fell back to the `XDG_RUNTIME_DIR` tmpfile path, where buffer allocation failed with `EOPNOTSUPP`. That caused `createShmBuffer()` to fail, `_glfwPlatformStartDrag()` to return `ENOMEM`, and `kitten dnd` to report:

```text
terminal responded with drag source error: ENOMEM:failed to start drag in OS
```

Including `<sys/mman.h>` enables the existing FreeBSD `shm_open(SHM_ANON)` path.

### Tested

```sh
gmake debug  # on FreeBSD
make debug   # on Linux
./kitty/launcher/kitty --version
./kitty/launcher/kitten --version
./test.py --module dnd
./test.py --module dnd_kitten dnd_kitten_drag
```

Also checked:

- FreeBSD 15.1-RELEASE + Hyprland 0.55.4 native Wayland: `kitten dnd` now starts a drag source successfully
- Linux Wayland: `./kitty/launcher/kitty` launches and drag-and-drop still works after the build fixes