### PR TITLE
Add elio to integrations

### DIFF
--- a/docs/dnd-protocol.rst
+++ b/docs/dnd-protocol.rst
@@ -559,3 +559,4 @@ Currently this protocol is supported in:
 
   * The kitty terminal emulator and the :doc:`dnd kitten </kittens/dnd>`
   * The `yazi <https://github.com/sxyazi/yazi/pull/4005>`__ terminal file manager
+  * The `elio <https://github.com/elio-fm/elio>`__ terminal file manager

--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -35,6 +35,7 @@ Some applications that use the kitty graphics protocol:
 * `chawan <https://chawan.net>`_ - TUI web browser
 * `desktui <https://github.com/mishushakov/desktui>`_ - a VNC client that draws a remote desktop in the terminal, one remote pixel per terminal pixel
 * :doc:`kitty-diff <kittens/diff>` - a side-by-side terminal diff program with support for images
+* `elio <https://github.com/elio-fm/elio>`_ - Batteries-included terminal file manager with rich previews
 * `fzf <https://github.com/junegunn/fzf/commit/d8188fce7b7bea982e7f9050c35e488e49fb8fd0>`_ - A command line fuzzy finder
 * `mpv <https://github.com/mpv-player/mpv/commit/874e28f4a41a916bb567a882063dd2589e9234e1>`_ - A video player that can play videos in the terminal
 * `neofetch <https://github.com/dylanaraps/neofetch>`_ - A command line system information tool

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -186,6 +186,14 @@ graphics protocol.
 Text-mode dual panel (orthodox) file manager and also terminal emulator, uses
 the kitty graphics and keyboard protocols (both as client and as terminal)
 
+.. _tool_elio:
+
+`elio <https://github.com/elio-fm/elio>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Batteries-included terminal file manager with previews using kitty's Classic
+protocol and Unicode placeholders, and native support for its Drag and Drop
+protocol.
+
 
 System and data visualisation tools
 ---------------------------------------


### PR DESCRIPTION
Adds elio to the file managers section of the integrations page and to the graphics and Drag and Drop protocol support lists.

elio supports previews through kitty's Classic protocol and Unicode placeholders, as well as the Drag and Drop protocol.