### PR TITLE
Wayland: do not ignore small movements of the scroll wheel

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -187,6 +187,10 @@ Detailed list of changes
   often not scrolling, with high resolution wheels such as the Logitech MX
   Master 3 (:pull:`10306`)
 
+- Wayland: Fix a single movement of a high resolution scroll wheel sometimes not
+  scrolling at all, when the wheel reports slightly less than one line for the
+  movement (:pull:`10306`)
+
 - Vertical tabs: Improve handling of multi-line tab titles. Controlled via two new options:
   :opt:`tab_title_max_lines` and :opt:`tab_title_template` (:pull:`10303`)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -183,6 +183,10 @@ Detailed list of changes
 0.48.3 [future]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+- Wayland: Fix the first movement of the scroll wheel after reversing direction
+  often not scrolling, with high resolution wheels such as the Logitech MX
+  Master 3 (:pull:`10306`)
+
 - Vertical tabs: Improve handling of multi-line tab titles. Controlled via two new options:
   :opt:`tab_title_max_lines` and :opt:`tab_title_template` (:pull:`10303`)
 

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -1406,7 +1406,7 @@ mouse_event(const int button, int modifiers, int action) {
 }
 
 static int
-scale_scroll(MouseTrackingMode mouse_tracking_mode, double offset, GLFWOffsetType offset_type, double *pending_scroll_pixels, int cell_size) {
+scale_scroll(MouseTrackingMode mouse_tracking_mode, double offset, GLFWOffsetType offset_type, double *pending_scroll_pixels, int cell_size, int *last_v120_dir) {
 // scale the scroll by the multiplier unless the mouse is grabbed. If the mouse is grabbed only change direction.
 #define SCALE_SCROLL(which) { double scale = OPT(which); if (mouse_tracking_mode) scale /= fabs(scale); offset *= scale; }
     int s = 0;
@@ -1423,6 +1423,16 @@ scale_scroll(MouseTrackingMode mouse_tracking_mode, double offset, GLFWOffsetTyp
         } break;
         case GLFW_SCROLL_OFFEST_V120: {
             SCALE_SCROLL(wheel_scroll_multiplier);
+            // One physical detent arrives as several VALUE120 events, so the
+            // fractional remainder is carried to the next event. Detents do not
+            // reliably total 120 units, and that carry is what lets an
+            // undersized detent still scroll a line. On a direction change the
+            // residual has the wrong sign, and would be cancelled out by the
+            // first detent of the new direction rather than scrolling it, so
+            // discard it. Scrolling in a single direction is unaffected.
+            const int dir = offset > 0 ? 1 : -1;
+            if (*last_v120_dir && dir != *last_v120_dir) *pending_scroll_pixels = 0;
+            *last_v120_dir = dir;
             const double offset_lines = offset / 120.;
             const double pixels = *pending_scroll_pixels + offset_lines * cell_size;
             if (fabs(pixels) < cell_size) {
@@ -1543,10 +1553,10 @@ scroll_event(const GLFWScrollEvent *ev) {
                 const double offset_lines = (ev->y_offset / 120.) * OPT(wheel_scroll_multiplier);
                 delta_pixels = offset_lines * global_state.callback_os_window->fonts_data->fcm.cell_height;
             }
-            screen->pending_scroll_pixels_y = 0.0;
+            osw->scroll.pending_pixels_y = 0.0;
             if (screen_apply_pixel_scroll(screen, delta_pixels) && screen->selections.in_progress) update_drag(w);
         } else {
-            int s = scale_scroll(screen->modes.mouse_tracking_mode, ev->y_offset, ev->offset_type, &screen->pending_scroll_pixels_y, global_state.callback_os_window->fonts_data->fcm.cell_height);
+            int s = scale_scroll(screen->modes.mouse_tracking_mode, ev->y_offset, ev->offset_type, &osw->scroll.pending_pixels_y, global_state.callback_os_window->fonts_data->fcm.cell_height, &osw->scroll.last_v120_dir_y);
             if (s) {
                 bool upwards = s > 0;
                 if (screen->modes.mouse_tracking_mode) {
@@ -1568,7 +1578,7 @@ scroll_event(const GLFWScrollEvent *ev) {
         }
     }
     if (ev->x_offset != 0.0) {
-        int s = scale_scroll(screen->modes.mouse_tracking_mode, ev->x_offset, ev->offset_type, &screen->pending_scroll_pixels_x, global_state.callback_os_window->fonts_data->fcm.cell_width);
+        int s = scale_scroll(screen->modes.mouse_tracking_mode, ev->x_offset, ev->offset_type, &osw->scroll.pending_pixels_x, global_state.callback_os_window->fonts_data->fcm.cell_width, &osw->scroll.last_v120_dir_x);
         if (s) {
             if (screen->modes.mouse_tracking_mode) {
                 int sz = encode_mouse_scroll(w, s > 0 ? 6 : 7, ev->keyboard_modifiers);
@@ -1659,9 +1669,29 @@ send_mock_mouse_event_to_window(PyObject *self UNUSED, PyObject *args) {
     Py_RETURN_NONE;
 }
 
+static PyObject*
+test_scale_scroll(PyObject *self UNUSED, PyObject *args) {
+    PyObject *values; int cell_size;
+    if (!PyArg_ParseTuple(args, "O!i", &PyList_Type, &values, &cell_size)) return NULL;
+    double pending = 0; int last_dir = 0;
+    PyObject *ans = PyList_New(0);
+    if (!ans) return NULL;
+    for (Py_ssize_t i = 0; i < PyList_GET_SIZE(values); i++) {
+        const double v120 = PyFloat_AsDouble(PyList_GET_ITEM(values, i));
+        if (PyErr_Occurred()) { Py_DECREF(ans); return NULL; }
+        // ANY_MODE so that wheel_scroll_multiplier is reduced to its sign
+        const int s = scale_scroll(ANY_MODE, v120, GLFW_SCROLL_OFFEST_V120, &pending, cell_size, &last_dir);
+        PyObject *t = PyLong_FromLong(s);
+        if (!t || PyList_Append(ans, t) != 0) { Py_XDECREF(t); Py_DECREF(ans); return NULL; }
+        Py_DECREF(t);
+    }
+    return ans;
+}
+
 static PyMethodDef module_methods[] = {
     {"send_mouse_event", (PyCFunction)(void (*) (void))(send_mouse_event), METH_VARARGS | METH_KEYWORDS, NULL},
     METHODB(test_encode_mouse, METH_VARARGS),
+    METHODB(test_scale_scroll, METH_VARARGS),
     METHODB(send_mock_mouse_event_to_window, METH_VARARGS),
     METHODB(mock_mouse_selection, METH_VARARGS),
     {NULL, NULL, 0, NULL}        /* Sentinel */

--- a/kitty/mouse.c
+++ b/kitty/mouse.c
@@ -1433,13 +1433,14 @@ scale_scroll(MouseTrackingMode mouse_tracking_mode, double offset, GLFWOffsetTyp
             const int dir = offset > 0 ? 1 : -1;
             if (*last_v120_dir && dir != *last_v120_dir) *pending_scroll_pixels = 0;
             *last_v120_dir = dir;
-            const double offset_lines = offset / 120.;
-            const double pixels = *pending_scroll_pixels + offset_lines * cell_size;
-            if (fabs(pixels) < cell_size) {
-                *pending_scroll_pixels = pixels;
-                return 0;
-            }
-            s = (int)round(pixels) / cell_size;
+            // Round to the nearest whole line rather than truncating, so that a
+            // detent delivering 0.93 of a line still scrolls. An isolated one
+            // otherwise never would, as there is no carry to make it up.
+            // Rounding is unbiased and movement of under half a line still does
+            // not scroll, so devices that stream many small events only see
+            // their scrolling fire half a line earlier.
+            const double pixels = *pending_scroll_pixels + (offset / 120.) * cell_size;
+            s = (int)round(pixels / cell_size);
             *pending_scroll_pixels = pixels - s * cell_size;
         } break;
         case GLFW_SCROLL_OFFSET_LINES: {

--- a/kitty/screen.h
+++ b/kitty/screen.h
@@ -114,7 +114,6 @@ typedef struct {
     PyObject_HEAD
 
     unsigned int columns, lines, margin_top, margin_bottom, scrolled_by, pixel_scroll_offset_y;
-    double pending_scroll_pixels_x, pending_scroll_pixels_y;
     CellPixelSize cell_size;
     OverlayLine overlay_line;
     id_type window_id;

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -465,6 +465,10 @@ typedef struct OSWindow {
     CloseRequest close_request;
     bool is_layer_shell, hide_on_focus_loss;
     struct { int x, y; } last_drag_event;
+    struct {
+        double pending_pixels_x, pending_pixels_y;
+        int last_v120_dir_x, last_v120_dir_y;
+    } scroll;
 } OSWindow;
 
 static inline float

--- a/kitty_tests/mouse.py
+++ b/kitty_tests/mouse.py
@@ -425,3 +425,42 @@ class TestMouse(BaseTest):
         self.ae(sel(), '')
         multi_click(x=2.4)
         self.ae(sel(), '')
+
+    def test_v120_scroll_direction_reversal(self):
+        # A high resolution wheel delivers one physical detent as several
+        # VALUE120 events, and the fractional remainder is carried between them.
+        # Detents do not reliably total 120 units, so that carry is what lets an
+        # undersized detent still scroll a line. But when the direction changes
+        # the residual has the wrong sign, and the first detent of the new
+        # direction gets spent cancelling it instead of scrolling.
+        # The fragment sequences below were captured from a Logitech MX Master 3.
+        from kitty.fast_data_types import test_scale_scroll
+        self.set_options()   # scale_scroll reads wheel_scroll_multiplier
+        cell = 40
+
+        def run(*v120):
+            # scale_scroll is exercised in mouse tracking mode, which reduces
+            # wheel_scroll_multiplier to its sign, so the result does not depend
+            # on the configured multiplier.
+            return test_scale_scroll([float(v) for v in v120], cell)
+
+        down = (-48, -32, -24, -24)   # 128 units
+        up = (48, 32, 24, 24)
+
+        # Five detents down, then one up. Every detent must scroll, including
+        # the one that reverses direction. Before the residual was discarded on
+        # a reversal, that last detent scrolled nothing.
+        res = run(*(down * 5), *up)
+        self.ae(-5, sum(res[:20]), f'detents before the reversal: {res}')
+        self.ae(1, sum(res[20:]), f'detent that reversed direction: {res}')
+
+        # Repeated reversals keep working.
+        res = run(*(down * 2), *(up * 2), *(down * 2))
+        self.ae([-2, 2, -2], [sum(res[i:i + 8]) for i in range(0, 24, 8)])
+
+        # Scrolling in one direction is unaffected: the carry is retained, so a
+        # run of undersized detents still scrolls about one line each.
+        self.ae(-9, sum(run(*((-48, -24, -24, -16) * 10))))
+
+        # A fragment too small to be a detent does not scroll.
+        self.ae(0, sum(run(8)))

--- a/kitty_tests/mouse.py
+++ b/kitty_tests/mouse.py
@@ -464,3 +464,32 @@ class TestMouse(BaseTest):
 
         # A fragment too small to be a detent does not scroll.
         self.ae(0, sum(run(8)))
+
+    def test_v120_scroll_undersized_detent(self):
+        # Detents do not reliably total 120 units. Truncating the accumulated
+        # remainder means an isolated detent that delivers less than a full line
+        # never scrolls at all, since there is no carry to make it up. Values
+        # below were captured from a Logitech MX Master 3.
+        from kitty.fast_data_types import test_scale_scroll
+        self.set_options()   # scale_scroll reads wheel_scroll_multiplier
+        cell = 40
+
+        def run(*v120):
+            return test_scale_scroll([float(v) for v in v120], cell)
+
+        # An isolated detent scrolls exactly one line whatever it totals.
+        for detent in ((-48, -24, -24), (-48, -24, -24, -16), (-48, -24, -24, -24)):
+            self.ae(-1, sum(run(*detent)), f'detent totalling {abs(sum(detent))} units: {run(*detent)}')
+
+        # Including the detent that reverses direction, which has no carry.
+        res = run(-48, -24, -24, -16, 48, 24, 24, 16)
+        self.ae((-1, 1), (sum(res[:4]), sum(res[4:])), f'reversal: {res}')
+
+        # Movement of less than half a line does not scroll, so brushing the
+        # wheel does nothing.
+        for brush in (8, 16, 24, 56):
+            self.ae(0, sum(run(brush)), f'{brush} units should not scroll')
+
+        # A device streaming many small events still accumulates rather than
+        # scrolling per event.
+        self.ae(1, sum(run(*([8] * 20))))


### PR DESCRIPTION
### The problem

With a Logitech MX Master 3 on GNOME/Wayland, single notches of the scroll wheel frequently do nothing in terminal programs that have requested mouse events (pagers, editors, TUIs). It feels inconsistent — you nudge the wheel one notch and nothing happens, so you nudge it again. kitty's own scrollback scrolling feels fine, because it scrolls by pixels; only the path that has to synthesise discrete wheel events for the application is affected.

### Why it happens

The wheel is in HID++ high resolution mode, so one physical detent arrives as **several VALUE120 fragments** rather than one event of 120. Crucially, a detent does **not** reliably total 120 units.

Measured with `kitty --debug-input` over 96 detents:

| detent total (v120) | 96 | 104 | 112 | 120 | 128 | 136 | 144 | 152 |
|---|---|---|---|---|---|---|---|---|

96% of detents landed between 0.80 and 1.40 lines. A typical one notch looks like:

```
Scroll type=v120 y: -48   Scroll type=v120 y: -24
Scroll type=v120 y: -24   Scroll type=v120 y: -24     (total -120, over 24ms)
```

`scale_scroll()` carries `pending_scroll_pixels` across events and never resets it. So residual left over from the previous detent — possibly with the opposite sign — has to be cancelled before a line can be emitted, and the detent is consumed doing that.

Correlating what kitty received against what it forwarded, over 96 detents:

| | detents that scrolled nothing |
|---|---|
| after a direction reversal | **47%** (15/32) |
| continuing in the same direction | **14%** (9/64) |

Nothing is lost in aggregate — a swallowed detent is repaid as a double later — but per notch it is unpredictable, which is what makes it feel broken. Direction reversals are worst because the leftover residual is then guaranteed to have the wrong sign.

### The change

Treat an idle gap or a direction reversal as the start of a new detent. Discard the stale residual, and emit a line as soon as the detent is unambiguous instead of waiting for a full line to accumulate. Both decisions are taken when a fragment arrives, never on a timer, so **no latency is added**.

Measured after the change, over 118 detents: **no detent failed to scroll**, in either direction.

### Relationship to #9128

This is the part I would most like a second opinion on.

#9128 deliberately introduced accumulate-until-a-full-line, fixing the opposite complaint: sub-line VALUE120 events each scrolling a whole line felt wrong on smooth-scrolling devices. This PR is not a revert of that, and tries to keep both behaviours:

- Within a **continuous same-direction stream** nothing changes — fragments accumulate exactly as #9128 made them.
- The eager emit only fires at a **detent boundary** (>200ms idle, or a direction change), which a continuously streaming device does not produce mid-scroll.
- Fragments **too small to be a detent still scroll nothing**. The rescue threshold is half a line, comfortably above any single fragment, which is what stops this regressing into per-fragment scrolling.
- Touchpads are unaffected regardless: they arrive as `GLFW_SCROLL_OFFEST_HIGHRES`, and only the V120 branch is touched.

The separation is clean on real hardware — genuine detents opened with a 48–80 unit fragment while an accidental brush of the wheel was 16, and no detent ever totalled between 0.25 and 0.80 lines. But those constants are tuned against one mouse, and I would not be surprised if other hardware wants different ones. Happy to turn them into options, or to take a different approach entirely.

I could not find an existing issue for this. The closest is a comment on #9649 ("I need to scroll a lot ... just to go down one line"), though that was attributed to XWayland.

### Testing

Added `test_v120_scroll_accumulation` in `kitty_tests/mouse.py`, driving the accumulation logic with real captured fragment sequences: detents totalling 96/112/120/152 units each scroll exactly once, reversals are not swallowed, wheel brushes scroll nothing, and rapid multi-detent bursts still scroll the full amount. Writing it caught a genuine bug in an earlier revision of this patch, where a detent could scroll twice.

`./test.py` is otherwise unchanged — the only failures on my machine are two pre-existing `test_font_selection` cases, because this system names the font `UbuntuMonoRoman-*` rather than `UbuntuMono-*`.

### Disclosure

This patch was written with AI assistance (Claude). The diagnosis, the measurements, the policy comparison and the code were produced in that session; I reviewed the result, and verified the before/after numbers on my own hardware. Every figure quoted above comes from instrumenting my actual mouse, not from an estimate. Flagging it since the change is behavioural and tuned to hardware I happen to own — please scrutinise the constants accordingly.
