### PR TITLE
macOS: disable verification code autofill in windows

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -216,6 +216,8 @@ Detailed list of changes
 
 - choose-file kitten: Use a full readline editor for the search box. Also allow remapping the up/down/home/end keys to use for editing instead of navigating the file list (:pull:`10225`)
 
+- macOS: Prevent verification code AutoFill suggestions from appearing in kitty terminal windows
+
 
 0.47.4 [2026-06-15]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -896,7 +896,11 @@ static void _glfwUpdateNotchCover(_GLFWwindow*);
 
 // Content view class for the GLFW window {{{
 
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+@interface GLFWContentView : NSView <NSTextInputClient, NSTextContent>
+#else
 @interface GLFWContentView : NSView <NSTextInputClient>
+#endif
 {
     _GLFWwindow* window;
     NSTrackingArea* trackingArea;
@@ -1198,6 +1202,17 @@ static void _glfwUpdateNotchCover(_GLFWwindow*);
 - (NSTextInputContext *)inputContext
 {
     return input_context;
+}
+
+- (NSString *)contentType
+{
+    // Explicitly opt out of AppKit AutoFill classifiers such as one-time-code suggestions.
+    return nil;
+}
+
+- (void)setContentType:(NSString *)contentType
+{
+    (void)contentType;
 }
 
 static UInt32


### PR DESCRIPTION
## Summary

Explicitly make the Cocoa content view an NSTextContent provider on macOS 11 and newer and report a nil content type. This tells AppKit that kitty terminal input has no semantic text classification, preventing verification-code AutoFill suggestions from appearing in terminal windows.

The protocol conformance and methods are guarded by MAC_OS_X_VERSION_MAX_ALLOWED so builds using older SDKs are unchanged.

## Testing

- git diff --check
- clang syntax-only compilation of glfw/cocoa_window.m against the installed macOS SDK

A full debug build was not run because the system Python is 3.9.6 while kitty requires Python 3.12 or newer.