### PR TITLE
Do not animate cursor trail while the cursor is hidden

### DIFF
--- a/kitty/cursor_trail.c
+++ b/kitty/cursor_trail.c
@@ -50,8 +50,12 @@ update_cursor_trail_target(CursorTrail *ct, Window *w, ndc_coords g) {
 }
 
 static bool
-should_skip_cursor_trail_update(CursorTrail *ct, ndc_coords g, OSWindow *os_window) {
+should_skip_cursor_trail_update(CursorTrail *ct, ndc_coords g, OSWindow *os_window, Window *w) {
     if (os_window->live_resize.in_progress) {
+        return true;
+    }
+
+    if (!WD.screen->modes.mDECTCEM && ct->opacity <= 0.0f) {
         return true;
     }
 
@@ -66,7 +70,7 @@ should_skip_cursor_trail_update(CursorTrail *ct, ndc_coords g, OSWindow *os_wind
 }
 
 static void
-update_cursor_trail_corners(CursorTrail *ct, ndc_coords g, monotonic_t now, OSWindow *os_window) {
+update_cursor_trail_corners(CursorTrail *ct, ndc_coords g, monotonic_t now, OSWindow *os_window, Window *w) {
     // the trail corners move towards the cursor corner at a speed proportional to their distance from the cursor corner.
     // equivalent to exponential ease out animation.
     static const int corner_index[2][4] = {{1, 1, 0, 0}, {0, 1, 1, 0}};
@@ -75,7 +79,7 @@ update_cursor_trail_corners(CursorTrail *ct, ndc_coords g, monotonic_t now, OSWi
     float decay_fast = OPT(cursor_trail_decay_fast);
     float decay_slow = OPT(cursor_trail_decay_slow);
 
-    if (should_skip_cursor_trail_update(ct, g, os_window)) {
+    if (should_skip_cursor_trail_update(ct, g, os_window, w)) {
         for (int i = 0; i < 4; ++i) {
             ct->corner_x[i] = EDGE(x, corner_index[0][i]);
             ct->corner_y[i] = EDGE(y, corner_index[1][i]);
@@ -169,7 +173,7 @@ update_cursor_trail(CursorTrail *ct, Window *w, monotonic_t now, OSWindow *os_wi
         update_cursor_trail_target(ct, w, g);
     }
 
-    update_cursor_trail_corners(ct, g, now, os_window);
+    update_cursor_trail_corners(ct, g, now, os_window, w);
     update_cursor_trail_opacity(ct, w, now);
 
     bool needs_render_prev = ct->needs_render;


### PR DESCRIPTION
Programs that hide the cursor with DECTCEM but keep moving it causes the trail to run a full animation after every cursor move, which is unnecessary since the cursor is invisible.

When the cursor is hidden and the trail has fully faded out, snap the trail corners to the cursor position instead of animating them. The trail still tracks the hidden cursor, so switching focus to or away from such a window still animates the trail.

Originally noticed this behavior in `bottom` resource monitoring tool (see https://github.com/ClementTsang/bottom/issues/2115), but this can be replicated with any client that hides cursor and changes its position for rendering. The worst case scenario can be demonstrated with this script:

```python
#!/usr/bin/env python3
"""Worst-case scenario for kitty's cursor_trail with a hidden cursor.

Hides the cursor and then moves it continuously to random cells while
changing text on every frame. The text shows where the hidden cursor
currently is, and an 'X' marker is drawn at that cell.

Usage: python worst_case.py [moves_per_second]   (default 1)
"""

import os
import random
import sys
import time


def write(s: str) -> None:
    sys.stdout.write(s)
    sys.stdout.flush()


def main() -> None:
    rate = float(sys.argv[1]) if len(sys.argv) > 1 else 1.0
    write("\x1b[?1049h\x1b[?25l")  # enter alt screen, hide cursor
    prev = None
    n = 0
    try:
        while True:
            cols, rows = os.get_terminal_size()
            row = random.randint(3, rows)
            col = random.randint(1, cols)
            n += 1
            out = []
            if prev is not None:
                out.append(f"\x1b[{prev[0]};{prev[1]}H ")  # erase old marker
            out.append(f"\x1b[1;1H\x1b[2Kmove #{n}: hidden cursor is at row {row}, col {col}")
            out.append(f"\x1b[{row};{col}HX")  # marker at the cursor cell
            out.append(f"\x1b[{row};{col}H")   # park the hidden cursor on it
            write("".join(out))
            prev = (row, col)
            time.sleep(1.0 / rate)
    except KeyboardInterrupt:
        pass
    finally:
        write("\x1b[?25h\x1b[?1049l")  # show cursor, leave alt screen


if __name__ == "__main__":
    main()
```

Here is the recording using htop running in another terminal emulator and 2 kitty instances running the above script: one is patched with this commit and another is not
 

https://github.com/user-attachments/assets/33b8e4b7-e317-4635-9236-7168d8f0295f

