### PR TITLE
docs/graphics-protocol: replace demo image

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -21,7 +21,7 @@ To see a quick demo, inside a |kitty| terminal run::
 You can also see a screenshot with more sophisticated features such as
 alpha-blending and text over graphics.
 
-.. image:: https://user-images.githubusercontent.com/1308621/31647475-1188ab66-b326-11e7-8d26-24b937f1c3e8.png
+.. image:: https://github.com/user-attachments/assets/78caad22-1798-4ec5-a6ee-2722c51ce875
     :alt: Demo of graphics rendering in kitty
     :align: center
 


### PR DESCRIPTION
The "Lenna" test image has been deprecated for several years at this point in the computer graphics scientific community for being an unauthorized, cropped scan of a Playboy magazine that is not only legally problematic regarding redistribution (see #661) but also raises questions about the appropriateness of using originally pornographic material in scientific literature. **If scientific journals now find it unacceptable, so should we, and we should do better**.

The image itself has been long gone from the repo itself following #661, but it's still present in a screenshot attached to the documentation. Although that resolved legal issues for Debian packaging, I think the fundamental problem with the Lenna image remains unsolved, and over the past 8 years the scientific consensus (and more importantly, the sentiment from the model herself, Lena Forsén) has been very clear that we shouldn't use this image in any shape or form now. So let's replace it with something actually wholesome and thematically appropriate!

Instead, I've taken a screenshot of `gr.py`, but with Lenna replaced with a photo of a friend's (@SugarNekoE's) cat. I took the original photo myself and licensed it under CC0 — no attribution is required, though it would certainly be welcome. Some minor things about the composition have been changed, such as the proportions of the images and the font used (sorry, I don't know which font the original used, I'm using Iosevka here since it's my system monospace font), but overall it shows off the capabilities of the Graphics Protocol as well as the original.

Please let me know of any feedback regarding the image selection and the composition, but I think this is a worthy step to take.

Direct link to the new image:
<img alt="The new demo image featuring a Maine Coon staring down from atop a bed" src="https://github.com/user-attachments/assets/78caad22-1798-4ec5-a6ee-2722c51ce875" height=600>
