### PR TITLE
docs: add Mobile SSH to terminals implementing the graphics protocol

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -68,6 +68,7 @@ Other terminals that have implemented the graphics protocol:
 
 * `Ghostty <https://ghostty.org>`_
 * `Konsole <https://invent.kde.org/utilities/konsole/-/merge_requests/594>`_
+* `Mobile SSH <https://mobile-ssh.github.io/docs/terminal/>`_
 * `st (with a patch) <https://st.suckless.org/patches/kitty-graphics-protocol>`_
 * `Warp <https://docs.warp.dev/getting-started/changelog#id-2025.03.26-v0.2025.03.26.08.10>`_
 * `wayst <https://github.com/91861/wayst>`_


### PR DESCRIPTION
Adds **Mobile SSH** to the list of other terminals that have implemented the graphics protocol.

Mobile SSH is a native SSH/terminal client for **Android and iOS**. It implements the kitty graphics protocol for inline images on both platforms — `direct` and `file` transmission media, PNG/GIF/WebP. Images are measured in cells and follow their line, so they survive pinch-zoom and re-wrap rather than being dropped.

Support is documented here (the linked page): https://mobile-ssh.github.io/docs/terminal/#shell-integration-and-inline-images

As far as I can tell this would be the first mobile terminal on the list.

Disclosure: I am the author, and the app is closed source, so the link is a documentation page rather than a commit — the same approach as the existing Warp entry.

Inserted in alphabetical position between Konsole and st. One line added, nothing else changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
