### PR TITLE
Document last non-empty get-text extent

### DIFF
--- a/kitty/rc/get_text.py
+++ b/kitty/rc/get_text.py
@@ -13,10 +13,10 @@ if TYPE_CHECKING:
 class GetText(RemoteCommand):
     protocol_spec = __doc__ = """
     match/str: The window to get text from
-    extent/choices.screen.first_cmd_output_on_screen.last_cmd_output.last_visited_cmd_output.all.selection.alternate.alternate_scrollback: \
+    extent/choices.screen.first_cmd_output_on_screen.last_cmd_output.last_visited_cmd_output.last_non_empty_output.all.selection.alternate.alternate_scrollback: \
         One of :code:`screen`, :code:`first_cmd_output_on_screen`, :code:`last_cmd_output`, \
-        :code:`last_visited_cmd_output`, :code:`all`, :code:`selection`, :code:`alternate`, \
-        or :code:`alternate_scrollback`
+        :code:`last_visited_cmd_output`, :code:`last_non_empty_output`, :code:`all`, \
+        :code:`selection`, :code:`alternate`, or :code:`alternate_scrollback`
     ansi/bool: Boolean, if True send ANSI formatting codes
     cursor/bool: Boolean, if True send cursor position/style as ANSI codes
     wrap_markers/bool: Boolean, if True add wrap markers to output


### PR DESCRIPTION
The get-text CLI and handler support last_non_empty_output, but the remote-control protocol schema omitted it. Add it to the protocol choices and generated documentation.

Tested: ./test.py --module remote_control