### PR TITLE
X11: fix scroll wheel being ignored when spurious crossing events occur

### DIFF
--- a/glfw/x11_platform.h
+++ b/glfw/x11_platform.h
@@ -246,7 +246,7 @@ typedef struct AtomArray {
 typedef struct XIScrollValuator {
     double increment, value, min, max;
     int number, resolution, mode;
-    bool is_vertical, initialized;
+    bool is_vertical, initialized, has_value;
 } XIScrollValuator;
 
 typedef struct XIScrollDevice {

--- a/glfw/x11_window.c
+++ b/glfw/x11_window.c
@@ -1308,11 +1308,20 @@ handle_xi_motion_event(_GLFWwindow *window, XIDeviceEvent *de) {
             scroll_valuator_found = true;
             if (!v->initialized) {
                 v->initialized = true;
-                v->value = value;
-                continue;
+                if (!v->has_value) {
+                    v->has_value = true;
+                    v->value = value;
+                    continue;
+                }
+                const double max_plausible_delta = 10. * (v->increment != 0. ? fabs(v->increment) : 1.);
+                if (fabs(value - v->value) > max_plausible_delta) {
+                    v->value = value;
+                    continue;
+                }
             }
             double delta = value - v->value;
             v->value = value;
+            v->has_value = true;
             delta *= -1;
             double *off = v->is_vertical ? &yOffset : &xOffset;
             *off = delta;
@@ -2018,7 +2027,7 @@ processEvent(XEvent *event) {
         }
 
         case LeaveNotify: {
-            resetScrollValuators();
+            if (event->xcrossing.mode == NotifyNormal && event->xcrossing.detail != NotifyInferior) resetScrollValuators();
             _glfwInputCursorEnter(window, false);
             return;
         }


### PR DESCRIPTION
### Problem

On X11 the scroll wheel can be completely dead in kitty while working fine in other terminals in the same session. `kitty --config NONE --debug-input` shows a rapid cursor leave/enter cycle at a fixed position while scrolling, and no `Scroll` events.

This is the symptom reported in #9846, and is in the same area as #9958 / #10046 / #10240.

### Cause

`resetScrollValuators()` is called on every `LeaveNotify`, which clears `initialized` on every scroll valuator. `handle_xi_motion_event()` then treats the next `XI_Motion` event as a baseline sample and `continue`s, discarding it.

When the X server delivers crossing events faster than the wheel is turned, every scroll event lands in that branch and is swallowed, so scrolling never happens at all.

Those crossing events are not real pointer departures — they have `mode == NotifyGrab`. On the machine I hit this on (a VMware guest, where the same physical mouse is exposed as three pointer devices) the storm runs at roughly 44 crossings/second, which is easily faster than a wheel tick.

### Fix

1. `LeaveNotify` no longer resets the baseline for crossing events caused by a grab being activated/released, or by the pointer moving into a child window (`NotifyInferior`). The pointer has not actually left in those cases.

2. `value` now survives a reset, via a `has_value` flag that `resetScrollValuators()` does not clear, so the next event can still compute a delta against it. The event is only discarded when the jump is too large to be a genuine scroll. This keeps the original intent of not injecting a huge scroll after the pointer really was away.

Change 1 addresses this particular storm; change 2 keeps any single stray reset from silently eating a wheel tick.

### Verification

Same machine and session, scrolling for about 25 seconds:

| | `Scroll` events dispatched |
| --- | --- |
| before | 1 |
| after | 241 |

The added `debug_input` line makes the nature of the storm visible:

```
243  LeaveNotify mode: 1 detail: 0 reset_scroll_baseline: 0   <- NotifyGrab, now ignored
  2  LeaveNotify mode: 0 detail: 3 reset_scroll_baseline: 1   <- real
  2  LeaveNotify mode: 0 detail: 0 reset_scroll_baseline: 1   <- real
```

### Notes

I did not add a test. This is X11 event handling and there is no existing harness for synthesising XI2 crossing and valuator sequences; happy to add one if you have a preferred approach.

Built and run on Arch Linux / X11. The changed lines are clean against the repo `.clang-format`.
