### PR TITLE
Complete session file completion

### DIFF
--- a/kitty/simple_cli_definitions.py
+++ b/kitty/simple_cli_definitions.py
@@ -432,7 +432,7 @@ Path to a log file to store STDOUT/STDERR when using :option:`--detach`
 
 
 --session
-completion=type:file ext:session relative:conf group:"Session files"
+completion=type:file ext:session,kitty-session,kitty_session relative:conf group:"Session files"
 Path to a file containing the startup :italic:`session` (tabs, windows, layout,
 programs). Use - to read from STDIN. See :ref:`sessions` for details and
 an example. Environment variables in the file name are expanded,

--- a/kitty_tests/completion.py
+++ b/kitty_tests/completion.py
@@ -9,6 +9,7 @@ import subprocess
 import tempfile
 
 from kitty.constants import kitten_exe as kitten
+from kitty.session import SESSION_FILE_EXTENSIONS
 
 from .base import BaseTest
 
@@ -109,6 +110,9 @@ def completion(self: TestCompletion, tdir: str):
     make_file('exe-not2.jpeg')
     make_file('sub/exe3', 0o700)
     make_file('sub/exe-not3.png')
+    session_files = tuple(f'project.{ext}' for ext in sorted(SESSION_FILE_EXTENSIONS))
+    for path in session_files:
+        make_file(f'sub/{path}')
 
     add('kitty x', all_words())
     add('kitty e', all_words('exe1', 'exe2'))
@@ -132,6 +136,7 @@ def completion(self: TestCompletion, tdir: str):
     add('kitty -c', all_words('-c'))
     add('kitty --', has_words('--config', '--single-instance', '--'))
     add('kitty --s', has_words('--session', '--start-as'))
+    add('kitty --session ', all_words(*session_files))
     add('kitty --start-as', all_words('--start-as'))
     add('kitty --start-as ', all_words('minimized', 'maximized', 'fullscreen', 'normal', 'hidden'))
     add('kitty -1 ', does_not_have_words('@ls', '@'))


### PR DESCRIPTION
kitty --session completion only lists .session files, although runtime also accepts .kitty-session and .kitty_session.

Complete all supported extensions and add a regression test against the completion executable.