### PR TITLE
Wayland: fix abort when dragging a tab out

### DIFF
--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -3334,9 +3334,21 @@ drag_icon_surface_handle_enter(void *data UNUSED, struct wl_surface *surface UNU
 static void
 drag_icon_surface_handle_leave(void *data UNUSED, struct wl_surface *surface UNUSED, struct wl_output *output UNUSED) {}
 
+#ifdef WL_SURFACE_PREFERRED_BUFFER_SCALE_SINCE_VERSION
+static void
+drag_icon_surface_handle_preferred_buffer_scale(void *data UNUSED, struct wl_surface *surface UNUSED, int32_t scale UNUSED) {}
+
+static void
+drag_icon_surface_handle_preferred_buffer_transform(void *data UNUSED, struct wl_surface *surface UNUSED, uint32_t transform UNUSED) {}
+#endif
+
 static const struct wl_surface_listener drag_icon_surface_listener = {
     .enter = drag_icon_surface_handle_enter,
     .leave = drag_icon_surface_handle_leave,
+#ifdef WL_SURFACE_PREFERRED_BUFFER_SCALE_SINCE_VERSION
+    .preferred_buffer_scale = &drag_icon_surface_handle_preferred_buffer_scale,
+    .preferred_buffer_transform = &drag_icon_surface_handle_preferred_buffer_transform,
+#endif
 };
 
 #define dr _glfw.wl.drag.data_requests[i]


### PR DESCRIPTION
Fixes #10284.

`drag_icon_surface_listener` is registered with only `.enter` and `.leave` filled in. `wl_compositor` is bound at version 6 whenever the compositor offers it, so the drag icon is a version 6 surface and the compositor sends `wl_surface.preferred_buffer_scale` (opcode 2) while dragging. There is no slot for it, so libwayland aborts:

~~~text
listener function for opcode 2 of wl_surface is NULL
~~~

On KWin this makes kitty die every time a tab is dragged out of the window. It reproduces with `--config NONE`, and 0.48.0 is unaffected, so it came in with fe9828a0.

This adds no-op handlers for both version 6 events, guarded by the same `#ifdef WL_SURFACE_PREFERRED_BUFFER_SCALE_SINCE_VERSION` that `surfaceListener` already uses.

Discarding the scale rather than acting on it is deliberate: the drag icon's scale is already fixed at drag start from the source window, either through the viewport destination or `wl_surface_set_buffer_scale`, and the surface's `wl_output` enter/leave events are ignored too. So this restores the pre-fe9828a0 behavior and nothing else. Rescaling the icon when it crosses onto a differently scaled output would be a separate change.

Tested on Arch, KWin 6.7.3, wayland 1.25.0: dragging tabs out works again, no coredumps and no wayland listener errors. No tests added since reproducing this needs a live compositor.
