### PR TITLE
Revert "macos: explicitly enable modern window corners on macOS 26"

### DIFF
--- a/glfw/cocoa_window.m
+++ b/glfw/cocoa_window.m
@@ -3910,18 +3910,6 @@ apply_titlebar_color_settings(_GLFWwindow *window) {
 #undef tc
 }
 
-static void
-apply_window_corner_curve(_GLFWwindow *window) {
-    if (!window || !window->decorated) return;
-    if (@available(macOS 26.0, *)) {
-        GLFWWindow *nsw = window->ns.object;
-        NSView *frame_view = nsw.contentView.superview;
-        CALayer *layer = frame_view.layer;
-        if (!layer) return;
-        layer.cornerCurve = kCACornerCurveContinuous;
-    }
-}
-
 
 GLFWAPI void
 glfwCocoaSetWindowLevel(GLFWwindow *w, const char *level_spec) {
@@ -4064,7 +4052,6 @@ glfwCocoaSetWindowChrome(
         if (desired_mask != current_style_mask) { [nsw setStyleMask:desired_mask]; }
 #undef tc
         apply_titlebar_color_settings(window);
-        apply_window_corner_curve(window);
 
         // HACK: Changing the style mask can cause the first responder to be cleared
         [nsw makeFirstResponder:window->ns.view];

--- a/setup.py
+++ b/setup.py
@@ -1213,7 +1213,7 @@ def glfw_init_env(
 
     elif module == 'cocoa':
         ans.cppflags.append('-DGL_SILENCE_DEPRECATION')
-        for f_ in 'Cocoa IOKit CoreFoundation CoreVideo QuartzCore UniformTypeIdentifiers'.split():
+        for f_ in 'Cocoa IOKit CoreFoundation CoreVideo UniformTypeIdentifiers'.split():
             ans.ldpaths.extend(('-framework', f_))
 
     elif module == 'wayland':


### PR DESCRIPTION
> This reverts commit b16221a1d3fd62db01cdc70df647b43168495310.

This reverts [#9890](https://github.com/kovidgoyal/kitty/pull/9890) because manually setting `CALayer.cornerCurve` is not the correct way to adopt the new macOS 26 window corners. AppKit should manage them automatically when kitty is built with the macOS 26 SDK.

It appears that the official releases do not use the macOS artifacts built by GitHub Actions. Are they built by a separate service? If so, its build SDK needs to be upgraded to the macOS 26 SDK for the new AppKit-managed window corners to take effect. Could it be upgraded?

Sorry for the unnecessary change and the extra maintenance work caused by the original PR.

