### PR TITLE
Add desktui to the list of applications using the graphics protocol

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -32,6 +32,7 @@ Some applications that use the kitty graphics protocol:
 * `bicat <https://github.com/stevenxxiu/bicat>`_ - a terminal image viewer that also works in the Vifm file manager, with nested Tmux support
 * `broot <https://dystroy.org/broot/>`_ - a terminal file explorer and manager, with preview of images, SVG, PDF, etc.
 * `chafa <https://github.com/hpjansson/chafa>`_  - a terminal image viewer
+* `desktui <https://github.com/mishushakov/desktui>`_ - a VNC client that draws a remote desktop in the terminal, one remote pixel per terminal pixel
 * :doc:`kitty-diff <kittens/diff>` - a side-by-side terminal diff program with support for images
 * `fzf <https://github.com/junegunn/fzf/commit/d8188fce7b7bea982e7f9050c35e488e49fb8fd0>`_ - A command line fuzzy finder
 * `mpv <https://github.com/mpv-player/mpv/commit/874e28f4a41a916bb567a882063dd2589e9234e1>`_ - A video player that can play videos in the terminal


### PR DESCRIPTION
desktui is a VNC client that renders the remote framebuffer with the graphics protocol — one remote pixel per terminal pixel, rather than half-block mosaics.

Repo: https://github.com/mishushakov/desktui

🤖 Generated with [Claude Code](https://claude.com/claude-code)