### PR TITLE
Add `focus_bias` option for vertical and horizontal layouts

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -190,6 +190,8 @@ Detailed list of changes
 
 - kitten @ get-text: Add support for :code:`alternate` and :code:`alternate_scrollback` extents to fetch text from the alternate screen buffer (:iss:`10165`)
 
+- Add a new ``verticalfocus`` layout that gives the focused window a configurable larger share of the vertical space.
+
 - Wayland: Fix first OS window being a few cells too small when ``initial_window_width/initial_window_height`` are set in cells and a fractional display scale is in use (:iss:`10146`)
 
 - macOS: New option :opt:`macos_ns_window_layer` to more precisely control what

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -190,7 +190,7 @@ Detailed list of changes
 
 - kitten @ get-text: Add support for :code:`alternate` and :code:`alternate_scrollback` extents to fetch text from the alternate screen buffer (:iss:`10165`)
 
-- Add a new ``verticalfocus`` layout that gives the focused window a configurable larger share of the vertical space.
+- Add a ``focus_bias`` option to the vertical and horizontal layouts that gives the focused window at least an equal share, or a configurable larger share, of the available space.
 
 - Wayland: Fix first OS window being a few cells too small when ``initial_window_width/initial_window_height`` are set in cells and a fractional display scale is in use (:iss:`10146`)
 

--- a/docs/layouts.rst
+++ b/docs/layouts.rst
@@ -284,6 +284,25 @@ All windows are shown one below the other. This layout has no options::
     └──────────────────────────────┘
 
 
+The Vertical focus layout
+-----------------------------
+
+The ``verticalfocus`` layout is similar to the ``vertical`` layout, but the
+currently focused window is given a larger share of the vertical space. The
+amount of space is controlled by the ``bias`` option, an integer between ``10``
+and ``90`` that defaults to ``60``::
+
+    enabled_layouts verticalfocus:bias=60
+
+With three windows and ``bias=60``, the focused window receives 60 percent of
+the height and the remaining windows share the rest equally. The larger region
+follows the focus when you switch windows.
+
+You can also map a key to cycle the focus bias, for example::
+
+    map ctrl+. layout_action bias 60 70 80
+
+
 .. _window_resizing:
 
 Resizing windows

--- a/docs/layouts.rst
+++ b/docs/layouts.rst
@@ -245,9 +245,12 @@ other. A value of ``auto`` means the axis of the split is chosen automatically
 The Horizontal Layout
 ------------------------
 
-All windows are shown side by side. This layout has no options::
+All windows are shown side by side. This layout can optionally give the
+focused window a larger share of the width with ``focus_bias``, an integer
+between ``10`` and ``90``. Values below an equal share are treated as equal
+share::
 
-    enabled_layouts horizontal
+    enabled_layouts horizontal:focus_bias=60
 
     ┌─────────┬──────────┬─────────┐
     │         │          │         │
@@ -265,9 +268,12 @@ All windows are shown side by side. This layout has no options::
 The Vertical Layout
 -----------------------
 
-All windows are shown one below the other. This layout has no options::
+All windows are shown one below the other. This layout can optionally give the
+focused window a larger share of the height with ``focus_bias``, an integer
+between ``10`` and ``90``. Values below an equal share are treated as equal
+share::
 
-    enabled_layouts vertical
+    enabled_layouts vertical:focus_bias=60
 
     ┌──────────────────────────────┐
     │                              │
@@ -283,24 +289,13 @@ All windows are shown one below the other. This layout has no options::
     │                              │
     └──────────────────────────────┘
 
-
-The Vertical focus layout
------------------------------
-
-The ``verticalfocus`` layout is similar to the ``vertical`` layout, but the
-currently focused window is given a larger share of the vertical space. The
-amount of space is controlled by the ``bias`` option, an integer between ``10``
-and ``90`` that defaults to ``60``::
-
-    enabled_layouts verticalfocus:bias=60
-
-With three windows and ``bias=60``, the focused window receives 60 percent of
-the height and the remaining windows share the rest equally. The larger region
-follows the focus when you switch windows.
+With three windows and ``focus_bias=60``, the focused window receives 60
+percent of the main axis and the remaining windows share the rest equally. The
+larger region follows the focus when you switch windows.
 
 You can also map a key to cycle the focus bias, for example::
 
-    map ctrl+. layout_action bias 60 70 80
+    map ctrl+. layout_action focus_bias 60 70 80
 
 
 .. _window_resizing:

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -2565,6 +2565,20 @@ class Boss:
         if tab:
             tab.set_active_window(window_id)
 
+    def switch_focus_to_in_active_tab_defer_relayout(self, window_id: int) -> None:
+        tab = self.active_tab
+        if tab:
+            tab.set_active_window(window_id, defer_focus_relayout=True)
+
+    def relayout_deferred_focus_change(self, window_id: int = 0) -> None:
+        tab = None
+        if window_id:
+            w = self.window_id_map.get(window_id)
+            tab = w.tabref() if w is not None else None
+        tab = tab or self.active_tab
+        if tab:
+            tab.relayout_deferred_focus_change()
+
     def drag_resize_start(
         self, edges: int, x: float, y: float, window_id: int, cell_width: int, cell_height: int,
     ) -> bool:

--- a/kitty/layout/base.py
+++ b/kitty/layout/base.py
@@ -242,6 +242,7 @@ class Layout:
     must_draw_borders = False  # can be overridden to customize behavior from kittens
     layout_opts = LayoutOpts({})
     only_active_window_visible = False
+    needs_relayout_on_focus_change = False
     drag_overlay_mode: ClassVar[DragOverlayMode] = DragOverlayMode.full
 
     def __init__(self, os_window_id: int, tab_id: int, layout_opts: str = '') -> None:

--- a/kitty/layout/interface.py
+++ b/kitty/layout/interface.py
@@ -7,13 +7,14 @@ from .grid import Grid
 from .splits import Splits
 from .stack import Stack
 from .tall import Fat, Tall
-from .vertical import Horizontal, Vertical
+from .vertical import Horizontal, Vertical, VerticalFocus
 
 all_layouts: dict[str, type[Layout]] = {
     Stack.name: Stack,
     Tall.name: Tall,
     Fat.name: Fat,
     Vertical.name: Vertical,
+    VerticalFocus.name: VerticalFocus,
     Horizontal.name: Horizontal,
     Grid.name: Grid,
     Splits.name: Splits,

--- a/kitty/layout/interface.py
+++ b/kitty/layout/interface.py
@@ -7,14 +7,13 @@ from .grid import Grid
 from .splits import Splits
 from .stack import Stack
 from .tall import Fat, Tall
-from .vertical import Horizontal, Vertical, VerticalFocus
+from .vertical import Horizontal, Vertical
 
 all_layouts: dict[str, type[Layout]] = {
     Stack.name: Stack,
     Tall.name: Tall,
     Fat.name: Fat,
     Vertical.name: Vertical,
-    VerticalFocus.name: VerticalFocus,
     Horizontal.name: Horizontal,
     Grid.name: Grid,
     Splits.name: Splits,

--- a/kitty/layout/vertical.py
+++ b/kitty/layout/vertical.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # License: GPLv3 Copyright: 2020, Kovid Goyal <kovid at kovidgoyal.net>
 
-from collections.abc import Generator, Iterable
+from collections.abc import Generator, Iterable, Sequence
 from typing import Any
 
 from kitty.borders import BorderColor
@@ -9,7 +9,7 @@ from kitty.types import Edges, NeighborsMap, WindowMapper
 from kitty.typing_compat import EdgeLiteral, WindowType
 from kitty.window_list import WindowGroup, WindowList
 
-from .base import BorderLine, DragOverlayMode, Layout, LayoutData, LayoutDimension, lgd
+from .base import BorderLine, DragOverlayMode, Layout, LayoutData, LayoutDimension, LayoutOpts, lgd
 
 
 def borders(
@@ -159,3 +159,70 @@ class Horizontal(Vertical):
     drag_overlay_mode = DragOverlayMode.axis_x
     main_axis_layout = Layout.xlayout
     perp_axis_layout = Layout.ylayout
+
+
+class FocusLayoutOpts(LayoutOpts):
+    bias: int = 60
+
+    def __init__(self, data: dict[str, str]):
+        try:
+            self.bias = int(data.get('bias', 60))
+        except Exception:
+            self.bias = 60
+        self.bias = max(10, min(self.bias, 90))
+
+    def serialized(self) -> dict[str, Any]:
+        return {'bias': self.bias}
+
+
+class VerticalFocus(Vertical):
+
+    name = 'verticalfocus'
+    layout_opts = FocusLayoutOpts({})
+    needs_relayout_on_focus_change = True
+
+    def focused_bias(self, all_windows: WindowList) -> Sequence[float] | None:
+        groups = tuple(all_windows.iter_all_layoutable_groups())
+        if len(groups) <= 1:
+            return None
+        active_group = all_windows.active_group
+        if active_group is None:
+            return None
+        try:
+            active_idx = groups.index(active_group)
+        except ValueError:
+            return None
+        focused = self.layout_opts.bias / 100.0
+        other = (1.0 - focused) / (len(groups) - 1)
+        return tuple(focused if i == active_idx else other for i in range(len(groups)))
+
+    def variable_layout(self, all_windows: WindowList, biased_map: dict[int, float]) -> LayoutDimension:
+        return self.main_axis_layout(all_windows.iter_all_layoutable_groups(), bias=self.focused_bias(all_windows))
+
+    def apply_bias(self, idx: int, increment: float, all_windows: WindowList, is_horizontal: bool = True) -> bool:
+        return False
+
+    def bias_slot(self, all_windows: WindowList, idx: int, fractional_bias: float, cell_increment_bias_h: float, cell_increment_bias_v: float) -> bool:
+        return False
+
+    def layout_action(self, action_name: str, args: Sequence[str], all_windows: WindowList) -> bool | None:
+        if action_name == 'bias':
+            if len(args) == 0:
+                raise ValueError('layout_action bias must contain at least one number between 10 and 90')
+            biases = args[0].split()
+            if len(biases) == 1:
+                biases.append('60')
+            try:
+                i = biases.index(str(self.layout_opts.bias)) + 1
+            except ValueError:
+                i = 0
+            try:
+                self.layout_opts.bias = max(10, min(int(biases[i % len(biases)]), 90))
+                return True
+            except Exception:
+                return False
+        return None
+
+    def set_layout_state(self, layout_state: dict[str, Any], map_group_id: WindowMapper) -> bool:
+        self.layout_opts = FocusLayoutOpts(layout_state['opts'])
+        return True

--- a/kitty/layout/vertical.py
+++ b/kitty/layout/vertical.py
@@ -59,6 +59,21 @@ def borders(
             yield x
 
 
+class VerticalLayoutOpts(LayoutOpts):
+    focus_bias: int = 0
+
+    def __init__(self, data: dict[str, str]):
+        try:
+            self.focus_bias = int(data.get('focus_bias', 0))
+        except Exception:
+            self.focus_bias = 0
+        if self.focus_bias:
+            self.focus_bias = max(10, min(self.focus_bias, 90))
+
+    def serialized(self) -> dict[str, Any]:
+        return {'focus_bias': self.focus_bias}
+
+
 class Vertical(Layout):
 
     name = 'vertical'
@@ -67,10 +82,30 @@ class Vertical(Layout):
     drag_overlay_mode = DragOverlayMode.axis_y
     main_axis_layout = Layout.ylayout
     perp_axis_layout = Layout.xlayout
+    layout_opts = VerticalLayoutOpts({})
+
+    @property
+    def needs_relayout_on_focus_change(self) -> bool:
+        return self.layout_opts.focus_bias > 0
+
+    def focused_bias(self, all_windows: WindowList) -> Sequence[float] | None:
+        groups = tuple(all_windows.iter_all_layoutable_groups())
+        if len(groups) <= 1 or not self.layout_opts.focus_bias:
+            return None
+        active_group = all_windows.active_group
+        if active_group is None:
+            return None
+        try:
+            active_idx = groups.index(active_group)
+        except ValueError:
+            return None
+        focused = max(self.layout_opts.focus_bias / 100.0, 1.0 / len(groups))
+        other = (1.0 - focused) / (len(groups) - 1)
+        return tuple(focused if i == active_idx else other for i in range(len(groups)))
 
     def variable_layout(self, all_windows: WindowList, biased_map: dict[int, float]) -> LayoutDimension:
         num_windows = all_windows.num_groups
-        bias = biased_map if num_windows > 1 else None
+        bias = self.focused_bias(all_windows) or (biased_map if num_windows > 1 else None)
         return self.main_axis_layout(all_windows.iter_all_layoutable_groups(), bias=bias)
 
     def fixed_layout(self, wg: WindowGroup) -> LayoutDimension:
@@ -96,6 +131,8 @@ class Vertical(Layout):
         return True
 
     def bias_slot(self, all_windows: WindowList, idx: int, fractional_bias: float, cell_increment_bias_h: float, cell_increment_bias_v: float) -> bool:
+        if self.layout_opts.focus_bias:
+            return False
         before_layout = tuple(self.variable_layout(all_windows, self.biased_map))
         self.biased_map[idx] = cell_increment_bias_h if self.main_is_horizontal else cell_increment_bias_v
         after_layout = tuple(self.variable_layout(all_windows, self.biased_map))
@@ -145,12 +182,32 @@ class Vertical(Layout):
             ans[akey] = after
         return ans
 
+    def layout_action(self, action_name: str, args: Sequence[str], all_windows: WindowList) -> bool | None:
+        if action_name == 'focus_bias':
+            if len(args) == 0:
+                raise ValueError('layout_action focus_bias must contain at least one number between 10 and 90')
+            biases = args[0].split()
+            if len(biases) == 1:
+                biases.append('60')
+            try:
+                i = biases.index(str(self.layout_opts.focus_bias)) + 1
+            except ValueError:
+                i = 0
+            try:
+                self.layout_opts.focus_bias = max(10, min(int(biases[i % len(biases)]), 90))
+                return True
+            except Exception:
+                return False
+        return None
+
     def layout_state(self) -> dict[str, Any]:
         return {'biased_map': self.biased_map}
 
     def set_layout_state(self, layout_state: dict[str, Any], map_group_id: WindowMapper) -> bool:
-        self.biased_map = {int(k): v for k, v in layout_state['biased_map'].items()}
+        self.biased_map = {int(k): v for k, v in layout_state.get('biased_map', {}).items()}
+        self.layout_opts = VerticalLayoutOpts(layout_state.get('opts', {}))
         return True
+
 
 class Horizontal(Vertical):
 
@@ -160,69 +217,3 @@ class Horizontal(Vertical):
     main_axis_layout = Layout.xlayout
     perp_axis_layout = Layout.ylayout
 
-
-class FocusLayoutOpts(LayoutOpts):
-    bias: int = 60
-
-    def __init__(self, data: dict[str, str]):
-        try:
-            self.bias = int(data.get('bias', 60))
-        except Exception:
-            self.bias = 60
-        self.bias = max(10, min(self.bias, 90))
-
-    def serialized(self) -> dict[str, Any]:
-        return {'bias': self.bias}
-
-
-class VerticalFocus(Vertical):
-
-    name = 'verticalfocus'
-    layout_opts = FocusLayoutOpts({})
-    needs_relayout_on_focus_change = True
-
-    def focused_bias(self, all_windows: WindowList) -> Sequence[float] | None:
-        groups = tuple(all_windows.iter_all_layoutable_groups())
-        if len(groups) <= 1:
-            return None
-        active_group = all_windows.active_group
-        if active_group is None:
-            return None
-        try:
-            active_idx = groups.index(active_group)
-        except ValueError:
-            return None
-        focused = self.layout_opts.bias / 100.0
-        other = (1.0 - focused) / (len(groups) - 1)
-        return tuple(focused if i == active_idx else other for i in range(len(groups)))
-
-    def variable_layout(self, all_windows: WindowList, biased_map: dict[int, float]) -> LayoutDimension:
-        return self.main_axis_layout(all_windows.iter_all_layoutable_groups(), bias=self.focused_bias(all_windows))
-
-    def apply_bias(self, idx: int, increment: float, all_windows: WindowList, is_horizontal: bool = True) -> bool:
-        return False
-
-    def bias_slot(self, all_windows: WindowList, idx: int, fractional_bias: float, cell_increment_bias_h: float, cell_increment_bias_v: float) -> bool:
-        return False
-
-    def layout_action(self, action_name: str, args: Sequence[str], all_windows: WindowList) -> bool | None:
-        if action_name == 'bias':
-            if len(args) == 0:
-                raise ValueError('layout_action bias must contain at least one number between 10 and 90')
-            biases = args[0].split()
-            if len(biases) == 1:
-                biases.append('60')
-            try:
-                i = biases.index(str(self.layout_opts.bias)) + 1
-            except ValueError:
-                i = 0
-            try:
-                self.layout_opts.bias = max(10, min(int(biases[i % len(biases)]), 90))
-                return True
-            except Exception:
-                return False
-        return None
-
-    def set_layout_state(self, layout_state: dict[str, Any], map_group_id: WindowMapper) -> bool:
-        self.layout_opts = FocusLayoutOpts(layout_state['opts'])
-        return True

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -873,7 +873,11 @@ HANDLER(handle_button_event) {
     if (handle_scrollbar_mouse(w, button, is_release ? RELEASE : PRESS, modifiers)) return;
 
     if (osw->is_focused && window_idx != t->active_window && !is_release) {
-        call_boss(switch_focus_to_in_active_tab, "K", t->windows[window_idx].id);
+        if (button == GLFW_MOUSE_BUTTON_LEFT) {
+            call_boss(switch_focus_to_in_active_tab_defer_relayout, "K", t->windows[window_idx].id);
+        } else {
+            call_boss(switch_focus_to_in_active_tab, "K", t->windows[window_idx].id);
+        }
     }
 
     Screen *screen = w->render_data.screen;
@@ -904,6 +908,7 @@ HANDLER(handle_button_event) {
         if (is_release) dispatch_possible_click(w, button, modifiers);
         else add_press(w, button, modifiers);
     }
+    if (button == GLFW_MOUSE_BUTTON_LEFT && is_release) call_boss(relayout_deferred_focus_change, "K", wid);
 }
 
 static int

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -873,11 +873,7 @@ HANDLER(handle_button_event) {
     if (handle_scrollbar_mouse(w, button, is_release ? RELEASE : PRESS, modifiers)) return;
 
     if (osw->is_focused && window_idx != t->active_window && !is_release) {
-        if (button == GLFW_MOUSE_BUTTON_LEFT) {
-            call_boss(switch_focus_to_in_active_tab_defer_relayout, "K", t->windows[window_idx].id);
-        } else {
-            call_boss(switch_focus_to_in_active_tab, "K", t->windows[window_idx].id);
-        }
+        call_boss(switch_focus_to_in_active_tab_defer_relayout, "K", t->windows[window_idx].id);
     }
 
     Screen *screen = w->render_data.screen;
@@ -908,7 +904,7 @@ HANDLER(handle_button_event) {
         if (is_release) dispatch_possible_click(w, button, modifiers);
         else add_press(w, button, modifiers);
     }
-    if (button == GLFW_MOUSE_BUTTON_LEFT && is_release) call_boss(relayout_deferred_focus_change, "K", wid);
+    if (is_release) call_boss(relayout_deferred_focus_change, "K", wid);
 }
 
 static int

--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -23,6 +23,7 @@ from .fast_data_types import (
     GLFW_MOUSE_BUTTON_MIDDLE,
     GLFW_PRESS,
     GLFW_RELEASE,
+    add_timer,
     add_tab,
     attach_window,
     buffer_keys_in_window,
@@ -188,6 +189,9 @@ class Tab:  # {{{
     has_indeterminate_progress: bool = False
     last_focused_window_with_progress_id: int = 0
     allow_relayouts: bool = True
+    defer_focus_relayout: bool = False
+    has_deferred_focus_relayout: bool = False
+    deferred_focus_relayout_timer_id: int | None = None
 
     def __init__(
         self,
@@ -442,8 +446,21 @@ class Tab:  # {{{
         w = self.active_window
         set_active_window(self.os_window_id, self.id, 0 if w is None else w.id)
         self.mark_tab_bar_dirty()
-        self.relayout_borders()
-        self.current_layout.update_visibility(self.windows)
+        if self.current_layout.needs_relayout_on_focus_change:
+            if self.defer_focus_relayout:
+                self.has_deferred_focus_relayout = True
+                if self.deferred_focus_relayout_timer_id is None:
+                    def relayout_later(timer_id: int | None) -> None:
+                        self.deferred_focus_relayout_timer_id = None
+                        self.relayout_deferred_focus_change()
+                    self.deferred_focus_relayout_timer_id = add_timer(relayout_later, 0.05, False)
+                self.relayout_borders()
+                self.current_layout.update_visibility(self.windows)
+            else:
+                self.relayout()
+        else:
+            self.relayout_borders()
+            self.current_layout.update_visibility(self.windows)
 
     def mark_tab_bar_dirty(self) -> None:
         tm = self.tab_manager_ref()
@@ -868,10 +885,21 @@ class Tab:  # {{{
             self.attach_window(window, overlay_for)
             overlay_for = window.id
 
-    def set_active_window(self, x: Window | int, for_keep_focus: Window | None = None) -> None:
+    def set_active_window(self, x: Window | int, for_keep_focus: Window | None = None, defer_focus_relayout: bool = False) -> None:
         if (w := self.windows.window_for_id(x) if isinstance(x, int) else x) is not None:
-            self.windows.set_active_window_group_for(w, for_keep_focus=for_keep_focus)
+            old_defer_focus_relayout = self.defer_focus_relayout
+            if defer_focus_relayout:
+                self.defer_focus_relayout = True
+            try:
+                self.windows.set_active_window_group_for(w, for_keep_focus=for_keep_focus)
+            finally:
+                self.defer_focus_relayout = old_defer_focus_relayout
             self.windows.move_window_to_top_of_group(w)
+
+    def relayout_deferred_focus_change(self) -> None:
+        if self.has_deferred_focus_relayout:
+            self.has_deferred_focus_relayout = False
+            self.relayout()
 
     def get_nth_window(self, n: int) -> Window | None:
         if self.windows:

--- a/kitty_tests/layout.py
+++ b/kitty_tests/layout.py
@@ -4,7 +4,7 @@
 from kitty.config import defaults
 from kitty.fast_data_types import BOTTOM_EDGE, LEFT_EDGE, RIGHT_EDGE, TOP_EDGE, Region
 from kitty.layout.base import layout_dimension, lgd
-from kitty.layout.interface import Grid, Horizontal, Splits, Stack, Tall
+from kitty.layout.interface import Grid, Horizontal, Splits, Stack, Tall, VerticalFocus, all_layouts
 from kitty.layout.splits import Pair, SplitsLayoutOpts
 from kitty.types import WindowGeometry
 from kitty.window import EdgeWidths
@@ -44,10 +44,10 @@ class Window:
         self.geometry = geometry
 
 
-def create_layout(cls, opts=None, border_width=2):
+def create_layout(cls, opts=None, border_width=2, layout_opts=''):
     if opts is None:
         opts = defaults
-    ans = cls(1, 1)
+    ans = cls(1, 1, layout_opts)
     ans.set_active_window_in_os_window = lambda idx: None
     ans.swap_windows_in_os_window = lambda a, b: None
     orig = ans._set_dimensions
@@ -250,6 +250,46 @@ class TestLayout(BaseTest):
         for layout_class in (Stack, Horizontal, Tall, Grid):
             q = create_layout(layout_class)
             self.do_overlay_test(q)
+
+    def test_focus_layouts(self):
+        self.assertIs(all_layouts['verticalfocus'], VerticalFocus)
+        self.ae(create_layout(VerticalFocus, layout_opts='bias=60').layout_opts.bias, 60)
+        self.ae(create_layout(VerticalFocus, layout_opts='bias=1').layout_opts.bias, 10)
+        self.ae(create_layout(VerticalFocus, layout_opts='bias=100').layout_opts.bias, 90)
+        self.ae(create_layout(VerticalFocus, layout_opts='bias=bad').layout_opts.bias, 60)
+
+        def focus_layout(active_idx=1, num=3, opts='bias=60'):
+            q = create_layout(VerticalFocus, layout_opts=opts)
+            def set_dimensions(all_windows):
+                lgd.central = Region((0, 0, 999, 999, 1000, 1000))
+                lgd.cell_width = lgd.cell_height = 10
+            q._set_dimensions = set_dimensions
+            windows = create_windows(q, num=num)
+            windows.set_active_group_idx(active_idx)
+            q(windows)
+            return q, windows
+
+        q, windows = focus_layout()
+        heights = [g.geometry.ynum for g in windows.groups]
+        self.assertGreater(heights[1], heights[0])
+        self.assertLessEqual(abs(heights[0] - heights[2]), 2)
+
+        q, windows = focus_layout(active_idx=0)
+        heights = [g.geometry.ynum for g in windows.groups]
+        self.ae(max(range(len(heights)), key=heights.__getitem__), 0)
+        windows.set_active_group_idx(2)
+        q(windows)
+        heights = [g.geometry.ynum for g in windows.groups]
+        self.ae(max(range(len(heights)), key=heights.__getitem__), 2)
+
+        q, windows = focus_layout(active_idx=0, num=1)
+        self.assertGreater(windows.groups[0].geometry.xnum, 0)
+        self.assertGreater(windows.groups[0].geometry.ynum, 0)
+
+        self.assertTrue(q.layout_action('bias', ('60 70 80',), windows))
+        self.ae(q.layout_opts.bias, 70)
+        self.assertTrue(q.layout_action('bias', ('70',), windows))
+        self.ae(q.layout_opts.bias, 60)
 
     def test_splits(self):
         q = create_layout(Splits)

--- a/kitty_tests/layout.py
+++ b/kitty_tests/layout.py
@@ -4,7 +4,7 @@
 from kitty.config import defaults
 from kitty.fast_data_types import BOTTOM_EDGE, LEFT_EDGE, RIGHT_EDGE, TOP_EDGE, Region
 from kitty.layout.base import layout_dimension, lgd
-from kitty.layout.interface import Grid, Horizontal, Splits, Stack, Tall, VerticalFocus, all_layouts
+from kitty.layout.interface import Grid, Horizontal, Splits, Stack, Tall, Vertical, all_layouts
 from kitty.layout.splits import Pair, SplitsLayoutOpts
 from kitty.types import WindowGeometry
 from kitty.window import EdgeWidths
@@ -252,14 +252,15 @@ class TestLayout(BaseTest):
             self.do_overlay_test(q)
 
     def test_focus_layouts(self):
-        self.assertIs(all_layouts['verticalfocus'], VerticalFocus)
-        self.ae(create_layout(VerticalFocus, layout_opts='bias=60').layout_opts.bias, 60)
-        self.ae(create_layout(VerticalFocus, layout_opts='bias=1').layout_opts.bias, 10)
-        self.ae(create_layout(VerticalFocus, layout_opts='bias=100').layout_opts.bias, 90)
-        self.ae(create_layout(VerticalFocus, layout_opts='bias=bad').layout_opts.bias, 60)
+        self.assertNotIn('verticalfocus', all_layouts)
+        self.ae(create_layout(Vertical).layout_opts.focus_bias, 0)
+        self.ae(create_layout(Vertical, layout_opts='focus_bias=60').layout_opts.focus_bias, 60)
+        self.ae(create_layout(Vertical, layout_opts='focus_bias=1').layout_opts.focus_bias, 10)
+        self.ae(create_layout(Vertical, layout_opts='focus_bias=100').layout_opts.focus_bias, 90)
+        self.ae(create_layout(Vertical, layout_opts='focus_bias=bad').layout_opts.focus_bias, 0)
 
-        def focus_layout(active_idx=1, num=3, opts='bias=60'):
-            q = create_layout(VerticalFocus, layout_opts=opts)
+        def focus_layout(layout_class=Vertical, active_idx=1, num=3, opts='focus_bias=60'):
+            q = create_layout(layout_class, layout_opts=opts)
             def set_dimensions(all_windows):
                 lgd.central = Region((0, 0, 999, 999, 1000, 1000))
                 lgd.cell_width = lgd.cell_height = 10
@@ -273,6 +274,8 @@ class TestLayout(BaseTest):
         heights = [g.geometry.ynum for g in windows.groups]
         self.assertGreater(heights[1], heights[0])
         self.assertLessEqual(abs(heights[0] - heights[2]), 2)
+        self.assertTrue(q.needs_relayout_on_focus_change)
+        self.assertFalse(create_layout(Vertical).needs_relayout_on_focus_change)
 
         q, windows = focus_layout(active_idx=0)
         heights = [g.geometry.ynum for g in windows.groups]
@@ -286,10 +289,22 @@ class TestLayout(BaseTest):
         self.assertGreater(windows.groups[0].geometry.xnum, 0)
         self.assertGreater(windows.groups[0].geometry.ynum, 0)
 
-        self.assertTrue(q.layout_action('bias', ('60 70 80',), windows))
-        self.ae(q.layout_opts.bias, 70)
-        self.assertTrue(q.layout_action('bias', ('70',), windows))
-        self.ae(q.layout_opts.bias, 60)
+        q, windows = focus_layout(active_idx=0, num=2, opts='focus_bias=40')
+        self.ae(q.focused_bias(windows), (0.5, 0.5))
+
+        q, windows = focus_layout(active_idx=0, num=3, opts='focus_bias=10')
+        for x in q.focused_bias(windows):
+            self.assertAlmostEqual(x, 1 / 3)
+
+        q, windows = focus_layout(Horizontal)
+        widths = [g.geometry.xnum for g in windows.groups]
+        self.assertGreater(widths[1], widths[0])
+        self.assertLessEqual(abs(widths[0] - widths[2]), 2)
+
+        self.assertTrue(q.layout_action('focus_bias', ('60 70 80',), windows))
+        self.ae(q.layout_opts.focus_bias, 70)
+        self.assertTrue(q.layout_action('focus_bias', ('70',), windows))
+        self.ae(q.layout_opts.focus_bias, 60)
 
     def test_splits(self):
         q = create_layout(Splits)


### PR DESCRIPTION
## Summary

Add `focus_bias`, an opt-in option for the existing `vertical` and `horizontal` layouts.

It gives the focused window at least an equal share, or a larger configurable share, of the layout's main axis. For example, with `focus_bias=60`, the focused window gets 60% of the height/width and the remaining windows split the other 40% equally.

```conf
enabled_layouts vertical:focus_bias=60,horizontal:focus_bias=60
```

The bias can also be changed at runtime:

```conf
map ctrl+. layout_action focus_bias 60 70 80
```

## Behavior

The larger slot follows focus automatically when `focus_bias` is enabled. Without it, the existing vertical/horizontal behavior is unchanged.

Keyboard focus changes relayout immediately. Mouse focus changes defer relayout until button release, so the press/release pair is handled against stable geometry. This avoids accidental text selection caused by the target pane expanding between mouse down and mouse up.

The deferred mouse relayout path is opt-in and only used by layouts that need relayout on focus change.

## Motivation

This is useful for portrait/tall windows with vertically stacked terminals, where one pane is the active working context and the others remain visible for logs or background tasks.

## Tests

- `./test.py --module layout`
- Manual mouse testing with multiple panes in `vertical:focus_bias=60`
