### PR TITLE
Allocate scrollback history segments with mmap

### DIFF
--- a/kitty/history.c
+++ b/kitty/history.c
@@ -10,6 +10,7 @@
 #include "charsets.h"
 #include "resize.h"
 #include <structmember.h>
+#include <sys/mman.h>
 #include "../3rdparty/ringbuf/ringbuf.h"
 
 extern PyTypeObject Line_Type;
@@ -22,22 +23,27 @@ add_segment(HistoryBuf *self, index_type num) {
     const size_t cpu_cells_size = self->xnum * SEGMENT_SIZE * sizeof(CPUCell);
     const size_t gpu_cells_size = self->xnum * SEGMENT_SIZE * sizeof(GPUCell);
     const size_t segment_size = cpu_cells_size + gpu_cells_size + SEGMENT_SIZE * sizeof(LineAttrs);
-    char *mem = calloc(num, segment_size);
-    if (!mem) fatal("Out of memory allocating new history buffer segment");
+    if (num > SIZE_MAX / segment_size) fatal("History buffer segment allocation is too large");
+    const size_t mmap_size = num * segment_size;
+    char *mem = mmap(NULL, mmap_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+    if (mem == MAP_FAILED) fatal("Out of memory allocating new history buffer segment");
     char *needs_free = mem;
     for (HistoryBufSegment *s = self->segments + self->num_segments; s < self->segments + self->num_segments + num; s++, mem += segment_size) {
         s->cpu_cells = (CPUCell*)mem;
         s->gpu_cells = (GPUCell*)(((uint8_t*)s->cpu_cells) + cpu_cells_size);
         s->line_attrs = (LineAttrs*)(((uint8_t*)s->gpu_cells) + gpu_cells_size);
         s->mem = NULL;
+        s->mmap_size = 0;
     }
     self->segments[self->num_segments].mem = needs_free;
+    self->segments[self->num_segments].mmap_size = mmap_size;
     self->num_segments += num;
 }
 
 static void
 free_segment(HistoryBufSegment *s) {
-    free(s->mem); zero_at_ptr(s);
+    if (s->mem && munmap(s->mem, s->mmap_size) != 0) log_error("Failed to unmap history buffer segment: %s", strerror(errno));
+    zero_at_ptr(s);
 }
 
 static index_type

--- a/kitty/history.h
+++ b/kitty/history.h
@@ -14,6 +14,7 @@ typedef struct {
     CPUCell *cpu_cells;
     LineAttrs *line_attrs;
     void *mem;
+    size_t mmap_size;
 } HistoryBufSegment;
 
 typedef struct {


### PR DESCRIPTION
## Problem

Kitty allocates scrollback history in MB-scale segments. On glibc, freeing the first mmap-backed segments raises the dynamic `M_MMAP_THRESHOLD`; later same-sized segments are then served from the brk heap. When a window closes or its buffers are resized, those freed segments can remain stranded in allocator bins for the lifetime of the shared kitty process.

This is visible as memory growth proportional to window/tab churn even after all affected windows are gone. In the reproducer from #10249, four open/fill/close cycles left an unpatched process 178 MB above baseline with a 220.7 MB brk heap.

## Solution

Allocate the existing batched history-buffer backing regions with anonymous `mmap` instead of `calloc`, and release them with `munmap` when the history buffer is cleared or destroyed.

The segment layout is otherwise unchanged: one contiguous zero-filled region still backs every batch created by `add_segment()`, with the first segment retaining ownership. The owner now also records the mapping length needed by `munmap`. This keeps the change scoped to scrollback rather than changing glibc policy for all large allocations in the process.

## Verification

- `nix-shell '<nixpkgs>' -A kitty --run 'python3 setup.py build --debug'` — compiled and linked all native targets without warnings or errors.
- `nix-shell '<nixpkgs>' -A kitty --run 'python3 test.py --module datatypes historybuf'` — the history-buffer test passes.
- `nix-shell '<nixpkgs>' -A kitty --run 'python3 test.py'` — 349 tests run; the sole failure is the pre-existing `ShellIntegrationWithKitten.test_bash_integration` cursor-shape timeout, previously reproduced on an unpatched pristine checkout; 5 tests skipped.
- Exact open/fill/close A/B, four cycles of 12,000 80-column lines per throwaway window, `scrollback_lines=10000`, direct debug binaries:

  | history allocation | final RSS delta | brk heap |
  |---|---:|---:|
  | unpatched `calloc` | +178,128 KB | 220.7 MB |
  | this PR (`mmap`) | +9,840 KB | 28.3 MB |

  The patched process reached its final value after cycle 2 and stayed flat through cycles 3–4; the control reproduced the original retained-heap growth with allocator environment overrides explicitly removed.

Ref #10249.
