### PR TITLE
docs: add kitty-action-menu to user kittens list

### DIFF
--- a/docs/kittens/custom.rst
+++ b/docs/kittens/custom.rst
@@ -333,3 +333,7 @@ Kittens created by kitty users
 
 `pdf-kitten <https://github.com/gelaechter/pdf-kitten>`__
     Allows you to export kitty's output to PDF, making use of weasyprint.
+
+`kitty-action-menu <https://github.com/olispeedy/kitty-action-menu>`__
+    A pop-up action menu (copy selection, copy link/path, paste, new tab, split,
+    close) opened by right-click or any mapping.


### PR DESCRIPTION
Adds a link to my kitten in the "Kittens created by kitty users" list.

**kitty-action-menu** is a pop-up action menu kitten: right-clicking (or any mapping) opens an overlay list of handy actions — copy selection, copy link/path, paste, new tab, split, close — implemented entirely via the kitten API (`handle_result` + `boss.combine`/remote control, no third-party deps). Copy Link/Path reuse the built-in `hints` kitten via `boss.combine`.

Repo: https://github.com/olispeedy/kitty-action-menu

It's licensed GPLv3, same as kitty, so it would be trivially upstreamable should that ever be of interest — but this PR only asks to be added to the user-kittens link list.

Docs-only change; no code touched.