### PR TITLE
macOS: avoid stale mouse positions after focus changes

### DIFF
--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -636,6 +636,25 @@ cursor_enter_callback(GLFWwindow *w, int entered) {
     global_state.callback_os_window = NULL;
 }
 
+static bool
+refresh_mouse_position_for_hit_test(GLFWwindow *w, OSWindow *window) {
+#ifdef __APPLE__
+    if (__builtin_available(macOS 26.0, *)) {
+        // AppKit can report stale mouseMoved locations after application focus changes.
+        // Query the current position for discrete pointer events without emitting a move event.
+        double x, y;
+        glfwGetCursorPos(w, &x, &y);
+        window->mouse_x = x * window->viewport_x_ratio;
+        window->mouse_y = y * window->viewport_y_ratio;
+        return true;
+    }
+#else
+    (void)w;
+    (void)window;
+#endif
+    return false;
+}
+
 static void
 mouse_button_callback(GLFWwindow *w, int button, int action, int mods) {
     if (!set_callback_window(w)) return;
@@ -648,12 +667,15 @@ mouse_button_callback(GLFWwindow *w, int button, int action, int mods) {
     OSWindow *window = global_state.callback_os_window;
     window->last_mouse_activity_at = now;
     if (button >= 0 && (unsigned int)button < arraysz(global_state.callback_os_window->mouse_button_pressed)) {
+        bool position_was_refreshed = refresh_mouse_position_for_hit_test(w, window);
         if (!window->has_received_cursor_pos_event) { // ensure mouse position is correct
             window->has_received_cursor_pos_event = true;
-            double x, y;
-            glfwGetCursorPos(w, &x, &y);
-            window->mouse_x = x * window->viewport_x_ratio;
-            window->mouse_y = y * window->viewport_y_ratio;
+            if (!position_was_refreshed) {
+                double x, y;
+                glfwGetCursorPos(w, &x, &y);
+                window->mouse_x = x * window->viewport_x_ratio;
+                window->mouse_y = y * window->viewport_y_ratio;
+            }
             if (is_window_ready_for_callbacks()) mouse_event(-1, mods, -1);
         }
         global_state.callback_os_window->mouse_button_pressed[button] = action == GLFW_PRESS ? true : false;
@@ -692,6 +714,7 @@ cursor_pos_callback(GLFWwindow *w, double x, double y) {
 static void
 scroll_callback(GLFWwindow *w, const GLFWScrollEvent *ev) {
     if (!set_callback_window(w)) return;
+    if (global_state.callback_os_window->is_focused) refresh_mouse_position_for_hit_test(w, global_state.callback_os_window);
     monotonic_t now = monotonic();
     if (OPT(mouse_hide.scroll_unhide)) cursor_active_callback(now);
     global_state.callback_os_window->last_mouse_activity_at = now;


### PR DESCRIPTION
## Summary

- on macOS 26, refresh only kitty's internal hit-test coordinates immediately before valid mouse button dispatch and focused scroll dispatch
- use `glfwGetCursorPos()` directly, without calling `_glfwInputCursorPos()` or emitting a cursor callback/synthetic move
- add no extra query to ordinary cursor-movement callbacks; older macOS releases and non-Apple platforms are unchanged

## Problem

On macOS 26, AppKit can deliver an `NSEvent` whose `locationInWindow` is stale after an application focus change. kitty then keeps the old GLFW cursor position and can route clicks and scrolling to the wrong pane until the application is refocused.

This matches libsdl-org/SDL#15967, where the event position becomes stale while the global mouse position remains correct:
https://github.com/libsdl-org/SDL/issues/15967

I reproduced this on macOS 26.5.1 (25F80), Apple M5, with a three-pane splits layout. Debug input showed a cursor move on focus-in followed by button and scroll events that continued using the cached pane position.

## Implementation

The Cocoa implementation of `glfwGetCursorPos()` already reads `mouseLocationOutsideOfEventStream`, which remains current in the failing case. Immediately before discrete pointer-event routing, this patch copies that queried position into `OSWindow.mouse_x/y` only. It deliberately does not feed the value back through GLFW's cursor-input path, so it cannot generate a spurious kitty mouse-move event.

The existing `scroll_event()` path already queries the cursor for an unfocused OS window. The new callback-side refresh therefore applies only to focused scroll dispatch and does not duplicate that query.

## Testing

- `./dev.sh build` passes on current master
- full `./test.py`: 671/674 tests pass; the three remaining failures are environment-specific and unrelated to pointer input: one SSH fake login-shell path invokes `xcode-select`, and two Consolas selection cases expect bold/italic faces not installed on this system
- the equivalent narrow patch builds and launches as kitty 0.48.2 on the affected macOS 26.5.1 machine

No automated regression test is included because the failure depends on AppKit emitting a stale system event across a real application focus transition.
