### PR TITLE
Add configurable cursor trail particles

### DIFF
--- a/kitty/cursor_trail.c
+++ b/kitty/cursor_trail.c
@@ -71,6 +71,85 @@ should_skip_cursor_trail_update(CursorTrail *ct, ndc_coords g, OSWindow *os_wind
     return false;
 }
 
+static uint32_t
+next_particle_random(CursorTrail *ct) {
+    if (!ct->particle_rng_inc) {
+        ct->particle_rng_state = 0x853C49E6748FEA9Bull;
+        ct->particle_rng_inc = (0xDA3E39CB94B95BDBull << 1u) | 1u;
+    }
+    uint64_t old_state = ct->particle_rng_state;
+    ct->particle_rng_state = old_state * 6364136223846793005ull + ct->particle_rng_inc;
+    uint32_t rot = (uint32_t)(old_state >> 59u);
+    uint32_t xsh = (uint32_t)(((old_state >> 18u) ^ old_state) >> 27u);
+    return (xsh >> rot) | (xsh << ((-rot) & 31u));
+}
+
+static float
+next_particle_float(CursorTrail *ct) {
+    return (float)ldexp((double)next_particle_random(ct), -32);
+}
+
+static void
+update_cursor_particles(CursorTrail *ct, Window *w, monotonic_t now, OSWindow *os_window, bool had_prev_edge) {
+    const float particle_lifetime = OPT(cursor_trail_particle_lifetime);
+    if (particle_lifetime <= 0.f) {
+        ct->num_particles = 0;
+        ct->particle_count_remainder = 0.f;
+        return;
+    }
+    const float dt = ct->updated_at ? (float)monotonic_t_to_s_double(now - ct->updated_at) : 0.f;
+    size_t i = 0;
+    while (i < ct->num_particles) {
+        CursorParticle *p = ct->particles + i;
+        p->lifetime -= dt;
+        if (p->lifetime <= 0.f) {
+            *p = ct->particles[--ct->num_particles];
+            continue;
+        }
+        p->x += p->speed_x * dt;
+        p->y += p->speed_y * dt;
+        const float angle = dt * p->rotation_speed;
+        const float s = sinf(angle), c = cosf(angle);
+        const float speed_x = p->speed_x;
+        p->speed_x = speed_x * c - p->speed_y * s;
+        p->speed_y = speed_x * s + p->speed_y * c;
+        i++;
+    }
+
+    if (!ct->target_updated || !had_prev_edge) return;
+    const float viewport_width = os_window->viewport_width, viewport_height = os_window->viewport_height;
+    const float current_x = (EDGE(x, 0) + EDGE(x, 1) + 2.f) * viewport_width * 0.25f;
+    const float current_y = (2.f - EDGE(y, 0) - EDGE(y, 1)) * viewport_height * 0.25f;
+    const float previous_x = (ct->prev_cursor_edge_x[0] + ct->prev_cursor_edge_x[1] + 2.f) * viewport_width * 0.25f;
+    const float previous_y = (2.f - ct->prev_cursor_edge_y[0] - ct->prev_cursor_edge_y[1]) * viewport_height * 0.25f;
+    const float travel_x = current_x - previous_x, travel_y = current_y - previous_y;
+    const float cursor_height = WD.screen->cell_size.height;
+    const float particle_count_float =
+        hypotf(travel_x, travel_y) / cursor_height * OPT(cursor_trail_particle_density) + ct->particle_count_remainder;
+    const size_t particle_count = (size_t)particle_count_float;
+    ct->particle_count_remainder = particle_count_float - particle_count;
+
+    for (i = 0; i < particle_count && ct->num_particles < arraysz(ct->particles); i++) {
+        const float t = (float)(i + 1u) / particle_count;
+        float dir_x = next_particle_float(ct) * 2.f - 1.f;
+        float dir_y = next_particle_float(ct) * 2.f - 1.f;
+        const float dir_length = hypotf(dir_x, dir_y);
+        if (dir_length > 0.f) {
+            dir_x /= dir_length;
+            dir_y /= dir_length;
+        }
+        CursorParticle *p = ct->particles + ct->num_particles++;
+        const float along_path = next_particle_float(ct);
+        p->x = previous_x + travel_x * along_path;
+        p->y = previous_y + travel_y * along_path + cursor_height * 0.5f;
+        p->speed_x = dir_x * 0.5f * 3.f * OPT(cursor_trail_particle_speed);
+        p->speed_y = (0.4f + fabsf(dir_y)) * 3.f * OPT(cursor_trail_particle_speed);
+        p->rotation_speed = (next_particle_float(ct) - 0.5f) * 1.57079632679f * OPT(cursor_trail_particle_curl);
+        p->lifetime = t * particle_lifetime;
+        p->color = WD.screen->last_rendered.cursor_bg;
+    }
+}
+
 static void
 update_cursor_trail_corners(CursorTrail *ct, ndc_coords g, monotonic_t now, OSWindow *os_window, Window *w) {
     // the trail corners move towards the cursor corner at a speed proportional to their distance from the cursor corner.
@@ -173,6 +252,12 @@ update_cursor_trail(CursorTrail *ct, Window *w, monotonic_t now, OSWindow *os_wi
     }
     if (ct->target_updated && had_prev_edge) ct->cursor_changed_at = now;
 
+    const bool particles_were_rendering = ct->num_particles > 0;
+    if (OPT(cursor_trail_particles)) update_cursor_particles(ct, w, now, os_window, had_prev_edge);
+    else {
+        ct->num_particles = 0;
+        ct->particle_count_remainder = 0.f;
+    }
     update_cursor_trail_corners(ct, g, now, os_window, w);
     update_cursor_trail_opacity(ct, w, now);
 
@@ -182,7 +267,7 @@ update_cursor_trail(CursorTrail *ct, Window *w, monotonic_t now, OSWindow *os_wi
     ct->updated_at = now;
 
     // returning true here will cause the cells to be drawn
-    return ct->needs_render || needs_render_prev;
+    return ct->needs_render || needs_render_prev || ct->num_particles > 0 || particles_were_rendering;
 }
 
 #undef WD

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -462,6 +462,72 @@ using the :opt:`custom_shaders` option, for example: :code:`custom_shaders curso
 )
 
 opt(
+    'cursor_trail_particles',
+    'no',
+    option_type='to_bool',
+    ctype='bool',
+    long_text="""
+Draw pixie dust particles along the cursor trail. The particles use the same
+motion model as Neovide's ``pixiedust`` cursor effect.
+This option requires :opt:`cursor_trail` to be enabled. The particles use
+:opt:`cursor_trail_color`, falling back to the cursor color when it is unset.
+""",
+)
+
+opt(
+    'cursor_trail_particle_opacity',
+    '235',
+    option_type='positive_float',
+    ctype='float',
+    long_text="""
+Set the maximum particle opacity using Neovide's 0--255 scale. Values above
+255 are treated as 255. Particles fade to transparent over their lifetime.
+""",
+)
+
+opt(
+    'cursor_trail_particle_lifetime',
+    '0.5',
+    option_type='positive_float',
+    ctype='float',
+    long_text="""
+Set how long cursor trail particles survive, in seconds. Set to zero to
+disable particle generation without changing :opt:`cursor_trail_particles`.
+""",
+)
+
+opt(
+    'cursor_trail_particle_density',
+    '1.4',
+    option_type='positive_float',
+    ctype='float',
+    long_text="""
+Set the number of particles generated per line of cursor travel.
+""",
+)
+
+opt(
+    'cursor_trail_particle_speed',
+    '13',
+    option_type='positive_float',
+    ctype='float',
+    long_text="""
+Set the speed of cursor trail particle movement in pixels per second.
+""",
+)
+
+opt(
+    'cursor_trail_particle_curl',
+    '1.0',
+    option_type='positive_float',
+    ctype='float',
+    long_text="""
+Set how quickly particle velocity rotates. Higher values produce curlier,
+more nervous motion; zero makes particles move in straight lines.
+""",
+)
+
+opt(
     'cursor_trail_decay',
     '0.1 0.4',
     option_type='cursor_trail_decay',

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -953,6 +953,24 @@ class Parser:
     def cursor_trail_decay(self, val: str, ans: dict[str, typing.Any]) -> None:
         ans['cursor_trail_decay'] = cursor_trail_decay(val)
 
+    def cursor_trail_particle_curl(self, val: str, ans: dict[str, typing.Any]) -> None:
+        ans['cursor_trail_particle_curl'] = positive_float(val)
+
+    def cursor_trail_particle_density(self, val: str, ans: dict[str, typing.Any]) -> None:
+        ans['cursor_trail_particle_density'] = positive_float(val)
+
+    def cursor_trail_particle_lifetime(self, val: str, ans: dict[str, typing.Any]) -> None:
+        ans['cursor_trail_particle_lifetime'] = positive_float(val)
+
+    def cursor_trail_particle_opacity(self, val: str, ans: dict[str, typing.Any]) -> None:
+        ans['cursor_trail_particle_opacity'] = positive_float(val)
+
+    def cursor_trail_particle_speed(self, val: str, ans: dict[str, typing.Any]) -> None:
+        ans['cursor_trail_particle_speed'] = positive_float(val)
+
+    def cursor_trail_particles(self, val: str, ans: dict[str, typing.Any]) -> None:
+        ans['cursor_trail_particles'] = to_bool(val)
+
     def cursor_trail_start_threshold(self, val: str, ans: dict[str, typing.Any]) -> None:
         ans['cursor_trail_start_threshold'] = cursor_trail_start_threshold(val)
 

--- a/kitty/options/to-c-generated.h
+++ b/kitty/options/to-c-generated.h
@@ -4,6 +4,7 @@
 #include "to-c.h"
 
 
+
 static void
 convert_from_python_font_size(PyObject *val, Options *opts) {
     opts->font_size = PyFloat_AsDouble(val);
@@ -209,6 +210,84 @@ convert_from_opts_cursor_trail(PyObject *py_opts, Options *opts) {
     PyObject *ret = PyObject_GetAttrString(py_opts, "cursor_trail");
     if (ret == NULL) return;
     convert_from_python_cursor_trail(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
+convert_from_python_cursor_trail_particles(PyObject *val, Options *opts) {
+    opts->cursor_trail_particles = PyObject_IsTrue(val);
+}
+
+static void
+convert_from_opts_cursor_trail_particles(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "cursor_trail_particles");
+    if (ret == NULL) return;
+    convert_from_python_cursor_trail_particles(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
+convert_from_python_cursor_trail_particle_opacity(PyObject *val, Options *opts) {
+    opts->cursor_trail_particle_opacity = PyFloat_AsFloat(val);
+}
+
+static void
+convert_from_opts_cursor_trail_particle_opacity(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "cursor_trail_particle_opacity");
+    if (ret == NULL) return;
+    convert_from_python_cursor_trail_particle_opacity(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
+convert_from_python_cursor_trail_particle_lifetime(PyObject *val, Options *opts) {
+    opts->cursor_trail_particle_lifetime = PyFloat_AsFloat(val);
+}
+
+static void
+convert_from_opts_cursor_trail_particle_lifetime(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "cursor_trail_particle_lifetime");
+    if (ret == NULL) return;
+    convert_from_python_cursor_trail_particle_lifetime(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
+convert_from_python_cursor_trail_particle_density(PyObject *val, Options *opts) {
+    opts->cursor_trail_particle_density = PyFloat_AsFloat(val);
+}
+
+static void
+convert_from_opts_cursor_trail_particle_density(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "cursor_trail_particle_density");
+    if (ret == NULL) return;
+    convert_from_python_cursor_trail_particle_density(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
+convert_from_python_cursor_trail_particle_speed(PyObject *val, Options *opts) {
+    opts->cursor_trail_particle_speed = PyFloat_AsFloat(val);
+}
+
+static void
+convert_from_opts_cursor_trail_particle_speed(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "cursor_trail_particle_speed");
+    if (ret == NULL) return;
+    convert_from_python_cursor_trail_particle_speed(ret, opts);
+    Py_DECREF(ret);
+}
+
+static void
+convert_from_python_cursor_trail_particle_curl(PyObject *val, Options *opts) {
+    opts->cursor_trail_particle_curl = PyFloat_AsFloat(val);
+}
+
+static void
+convert_from_opts_cursor_trail_particle_curl(PyObject *py_opts, Options *opts) {
+    PyObject *ret = PyObject_GetAttrString(py_opts, "cursor_trail_particle_curl");
+    if (ret == NULL) return;
+    convert_from_python_cursor_trail_particle_curl(ret, opts);
     Py_DECREF(ret);
 }
 
@@ -1584,6 +1663,18 @@ convert_opts_from_python_opts(PyObject *py_opts, Options *opts) {
     convert_from_opts_cursor_stop_blinking_after(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_cursor_trail(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_cursor_trail_particles(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_cursor_trail_particle_opacity(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_cursor_trail_particle_lifetime(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_cursor_trail_particle_density(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_cursor_trail_particle_speed(py_opts, opts);
+    if (PyErr_Occurred()) return false;
+    convert_from_opts_cursor_trail_particle_curl(py_opts, opts);
     if (PyErr_Occurred()) return false;
     convert_from_opts_cursor_trail_decay(py_opts, opts);
     if (PyErr_Occurred()) return false;

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -347,6 +347,12 @@ option_names = (
     'cursor_trail',
     'cursor_trail_color',
     'cursor_trail_decay',
+    'cursor_trail_particle_curl',
+    'cursor_trail_particle_density',
+    'cursor_trail_particle_lifetime',
+    'cursor_trail_particle_opacity',
+    'cursor_trail_particle_speed',
+    'cursor_trail_particles',
     'cursor_trail_start_threshold',
     'cursor_underline_thickness',
     'custom_shaders',
@@ -573,6 +579,12 @@ class Options:
     cursor_trail: int = 0
     cursor_trail_color: kitty.fast_data_types.Color | None = None
     cursor_trail_decay: tuple[float, float] = (0.1, 0.4)
+    cursor_trail_particle_curl: float = 1.0
+    cursor_trail_particle_density: float = 1.4
+    cursor_trail_particle_lifetime: float = 0.5
+    cursor_trail_particle_opacity: float = 235.0
+    cursor_trail_particle_speed: float = 13.0
+    cursor_trail_particles: bool = False
     cursor_trail_start_threshold: tuple[int, int] = (2, 2)
     cursor_underline_thickness: float = 2.0
     custom_shaders: tuple[str, ...] = ()

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -2167,6 +2167,34 @@ draw_cursor_trail(CursorTrail *trail, Window *active_window) {
     unbind_program();
 }
 
+static void
+draw_cursor_particles(CursorTrail *trail, OSWindow *os_window, Window *active_window) {
+    if (!active_window || !trail->num_particles) return;
+    bind_program(TRAIL_PROGRAM);
+    const float width = os_window->viewport_width, height = os_window->viewport_height;
+    const float particle_size = active_window->render_data.screen->cell_size.width * 0.28f;
+    const float half_size = particle_size * 0.5f;
+    const float cursor_edge[2] = {2.f, 2.f};
+    glUniform2fv(program_uniform_location(TRAIL_PROGRAM, "cursor_edge_x"), 1, cursor_edge);
+    glUniform2fv(program_uniform_location(TRAIL_PROGRAM, "cursor_edge_y"), 1, cursor_edge);
+    const color_type configured_color = OPT(cursor_trail_color);
+    const float particle_lifetime = OPT(cursor_trail_particle_lifetime);
+    const float particle_opacity = fminf(OPT(cursor_trail_particle_opacity), 255.f) / 255.f;
+    for (size_t i = 0; i < trail->num_particles; i++) {
+        const CursorParticle *p = trail->particles + i;
+        const float left = 2.f * (p->x - half_size) / width - 1.f, right = 2.f * (p->x + half_size) / width - 1.f;
+        const float top = 1.f - 2.f * (p->y - half_size) / height, bottom = 1.f - 2.f * (p->y + half_size) / height;
+        const float x_coords[4] = {right, right, left, left};
+        const float y_coords[4] = {top, bottom, bottom, top};
+        glUniform4fv(program_uniform_location(TRAIL_PROGRAM, "x_coords"), 1, x_coords);
+        glUniform4fv(program_uniform_location(TRAIL_PROGRAM, "y_coords"), 1, y_coords);
+        color_vec3(program_uniform_location(TRAIL_PROGRAM, "trail_color"), configured_color ? configured_color : p->color);
+        glUniform1f(program_uniform_location(TRAIL_PROGRAM, "trail_opacity"), fminf(p->lifetime / particle_lifetime * particle_opacity, 1.f));
+        draw_quad(true, 0);
+    }
+    unbind_program();
+}
+
 // }}}
 
 // OSWindow {{{
@@ -2702,6 +2730,7 @@ static void
 stop_os_window_rendering(OSWindow *os_window, Tab *tab, Window *active_window, monotonic_t now) {
     if (OPT(cursor_trail) && tab->cursor_trail.needs_render && !(custom_shaders.end.active && custom_shaders.end.bypass_builtin_trail))
         draw_cursor_trail(&tab->cursor_trail, active_window);
+    if (OPT(cursor_trail_particles)) draw_cursor_particles(&tab->cursor_trail, os_window, active_window);
     if (os_window->needs_layers) {
         float sx = global_state.layers_render_texture.width > 0 ? (float)os_window->viewport_width / (float)global_state.layers_render_texture.width : 1.f;
         float sy = global_state.layers_render_texture.height > 0 ? (float)os_window->viewport_height / (float)global_state.layers_render_texture.height : 1.f;

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -65,6 +65,12 @@ typedef struct Options {
     float cursor_beam_thickness;
     float cursor_underline_thickness;
     monotonic_t cursor_trail;
+    bool cursor_trail_particles;
+    float cursor_trail_particle_opacity;
+    float cursor_trail_particle_lifetime;
+    float cursor_trail_particle_density;
+    float cursor_trail_particle_speed;
+    float cursor_trail_particle_curl;
     float cursor_trail_decay_fast;
     float cursor_trail_decay_slow;
     color_type cursor_trail_color;
@@ -423,6 +429,11 @@ typedef struct BorderRects {
     ssize_t vao_idx;
 } BorderRects;
 
+typedef struct CursorParticle {
+    float x, y, speed_x, speed_y, rotation_speed, lifetime;
+    color_type color;
+} CursorParticle;
+
 typedef struct CursorTrail {
     bool needs_render;
     bool target_updated;  // set when cursor moves to a new cell; consumed by child-monitor to fire shader events
@@ -436,6 +447,10 @@ typedef struct CursorTrail {
     float cursor_edge_y[2];
     float prev_cursor_edge_x[2]; // cursor_edge_x before the most recent cursor move
     float prev_cursor_edge_y[2]; // cursor_edge_y before the most recent cursor move
+    CursorParticle particles[512];
+    size_t num_particles;
+    float particle_count_remainder;
+    uint64_t particle_rng_state, particle_rng_inc;
 } CursorTrail;
 
 typedef struct Tab {

--- a/kitty_tests/options.py
+++ b/kitty_tests/options.py
@@ -362,6 +362,21 @@ def conf_parsing(self):
     opts = p('inactive_text_alpha -2')
     self.ae(opts.inactive_text_alpha, -1.0)
 
+    opts = p(
+        'cursor_trail_particles yes',
+        'cursor_trail_particle_opacity 180',
+        'cursor_trail_particle_lifetime 0.8',
+        'cursor_trail_particle_density 2',
+        'cursor_trail_particle_speed 8',
+        'cursor_trail_particle_curl 3',
+    )
+    self.assertTrue(opts.cursor_trail_particles)
+    self.ae(opts.cursor_trail_particle_opacity, 180)
+    self.ae(opts.cursor_trail_particle_lifetime, 0.8)
+    self.ae(opts.cursor_trail_particle_density, 2)
+    self.ae(opts.cursor_trail_particle_speed, 8)
+    self.ae(opts.cursor_trail_particle_curl, 3)
+
     # deprecation handling
     opts = p('clear_all_shortcuts y', 'send_text all f1 hello')
     self.ae(len(opts.keyboard_modes[''].keymap), 1)


### PR DESCRIPTION
## What changed

- Add an optional `cursor_trail_particles` pixie-dust effect based on the cursor trail.
- Keep particle state on the CPU and render small quads with the existing trail shader.
- Add controls for particle opacity, lifetime, density, speed, and curl.
- Preserve the existing `cursor_trail_start_threshold` behavior for the built-in trail.
- Add configuration parsing coverage and generated option bindings.

The feature is disabled by default. A minimal configuration is:

```conf
cursor_trail 1
cursor_trail_particles yes
```

The default particle tuning is intentionally visible while remaining short-lived; all behavior parameters can be adjusted independently.

## Why

The existing cursor trail makes large jumps easy to follow, but it offers only a continuous shape. Optional particles provide an additional visual cue for cursor movement while leaving current behavior unchanged for users who do not enable it.

## Validation

- `/opt/homebrew/bin/go run bypy/devenv.go build`
- `dependencies/darwin-arm64/python/Python.framework/Versions/Current/bin/python3 test.py --module options`
- `git diff --check`
- Full Go suite passed outside the restricted sandbox.
- Serial full Python suite: 378 passed, 21 skipped, with two unrelated local failures: completion data is missing `set-os-window-title`, and the SSH shell-integration test receives `TERM=dumb` instead of `kitty`.
