### PR TITLE
Fix a few typos in the docs and the choose_files kitten

### DIFF
--- a/docs/dnd-protocol.rst
+++ b/docs/dnd-protocol.rst
@@ -504,7 +504,7 @@ Key      Value                 Default    Description
 
 ``m``    Chunking indicator    ``0``      ``0`` or ``1``
 
-``i``    Postive integer       ``0``      This id is for use by multiplexers.
+``i``    Positive integer       ``0``      This id is for use by multiplexers.
                                           When it is set, all responses from
                                           the terminal in that session will
                                           have it set to the same value.

--- a/kittens/choose_files/main.py
+++ b/kittens/choose_files/main.py
@@ -59,7 +59,7 @@ opt(
     '',
     add_to_default=False,
     long_text="""
-An ignore pattern to ignore matched files. Uses the same sytax as :code:`.gitignore` files (see :code:`man gitignore`).
+An ignore pattern to ignore matched files. Uses the same syntax as :code:`.gitignore` files (see :code:`man gitignore`).
 Anchored patterns match with respect to whatever directory is currently being displayed.
 Can be specified multiple times to use multiple patterns. Note that every pattern
 has to be checked against every file, so use sparingly.
@@ -188,7 +188,7 @@ map(
     long_text="""
 Type a file name/path rather than filtering the list of existing files.
 Useful when specifying a file or directory name for saving that does not yet exist.
-When choosing existing directories, will accept the directory whoose
+When choosing existing directories, will accept the directory whose
 contents are being currently displayed as the choice.
 Does not work when selecting files to open rather than to save.
 """,
@@ -292,7 +292,7 @@ The syntax is :code:`type:expression:Descriptive Name`.
 For example: :code:`mime:image/png:Images` and :code:`mime:image/gif:Images` and :code:`glob:*.[tT][xX][Tt]:Text files`.
 Note that glob patterns are case-sensitive. The mimetype specification is treated as a glob expressions as well, so you can,
 for example, use :code:`mime:text/*` to match all text files. The first filter in the list will be applied by default. Use a filter
-such as :code:`glob:*:All` to match all files. Note that filtering only appies to files, not directories.
+such as :code:`glob:*:All` to match all files. Note that filtering only applies to files, not directories.
 
 
 --suggested-save-file-name


### PR DESCRIPTION
Spotted while reading the dnd protocol docs and using the choose_files kitten:

- docs/dnd-protocol.rst: Postive -> Positive
- choose_files main.py: sytax -> syntax, appies -> applies, whoose -> whose (all in the option help text)