### PR TITLE
Strip control characters from the path reported by OSC 7

### DIFF
--- a/kitty/utils.py
+++ b/kitty/utils.py
@@ -967,12 +967,17 @@ def cleanup_ssh_control_masters() -> None:
 def path_from_osc7_url(url: str | bytes) -> str:
     if isinstance(url, bytes):
         url = url.decode('utf-8')
+    ans = ''
     if url.startswith('kitty-shell-cwd://'):
-        return '/' + url.split('/', 3)[-1]
-    if url.startswith('file://'):
+        ans = '/' + url.split('/', 3)[-1]
+    elif url.startswith('file://'):
         from urllib.parse import unquote, urlparse
-        return unquote(urlparse(url).path)
-    return ''
+        ans = unquote(urlparse(url).path)
+    # The URL comes from an escape sequence, so it can contain anything, including
+    # control characters. A NUL in particular cannot be part of a path and makes
+    # os.fork() raise, which is fatal when the path is written to a session file
+    # and used as a --cwd on startup.
+    return control_codes_pat().sub('', ans)
 
 
 @run_once

--- a/kitty_tests/datatypes.py
+++ b/kitty_tests/datatypes.py
@@ -59,6 +59,20 @@ class TestDataTypes(BaseTest):
         t('a\0\x01😸\x03\x04\t\rc', 'a\u2400\u2401😸\u2403\u2404\t\u240dc')
         t('a\nb\tc d', 'a\nb\tc d')
 
+    def test_path_from_osc7_url(self):
+        from kitty.utils import path_from_osc7_url
+        self.ae('/tmp/x', path_from_osc7_url('file://host/tmp/x'))
+        self.ae('/tmp/x', path_from_osc7_url(b'file://host/tmp/x'))
+        self.ae('/tmp/a b', path_from_osc7_url('file://host/tmp/a%20b'))
+        self.ae('/tmp/x', path_from_osc7_url('kitty-shell-cwd://host/tmp/x'))
+        self.ae('', path_from_osc7_url('not-a-url'))
+        # the URL comes from an escape sequence, so it can contain control codes. A
+        # NUL in a path makes os.fork() raise, so they must not survive.
+        self.ae('/tmp/x', path_from_osc7_url('file://host/tmp/x\0'))
+        self.ae('/tmp/xy', path_from_osc7_url('file://host/tmp/x\0y'))
+        self.ae('/tmp/x', path_from_osc7_url('kitty-shell-cwd://host/tmp/x\0'))
+        self.ae('/tmp/xy', path_from_osc7_url('file://host/tmp/x\x1by'))
+
     def test_to_color(self):
         for x in 'xxx #12 #1234 rgb:a/b'.split():
             self.assertIsNone(to_color(x))


### PR DESCRIPTION
The OSC 7 payload comes from an escape sequence, so it can contain any bytes,
including control characters. `path_from_osc7_url()` passed them through, and a
NUL cannot appear in a path: `os.fork()` raises `ValueError` for it.

That is normally harmless, but `save_as_session` writes the reported cwd into the
session file as a `--cwd` argument. Restoring such a session then fails in
`Child.fork()` with `ValueError: embedded null character` before any window is
created, so kitty does not start at all until the session file is edited by hand.
I hit this with a multiplexer that replayed OSC 7 with a stray trailing NUL on
reattach.

Strip control characters from the path, as is already done for titles.
