### PR TITLE
Make first mouse clicks activate and pass through

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -1016,7 +1016,7 @@ static void _glfwUpdateNotchCover(_GLFWwindow*);
 - (BOOL)acceptsFirstMouse:(NSEvent *)event
 {
     (void)event;
-    return NO;  // changed by Kovid, to follow cocoa platform conventions
+    return YES;  // follow cocoa platform conventions
 }
 
 - (void)mouseDown:(NSEvent *)event

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -870,27 +870,10 @@ HANDLER(handle_button_event) {
     Tab *t = osw->tabs + osw->active_tab;
     bool is_release = !osw->mouse_button_pressed[button];
 
-    if (button == GLFW_MOUSE_BUTTON_LEFT && osw->suppress_left_mouse_release) {
-        osw->suppress_left_mouse_release = false;
-        if (is_release) {
-            zero_at_ptr(&w->drag_source.initial_left_press);
-            return;
-        }
-    }
-
     if (handle_scrollbar_mouse(w, button, is_release ? RELEASE : PRESS, modifiers)) return;
 
-    bool suppress_child_forwarding = false;
     if (osw->is_focused && window_idx != t->active_window && !is_release) {
         call_boss(switch_focus_to_in_active_tab, "K", t->windows[window_idx].id);
-        if (button == GLFW_MOUSE_BUTTON_LEFT) {
-            // Treat split-focus transfer clicks as focus-only for child processes:
-            // suppress forwarding the left press and matching release to the child
-            // to avoid release-without-press reports. Still allow kitty to process
-            // the event internally (e.g., start text selection via click-and-drag).
-            osw->suppress_left_mouse_release = true;
-            suppress_child_forwarding = true;
-        }
     }
 
     Screen *screen = w->render_data.screen;
@@ -909,7 +892,7 @@ HANDLER(handle_button_event) {
     }
     id_type wid = w->id;
     if (!dispatch_mouse_event(w, button, is_release ? -1 : 1, modifiers, screen->modes.mouse_tracking_mode != 0)) {
-        if (!suppress_child_forwarding && screen->modes.mouse_tracking_mode != 0) {
+        if (screen->modes.mouse_tracking_mode != 0) {
             int sz = encode_mouse_button(w, button, is_release ? RELEASE : PRESS, modifiers);
             if (sz > 0) { mouse_event_buf[sz] = 0; write_escape_code_to_child(screen, ESC_CSI, mouse_event_buf); }
         }
@@ -1316,10 +1299,6 @@ mouse_event(const int button, int modifiers, int action) {
             w = window_for_id(global_state.active_drag_in_window);
             if (w) {
                 end_drag(w);
-                // Clear any stale suppress flag that was set during a focus-transfer
-                // press, since the drag release bypasses handle_button_event where
-                // it would normally be cleared.
-                if (osw) osw->suppress_left_mouse_release = false;
                 debug("handled as drag end\n");
                 dispatch_possible_click(w, button, modifiers);
                 return;

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -446,7 +446,6 @@ typedef struct OSWindow {
     double mouse_x, mouse_y;
     bool mouse_button_pressed[32];
     bool has_too_few_tabs;
-    bool suppress_left_mouse_release;
     PyObject *window_title;
     bool disallow_title_changes, title_is_overriden;
     bool viewport_size_dirty, viewport_updated_at_least_once;


### PR DESCRIPTION
## Summary

Allow first mouse clicks to both activate/focus the target and pass through to the clicked element.

This applies to:
- inactive Cocoa OS windows via `acceptsFirstMouse:`
- inactive kitty windows inside an already focused OS window

## Details

The original Cocoa-only change would have made inactive OS windows pass first clicks through, while inactive kitty windows inside a focused OS window still treated the first click as focus-only.

This patch updates the kitty-internal behavior as well, so both levels now follow the same rule: the first click focuses the target and continues through the normal mouse handling path.

In particular, clicking an inactive kitty window inside a focused OS window still switches kitty focus to the clicked window, but no longer suppresses forwarding of the initial left click and matching release. This allows the click to be handled normally, including by kitty mouse mappings and mouse-tracking applications.

This change only adjusts Cocoa OS-window behavior and kitty's own internal window behavior.

## Testing

- `./dev.sh build`
- `./test.py --module mouse`
- `./test.py --module glfw`
- `./test.py --module layout`

Implemented with assistance from Codex.