### PR TITLE
Remember maximized window state across restarts

### DIFF
--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -2140,7 +2140,7 @@ class Boss:
         else:
             self.mark_os_window_for_close(os_window_id, NO_CLOSE_REQUESTED)
 
-    def on_os_window_closed(self, os_window_id: int, x: int, y: int, viewport_width: int, viewport_height: int, is_layer_shell: bool) -> None:
+    def on_os_window_closed(self, os_window_id: int, x: int, y: int, viewport_width: int, viewport_height: int, was_maximized: bool, is_layer_shell: bool) -> None:
         tm = self.os_window_map.pop(os_window_id, None)
         opts = get_options()
         if not is_layer_shell:
@@ -2148,6 +2148,7 @@ class Boss:
                 self.cached_values['window-pos'] = x, y
                 self.cached_values['monitor-workarea'] = glfw_get_monitor_workarea()
             self.cached_values['window-size'] = viewport_width, viewport_height
+            self.cached_values['window-state'] = 'maximized' if was_maximized else 'normal'
         if tm is not None:
             tm.destroy()
         for window_id in tuple(w.id for w in self.window_id_map.values() if getattr(w, 'os_window_id', None) == os_window_id):

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -2140,7 +2140,9 @@ class Boss:
         else:
             self.mark_os_window_for_close(os_window_id, NO_CLOSE_REQUESTED)
 
-    def on_os_window_closed(self, os_window_id: int, x: int, y: int, viewport_width: int, viewport_height: int, was_maximized: bool, is_layer_shell: bool) -> None:
+    def on_os_window_closed(
+        self, os_window_id: int, x: int, y: int, viewport_width: int, viewport_height: int, was_maximized: bool, is_layer_shell: bool
+    ) -> None:
         tm = self.os_window_map.pop(os_window_id, None)
         opts = get_options()
         if not is_layer_shell:

--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -1222,8 +1222,12 @@ close_os_window(ChildMonitor *self, OSWindow *os_window) {
     int x = 0, y = 0;
     if (os_window->handle && !global_state.is_wayland) glfwGetWindowPos(os_window->handle, &x, &y);
     bool is_layer_shell = os_window->is_layer_shell;
+    bool was_maximized = false;
+    if (os_window->handle && !is_layer_shell) {
+        was_maximized = glfwGetWindowAttrib(os_window->handle, GLFW_MAXIMIZED) != 0;
+    }
     destroy_os_window(os_window);
-    call_boss(on_os_window_closed, "KiiiiO", os_window->id, x, y, w, h, is_layer_shell ? Py_True : Py_False);
+    call_boss(on_os_window_closed, "KiiiiOO", os_window->id, x, y, w, h, was_maximized ? Py_True : Py_False, is_layer_shell ? Py_True : Py_False);
     for (size_t t=0; t < os_window->num_tabs; t++) {
         Tab *tab = os_window->tabs + t;
         for (size_t w = 0; w < tab->num_windows; w++) mark_child_for_close(self, tab->windows[w].id);

--- a/kitty/main.py
+++ b/kitty/main.py
@@ -304,6 +304,9 @@ def _run_app(opts: Options, args: CLIOptions, bad_lines: Sequence[BadLine] = (),
         window_state = (args.start_as if args.start_as and args.start_as != 'normal' else None) or (
             getattr(startup_sessions[0], 'os_window_state', None) if startup_sessions else None
         )
+        # Remember the maximized state from the previous session, if enabled.
+        if window_state is None and opts.remember_window_size:
+            window_state = cached_values.get('window-state') or None
         wstate = parse_os_window_state(window_state) if window_state is not None else None
 
         with startup_notification_handler(extra_callback=run_app.first_window_callback) as pre_show_callback:


### PR DESCRIPTION
When `remember_window_size` is enabled, kitty already restores the
previous window size. This change also remembers whether the window was
maximized and re-maximizes it on startup.

- `child-monitor.c`: read `GLFW_MAXIMIZED` before the window is destroyed
  and pass it to the boss process.
- `boss.py`: cache `window-state` (`maximized`/`normal`) on window close.
- `main.py`: when no explicit start state is given and
  `remember_window_size` is on, restore the cached state.

Tested on kwin-x11 and kwin-wayland; compile + unit tests pass.
No behavior change when `remember_window_size` is off.