### PR TITLE
Wayland: use (0, 0) rather than [0] for picking the monitor to guess scale from at startup

### DIFF
--- a/glfw/wl_monitor.c
+++ b/glfw/wl_monitor.c
@@ -351,8 +351,31 @@ GLFWAPI double glfwGetWaylandCurrentMonitorFractionalScale(void)
         if (window && window->wl.monitorsCount > 0)
             monitor = window->wl.monitors[0];
     }
-    if (!monitor)
-        monitor = _glfw.monitors[0];
+    if (!monitor) {
+        // No focused window to key off of (typically the first window at
+        // startup). Prefer the output at the logical origin (0, 0): the
+        // compositor's top-left/primary output is a better guess for where a
+        // new window will be placed than registry order. Fall back to the
+        // first output if no output reports position (0, 0).
+        //
+        // xdg_output geometry arrives asynchronously and x/y remain zero until
+        // it does, so wait for every monitor's logical geometry before trusting
+        // the reported positions (otherwise an as-yet-unpositioned output would
+        // spuriously match (0, 0)).
+        for (int i = 0; i < _glfw.monitorCount; i++) {
+            _GLFWmonitor *m = _glfw.monitors[i];
+            while (m->wl.xdg_output && m->wl.xdg_logical_width <= 0) {
+                if (wl_display_roundtrip(_glfw.wl.display) < 0) break;
+            }
+        }
+        for (int i = 0; i < _glfw.monitorCount; i++) {
+            _GLFWmonitor *m = _glfw.monitors[i];
+            if (m->wl.xdg_output && m->wl.xdg_logical_width > 0 &&
+                m->wl.x == 0 && m->wl.y == 0) { monitor = m; break; }
+        }
+        if (!monitor)
+            monitor = _glfw.monitors[0];
+    }
 
     if (!monitor->wl.xdg_output)
         return monitor->wl.scale > 0 ? (double)monitor->wl.scale : 1.0;


### PR DESCRIPTION
For logical-to-physical pixel scaling on Wayland (needed for non-blurry integer-pixel character cell size calculations), use the first of:
- scaling hint provided directly by Wayland for the surface (pre-existing in a different function, may come later)
- the scaling factor of the monitor with current/most-recently keyboard-focused Kitty window (pre-existing)
- the scaling factor of the monitor at logical (0, 0) position <= added in this PR
- the scaling factor of the first monitor in the monitor list (pre-existing)
- 1.0 (pre-existing)

Since xdg_output geometry (including position) arrives asynchronously and x/y read zero until it does, wait for every monitor's logical geometry before trusting the reported positions, so an as-yet-unpositioned output cannot spuriously match (0, 0).

Discussed in #10268.