### PR TITLE
Report parallel test failures

### DIFF
--- a/kitty_tests/main.py
+++ b/kitty_tests/main.py
@@ -298,10 +298,15 @@ class PipeTestResult(unittest.TestResult):
         super().addUnexpectedSuccess(test)
         self._send({'t': 'xpass', 'id': str(test), 'e': self._elapsed()})
 
+    def addSubTest(self, test: unittest.TestCase, subtest: unittest.TestCase, err: Any) -> None:
+        super().addSubTest(test, subtest, err)
+        if err is not None:
+            record_type = 'fail' if issubclass(err[0], test.failureException) else 'error'
+            self._send({'t': record_type, 'id': str(subtest), 'e': self._elapsed(), 'msg': self._exc_info_to_string(err, test)})
+
 
 def run_test_worker(tests: list[unittest.TestCase], write_fd: int) -> None:
     """Execute in a forked child: run tests, send results over write_fd, then exit."""
-    result: Optional[PipeTestResult] = None
     exit_code = 1
     try:
         with env_for_python_tests():
@@ -310,7 +315,9 @@ def run_test_worker(tests: list[unittest.TestCase], write_fd: int) -> None:
             with forwardable_stdio():
                 result = PipeTestResult(write_fd)
                 unittest.TestSuite(tests).run(result)
-                exit_code = 0 if not result.failures and not result.errors else 1
+                # Test outcomes are part of the pipe protocol. A non-zero
+                # process status is reserved for worker failures.
+                exit_code = 0
     except Exception:
         import traceback
 
@@ -528,7 +535,9 @@ def collect_worker_results(
                         py_worker_errors.append(rec['msg'])
 
     for pid in pids:
-        os.waitpid(pid, 0)
+        _, status = os.waitpid(pid, 0)
+        if status != 0:
+            py_worker_errors.append(f'Python test worker {pid} exited with status {os.waitstatus_to_exitcode(status)}')
 
     elapsed = time.monotonic() - start
 

--- a/kitty_tests/main.py
+++ b/kitty_tests/main.py
@@ -26,6 +26,13 @@ from . import is_ci
 PARALLEL_THRESHOLD = 20
 
 
+def should_fork_test_workers(test_count: int, platform: str = sys.platform) -> bool:
+    # CoreFoundation rejects running code in a child forked from a
+    # multi-threaded process. The test launcher initializes native macOS
+    # services before this decision, so macOS tests must remain in-process.
+    return platform != 'darwin' and test_count > PARALLEL_THRESHOLD
+
+
 def contents(package: str) -> Iterator[str]:
     try:
         if sys.version_info[:2] < (3, 10):
@@ -664,7 +671,7 @@ def run_tests(report_env: bool = False) -> None:
 
     # Fork Python workers before modifying the main-process env; each worker
     # calls env_for_python_tests independently for full HOME/XDG isolation.
-    use_parallel = len(tests_list) > PARALLEL_THRESHOLD
+    use_parallel = should_fork_test_workers(len(tests_list))
     if use_parallel:
         pids, read_fds = fork_test_workers(tests_list)
 

--- a/kitty_tests/test_runner.py
+++ b/kitty_tests/test_runner.py
@@ -7,10 +7,15 @@ import os
 import unittest
 from contextlib import redirect_stdout
 
-from .main import PipeTestResult, collect_worker_results
+from .main import PipeTestResult, collect_worker_results, should_fork_test_workers
 
 
 class TestParallelTestRunner(unittest.TestCase):
+    def test_parallel_workers_are_disabled_on_macos(self) -> None:
+        self.assertFalse(should_fork_test_workers(100, 'darwin'))
+        self.assertFalse(should_fork_test_workers(20, 'linux'))
+        self.assertTrue(should_fork_test_workers(21, 'linux'))
+
     def test_subtest_failures_are_reported(self) -> None:
         class FailingSubTest(unittest.TestCase):
             def runTest(self) -> None:

--- a/kitty_tests/test_runner.py
+++ b/kitty_tests/test_runner.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# License: GPL v3 Copyright: 2026, Kovid Goyal <kovid at kovidgoyal.net>
+
+import io
+import json
+import os
+import unittest
+from contextlib import redirect_stdout
+
+from .main import PipeTestResult, collect_worker_results
+
+
+class TestParallelTestRunner(unittest.TestCase):
+    def test_subtest_failures_are_reported(self) -> None:
+        class FailingSubTest(unittest.TestCase):
+            def runTest(self) -> None:
+                with self.subTest(value='bad'):
+                    self.fail('subtest failure')
+
+        read_fd, write_fd = os.pipe()
+        try:
+            result = PipeTestResult(write_fd)
+            unittest.TestSuite((FailingSubTest(),)).run(result)
+        finally:
+            os.close(write_fd)
+        try:
+            records = [json.loads(line) for line in os.read(read_fd, 64 * 1024).splitlines()]
+        finally:
+            os.close(read_fd)
+
+        self.assertFalse(result.wasSuccessful())
+        failure = next(record for record in records if record['t'] == 'fail')
+        self.assertIn("value='bad'", failure['id'])
+        self.assertIn('subtest failure', failure['msg'])
+
+    def test_worker_exit_failure_is_not_ignored(self) -> None:
+        read_fd, write_fd = os.pipe()
+        pid = os.fork()
+        if pid == 0:
+            os.close(read_fd)
+            os.close(write_fd)
+            os._exit(3)
+
+        os.close(write_fd)
+        output = io.StringIO()
+        with redirect_stdout(output):
+            python_ok, go_ok = collect_worker_results([pid], [read_fd], 0)
+
+        self.assertFalse(python_ok)
+        self.assertTrue(go_ok)
+        self.assertIn('exited with status 3', output.getvalue())


### PR DESCRIPTION
Report failing subtests and nonzero worker exits instead of allowing false-green runs.

Keep Python tests in-process on macOS, where post-threading forked workers crash, and add regressions for both paths.