### PR TITLE
fix stack BOF in serialize() in key_encoding.c

### DIFF
--- a/kitty/key_encoding.c
+++ b/kitty/key_encoding.c
@@ -93,6 +93,7 @@ serialize(const EncodingData *data, char *output, const char csi_trailer) {
         }
     }
 #undef P
+    if (pos > KEY_BUFFER_SIZE - 2) pos = KEY_BUFFER_SIZE - 2;
     output[pos++] = csi_trailer;
     output[pos] = 0;
     return pos;


### PR DESCRIPTION
found by fuzzing random targets via afl

initial guess:
the P macro calls snprintf(size=0) to clamp writes when the output buffer is full however snprintf with size=0 writes nothing but still returns the number of bytes it would have written, so `pos` keeps accumulating past KEY_BUFFER_SIZE-2
two unconditional writes after the loop then write past the end of the stack buffer:

```c
output[pos++] = csi_trailer; /* pos may be >= KEY_BUFFER_SIZE */
output[pos] = 0;
```

```python3
import kitty.fast_data_types as d
r = d.encode_key_for_tty(
    key=0x30303030,
    shifted_key=0x30303030,
    alternate_key=0x30303030,
    mods=0x3d,
    action=1,
    key_encoding_flags=29,
    text='0'*31)
print(repr(r))
```

`'\x1b[808464432:808464432:808464432;62;48:48:48:48:48:48:48:48:48:48:48:48:48:48:48:48:48:48:48:48:48:48:48:48:48:48:48:48:48:48:\x00\x00u'`

this should not be exploitable so sending fix as-it-is