### PR TITLE
Fix IME popup position after text_input re-enters on Wayland

### DIFF
--- a/glfw/wl_text_input.c
+++ b/glfw/wl_text_input.c
@@ -35,6 +35,15 @@ text_input_enter(void *data UNUSED, struct zwp_text_input_v3 *txt_input, struct 
         ime_focused = true;
         zwp_text_input_v3_enable(txt_input);
         zwp_text_input_v3_set_content_type(txt_input, ZWP_TEXT_INPUT_V3_CONTENT_HINT_NONE, ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_TERMINAL);
+	if (last_cursor_width > 0) {
+            zwp_text_input_v3_set_cursor_rectangle(
+                txt_input,
+                last_cursor_left,
+                last_cursor_top,
+                last_cursor_width,
+                last_cursor_height
+            );
+        }
         commit();
     }
 }


### PR DESCRIPTION
When a kitty window regains text-input focus (e.g. switching back to a workspace in sway), the zwp_text_input_v3::enter event is fired without a corresponding wl_keyboard.enter. text_input_enter() only called enable + set_content_type, leaving the cursor rectangle at (0,0) and causing the IME popup to appear at the top-left corner.

Restore the last known cursor rectangle (saved during normal input) in text_input_enter() so the popup immediately appears at the correct position.

Tested on sway 1.12 + fcitx5.