### PR TITLE
macos: allow OS windows to participate in Split View tiling

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -2344,7 +2344,8 @@ createNativeWindow(_GLFWwindow *window, const _GLFWwndconfig *wndconfig, const _
         }
 
         if (wndconfig->resizable) {
-            const NSWindowCollectionBehavior behavior = NSWindowCollectionBehaviorFullScreenPrimary | NSWindowCollectionBehaviorManaged;
+            const NSWindowCollectionBehavior behavior =
+                NSWindowCollectionBehaviorFullScreenPrimary | NSWindowCollectionBehaviorFullScreenAllowsTiling | NSWindowCollectionBehaviorManaged;
             [window->ns.object setCollectionBehavior:behavior];
         }
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/d347df71-e776-4cbe-8c68-b6461f9be84f

Adds this small MacOS tiling integration