### PR TITLE
Vertical tabs: support multi-line and wrapped tab titles

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -193,6 +193,10 @@ Detailed list of changes
 - Vertical tabs: fill each tab's background for the full width of the tab bar, so
   titles shorter than the sidebar no longer leave a ragged edge
 
+- Vertical tabs: add :opt:`tab_title_wrap` to wrap long tab titles over multiple
+  lines instead of truncating them, either at the width of the tab bar or at a
+  specified number of cells (:iss:`10302`)
+
 
 0.48.2 [2026-07-30]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -190,6 +190,9 @@ Detailed list of changes
 - Vertical tabs: pack tabs according to the number of lines each title actually
   uses, instead of reserving the same number of lines for every tab
 
+- Vertical tabs: fill each tab's background for the full width of the tab bar, so
+  titles shorter than the sidebar no longer leave a ragged edge
+
 
 0.48.2 [2026-07-30]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -180,6 +180,17 @@ Detailed list of changes
 -------------------------------------
 
 
+0.48.3 [future]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Vertical tabs: allow tab titles to span multiple lines, controlled by the new
+  :opt:`tab_title_max_lines` option. Newlines in :opt:`tab_title_template` now
+  start a new line rather than being drawn at an offset (:iss:`10302`)
+
+- Vertical tabs: pack tabs according to the number of lines each title actually
+  uses, instead of reserving the same number of lines for every tab
+
+
 0.48.2 [2026-07-30]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/kitty/data-types.c
+++ b/kitty/data-types.c
@@ -871,6 +871,7 @@ PyInit_fast_data_types(void) {
     PyModule_AddIntMacro(m, CURSOR_HOLLOW);
     PyModule_AddIntMacro(m, NO_CURSOR_SHAPE);
     PyModule_AddIntMacro(m, DECAWM);
+    PyModule_AddIntMacro(m, LNM);
     PyModule_AddIntMacro(m, DECCOLM);
     PyModule_AddIntMacro(m, DECOM);
     PyModule_AddIntMacro(m, IRM);

--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -871,6 +871,9 @@ def background_opacity_of(os_window_id: int) -> Optional[float]:
 def read_command_response(fd: int, timeout: float, list: List[bytes]) -> None:
     pass
 
+def split_into_graphemes(string: str) -> List[str]:
+    pass
+
 def wcswidth(string: str) -> int:
     pass
 
@@ -983,6 +986,8 @@ def parse_input_from_terminal(
 
 class Line:
     def sprite_at(self, cell: int) -> int: ...
+
+    def cursor_from(self, x: int, y: int = 0) -> Cursor: ...
 
 def test_shape(line: Line, path: Optional[str] = None, index: int = 0) -> List[Tuple[int, int, int, Tuple[int, ...]]]:
     pass

--- a/kitty/fast_data_types.pyi
+++ b/kitty/fast_data_types.pyi
@@ -279,6 +279,7 @@ CURSOR_HOLLOW: int
 NO_CURSOR_SHAPE: int
 CURSOR_UNDERLINE: int
 DECAWM: int
+LNM: int
 BGIMAGE_PROGRAM: int
 CELL_PROGRAM: int
 CELL_FG_PROGRAM: int
@@ -1167,6 +1168,9 @@ class Screen:
         pass
 
     def clear_selection(self) -> None:
+        pass
+
+    def set_mode(self, mode: int, private: bool = False) -> None:
         pass
 
     def reset_mode(self, mode: int, private: bool = False) -> None:

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -2235,6 +2235,27 @@ this is greater than one.
 )
 
 opt(
+    'tab_title_wrap',
+    'no',
+    option_type='tab_title_wrap',
+    long_text="""
+Wrap tab titles that are too long to fit instead of truncating them, for
+vertical tab bars only (see :opt:`tab_bar_edge`). Can be :code:`no` (the
+default) to truncate with an ellipsis as before, :code:`yes` to wrap at the
+width of the tab bar, or a number to wrap at that many cells, for example::
+
+    tab_title_wrap yes
+    tab_title_wrap 20
+
+Wrapping is limited by :opt:`tab_title_max_lines`, so it has no visible effect
+while that is :code:`1`. When a title needs more lines than are allowed, the
+last line it is given is truncated with an ellipsis. Explicit newlines in
+:opt:`tab_title_template` still start a new line, and each of the resulting
+lines is wrapped independently.
+""",
+)
+
+opt(
     'tab_title_template',
     '"{fmt.fg.red}{bell_symbol}{activity_symbol}{secure_input_symbol}{fmt.fg.tab}{tab.last_focused_progress_percent}{title}"',
     option_type='tab_title_template',

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -2214,6 +2214,27 @@ left unset.
 )
 
 opt(
+    'tab_title_max_lines',
+    '1',
+    option_type='positive_int',
+    long_text="""
+The maximum number of lines each tab may occupy, for vertical tab bars only
+(see :opt:`tab_bar_edge`). Titles containing newlines are rendered over
+multiple lines, up to this limit; any remaining lines are dropped. A value of
+:code:`1` (the default) keeps every tab on a single line, so newlines in
+:opt:`tab_title_template` have no effect. Increase it to make room for
+multi-line titles, for example::
+
+    tab_title_max_lines 2
+    tab_title_template "{index}: {tab.active_exe}\\n{title}"
+
+Note that tabs are packed according to the number of lines each title actually
+uses, so a tab with a single-line title still occupies only one line even when
+this is greater than one.
+""",
+)
+
+opt(
     'tab_title_template',
     '"{fmt.fg.red}{bell_symbol}{activity_symbol}{secure_input_symbol}{fmt.fg.tab}{tab.last_focused_progress_percent}{title}"',
     option_type='tab_title_template',

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -1421,6 +1421,9 @@ class Parser:
     def tab_title_max_length(self, val: str, ans: dict[str, typing.Any]) -> None:
         ans['tab_title_max_length'] = positive_int(val)
 
+    def tab_title_max_lines(self, val: str, ans: dict[str, typing.Any]) -> None:
+        ans['tab_title_max_lines'] = positive_int(val)
+
     def tab_title_template(self, val: str, ans: dict[str, typing.Any]) -> None:
         ans['tab_title_template'] = tab_title_template(val)
 

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -21,7 +21,7 @@ from kitty.options.utils import (
     resize_debounce_time, scrollback_lines, scrollback_pager_history_size, scrollbar_color,
     shell_integration, show_hyperlink_targets, store_multiple, symbol_map, tab_activity_symbol,
     tab_bar_edge, tab_bar_margin_height, tab_bar_min_tabs, tab_fade, tab_font_style, tab_separator,
-    tab_title_template, text_fg_override_threshold, titlebar_color, to_cursor_shape,
+    tab_title_template, tab_title_wrap, text_fg_override_threshold, titlebar_color, to_cursor_shape,
     to_cursor_unfocused_shape, to_font_size, to_layout_names, to_modifiers,
     transparent_background_colors, underline_exclusion, url_prefixes, url_style, visual_bell_duration,
     visual_window_select_characters, window_border_width, window_logo_scale, window_size
@@ -1426,6 +1426,9 @@ class Parser:
 
     def tab_title_template(self, val: str, ans: dict[str, typing.Any]) -> None:
         ans['tab_title_template'] = tab_title_template(val)
+
+    def tab_title_wrap(self, val: str, ans: dict[str, typing.Any]) -> None:
+        ans['tab_title_wrap'] = tab_title_wrap(val)
 
     def term(self, val: str, ans: dict[str, typing.Any]) -> None:
         ans['term'] = str(val)

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -476,6 +476,7 @@ option_names = (
     'tab_separator',
     'tab_switch_strategy',
     'tab_title_max_length',
+    'tab_title_max_lines',
     'tab_title_template',
     'term',
     'terminfo_type',
@@ -685,6 +686,7 @@ class Options:
     tab_separator: str = ' ┇'
     tab_switch_strategy: choices_for_tab_switch_strategy = 'previous'
     tab_title_max_length: int = 0
+    tab_title_max_lines: int = 1
     tab_title_template: str = '{fmt.fg.red}{bell_symbol}{activity_symbol}{secure_input_symbol}{fmt.fg.tab}{tab.last_focused_progress_percent}{title}'
     term: str = 'xterm-kitty'
     terminfo_type: choices_for_terminfo_type = 'path'

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -478,6 +478,7 @@ option_names = (
     'tab_title_max_length',
     'tab_title_max_lines',
     'tab_title_template',
+    'tab_title_wrap',
     'term',
     'terminfo_type',
     'text_composition_strategy',
@@ -688,6 +689,7 @@ class Options:
     tab_title_max_length: int = 0
     tab_title_max_lines: int = 1
     tab_title_template: str = '{fmt.fg.red}{bell_symbol}{activity_symbol}{secure_input_symbol}{fmt.fg.tab}{tab.last_focused_progress_percent}{title}'
+    tab_title_wrap: int = 0
     term: str = 'xterm-kitty'
     terminfo_type: choices_for_terminfo_type = 'path'
     text_composition_strategy: str = 'platform'

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -817,6 +817,16 @@ def active_tab_title_template(x: str) -> str | None:
     return None if x == 'none' else x
 
 
+def tab_title_wrap(x: str) -> int:
+    '''no/0 -> 0 (disabled), yes -> -1 (wrap at the tab bar width), N -> wrap at N cells'''
+    x = x.lower()
+    if x in ('n', 'no', 'false', 'none'):
+        return 0
+    if to_bool(x):
+        return -1
+    return positive_int(x)
+
+
 def text_fg_override_threshold(x: str) -> tuple[float, Literal['%', 'ratio']]:
     val, unit = number_with_unit(x, '%', 'ratio')
     return val, cast(Literal['%', 'ratio'], unit)

--- a/kitty/tab_bar.py
+++ b/kitty/tab_bar.py
@@ -29,6 +29,7 @@ from .fast_data_types import (
     get_options,
     pt_to_px,
     set_tab_bar_render_data,
+    split_into_graphemes,
     update_tab_bar_edge_colors,
     viewport_for_window,
     wcswidth,
@@ -82,6 +83,7 @@ class DrawData(NamedTuple):
     tab_bar_edge: EdgeLiteral
     max_tab_title_length: int
     max_tab_title_lines: int
+    wrap_width: int
     os_window_id: int
 
     def tab_fg(self, tab: TabBarData) -> int:
@@ -370,12 +372,74 @@ def apply_title_template(draw_data: DrawData, tab: TabBarData, index: int, max_t
     return title
 
 
+def wrap_title(title: str, width: int) -> str:
+    '''Insert newlines into title so that no line is wider than width cells.
+
+    SGR escapes are zero width, so they never count towards the width and are
+    left attached to the text that follows them. Splitting happens on grapheme
+    boundaries so that a wrap can never land inside a multi-codepoint grapheme.
+    '''
+    if width < 1:
+        return title
+    lines = []
+    for paragraph in title.split('\n'):
+        cur, cur_width = '', 0
+        for part in sgr_sanitizer_pat(for_splitting=True).split(paragraph):
+            if not part:
+                continue
+            if part.startswith('\x1b'):
+                cur += part
+                continue
+            for grapheme in split_into_graphemes(part):
+                w = max(0, wcswidth(grapheme))
+                if cur_width and cur_width + w > width:
+                    lines.append(cur)
+                    cur, cur_width = '', 0
+                cur += grapheme
+                cur_width += w
+        lines.append(cur)
+    return '\n'.join(lines)
+
+
+def truncate_line(line: str, width: int) -> str:
+    '''Append an ellipsis to line, trimming it so the result fits in width cells.
+
+    Used to mark a title as having had content dropped, so the ellipsis is added
+    even when line already fits.
+    '''
+    if width < 1:
+        return line
+    out, cur_width = '', 0
+    for part in sgr_sanitizer_pat(for_splitting=True).split(line):
+        if not part:
+            continue
+        if part.startswith('\x1b'):
+            out += part
+            continue
+        for grapheme in split_into_graphemes(part):
+            w = max(0, wcswidth(grapheme))
+            if cur_width + w > width - 1:
+                return out + '…'
+            out += grapheme
+            cur_width += w
+    return out + '…'
+
+
 def draw_title(draw_data: DrawData, screen: Screen, tab: TabBarData, index: int, max_title_length: int = 0) -> None:
     title = apply_title_template(draw_data, tab, index, max_title_length)
+    if draw_data.max_tab_title_lines > 1 and draw_data.wrap_width:
+        title = wrap_title(title, draw_data.wrap_width)
     if '\n' in title:
         # Drop lines that do not fit, so a title cannot bleed into the tab below
         # it. A limit of one also keeps horizontal tab bars on a single row.
-        title = '\n'.join(title.split('\n')[:max(1, draw_data.max_tab_title_lines)])
+        lines = title.split('\n')
+        limit = max(1, draw_data.max_tab_title_lines)
+        if len(lines) > limit:
+            # Mark the truncation, since the caller's ellipsis logic only fires
+            # when the final line reaches the full width of the tab.
+            del lines[limit:]
+            lines[-1] = truncate_line(lines[-1], draw_data.wrap_width or max_title_length)
+        title = '\n'.join(lines)
     before_draw = screen.cursor.x
     draw_attributed_string(title, screen)
     if draw_data.max_tab_title_length > 0:
@@ -643,6 +707,7 @@ class TabBar:
         # Multi-line titles only make sense for vertical tab bars, where each
         # tab gets its own row(s).
         self.max_tab_title_lines = max(1, opts.tab_title_max_lines) if self.is_vertical else 1
+        self.tab_title_wrap = opts.tab_title_wrap if self.is_vertical else 0
         self.margin_width = pt_to_px(opts.tab_bar_margin_width, self.os_window_id)
         self.cell_width, cell_height = cell_size_for_window(self.os_window_id)
         if not hasattr(self, 'screen'):
@@ -683,6 +748,7 @@ class TabBar:
             edge_name_map[opts.tab_bar_edge],
             opts.tab_title_max_length,
             self.max_tab_title_lines,
+            0,  # resolved per-layout, since 'yes' means the tab bar's width
             self.os_window_id,
         )
         ts = opts.tab_bar_style
@@ -948,6 +1014,9 @@ class TabBar:
         # Never allow a title to use more lines than remain below it, otherwise
         # drawing it would scroll the tab bar and lose the tabs already drawn.
         max_tab_lines = max(1, min(self.max_tab_title_lines, s.lines))
+        # tab_title_wrap of -1 ('yes') means wrap at whatever width the tab bar
+        # happens to have, which is only known now that the screen is laid out.
+        wrap_width = max_tab_length if self.tab_title_wrap < 0 else min(self.tab_title_wrap, max_tab_length)
 
         def draw_one(i: int, t: TabBarData, row: int, for_layout: bool, height: int = 0) -> int:
             'Draw tab i at row, returning the number of lines it occupies'
@@ -969,7 +1038,7 @@ class TabBar:
             ed.prev_tab = data[i - 1] if i > 0 else None
             ed.next_tab = data[i + 1] if i + 1 < len(data) else None
             ed.for_layout = for_layout
-            dd = self.draw_data._replace(max_tab_title_lines=min(max_tab_lines, s.lines - row))
+            dd = self.draw_data._replace(max_tab_title_lines=min(max_tab_lines, s.lines - row), wrap_width=wrap_width)
             self.draw_func(dd, s, t, 0, max_tab_length, i + 1, True, ed)
             return min(max_tab_lines, max(1, s.cursor.y - row + 1))
 

--- a/kitty/tab_bar.py
+++ b/kitty/tab_bar.py
@@ -949,13 +949,22 @@ class TabBar:
         # drawing it would scroll the tab bar and lose the tabs already drawn.
         max_tab_lines = max(1, min(self.max_tab_title_lines, s.lines))
 
-        def draw_one(i: int, t: TabBarData, row: int, for_layout: bool) -> int:
+        def draw_one(i: int, t: TabBarData, row: int, for_layout: bool, height: int = 0) -> int:
             'Draw tab i at row, returning the number of lines it occupies'
-            s.cursor.x = 0
-            s.cursor.y = row
-            s.cursor.bg = as_rgb(self.draw_data.tab_bg(t))
+            bg = as_rgb(self.draw_data.tab_bg(t))
+            s.cursor.bg = bg
             s.cursor.fg = as_rgb(self.draw_data.tab_fg(t))
             s.cursor.bold, s.cursor.italic = self.active_font_style if t.is_active else self.inactive_font_style
+            if height:
+                # Fill the tab's full width first and draw the title over it, so
+                # that a short line does not leave the rest of the row showing
+                # the tab bar background.
+                for line in range(row, min(s.lines, row + height)):
+                    s.cursor.x = 0
+                    s.cursor.y = line
+                    s.draw(' ' * s.columns)
+            s.cursor.x = 0
+            s.cursor.y = row
             ed = ExtraData()
             ed.prev_tab = data[i - 1] if i > 0 else None
             ed.next_tab = data[i + 1] if i + 1 < len(data) else None
@@ -1009,7 +1018,7 @@ class TabBar:
         for i, t in enumerate(data[:rows_to_draw]):
             if i:
                 row += spacing
-            draw_one(i, t, row, False)
+            draw_one(i, t, row, False, height=heights[i])
             cr.append(TabExtent(tab_id=t.tab_id, x=CellRange(0, s.columns - 1), y=CellRange(row, min(s.lines - 1, row + heights[i] - 1))))
             row += heights[i]
         if draw_ellipsis:

--- a/kitty/tab_bar.py
+++ b/kitty/tab_bar.py
@@ -18,6 +18,7 @@ from .fast_data_types import (
     BOTTOM_EDGE,
     DECAWM,
     LEFT_EDGE,
+    LNM,
     RIGHT_EDGE,
     TOP_EDGE,
     Color,
@@ -80,6 +81,7 @@ class DrawData(NamedTuple):
     powerline_style: PowerlineStyle
     tab_bar_edge: EdgeLiteral
     max_tab_title_length: int
+    max_tab_title_lines: int
     os_window_id: int
 
     def tab_fg(self, tab: TabBarData) -> int:
@@ -106,7 +108,6 @@ def as_rgb(x: int) -> int:
 
 
 VERTICAL_EDGES = frozenset({LEFT_EDGE, RIGHT_EDGE})
-MAX_VERTICAL_TAB_LINES = 2
 
 
 def is_vertical_edge(edge: int) -> bool:
@@ -371,6 +372,10 @@ def apply_title_template(draw_data: DrawData, tab: TabBarData, index: int, max_t
 
 def draw_title(draw_data: DrawData, screen: Screen, tab: TabBarData, index: int, max_title_length: int = 0) -> None:
     title = apply_title_template(draw_data, tab, index, max_title_length)
+    if '\n' in title:
+        # Drop lines that do not fit, so a title cannot bleed into the tab below
+        # it. A limit of one also keeps horizontal tab bars on a single row.
+        title = '\n'.join(title.split('\n')[:max(1, draw_data.max_tab_title_lines)])
     before_draw = screen.cursor.x
     draw_attributed_string(title, screen)
     if draw_data.max_tab_title_length > 0:
@@ -635,6 +640,9 @@ class TabBar:
         self.dirty = True
         self.tab_bar_edge = opts.tab_bar_edge
         self.is_vertical = is_vertical_edge(opts.tab_bar_edge)
+        # Multi-line titles only make sense for vertical tab bars, where each
+        # tab gets its own row(s).
+        self.max_tab_title_lines = max(1, opts.tab_title_max_lines) if self.is_vertical else 1
         self.margin_width = pt_to_px(opts.tab_bar_margin_width, self.os_window_id)
         self.cell_width, cell_height = cell_size_for_window(self.os_window_id)
         if not hasattr(self, 'screen'):
@@ -674,6 +682,7 @@ class TabBar:
             opts.tab_powerline_style,
             edge_name_map[opts.tab_bar_edge],
             opts.tab_title_max_length,
+            self.max_tab_title_lines,
             self.os_window_id,
         )
         ts = opts.tab_bar_style
@@ -815,6 +824,9 @@ class TabBar:
             ncols = max(1, tab_bar.width // cell_width)
             s.resize(nlines, ncols)
             s.reset_mode(DECAWM)
+            # So that a newline in a tab title returns to the start of the next
+            # line rather than staircasing to the right.
+            s.set_mode(LNM)
             cell_area_height = nlines * cell_height
             available_height_for_top_margin = max(0, tab_bar.height - self.margin_width - cell_area_height)
             extra_height = max(0, tab_bar.height - 2 * self.margin_width - cell_area_height)
@@ -933,14 +945,59 @@ class TabBar:
         if not data:
             return self._update_edge_defaults(True)
         max_tab_length = max(1, s.columns - 1)
-        tab_line_height = max(1, min(MAX_VERTICAL_TAB_LINES, s.lines // max(1, len(data))))
-        rows_to_draw = min(len(data), max(1, s.lines // tab_line_height))
-        draw_ellipsis = len(data) > rows_to_draw and s.lines > 1
+        # Never allow a title to use more lines than remain below it, otherwise
+        # drawing it would scroll the tab bar and lose the tabs already drawn.
+        max_tab_lines = max(1, min(self.max_tab_title_lines, s.lines))
+
+        def draw_one(i: int, t: TabBarData, row: int, for_layout: bool) -> int:
+            'Draw tab i at row, returning the number of lines it occupies'
+            s.cursor.x = 0
+            s.cursor.y = row
+            s.cursor.bg = as_rgb(self.draw_data.tab_bg(t))
+            s.cursor.fg = as_rgb(self.draw_data.tab_fg(t))
+            s.cursor.bold, s.cursor.italic = self.active_font_style if t.is_active else self.inactive_font_style
+            ed = ExtraData()
+            ed.prev_tab = data[i - 1] if i > 0 else None
+            ed.next_tab = data[i + 1] if i + 1 < len(data) else None
+            ed.for_layout = for_layout
+            dd = self.draw_data._replace(max_tab_title_lines=min(max_tab_lines, s.lines - row))
+            self.draw_func(dd, s, t, 0, max_tab_length, i + 1, True, ed)
+            return min(max_tab_lines, max(1, s.cursor.y - row + 1))
+
+        # Measure how many lines each title actually needs, so that tabs can be
+        # packed without overlapping. Drawing is the only way to measure, since
+        # a custom draw_tab function may render anything it likes.
+        heights = [draw_one(i, t, 0, True) for i, t in enumerate(data)]
+        s.cursor.x = s.cursor.y = 0
+        s.erase_in_display(2, False)
+
+        def num_that_fit(budget: int, spacing: int) -> tuple[int, int]:
+            n = total = 0
+            for h in heights:
+                needed = h + (spacing if n else 0)
+                if total + needed > budget:
+                    break
+                total += needed
+                n += 1
+            return n, total
+
+        # Leave a blank line between tabs while there is room for it, dropping it
+        # automatically once the tabs need the space.
+        spacing = 1
+        rows_to_draw, drawn_lines = num_that_fit(s.lines, spacing)
+        if rows_to_draw < len(data):
+            spacing = 0
+            rows_to_draw, drawn_lines = num_that_fit(s.lines, spacing)
+        draw_ellipsis = rows_to_draw < len(data) and s.lines > 1
         if draw_ellipsis:
-            tab_line_height = 1
-            rows_to_draw = min(len(data), s.lines)
-            rows_to_draw -= 1
-        total_lines = rows_to_draw * tab_line_height + int(draw_ellipsis)
+            # Reserve a line for the ellipsis, unless that leaves no room for
+            # even a single tab, in which case prefer showing the tab.
+            n, total = num_that_fit(s.lines - 1, spacing)
+            if n:
+                rows_to_draw, drawn_lines = n, total
+            else:
+                draw_ellipsis = False
+        total_lines = drawn_lines + int(draw_ellipsis)
         if self.tab_bar_align == 'center':
             start_row = max(0, (s.lines - total_lines) // 2)
         elif self.tab_bar_align == 'end':
@@ -948,18 +1005,16 @@ class TabBar:
         else:
             start_row = 0
         cr: list[TabExtent] = []
+        row = start_row
         for i, t in enumerate(data[:rows_to_draw]):
-            s.cursor.x = 0
-            row = start_row + i * tab_line_height
-            s.cursor.y = row
-            s.cursor.bg = as_rgb(self.draw_data.tab_bg(t))
-            s.cursor.fg = as_rgb(self.draw_data.tab_fg(t))
-            s.cursor.bold, s.cursor.italic = self.active_font_style if t.is_active else self.inactive_font_style
-            self.draw_func(self.draw_data, s, t, 0, max_tab_length, i + 1, True, ExtraData())
-            cr.append(TabExtent(tab_id=t.tab_id, x=CellRange(0, s.columns - 1), y=CellRange(row, min(s.lines - 1, row + tab_line_height - 1))))
+            if i:
+                row += spacing
+            draw_one(i, t, row, False)
+            cr.append(TabExtent(tab_id=t.tab_id, x=CellRange(0, s.columns - 1), y=CellRange(row, min(s.lines - 1, row + heights[i] - 1))))
+            row += heights[i]
         if draw_ellipsis:
             s.cursor.x = 0
-            s.cursor.y = start_row + rows_to_draw * tab_line_height
+            s.cursor.y = row
             s.cursor.bg = as_rgb(color_as_int(self.draw_data.default_bg))
             s.cursor.fg = as_rgb(0xFF0000)
             s.draw('…')

--- a/kitty_tests/tab_bar.py
+++ b/kitty_tests/tab_bar.py
@@ -193,6 +193,21 @@ class TestTabBar(BaseTest):
         tb = self.vertical_tab_bar(num_tabs=4, height=140)
         self.ae(self.screen_lines(tb), ['t0', '', 't1', '', 't2', '', 't3'])
         self.ae(len(tb.tab_extents), 4)
+    def test_vertical_tab_bar_fills_tab_width(self) -> None:
+        # every line a tab occupies must be padded to the full width of the bar
+        # in that tab's colors, otherwise uneven line lengths leave a ragged edge
+        tb = self.vertical_tab_bar(tab_title_template='{title}\\nlonger-line', tab_title_max_lines=2)
+        s = tb.screen
+        self.ae([len(str(s.line(i))) for i in (0, 1, 3, 4)], [s.columns] * 4)
+
+        def bg_of(line: int, col: int) -> int:
+            return int(s.line(line).cursor_from(col).bg)
+
+        # the padding after a short line uses the tab background, not the bar's
+        for line in (0, 1):
+            self.ae(bg_of(line, s.columns - 1), bg_of(line, 0))
+        # and the two tabs still have distinct backgrounds
+        self.assertNotEqual(bg_of(0, 0), bg_of(3, 0))
 
     def test_vertical_tab_bar_title_taller_than_bar(self) -> None:
         # a title needing more lines than the bar has must be clipped from the

--- a/kitty_tests/tab_bar.py
+++ b/kitty_tests/tab_bar.py
@@ -4,7 +4,8 @@
 from unittest.mock import patch
 
 from kitty.fast_data_types import LEFT_EDGE, Region
-from kitty.tab_bar import CellRange, TabBar, TabBarData
+from kitty.options.utils import tab_title_wrap
+from kitty.tab_bar import CellRange, TabBar, TabBarData, truncate_line, wrap_title
 
 from . import BaseTest
 
@@ -115,9 +116,10 @@ class TestTabBar(BaseTest):
         return [str(s.line(i)).rstrip() for i in range(s.lines)]
 
     def test_vertical_tab_bar_multiline_titles(self) -> None:
-        # newlines are ignored unless tab_title_max_lines allows them
+        # newlines are ignored unless tab_title_max_lines allows them, and the
+        # dropped lines are marked with an ellipsis
         tb = self.vertical_tab_bar(tab_title_template='{title}\\nbr')
-        self.ae(self.screen_lines(tb)[:4], ['t0', '', 't1', ''])
+        self.ae(self.screen_lines(tb)[:4], ['t0…', '', 't1…', ''])
         self.ae(tuple(te.y for te in tb.tab_extents), (CellRange(0, 0), CellRange(2, 2)))
 
         # a newline now starts a new line at column zero, without staircasing,
@@ -128,7 +130,7 @@ class TestTabBar(BaseTest):
 
         # lines beyond the limit are dropped rather than bleeding into the next tab
         tb = self.vertical_tab_bar(tab_title_template='{title}\\nbr\\nextra', tab_title_max_lines=2)
-        self.ae(self.screen_lines(tb)[:6], ['t0', 'br', '', 't1', 'br', ''])
+        self.ae(self.screen_lines(tb)[:6], ['t0', 'br…', '', 't1', 'br…', ''])
         self.ae(tuple(te.y for te in tb.tab_extents), (CellRange(0, 1), CellRange(3, 4)))
 
     def test_vertical_tab_bar_mixed_title_heights(self) -> None:
@@ -213,7 +215,7 @@ class TestTabBar(BaseTest):
         # a title needing more lines than the bar has must be clipped from the
         # bottom rather than scrolling the tab bar and losing its first lines
         tb = self.vertical_tab_bar(num_tabs=1, height=60, tab_title_template='{title}\\na\\nb\\nc\\nd', tab_title_max_lines=5)
-        self.ae(self.screen_lines(tb), ['t0', 'a', 'b'])
+        self.ae(self.screen_lines(tb), ['t0', 'a', 'b…'])
         self.ae(tuple(te.y for te in tb.tab_extents), (CellRange(0, 2),))
 
     def test_vertical_tab_bar_multiline_overflow(self) -> None:
@@ -222,3 +224,69 @@ class TestTabBar(BaseTest):
         tb = self.vertical_tab_bar(num_tabs=6, height=100, tab_title_template='{title}\\nbr', tab_title_max_lines=2)
         self.ae(self.screen_lines(tb), ['t0', 'br', 't1', 'br', '…'])
         self.ae(tuple(te.y for te in tb.tab_extents), (CellRange(0, 1), CellRange(2, 3)))
+
+    def test_wrap_title(self) -> None:
+        self.ae(wrap_title('hello world foo', 6).split('\n'), ['hello ', 'world ', 'foo'])
+        # a word longer than the width has to be broken mid-word
+        self.ae(wrap_title('unbreakable', 4).split('\n'), ['unbr', 'eaka', 'ble'])
+        # explicit newlines are preserved and each line wrapped independently
+        self.ae(wrap_title('a\nbb ccc', 4).split('\n'), ['a', 'bb c', 'cc'])
+        # SGR escapes are zero width, so they do not count towards the width and
+        # are never split in half
+        self.ae(wrap_title('\x1b[31mred text', 4).split('\n'), ['\x1b[31mred ', 'text'])
+        # wide characters take two cells each
+        self.ae(wrap_title('日本語', 4).split('\n'), ['日本', '語'])
+        # a width of zero means no wrapping
+        self.ae(wrap_title('abc', 0), 'abc')
+
+    def test_truncate_line(self) -> None:
+        self.ae(truncate_line('abcdef', 4), 'abc…')
+        self.ae(truncate_line('日本語', 4), '日…')
+        # the ellipsis marks dropped content, so it is added even when the text
+        # itself would have fit
+        self.ae(truncate_line('ab', 4), 'ab…')
+        self.ae(truncate_line('abcd', 4), 'abc…')
+
+    def test_tab_title_wrap_option(self) -> None:
+        for off in ('no', 'No', 'n', 'false', 'none', '0'):
+            self.ae(tab_title_wrap(off), 0)
+        for on in ('yes', 'y', 'true', 'YES'):
+            self.ae(tab_title_wrap(on), -1)
+        self.ae(tab_title_wrap('20'), 20)
+
+    def test_vertical_tab_bar_wrapping(self) -> None:
+        # set_options bypasses the config parser, so these take parsed values:
+        # -1 is 'yes' (wrap at the width of the tab bar), a positive int a width
+        long_title = 'feature/some-really-long-branch'
+
+        def tb_with(**opts: object) -> list[str]:
+            self.set_options({
+                'tab_bar_edge': LEFT_EDGE,
+                'tab_bar_style': 'separator',
+                'tab_title_template': '{title}',
+                **opts,
+            })
+            central, tab_bar = region(140, 0, 740, 240), region(0, 0, 140, 240)
+            with (
+                patch('kitty.tab_bar.cell_size_for_window', return_value=(10, 20)),
+                patch('kitty.tab_bar.viewport_for_window', return_value=(central, tab_bar, 740, 240, 10, 20)),
+                patch('kitty.tab_bar.set_tab_bar_render_data'),
+                patch('kitty.tab_bar.get_boss', return_value=DummyBoss()),
+            ):
+                tb = TabBar(1)
+                tb.layout()
+                tb.update((TabBarData(title=long_title, tab_id=1, is_active=True),))
+            return [line for line in self.screen_lines(tb) if line]
+
+        # off by default: the title is truncated onto a single line as before.
+        # The trailing text is the tail the separator style draws past the
+        # ellipsis, which predates wrapping.
+        self.ae(tb_with(tab_title_max_lines=3), ['feature/som… h'])
+        # 'yes' wraps at the width of the tab bar
+        self.ae(tb_with(tab_title_max_lines=3, tab_title_wrap=-1), ['feature/some-', 'really-long-b', 'ranch'])
+        # a number wraps at that many cells
+        self.ae(tb_with(tab_title_max_lines=3, tab_title_wrap=8), ['feature/', 'some-rea', 'lly-lon…'])
+        # wrapping needs more than one line to have any effect
+        self.ae(tb_with(tab_title_max_lines=1, tab_title_wrap=-1), ['feature/som… h'])
+        # when wrapping needs more lines than allowed, the last one is truncated
+        self.ae(tb_with(tab_title_max_lines=2, tab_title_wrap=-1), ['feature/some-', 'really-long…'])

--- a/kitty_tests/tab_bar.py
+++ b/kitty_tests/tab_bar.py
@@ -4,7 +4,7 @@
 from unittest.mock import patch
 
 from kitty.fast_data_types import LEFT_EDGE, Region
-from kitty.tab_bar import TabBar, TabBarData
+from kitty.tab_bar import CellRange, TabBar, TabBarData
 
 from . import BaseTest
 
@@ -51,11 +51,13 @@ class TestTabBar(BaseTest):
         self.assertTrue(tb.is_vertical)
         self.ae(geometries[-1], (0, 0, 120, 160))
         self.ae(tb.drag_axis_coordinate(5, 35), 35)
+        # single line titles occupy one line each, separated by a blank line
+        self.ae(tuple(te.y for te in tb.tab_extents), (CellRange(0, 0), CellRange(2, 2), CellRange(4, 4)))
         self.ae(tb.tab_id_at(5, 10), 1)
-        self.ae(tb.tab_id_at(110, 35), 1)
-        self.ae(tb.tab_id_at(60, 55), 2)
-        self.ae(tb.tab_id_at(60, 95), 3)
-        self.ae(tb.tab_id_at(60, 135), 0)
+        self.ae(tb.tab_id_at(110, 10), 1)
+        self.ae(tb.tab_id_at(60, 50), 2)
+        self.ae(tb.tab_id_at(60, 90), 3)
+        self.ae(tb.tab_id_at(60, 130), 0)
         self.ae(tb.tab_id_at(180, 10), 0)
 
     def test_vertical_tab_bar_alignment(self) -> None:
@@ -82,8 +84,126 @@ class TestTabBar(BaseTest):
                 TabBarData(title='two', tab_id=2),
             ))
 
-        self.ae(tb.tab_extents[0].y, (4, 5))
-        self.ae(tb.tab_extents[1].y, (6, 7))
+        # 8 lines available, two single line tabs plus a gap, aligned to the end
+        self.ae(tuple(te.y for te in tb.tab_extents), (CellRange(5, 5), CellRange(7, 7)))
         self.ae(tb.tab_id_at(5, 10), 0)
         self.ae(tb.tab_id_at(5, 110), 1)
         self.ae(tb.tab_id_at(5, 150), 2)
+
+    def vertical_tab_bar(self, num_tabs: int = 2, height: int = 160, **opts: object) -> TabBar:
+        self.set_options({
+            'tab_bar_edge': LEFT_EDGE,
+            'tab_bar_style': 'separator',
+            'tab_title_template': '{title}',
+            **opts,
+        })
+        central = region(120, 0, 400, height)
+        tab_bar = region(0, 0, 120, height)
+        with (
+            patch('kitty.tab_bar.cell_size_for_window', return_value=(10, 20)),
+            patch('kitty.tab_bar.viewport_for_window', return_value=(central, tab_bar, 400, height, 10, 20)),
+            patch('kitty.tab_bar.set_tab_bar_render_data'),
+            patch('kitty.tab_bar.get_boss', return_value=DummyBoss()),
+        ):
+            tb = TabBar(1)
+            tb.layout()
+            tb.update(tuple(TabBarData(title=f't{i}', tab_id=i + 1, is_active=i == 0) for i in range(num_tabs)))
+        return tb
+
+    def screen_lines(self, tb: TabBar) -> list[str]:
+        s = tb.screen
+        return [str(s.line(i)).rstrip() for i in range(s.lines)]
+
+    def test_vertical_tab_bar_multiline_titles(self) -> None:
+        # newlines are ignored unless tab_title_max_lines allows them
+        tb = self.vertical_tab_bar(tab_title_template='{title}\\nbr')
+        self.ae(self.screen_lines(tb)[:4], ['t0', '', 't1', ''])
+        self.ae(tuple(te.y for te in tb.tab_extents), (CellRange(0, 0), CellRange(2, 2)))
+
+        # a newline now starts a new line at column zero, without staircasing,
+        # and each tab occupies the two lines its title needs
+        tb = self.vertical_tab_bar(tab_title_template='{title}\\nbr', tab_title_max_lines=2)
+        self.ae(self.screen_lines(tb)[:6], ['t0', 'br', '', 't1', 'br', ''])
+        self.ae(tuple(te.y for te in tb.tab_extents), (CellRange(0, 1), CellRange(3, 4)))
+
+        # lines beyond the limit are dropped rather than bleeding into the next tab
+        tb = self.vertical_tab_bar(tab_title_template='{title}\\nbr\\nextra', tab_title_max_lines=2)
+        self.ae(self.screen_lines(tb)[:6], ['t0', 'br', '', 't1', 'br', ''])
+        self.ae(tuple(te.y for te in tb.tab_extents), (CellRange(0, 1), CellRange(3, 4)))
+
+    def test_vertical_tab_bar_mixed_title_heights(self) -> None:
+        # a tab whose title has no newline stays one line tall even when the
+        # limit is higher, so tabs pack according to what they actually use
+        self.set_options({
+            'tab_bar_edge': LEFT_EDGE,
+            'tab_bar_style': 'separator',
+            'tab_title_template': '{title}',
+            'tab_title_max_lines': 3,
+        })
+        central = region(120, 0, 400, 160)
+        tab_bar = region(0, 0, 120, 160)
+        with (
+            patch('kitty.tab_bar.cell_size_for_window', return_value=(10, 20)),
+            patch('kitty.tab_bar.viewport_for_window', return_value=(central, tab_bar, 400, 160, 10, 20)),
+            patch('kitty.tab_bar.set_tab_bar_render_data'),
+            patch('kitty.tab_bar.get_boss', return_value=DummyBoss()),
+        ):
+            tb = TabBar(1)
+            tb.layout()
+            tb.update((
+                TabBarData(title='one\ntwo', tab_id=1, is_active=True),
+                TabBarData(title='solo', tab_id=2),
+                TabBarData(title='a\nb\nc', tab_id=3),
+            ))
+        self.ae(self.screen_lines(tb)[:8], ['one', 'two', '', 'solo', '', 'a', 'b', 'c'])
+        self.ae(tuple(te.y for te in tb.tab_extents), (CellRange(0, 1), CellRange(3, 3), CellRange(5, 7)))
+        self.ae(tb.tab_id_at(5, 10), 1)
+        self.ae(tb.tab_id_at(5, 30), 1)
+        self.ae(tb.tab_id_at(5, 70), 2)
+        self.ae(tb.tab_id_at(5, 110), 3)
+        self.ae(tb.tab_id_at(5, 150), 3)
+
+    def test_vertical_tab_bar_tab_spacing(self) -> None:
+        # a blank line is left between tabs while there is room for it, but not
+        # above the first tab, and the gaps are not part of any tab's extent so
+        # clicking one activates nothing
+        tb = self.vertical_tab_bar(num_tabs=3)
+        self.ae(self.screen_lines(tb)[:6], ['t0', '', 't1', '', 't2', ''])
+        self.ae(tuple(te.y for te in tb.tab_extents), (CellRange(0, 0), CellRange(2, 2), CellRange(4, 4)))
+        self.ae(tb.tab_id_at(5, 10), 1)
+        self.ae(tb.tab_id_at(5, 30), 0)
+        self.ae(tb.tab_id_at(5, 50), 2)
+
+        # the gap uses the tab bar background, not the neighbouring tab's
+        self.ae(int(tb.screen.line(1).cursor_from(0).bg), 0)
+
+        # spacing applies between multi-line tabs too
+        tb = self.vertical_tab_bar(num_tabs=2, tab_title_max_lines=2, tab_title_template='{title}\\nbr')
+        self.ae(self.screen_lines(tb)[:6], ['t0', 'br', '', 't1', 'br', ''])
+        self.ae(tuple(te.y for te in tb.tab_extents), (CellRange(0, 1), CellRange(3, 4)))
+
+    def test_vertical_tab_bar_tab_spacing_dropped_when_crowded(self) -> None:
+        # once the tabs need the space the blank lines go away automatically,
+        # rather than tabs being dropped in favour of keeping the gaps
+        tb = self.vertical_tab_bar(num_tabs=8, height=160)
+        self.ae(self.screen_lines(tb), [f't{i}' for i in range(8)])
+        self.ae(len(tb.tab_extents), 8)
+
+        # exactly enough room for spacing: 4 tabs need 4 + 3 gaps == 7 lines
+        tb = self.vertical_tab_bar(num_tabs=4, height=140)
+        self.ae(self.screen_lines(tb), ['t0', '', 't1', '', 't2', '', 't3'])
+        self.ae(len(tb.tab_extents), 4)
+
+    def test_vertical_tab_bar_title_taller_than_bar(self) -> None:
+        # a title needing more lines than the bar has must be clipped from the
+        # bottom rather than scrolling the tab bar and losing its first lines
+        tb = self.vertical_tab_bar(num_tabs=1, height=60, tab_title_template='{title}\\na\\nb\\nc\\nd', tab_title_max_lines=5)
+        self.ae(self.screen_lines(tb), ['t0', 'a', 'b'])
+        self.ae(tuple(te.y for te in tb.tab_extents), (CellRange(0, 2),))
+
+    def test_vertical_tab_bar_multiline_overflow(self) -> None:
+        # only 4 lines fit, so two 2-line tabs are drawn and the rest are
+        # replaced by an ellipsis on the last line
+        tb = self.vertical_tab_bar(num_tabs=6, height=100, tab_title_template='{title}\\nbr', tab_title_max_lines=2)
+        self.ae(self.screen_lines(tb), ['t0', 'br', 't1', 'br', '…'])
+        self.ae(tuple(te.y for te in tb.tab_extents), (CellRange(0, 1), CellRange(2, 3)))

--- a/kitty_tests/tab_bar.py
+++ b/kitty_tests/tab_bar.py
@@ -290,3 +290,38 @@ class TestTabBar(BaseTest):
         self.ae(tb_with(tab_title_max_lines=1, tab_title_wrap=-1), ['feature/som… h'])
         # when wrapping needs more lines than allowed, the last one is truncated
         self.ae(tb_with(tab_title_max_lines=2, tab_title_wrap=-1), ['feature/some-', 'really-long…'])
+        # a wrap width wider than the bar is clamped to the bar, so the result
+        # matches wrapping at the bar's width
+        self.ae(tb_with(tab_title_max_lines=3, tab_title_wrap=99), ['feature/some-', 'really-long-b', 'ranch'])
+
+    def test_vertical_tab_bar_wrapping_with_newlines(self) -> None:
+        # an explicit newline still breaks the line, and each resulting line is
+        # wrapped independently
+        tb = self.vertical_tab_bar(
+            num_tabs=1, height=200, tab_title_max_lines=4, tab_title_wrap=-1,
+            tab_title_template='a-really-long-first\\nshort')
+        self.ae([line for line in self.screen_lines(tb) if line], ['a-really-lo', 'ng-first', 'short'])
+
+    def test_vertical_tab_bar_wrapping_overflow(self) -> None:
+        # wrapped tabs are packed by the lines they use, and once they stop
+        # fitting the remainder is replaced by the overflow ellipsis
+        long_title = 'feature/really-long-branch-name'
+        self.set_options({
+            'tab_bar_edge': LEFT_EDGE,
+            'tab_bar_style': 'separator',
+            'tab_title_template': '{title}',
+            'tab_title_max_lines': 2,
+            'tab_title_wrap': -1,
+        })
+        central, tab_bar = region(140, 0, 740, 100), region(0, 0, 140, 100)
+        with (
+            patch('kitty.tab_bar.cell_size_for_window', return_value=(10, 20)),
+            patch('kitty.tab_bar.viewport_for_window', return_value=(central, tab_bar, 740, 100, 10, 20)),
+            patch('kitty.tab_bar.set_tab_bar_render_data'),
+            patch('kitty.tab_bar.get_boss', return_value=DummyBoss()),
+        ):
+            tb = TabBar(1)
+            tb.layout()
+            tb.update(tuple(TabBarData(title=long_title, tab_id=i + 1, is_active=i == 0) for i in range(3)))
+        self.ae(self.screen_lines(tb), ['feature/reall', 'y-long-bran…', 'feature/reall', 'y-long-bran…', '…'])
+        self.ae(tuple(te.y for te in tb.tab_extents), (CellRange(0, 1), CellRange(2, 3)))


### PR DESCRIPTION
Fixes #10302.

Vertical tab titles were limited to a single line, so long titles got
truncated even though the sidebar has plenty of unused vertical space.
Newlines in tab_title_template looked like they almost worked, but each
line was drawn where the previous one ended and titles collided with the
tab below after two lines.

Titles can now span multiple lines, and tabs are packed by the number of
lines each title actually uses rather than a fixed two. The blank line
between tabs is preserved, still inserted while there is room and dropped
automatically once the tabs need the space.

Two new options, both vertical-only and defaulting to current behavior:

- `tab_title_max_lines` (default 1) - how many lines a title may use
- `tab_title_wrap` (default no) - `no`, `yes` to wrap at the tab bar
  width, or a number of cells

Also included as a separate commit: vertical tabs only painted each line
as far as its text reached, leaving a ragged right edge. That predates
this change and is visible with single-line titles on master, but
multi-line titles make it obvious.

One behavior change for existing vertical tab bar users: a title
containing newlines now shows an ellipsis to mark lines dropped by the
line limit.

Four commits, each self-contained. The background fill is separable if
you would rather take it on its own.
