### PR TITLE
Wayland: fail window creation cleanly when the OpenGL context cannot be created

### DIFF
--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -1509,7 +1509,7 @@ int _glfwPlatformCreateWindow(
     // and only then create the OpenGL context.
     if (window->wl.visible) loop_till_window_fully_created(window);
     debug("Creating OpenGL context and attaching it to window\n");
-    if (ctxconfig->client != GLFW_NO_API) attach_opengl_context_to_window(window, ctxconfig, fbconfig);
+    if (ctxconfig->client != GLFW_NO_API && !attach_opengl_context_to_window(window, ctxconfig, fbconfig)) return false;
     return true;
 }
 


### PR DESCRIPTION
## Problem

On Wayland, when the OpenGL context cannot be attached to the new window — most easily reproduced when libEGL cannot be loaded — kitty crashes with SIGSEGV instead of printing its intended "Failed to create GLFWwindow. This usually happens because of old/broken OpenGL drivers." error.

`_glfwPlatformCreateWindow()` in `glfw/wl_window.c` ignores the return value of `attach_opengl_context_to_window()` and returns `true` unconditionally, so the failure (which the helper carefully reports) is dropped, `window->context` stays zeroed, and `glfwCreateWindow()` proceeds into `_glfwRefreshContextAttribs()` → `glfwMakeContextCurrent()`, which calls the NULL `context.makeCurrent` pointer:

```
#0  0x0000000000000000 in ?? ()
#1  glfwMakeContextCurrent (handle=0x555555876b10) at glfw/context.c:456
#2  _glfwRefreshContextAttribs (...) at glfw/context.c:195
#3  glfwCreateWindow (...) at glfw/window.c:269
#4  create_os_window (...) at kitty/glfw.c:1825
```

The X11 backend already propagates these failures (`x11_window.c` returns `false` on `_glfwInitEGL()`/`_glfwInitGLX()` failure).

## Fix

Propagate the helper's failure, letting `glfwCreateWindow()` clean up and return NULL as designed.

## Verification

Built from source on NixOS/Hyprland. Without the fix, running the binary in an environment where libEGL is not on the library path: `[glfw error 65542]: EGL: Library not found` followed by SIGSEGV (exit 139). With the fix: the same glfw error followed by the intended `OSError: Failed to create GLFWwindow. ...` and clean exit 1. With a working EGL, kitty starts and runs normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmM6PQrSmk8b1XHNFVbBet