### PR TITLE
Add centered sized overlays

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -29,7 +29,9 @@ Glossary
 
    overlay
       An *overlay window* is a :term:`kitty window <window>` that is placed on
-      top of an existing kitty window, entirely covering it. Overlays are used
+      top of an existing kitty window. It covers the parent window by default,
+      but can be centered at a smaller size using the :option:`launch --overlay-width`
+      and :option:`launch --overlay-height` options. Overlays are used
       throughout kitty, for example, to display the :ref:`the scrollback buffer <scrollback>`,
       to display :doc:`hints </kittens/hints>`, for :doc:`unicode input
       </kittens/unicode_input>` etc. Normal overlays are meant for short

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -2014,7 +2014,7 @@ class Boss:
             x -= central.left
             y -= central.top
             if tab := tm.active_tab:
-                for window in tab:
+                for window in reversed(tuple(tab)):
                     if window.is_visible_in_layout:
                         g = window.geometry
                         if g.left <= x < g.right and g.top <= y < g.bottom:
@@ -2563,6 +2563,9 @@ class Boss:
     def switch_focus_to_in_active_tab(self, window_id: int) -> None:
         tab = self.active_tab
         if tab:
+            active_group = tab.windows.active_group
+            if active_group is not None and active_group.has_sized_overlay and active_group.has_window_id(window_id):
+                return
             tab.set_active_window(window_id)
 
     def drag_resize_start(

--- a/kitty/launch.py
+++ b/kitty/launch.py
@@ -126,6 +126,20 @@ Where to launch the child process:
 #placeholder_for_formatting#
 
 
+--overlay-width
+type=int
+default=0
+The width of an overlay window in terminal columns. A value of zero uses the
+width of the parent window. Has no effect for non-overlay windows.
+
+
+--overlay-height
+type=int
+default=0
+The height of an overlay window in terminal rows. A value of zero uses the
+height of the parent window. Has no effect for non-overlay windows.
+
+
 --keep-focus --dont-take-focus
 type=bool-set
 Keep the focus on the currently active window instead of switching to the newly
@@ -584,6 +598,8 @@ class LaunchKwds(TypedDict):
     marker: str | None
     cmd: list[str] | None
     overlay_for: int | None
+    overlay_width: int
+    overlay_height: int
     stdin: bytes | None
     hold: bool
     bias: float | None
@@ -649,6 +665,8 @@ def _launch(
     child_death_callback: Callable[[int, Exception | None], None] | None = None,
     startup_command_via_shell_integration: Sequence[str] | str = (),
 ) -> Window | None:
+    if opts.overlay_width < 0 or opts.overlay_height < 0:
+        raise ValueError('Overlay width and height must be non-negative')
     source_window = boss.active_window_for_cwd
     if opts.source_window:
         for qw in boss.match_windows(opts.source_window, rc_from_window):
@@ -686,6 +704,8 @@ def _launch(
         'marker': opts.marker or None,
         'cmd': None,
         'overlay_for': None,
+        'overlay_width': 0,
+        'overlay_height': 0,
         'stdin': None,
         'hold': False,
         'bias': None,
@@ -785,6 +805,8 @@ def _launch(
         base_for_overlay = target_tab.active_window
     if opts.type in ('overlay', 'overlay-main') and base_for_overlay:
         kw['overlay_for'] = base_for_overlay.id
+        kw['overlay_width'] = opts.overlay_width
+        kw['overlay_height'] = opts.overlay_height
     if opts.type == 'background':
         cmd = kw['cmd']
         if not cmd:
@@ -887,7 +909,8 @@ def clone_safe_opts() -> frozenset[str]:
     return frozenset((
         'window_title', 'tab_title', 'type', 'keep_focus', 'cwd', 'var', 'hold',
         'location', 'os_window_class', 'os_window_name', 'os_window_title', 'os_window_state',
-        'os_window_position', 'logo', 'logo_position', 'logo_alpha', 'spacing', 'next_to', 'hold_after_ssh'
+        'os_window_position', 'logo', 'logo_position', 'logo_alpha', 'spacing', 'next_to', 'hold_after_ssh',
+        'overlay_width', 'overlay_height',
     ))
 
 

--- a/kitty/layout/base.py
+++ b/kitty/layout/base.py
@@ -389,10 +389,15 @@ class Layout:
         return False
 
     def update_visibility(self, all_windows: WindowList) -> None:
-        active_window = all_windows.active_window
-        for window, is_group_leader in all_windows.iter_windows_with_visibility():
-            is_visible = window is active_window or (is_group_leader and not self.only_active_window_visible)
-            window.set_visible_in_layout(is_visible)
+        active_group = all_windows.active_group
+        for group in all_windows.groups:
+            group_is_visible = group is active_group or not self.only_active_window_visible
+            show_overlay_parent = group_is_visible and group.has_sized_overlay
+            active_window_id = group.active_window_id
+            for window in group:
+                window.set_visible_in_layout(
+                    group_is_visible and (show_overlay_parent or window.id == active_window_id)
+                )
 
     def _set_dimensions(self, all_windows: WindowList) -> None:
         lgd.central, tab_bar, vw, vh, lgd.cell_width, lgd.cell_height = viewport_for_window(self.os_window_id)

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -1064,7 +1064,7 @@ mouse_region(bool detect_borders, bool detect_title_bar) {
                 ans.window_border = 0;
             }
         }
-        for (unsigned int i = 0; i < t->num_windows; i++) {
+        for (unsigned int i = t->num_windows; i-- > 0;) {
             Window *win = t->windows + i;
             if (contains_mouse(win) && win->render_data.screen) {
                 ans.window_idx = i; ans.window = win; break;
@@ -1083,7 +1083,7 @@ mouse_region(bool detect_borders, bool detect_title_bar) {
         // window's scrollbar hit area. The scrollbar may be drawn in the margin
         // which is outside the area covered by contains_mouse.
         if (!ans.window && OPT(scrollbar_interactive)) {
-            for (unsigned int i = 0; i < t->num_windows; i++) {
+            for (unsigned int i = t->num_windows; i-- > 0;) {
                 Window *win = t->windows + i;
                 if (!win->visible || !win->render_data.screen) continue;
                 if (get_scrollbar_hit_type(win, w->mouse_x, w->mouse_y) != SCROLLBAR_HIT_NONE) {
@@ -1101,7 +1101,7 @@ closest_window_for_event(unsigned int *window_idx) {
     double closest_distance = UINT_MAX;
     if (global_state.callback_os_window->num_tabs > 0) {
         Tab *t = global_state.callback_os_window->tabs + global_state.callback_os_window->active_tab;
-        for (unsigned int i = 0; i < t->num_windows; i++) {
+        for (unsigned int i = t->num_windows; i-- > 0;) {
             Window *w = t->windows + i;
             if (w->visible) {
                 double d = distance_to_window(w);

--- a/kitty/rc/launch.py
+++ b/kitty/rc/launch.py
@@ -46,6 +46,8 @@ class Launch(RemoteCommand):
     stdin_add_line_wrap_markers/bool: Boolean indicating whether to add line wrap markers to stdin
     spacing/list.str: A list of spacing specifications, see the docs for the set-spacing command
     marker/str: Specification for marker for new window, for example: "text 1 ERROR"
+    overlay_width/int: Width of an overlay in terminal columns, or zero to use the parent width
+    overlay_height/int: Height of an overlay in terminal rows, or zero to use the parent height
     logo/str: Path to window logo
     logo_position/str: Window logo position as string or empty string to use default
     logo_alpha/float: Window logo alpha or -1 to use default

--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -743,6 +743,8 @@ class Tab:  # {{{
         cwd_from: CwdRequest | None = None,
         cwd: str | None = None,
         overlay_for: int | None = None,
+        overlay_width: int = 0,
+        overlay_height: int = 0,
         env: dict[str, str] | None = None,
         location: str | None = None,
         copy_colors_from: Window | None = None,
@@ -762,7 +764,8 @@ class Tab:  # {{{
     ) -> Window:
         cs = WindowCreationSpec(
             use_shell=use_shell, cmd=cmd, has_stdin=bool(stdin), override_title=override_title, cwd_from=cwd_from,
-            cwd=cwd, overlay_for=overlay_for, env=None if env is None else tuple(env.items()), location=location,
+            cwd=cwd, overlay_for=overlay_for, overlay_width=overlay_width, overlay_height=overlay_height,
+            env=None if env is None else tuple(env.items()), location=location,
             copy_colors_from=None if copy_colors_from is None else copy_colors_from.id,
             allow_remote_control=allow_remote_control,
             remote_control_passwords=None if remote_control_passwords is None else remote_control_passwords.copy(),
@@ -780,6 +783,8 @@ class Tab:  # {{{
             copy_colors_from=copy_colors_from, watchers=watchers,
             allow_remote_control=allow_remote_control, remote_control_passwords=remote_control_passwords
         )
+        window.overlay_width = overlay_width
+        window.overlay_height = overlay_height
         window.creation_spec = cs
         # Must add child before laying out so that resize_pty succeeds
         get_boss().add_child(window)
@@ -1867,7 +1872,10 @@ class TabManager:  # {{{
             return
         if action == GLFW_PRESS:
             if (w := boss.window_id_map.get(window_id)) is not None:
-                boss.set_active_window(w, switch_os_window_if_needed=True)
+                tab = w.tabref()
+                active_group = tab.windows.active_group if tab is not None else None
+                if active_group is None or not active_group.has_sized_overlay or w not in active_group:
+                    boss.set_active_window(w, switch_os_window_if_needed=True)
             threshold = get_options().drag_threshold
             if threshold:
                 set_window_being_dragged(window_id, False, x, y)
@@ -1934,7 +1942,7 @@ class TabManager:  # {{{
         rel_y = y - central.top
         if (active_tab := self.active_tab) is None:
             return None
-        for win in active_tab:
+        for win in reversed(tuple(active_tab)):
             g = win.geometry
             if g.left <= rel_x < g.right and g.top <= rel_y < g.bottom:
                 return win
@@ -2063,7 +2071,7 @@ class TabManager:  # {{{
         dest_in_title_bar = False
         opts = get_options()
         cw, ch = cell_size_for_window(self.os_window_id)
-        for win in active_tab:
+        for win in reversed(tuple(active_tab)):
             g = win.geometry
             if opts.window_title_bar == 'top':
                 tb_top, tb_bottom = g.top, g.top + ch

--- a/kitty/window.py
+++ b/kitty/window.py
@@ -398,6 +398,8 @@ class WindowCreationSpec(NamedTuple):
     cwd_from: CwdRequest | None = None
     cwd: str | None = None
     overlay_for: int | None = None
+    overlay_width: int = 0
+    overlay_height: int = 0
     env: tuple[tuple[str, str], ...] | None = None
     location: str | None = None
     copy_colors_from: int | None = None
@@ -769,6 +771,8 @@ class Window:
         self.tabref: Callable[[], TabType | None] = weakref.ref(tab)
         self.destroyed = False
         self.geometry: WindowGeometry = WindowGeometry(0, 0, 0, 0, 0, 0)
+        self.overlay_width = 0
+        self.overlay_height = 0
         self._title_bar_screen: Any = None
         self.needs_layout = True
         self.is_visible_in_layout: bool = True
@@ -2258,6 +2262,10 @@ class Window:
         if is_overlay:
             t = 'overlay-main' if self.overlay_type is OverlayType.main else 'overlay'
             ans.append(f'--type={t}')
+            if self.overlay_width:
+                ans.append(f'--overlay-width={self.overlay_width}')
+            if self.overlay_height:
+                ans.append(f'--overlay-height={self.overlay_height}')
 
         from kittens.ssh.utils import is_kitten_cmdline as is_ssh_kitten_cmdline
         from kittens.ssh.utils import remove_env_var_from_cmdline, set_cwd_in_cmdline, set_single_env_var_in_cmdline

--- a/kitty/window_list.py
+++ b/kitty/window_list.py
@@ -9,7 +9,7 @@ from itertools import count
 from typing import Any, Deque, Union
 
 from .fast_data_types import Color, get_options
-from .types import OverlayType, WindowGeometry
+from .types import Edges, OverlayType, WindowGeometry
 from .typing_compat import EdgeLiteral, TabType, WindowType
 
 WindowOrId = Union[WindowType, int]
@@ -32,6 +32,7 @@ class WindowGroup:
     def __init__(self) -> None:
         self.windows: list[WindowType] = []
         self.id = next(group_id_counter)
+        self.layout_geometry: WindowGeometry | None = None
 
     def __repr__(self) -> str:
         return f'WindowGroup(id={self.id}, windows={", ".join(str(w.id) for w in self.windows)})'
@@ -139,8 +140,38 @@ class WindowGroup:
         return w.effective_border()
 
     def set_geometry(self, geom: WindowGeometry) -> None:
+        self.layout_geometry = geom
         for w in self.windows:
-            w.set_geometry(geom)
+            width = int(getattr(w, 'overlay_width', 0) or 0)
+            height = int(getattr(w, 'overlay_height', 0) or 0)
+            if len(self.windows) < 2 or not (width or height):
+                w.set_geometry(geom)
+                continue
+
+            xnum = min(width, geom.xnum) if width else geom.xnum
+            title_bar_rows = 1 if getattr(w, 'show_title_bar', False) and geom.ynum > 1 else 0
+            ynum = min(height + title_bar_rows, geom.ynum) if height else geom.ynum
+            cell_width = (geom.right - geom.left) // geom.xnum if geom.xnum else 0
+            cell_height = (geom.bottom - geom.top) // geom.ynum if geom.ynum else 0
+            left = geom.left + (geom.xnum - xnum) // 2 * cell_width
+            top = geom.top + (geom.ynum - ynum) // 2 * cell_height
+            spaces = Edges(
+                geom.spaces.left if not width else 0,
+                geom.spaces.top if not height else 0,
+                geom.spaces.right if not width else 0,
+                geom.spaces.bottom if not height else 0,
+            )
+            w.set_geometry(WindowGeometry(
+                left=left, top=top, right=left + xnum * cell_width, bottom=top + ynum * cell_height,
+                xnum=xnum, ynum=ynum, spaces=spaces,
+            ))
+
+    @property
+    def has_sized_overlay(self) -> bool:
+        if len(self.windows) < 2:
+            return False
+        w = self.windows[-1]
+        return bool(getattr(w, 'overlay_width', 0) or getattr(w, 'overlay_height', 0))
 
     @property
     def default_bg(self) -> Color:
@@ -151,9 +182,10 @@ class WindowGroup:
 
     @property
     def geometry(self) -> WindowGeometry | None:
+        if self.has_sized_overlay and self.layout_geometry is not None:
+            return self.layout_geometry
         if self.windows:
-            w = self.windows[-1]
-            return w.geometry
+            return self.windows[-1].geometry
         return None
 
     @property

--- a/kitty_tests/layout.py
+++ b/kitty_tests/layout.py
@@ -6,7 +6,7 @@ from kitty.fast_data_types import BOTTOM_EDGE, LEFT_EDGE, RIGHT_EDGE, TOP_EDGE, 
 from kitty.layout.base import layout_dimension, lgd
 from kitty.layout.interface import Grid, Horizontal, Splits, Stack, Tall
 from kitty.layout.splits import Pair, SplitsLayoutOpts
-from kitty.types import WindowGeometry
+from kitty.types import Edges, WindowGeometry
 from kitty.window import EdgeWidths
 from kitty.window_list import WindowList, reset_group_id_counter
 
@@ -24,6 +24,9 @@ class Window:
         self.padding = EdgeWidths()
         self.margin = EdgeWidths()
         self.focused = False
+        self.overlay_width = 0
+        self.overlay_height = 0
+        self.show_title_bar = False
 
     def focus_changed(self, focused):
         self.focused = focused
@@ -250,6 +253,49 @@ class TestLayout(BaseTest):
         for layout_class in (Stack, Horizontal, Tall, Grid):
             q = create_layout(layout_class)
             self.do_overlay_test(q)
+
+    def test_sized_overlay_geometry_and_visibility(self):
+        layout = create_layout(Horizontal)
+        windows = create_windows(layout, num=1)
+        parent = windows.active_window
+        overlay = Window(2)
+        overlay.overlay_width = 40
+        overlay.overlay_height = 10
+        windows.add_window(overlay, group_of=parent)
+        group = windows.active_group
+        self.assertIsNotNone(group)
+        geometry = WindowGeometry(10, 20, 1010, 620, 100, 30, Edges(2, 3, 4, 5))
+
+        group.set_geometry(geometry)
+        self.ae(parent.geometry, geometry)
+        self.ae(group.geometry, geometry)
+        self.ae(overlay.geometry, WindowGeometry(310, 220, 710, 420, 40, 10))
+
+        layout.update_visibility(windows)
+        self.assertTrue(parent.is_visible_in_layout)
+        self.assertTrue(overlay.is_visible_in_layout)
+
+        overlay.overlay_width = 0
+        overlay.overlay_height = 0
+        group.set_geometry(geometry)
+        layout.update_visibility(windows)
+        self.ae(overlay.geometry, geometry)
+        self.assertFalse(parent.is_visible_in_layout)
+        self.assertTrue(overlay.is_visible_in_layout)
+
+        overlay.overlay_width = 200
+        overlay.overlay_height = 50
+        group.set_geometry(geometry)
+        self.ae(overlay.geometry, WindowGeometry(10, 20, 1010, 620, 100, 30))
+
+        overlay.overlay_width = 0
+        overlay.overlay_height = 8
+        group.set_geometry(geometry)
+        self.ae(overlay.geometry, WindowGeometry(10, 240, 1010, 400, 100, 8, Edges(2, 0, 4, 0)))
+
+        overlay.show_title_bar = True
+        group.set_geometry(geometry)
+        self.ae(overlay.geometry.ynum, 9)
 
     def test_splits(self):
         q = create_layout(Splits)

--- a/kitty_tests/options.py
+++ b/kitty_tests/options.py
@@ -36,6 +36,23 @@ class TestConfParsing(BaseTest):
     def test_cli_parsing(self):
         cli_parsing(self)
 
+    def test_launch_overlay_size_options(self):
+        from kitty.launch import _launch, parse_launch_args
+
+        opts, args = parse_launch_args(['--type=overlay', '--overlay-width=80', '--overlay-height=24', 'sh'])
+        self.assertEqual(args, ['sh'])
+        self.assertEqual(opts.overlay_width, 80)
+        self.assertEqual(opts.overlay_height, 24)
+
+        defaults, unused = parse_launch_args()
+        self.assertFalse(unused)
+        self.assertEqual(defaults.overlay_width, 0)
+        self.assertEqual(defaults.overlay_height, 0)
+
+        opts.overlay_width = -1
+        with self.assertRaisesRegex(ValueError, 'non-negative'):
+            _launch(None, opts, [])  # type: ignore[arg-type]
+
 
 def cli_parsing(self):
     from kitty.cli import CLIOptions, Options, parse_cmdline, parse_option_spec


### PR DESCRIPTION
Add optional `--overlay-width` and `--overlay-height` launch settings so overlay and overlay-main windows can be centered at a requested terminal-cell size while preserving the existing full-parent defaults.

Sized overlays keep their parent visible, clamp oversized dimensions, retain keyboard focus, and use topmost mouse hit-testing. The dimensions are supported by remote-control launch and session serialization.

Tests:
- `./test.py --module layout` (12 passed)
- `./test.py --module options` (4 passed)
- Native C compilation and linking passed
- Full suite: 352 passed, 7 skipped, with 2 unrelated local JetBrains Mono font-selection failures