### PR TITLE
Fix doubled words in docs and a test comment

### DIFF
--- a/docs/shell-integration.rst
+++ b/docs/shell-integration.rst
@@ -269,7 +269,7 @@ over SSH when using :doc:`kittens/ssh`.
 
 The :command:`clone-in-kitty` command takes almost all the same arguments as the
 :doc:`launch <launch>` command, so you can open a new tab instead or a new OS
-window, etc. Arguments of launch that that don't
+window, etc. Arguments of launch that don't
 make sense when cloning are ignored. Most prominently, the following options are
 ignored: :option:`--allow-remote-control <launch --allow-remote-control>`,
 :option:`--copy-cmdline <launch --copy-cmdline>`, :option:`--copy-env <launch

--- a/kitty_tests/graphics.py
+++ b/kitty_tests/graphics.py
@@ -750,7 +750,7 @@ class TestGraphics(BaseTest):
         self.ae(positions(), {(1, 5): {'x': 2, 'y': 2}, (1, 2): {'x': 3, 'y': 4}})
 
     def test_unicode_placeholders(self):
-        # This test tests basic image placement using using unicode placeholders
+        # This test tests basic image placement using unicode placeholders
         cw, ch = 10, 20
         s, dx, dy, put_image, put_ref, layers, rect_eq = put_helpers(self, cw, ch)
         # Upload two images.


### PR DESCRIPTION
Two mechanical typo fixes found by a doubled-word scan:

- `docs/shell-integration.rst`: "Arguments of launch that that don't" → "that don't"
- `kitty_tests/graphics.py`: "using using unicode placeholders" → "using unicode placeholders" (comment only)

No behavior changes.