### PR TITLE
Add captain-miao tool to integrations documentation

### DIFF
--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -429,3 +429,10 @@ raw-mode.
 `glkitty <https://github.com/michaeljclark/glkitty>`_
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 C library to draw OpenGL shaders in the terminal with a glgears demo
+
+.. tool_captain_miao:
+
+`captain-miao <https://github.com/hyperlogue/captain-miao>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+TUI to monitor and organize multiple AI coding sessions, by leveraging 
+the kitty remote control protocol


### PR DESCRIPTION
captain-miao is a TUI app to manage multiple AI coding sessions. It deeply integrates into the kitty terminal through the remote control. I think it's a nice showcase for this unique capability of kitty.

https://github.com/hyperlogue/captain-miao