### PR TITLE
Fix hang on Scroll Up (CSI S) with a huge count

### DIFF
--- a/kitty/screen.c
+++ b/kitty/screen.c
@@ -2425,6 +2425,11 @@ screen_scroll(Screen *self, unsigned int count) {
     // Scroll the screen up by count lines, not moving the cursor
     unsigned int top = self->margin_top, bottom = self->margin_bottom;
     const bool add_to_history = self->linebuf == self->main_linebuf && self->margin_top == 0;
+    // Scrolling up by more than the number of lines on screen blanks the
+    // entire scrolling region, so clamp to avoid a multi-billion iteration
+    // busy-loop when a program emits e.g. CSI 2147483647 S. See _reverse_scroll
+    // which caps count the same way.
+    count = MIN(count, self->lines);
     while (count > 0) {
         count--;
         INDEX_UP(add_to_history);

--- a/kitty_tests/screen.py
+++ b/kitty_tests/screen.py
@@ -120,6 +120,21 @@ class TestScreen(BaseTest):
         parse_bytes(s, b'\x1b[3b')
         self.ae(str(s.line(1)), ' ' * 4)
 
+    def test_scroll_huge_count(self):
+        # CSI Ps S (Scroll Up) with a huge count must not busy-loop for
+        # billions of iterations. Scrolling up by more than the number of
+        # lines blanks the region, so the result is identical to scrolling
+        # by the screen height. Regression test for a hang on e.g. CSI
+        # 2147483647 S.
+        s = self.create_screen()
+        for i in range(s.lines):
+            s.draw(str(i))
+            if i + 1 < s.lines:
+                parse_bytes(s, b'\r\n')
+        parse_bytes(s, b'\x1b[2147483647S')  # INT_MAX scroll up
+        for i in range(s.lines):
+            self.ae(str(s.line(i)).strip(), '')
+
     def test_emoji_skin_tone_modifiers(self):
         s = self.create_screen()
         q = chr(0x1F469) + chr(0x1F3FD)


### PR DESCRIPTION
Fixes #10333.

`CSI Ps S` (Scroll Up) with a large count, e.g. `printf '\e[2147483647S'`, hangs the terminal: 100% CPU on one core, no repaint, needs a hard kill. `screen_scroll()` looped `count` times with no bound (~2.1 billion iterations here), each shuffling rows through the linebuf and pushing blank lines into scrollback.

Scrolling up by more than the number of lines on screen blanks the whole region, so past `self->lines` every iteration is wasted work. This clamps `count` to `self->lines`, matching what `_reverse_scroll()` (Scroll Down) already does.

Added a regression test (`test_scroll_huge_count`) that feeds `CSI 2147483647 S` and asserts the region ends up blank. Whole `TestScreen` suite still passes (45 tests).
