### PR TITLE
shaders/slang: fix pipeline parsing and multi-pass module collisions

### DIFF
--- a/kitty/shaders/slang.py
+++ b/kitty/shaders/slang.py
@@ -20,7 +20,7 @@ from enum import StrEnum, auto
 from functools import lru_cache, partial
 from itertools import chain, product
 from types import MappingProxyType
-from typing import Any, Callable, Iterable, Iterator, Literal, NamedTuple, TypedDict, TypeGuard, get_args
+from typing import Any, Callable, Iterable, Iterator, Literal, NamedTuple, TypedDict, TypeGuard
 
 from kitty.constants import read_kitty_resource, shaders_dir, slangc
 from kitty.fast_data_types import (
@@ -1090,11 +1090,11 @@ class Slot(StrEnum):
 
 
 def is_valid_named_texture(x: str) -> TypeGuard[NamedTexture]:
-    return x in get_args(NamedTexture)
+    return x in NamedTexture._value2member_map_
 
 
 def is_valid_slot(x: str) -> TypeGuard[Slot]:
-    return x in get_args(Slot)
+    return x in Slot._value2member_map_
 
 
 VALID_VAR_TYPES: frozenset[str] = frozenset({'uint', 'int', 'float', 'double', 'bool'})
@@ -1271,7 +1271,7 @@ def parse_pipeline_definition(lines: Iterable[str], pipeline_name: str, pipeline
                 case 'viewport_size':
                     current_group['viewport_size'] = unit_float(parts[1]), unit_float(parts[1 if len(parts) < 3 else 2])
                 case 'output_texture':
-                    if not is_valid_named_texture(parts[1]):
+                    if not is_valid_named_texture(parts[1]) or parts[1] not in textures:
                         raise ValueError(f'output_texture {parts[1]} does not appear in textures')
                     current_group['output_texture'] = parts[1]
                 case 'shaders':
@@ -1394,7 +1394,9 @@ def build_custom_shader_pipeline_ir(pipeline: Pipeline, cache_dir: str, invocati
                     inc = ['-I', import_dir] if import_dir else []
                     cmd = bc + inc + ['-module-name', modname, '-o', module_file, '--', '-']
                     invocation_tracker.add(tuple(cmd))
-                    cp = subprocess.run(cmd, input=specialized_src, capture_output=True)
+                    # Rename fragment_main to a unique per-module function name to avoid import ambiguity
+                    specialized_text = re.sub(r'\bfragment_main\b', f'fragment_main_{modname}', specialized_src.decode())
+                    cp = subprocess.run(cmd, input=specialized_text.encode(), capture_output=True)
                     if cp.returncode != 0:
                         raise SlangFailed(name, cp)
                     mtime = max(mtime, os.stat(module_file).st_mtime_ns)
@@ -1411,13 +1413,14 @@ def build_custom_shader_pipeline_ir(pipeline: Pipeline, cache_dir: str, invocati
         vars_key = tuple(sorted(merged_vars.items()))
         module_name = module_names[(name, vars_key)]
         entry_point = f'fragment_main{i}'
+        entry_func = f'fragment_main_{module_name}'
         wrapper_src = f"""#language slang 2026
 implementing {slot_module_name};
 import kitty_custom_shader_types;
 import {module_name};
 public float4 {entry_point}(
     float4 inp, KittyTextures t, KittyCustomShaderData d, float4 viewport, float animation_progress
-) {{ return fragment_main(inp, t, d, viewport, animation_progress); }}
+) {{ return {entry_func}(inp, t, d, viewport, animation_progress); }}
 """
         wrappers[f'wrapper{i}.slang'] = wrapper_src
         entry_points.append(entry_point)


### PR DESCRIPTION
Fix two issues in custom shader pipeline parsing and IR compilation:

1. Fix `is_valid_named_texture` and `is_valid_slot` always returning False
   - `typing.get_args()` returns an empty tuple when called on `StrEnum` types (`NamedTexture`, `Slot`), causing `parse_pipeline_definition` to fail with "output_texture <name> does not appear in textures".
   - Switched checks to query `._value2member_map_` directly.

2. Fix ambiguous `fragment_main` symbol collision across pipeline passes
   - Importing multiple specialized Slang modules into wrapper files for multi-pass pipelines introduced duplicate `fragment_main` declarations into the same slot scope, causing `slangc` to throw E39999 (ambiguous function call).
   - Renamed `fragment_main` inside specialized module sources to a unique per-module identifier (`fragment_main_{modname}`) and updated wrapper call sites accordingly.

Without these fixes e.g. `output_texture persist` cannot be used.
Included a demo which persist the data between frames when mouse is clicked.
[northern_lights.pipeline.txt](https://github.com/user-attachments/files/30879131/northern_lights.pipeline.txt)
[northern_lights.slang.txt](https://github.com/user-attachments/files/30879132/northern_lights.slang.txt)
<img width="1714" height="1296" alt="northern_lights" src="https://github.com/user-attachments/assets/bdda9a04-f4ee-40b7-9be5-ab0c5b27c84c" />
