### PR TITLE
Wayland: fix crash when an output global is removed

### DIFF
--- a/glfw/wl_window.c
+++ b/glfw/wl_window.c
@@ -549,7 +549,15 @@ static const struct zxdg_toplevel_decoration_v1_listener xdgDecorationListener =
 static void
 surfaceHandleEnter(void *data, struct wl_surface *surface UNUSED, struct wl_output *output) {
     _GLFWwindow *window = data;
+    // output is NULL when the wl_output global it refers to was removed before
+    // this event was dispatched. Wayland delivers destroyed objects as NULL even
+    // for arguments declared non-nullable, so this must be handled.
+    // See https://wayland.freedesktop.org/docs/html/apc.html
+    if (!output) return;
     _GLFWmonitor *monitor = wl_output_get_user_data(output);
+    // never store NULL in window->wl.monitors as checkScaleChange() dereferences
+    // every entry unconditionally
+    if (!monitor) return;
 
     if (window->wl.monitorsCount + 1 > window->wl.monitorsSize) {
         ++window->wl.monitorsSize;
@@ -567,15 +575,17 @@ surfaceHandleEnter(void *data, struct wl_surface *surface UNUSED, struct wl_outp
 static void
 surfaceHandleLeave(void *data, struct wl_surface *surface UNUSED, struct wl_output *output) {
     _GLFWwindow *window = data;
+    // output is NULL when the wl_output global it refers to was removed before
+    // this event was dispatched, see the comment in surfaceHandleEnter(). In that
+    // case registryHandleGlobalRemove() has already dropped the monitor from
+    // window->wl.monitors, so there is nothing left to do here.
+    if (!output) return;
     _GLFWmonitor *monitor = wl_output_get_user_data(output);
-    bool found;
-    int i;
+    if (!monitor) return;
 
-    for (i = 0, found = false; i < window->wl.monitorsCount - 1; ++i) {
-        if (monitor == window->wl.monitors[i]) found = true;
-        if (found) window->wl.monitors[i] = window->wl.monitors[i + 1];
+    for (int i = window->wl.monitorsCount - 1; i >= 0; i--) {
+        if (window->wl.monitors[i] == monitor) { remove_i_from_array(window->wl.monitors, i, window->wl.monitorsCount); }
     }
-    window->wl.monitors[--window->wl.monitorsCount] = NULL;
 
     if (checkScaleChange(window)) {
         debug("Scale changed to %.3f for window %llu in surfaceHandleLeave\n", _glfwWaylandWindowScale(window), window->id);


### PR DESCRIPTION
Fixes #10363

`surfaceHandleEnter()` and `surfaceHandleLeave()` pass the event's `output` argument straight to `wl_output_get_user_data()`. Wayland delivers object arguments as NULL when the client destroyed the object before the event was dispatched — [documented behaviour clients are expected to handle](https://wayland.freedesktop.org/docs/html/apc.html) — so kitty segfaults reading `NULL+0x30` whenever a `wl_output` global goes away while a window is open. Switching a monitor to another input reproduces it every time.

This is the same guard `get_window_from_surface()` (`glfw/wl_init.c:66-69`) already applies to `wl_surface`; these two handlers were the call sites without it.

`monitor` is checked as well as `output`, because `checkScaleChange()` dereferences every entry of `window->wl.monitors[]` unconditionally — guarding only the `wl_output_get_user_data()` call would relocate the crash rather than remove it.

### Two pre-existing bugs in `surfaceHandleLeave()`

Both fall out of the removal loop, so they are fixed here rather than left in place:

- The search stopped at `monitorsCount - 1` and never compared the last entry, while the trailing `window->wl.monitors[--window->wl.monitorsCount] = NULL;` ran unconditionally. A `leave` for a monitor not in the list therefore evicted an unrelated one. Note that simply guarding that line on `found` would regress the common case — leaving the last monitor currently works only by falling through to that unconditional decrement.
- The same statement ran with `monitorsCount == 0`, writing to `monitors[-1]` and leaving the count negative.

The loop is now the `remove_i_from_array()` form already used on this same array in `registryHandleGlobalRemove()` (`glfw/wl_init.c:666`), which handles both.

### Verification

Run as an A/B on the reported hardware (3 outputs, cosmic-comp, NVIDIA): two 0.48.2 windows both placed on the monitor being detached, one stock and one patched, each in its own systemd scope so neither could take the other down. On the switch the stock window died with the usual `segfault at 30 ... libwayland-client.so.0`, and the patched window survived the same event and stayed usable. The patched build has since been dragged across all three outputs with no misbehaviour.

No test is included: the backend handlers are `static` in a platform extension with no C test harness in the tree, and the trigger is a race between the compositor's event and the client's own proxy destruction, which can't be scheduled. Happy to add one if you have a preferred approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
