### PR TITLE
Remove timer when scroll finished

### DIFF
--- a/kitty/window.py
+++ b/kitty/window.py
@@ -2461,6 +2461,7 @@ class Window:
         if progress >= 1.0:
             # Ensure we land exactly on a line boundary with pixel_scroll_offset_y = 0
             self.screen.scroll_to_absolute(max(0, a.start_scrolled_by - a.total))
+            remove_timer(a.timer)
             a.timer = 0
         else:
             # Use absolute positioning to avoid pixel rounding errors from incremental fractional scrolls


### PR DESCRIPTION
If smooth scrolling has reached its target, scroll_animation_tick() clears the timer ID in the animation object. However, the timer was not removed, which resulted in the timers potentially accumulating and preventing the creation of new timers eventually. This caused smooth scrolling to stop working in the terminal.

I think the issue was exacerbated on my machine, because my keyboard's repetition rate is set quite high.