### PR TITLE
Fix Bash SSH hostname detection

### DIFF
--- a/kitty/rc/get_text.py
+++ b/kitty/rc/get_text.py
@@ -11,9 +11,11 @@ if TYPE_CHECKING:
 
 
 class GetText(RemoteCommand):
-    protocol_spec = __doc__ = """
+    protocol_spec = __doc__ = (
+        """
     match/str: The window to get text from
-    extent/choices.screen.first_cmd_output_on_screen.last_cmd_output.last_visited_cmd_output.last_non_empty_output.all.selection.alternate.alternate_scrollback: \
+    extent/choices.screen.first_cmd_output_on_screen.last_cmd_output.last_visited_cmd_output.last_non_empty_output."""
+        """all.selection.alternate.alternate_scrollback: \
         One of :code:`screen`, :code:`first_cmd_output_on_screen`, :code:`last_cmd_output`, \
         :code:`last_visited_cmd_output`, :code:`last_non_empty_output`, :code:`all`, \
         :code:`selection`, :code:`alternate`, or :code:`alternate_scrollback`
@@ -23,6 +25,7 @@ class GetText(RemoteCommand):
     clear_selection/bool: Boolean, if True clear the selection in the matched window
     self/bool: Boolean, if True use window the command was run in
     """
+    )
 
     short_desc = 'Get text from the specified window'
     options_spec = (

--- a/kitty_tests/shell_integration.py
+++ b/kitty_tests/shell_integration.py
@@ -178,6 +178,25 @@ class ShellIntegration(BaseTest):
                 self.assertEqual(cp.returncode, 0, cp.stderr.decode())
                 self.assertEqual(cp.stdout.decode() != 'original', has_command_hook)
 
+    @unittest.skipUnless(bash_ok(), 'bash not installed, too old, or debug build')
+    def test_bash_ssh_hostname_fallback(self):
+        if self.with_kitten:
+            return
+        integration_script = os.path.join(shell_integration_dir, 'bash', 'kitty.bash')
+        command = 'PS1="prompt> "; source "$KITTY_BASH_INTEGRATION"; _ksi_prompt_command; printf %s "${PS1@P}"'
+        with tempfile.TemporaryDirectory() as home_dir:
+            home_dir = os.path.realpath(home_dir)
+            who = os.path.join(home_dir, 'who')
+            with open(who, 'w') as f:
+                f.write("#!/bin/sh\nprintf '%s\\n' 'user pts/0 (192.0.2.1)'\n")
+            os.chmod(who, 0o755)
+            env = basic_shell_env(home_dir)
+            env['KITTY_BASH_INTEGRATION'] = integration_script
+            env['PATH'] = os.pathsep.join((home_dir, env['PATH']))
+            cp = subprocess.run(['bash', '--noprofile', '--norc', '-ic', command], cwd=home_dir, env=env, capture_output=True)
+            self.assertEqual(cp.returncode, 0, cp.stderr.decode())
+            self.assertIn(': ~\x07', cp.stdout.decode())
+
     @unittest.skipUnless(shutil.which('fish'), 'fish not installed')
     def test_fish_sudo_parser(self):
         if self.with_kitten:

--- a/shell-integration/bash/kitty.bash
+++ b/shell-integration/bash/kitty.bash
@@ -236,7 +236,7 @@ _ksi_main() {
                 # connected to most SSH servers
                 # or use ssh kitten to connected to some SSH servers that do not set SSH_TTY
                 _ksi_prompt[hostname_prefix]="\h: "
-            elif [[ -n "$(builtin command -v who)" && "$(builtin command who -m 2> /dev/null)" =~ "\([a-fA-F.:0-9]+\)$" ]]; then
+            elif [[ -n "$(builtin command -v who)" && "$(builtin command who -m 2> /dev/null)" =~ \([a-fA-F.:0-9]+\)$ ]]; then
                 # the shell integration script is installed manually on the remote system
                 # the environment variables are cleared after sudo
                 # OpenSSH's sshd creates entries in utmp for every login so use those


### PR DESCRIPTION
Bash treats a quoted =~ operand as a literal string, so the who -m fallback never detected remote sessions. Leave the regular expression unquoted and cover the resulting prompt title.

Also wrap the existing get-text protocol schema without changing its value so repo-wide Ruff passes.

Tested: ./test.py