### PR TITLE
feat(quick-access-terminal): make --layer configurable

### DIFF
--- a/kittens/quick_access_terminal/main.go
+++ b/kittens/quick_access_terminal/main.go
@@ -37,10 +37,11 @@ func main(cmd *cli.Command, opts *Options, args []string) (rc int, err error) {
 	if err != nil {
 		return 1, err
 	}
-	argv := []string{kitty_exe, "+kitten", "panel", "--toggle-visibility", "--exclusive-zone=0", "--override-exclusive-zone", "--layer=overlay", "--single-instance", "--move-to-active-monitor"}
+	argv := []string{kitty_exe, "+kitten", "panel", "--toggle-visibility", "--exclusive-zone=0", "--override-exclusive-zone", "--single-instance", "--move-to-active-monitor"}
 	argv = append(argv, fmt.Sprintf("--lines=%s", conf.Lines))
 	argv = append(argv, fmt.Sprintf("--columns=%s", conf.Columns))
 	argv = append(argv, fmt.Sprintf("--edge=%s", conf.Edge))
+	argv = append(argv, fmt.Sprintf("--layer=%s", conf.Layer))
 	if conf.Margin_top != 0 {
 		argv = append(argv, fmt.Sprintf("--margin-top=%d", conf.Margin_top))
 	}

--- a/kittens/quick_access_terminal/main.py
+++ b/kittens/quick_access_terminal/main.py
@@ -40,6 +40,8 @@ opt('columns', '80', long_text=panel_opts['columns'].help)
 
 opt('edge', 'top', choices=panel_opts['edge'].choices, long_text=help_of('edge'))
 
+opt('layer', 'overlay', choices=panel_opts['layer'].choices, long_text=help_of('layer'))
+
 opt('background_opacity', '0.85', option_type='unit_float', long_text='''
 The background opacity of the window. This works the same as the kitty
 option of the same name, it is present here as it has a different


### PR DESCRIPTION
Related: #10172

The `--layer` parameter for the panel kitten was hardcoded to `overlay`
in the quick access terminal Go code. This change exposes it as a
configurable option in `quick-access-terminal.conf`, matching how
`--edge` is already handled.

Users can now set e.g. `layer top` in their config file to allow
input method popups (like fcitx) to appear above the QAT panel.

Changes:
- `kittens/quick_access_terminal/main.py`: add `layer` option with
  choices from the panel kitten spec, defaulting to `overlay`
- `kittens/quick_access_terminal/main.go`: use `conf.Layer` instead of
  hardcoded `--layer=overlay`

