### PR TITLE
Add remote control command for OS window titles

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -184,6 +184,10 @@ Detailed list of changes
 
 - Add a new :code:`kitten @ screenshot` remote control command to take a pixel perfect PNG screenshot of an OS Window, tab or window
 
+- Add a new :code:`kitten @ set-os-window-title` remote control command to set
+  the title for an already-open OS Window and optionally restore automatic
+  title tracking when no title is specified
+
 - A new option, :opt:`padding_fill_strategy` to control how the thin padding strips that appear when the window size is not an exact multiple of the cell size are colored. You can choose to have the padding colored to match the background of each neighboring cell, effectively extending the size of the cell or you can continue to use the existing behavior of using the background.
 
 - Wayland: Fix the first movement of the scroll wheel after reversing direction

--- a/kitty/rc/set_os_window_title.py
+++ b/kitty/rc/set_os_window_title.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# License: GPLv3 Copyright: 2020, Kovid Goyal <kovid at kovidgoyal.net>
+
+from typing import TYPE_CHECKING
+
+from kitty.fast_data_types import set_os_window_title as set_os_window_title_impl
+
+from .base import MATCH_WINDOW_OPTION, ArgsType, Boss, PayloadGetType, PayloadType, RCOptions, RemoteCommand, ResponseType, Window
+
+if TYPE_CHECKING:
+    from kitty.cli_stub import SetOsWindowTitleRCOptions as CLIOptions
+
+
+class SetOsWindowTitle(RemoteCommand):
+    protocol_spec = __doc__ = """
+    title/str: The new title
+    match/str: Which OS windows to change, matched via their contained windows
+    """
+
+    short_desc = 'Set the OS window title'
+    desc = (
+        'Set the title for the OS windows containing the specified windows. If you use the '
+        ':option:`kitten @ set-os-window-title --match` option the title will be set for all matched OS windows. '
+        'By default, only the OS window in which the command is run is affected. If you do not specify a title, the '
+        'title of the currently active window in each OS window is used.'
+    )
+    options_spec = MATCH_WINDOW_OPTION
+    args = RemoteCommand.Args(spec='[TITLE ...]', json_field='title', special_parse='expand_ansi_c_escapes_in_args(args...)')
+
+    def message_to_kitty(self, global_opts: RCOptions, opts: 'CLIOptions', args: ArgsType) -> PayloadType:
+        ans = {'match': opts.match, 'self': True}
+        title = ' '.join(args)
+        if title:
+            ans['title'] = title
+        return ans
+
+    def response_from_kitty(self, boss: Boss, window: Window | None, payload_get: PayloadGetType) -> ResponseType:
+        title = payload_get('title') or ''
+        for os_window_id in {w.os_window_id for w in self.windows_for_match_payload(boss, window, payload_get) if w}:
+            set_os_window_title_impl(os_window_id, title)
+        return None
+
+
+set_os_window_title = SetOsWindowTitle()

--- a/kitty_tests/completion.py
+++ b/kitty_tests/completion.py
@@ -94,6 +94,7 @@ def completion(self: TestCompletion, tdir: str):
 
     add('kitty ', has_words('@', '+', '+open'))
     add('kitty @ l', has_words('ls', 'last-used-layout', 'launch'))
+    add('kitty @ set-o', has_words('set-os-window-title'))
 
     def make_file(path, mode=None):
         with open(os.path.join(tdir, path), mode='x') as f:

--- a/kitty_tests/remote_control.py
+++ b/kitty_tests/remote_control.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# License: GPLv3 Copyright: 2026 Kovid Goyal <kovid at kovidgoyal.net>
+
+from unittest.mock import patch
+
+from kitty.rc.base import PayloadGetter, all_command_names, command_for_name
+
+from .base import BaseTest
+
+
+class Window:
+    def __init__(self, id: int, os_window_id: int):
+        self.id = id
+        self.os_window_id = os_window_id
+
+
+class Boss:
+    def __init__(self, windows: list[Window]):
+        self.active_window = windows[0]
+        self.all_windows = windows
+
+    def match_windows(self, expr: str, self_window: Window | None = None):
+        if expr == 'all':
+            yield from self.all_windows
+            return
+        for window in self.all_windows:
+            if str(window.id) == expr:
+                yield window
+
+
+class TestRemoteControl(BaseTest):
+    def test_set_os_window_title_command_is_registered(self):
+        self.assertIn('set_os_window_title', all_command_names())
+        self.ae(command_for_name('set-os-window-title').name, 'set-os-window-title')
+
+    def test_set_os_window_title_dedupes_os_windows(self):
+        windows = [Window(1, 11), Window(2, 11), Window(3, 22)]
+        boss = Boss(windows)
+        cmd = command_for_name('set-os-window-title')
+
+        with patch('kitty.rc.set_os_window_title.set_os_window_title_impl') as setter:
+            cmd.response_from_kitty(boss, windows[0], PayloadGetter(cmd, {'match': 'all', 'self': True, 'title': 'repo'}))
+
+        self.ae({call.args for call in setter.call_args_list}, {(11, 'repo'), (22, 'repo')})
+
+    def test_set_os_window_title_without_title_resets_override(self):
+        windows = [Window(1, 11)]
+        boss = Boss(windows)
+        cmd = command_for_name('set-os-window-title')
+
+        with patch('kitty.rc.set_os_window_title.set_os_window_title_impl') as setter:
+            cmd.response_from_kitty(boss, windows[0], PayloadGetter(cmd, {'self': True}))
+
+        setter.assert_called_once_with(11, '')


### PR DESCRIPTION
## Summary
Before this change, kitty could only control the OS window title indirectly through the active tab/window state, or by setting a title at OS-window creation time.

That meant there was no remote-control command for this workflow:
- open a kitty OS window
- later decide what its OS window title should be
- keep that OS window title independent from subsequent tab/window title changes

This patch adds a new `kitty @ set-os-window-title` command so the OS window title can be updated explicitly at runtime.

With this change, callers can:
- set the OS window title after the window already exists
- target OS windows through their contained kitty windows, like other remote-control commands do
- reset the override by calling the command without a title

## Implementation
- add the new `set-os-window-title` remote control command
- wire it to the OS-window title setter implementation
- document the command in the changelog
- add registration, behavior, and completion coverage

## Testing
- `./kitty/launcher/kitty +launch test.py --module remote_control`
- `./kitty/launcher/kitty +launch test.py --module completion`