### PR TITLE
Fix composed animation frame metadata

### DIFF
--- a/kitty/graphics.c
+++ b/kitty/graphics.c
@@ -2159,16 +2159,10 @@ handle_compose_command(GraphicsManager *self, bool *is_dirty, const GraphicsComm
     compose_rectangles(d, dest_data.buf, (size_t)img->width * img->height * d.under_px_sz, src_data.buf, (size_t)img->width * img->height * d.over_px_sz);
     bool transient = src_data.transient || dest_data.transient;
     const ImageAndFrame key = {.image_id = img->internal_id, .frame_id = dest_frame->id};
-    // frame is now a fully coalesced frame
-    dest_frame->x = 0;
-    dest_frame->y = 0;
-    dest_frame->width = img->width;
-    dest_frame->height = img->height;
-    dest_frame->base_frame_id = 0;
-    dest_frame->bgcolor = 0;
     // Upload before caching, the cache takes ownership of the data
-    *is_dirty = (g->other_frame_number - 1) == img->current_frame_index;
-    if (*is_dirty) update_current_frame(self, img, &dest_data);
+    const bool is_current_frame = (g->other_frame_number - 1) == img->current_frame_index;
+    *is_dirty = is_current_frame;
+    if (is_current_frame) update_current_frame(self, img, &dest_data);
     const size_t dest_sz = ((size_t)(dest_data.is_opaque ? 3 : 4)) * img->width * img->height;
     void *dest_buf = dest_data.buf;
     dest_data.buf = NULL;
@@ -2177,6 +2171,17 @@ handle_compose_command(GraphicsManager *self, bool *is_dirty, const GraphicsComm
         if (PyErr_Occurred()) PyErr_Print();
         set_command_failed_response("ENOSPC", "Failed to store image data in cache");
     } else {
+        // The frame is now a fully coalesced frame. Commit its descriptor only
+        // after the matching data has been accepted by the cache.
+        dest_frame->x = 0;
+        dest_frame->y = 0;
+        dest_frame->width = img->width;
+        dest_frame->height = img->height;
+        dest_frame->base_frame_id = 0;
+        dest_frame->bgcolor = 0;
+        dest_frame->is_opaque = dest_data.is_opaque;
+        dest_frame->is_4byte_aligned = dest_data.is_4byte_aligned;
+        dest_frame->alpha_blend = false;
         dest_frame->transient = transient;
     }
 }

--- a/kitty_tests/graphics.py
+++ b/kitty_tests/graphics.py
@@ -1451,6 +1451,20 @@ class TestGraphics(BaseTest):
                 {'gap': 40, 'id': 3, 'data': b'3' * 12 + (b'333abc' + b'3' * 6) * 2},
             ),
         )
+
+        # Composing into a frame materializes it as a full frame. Its pixel
+        # format metadata must be updated to match the coalesced frame data.
+        rgba_screen = self.create_screen()
+        rgba_grman = rgba_screen.grman
+        rgba_li = make_send_command(rgba_screen)
+        self.assertEqual(rgba_li(payload=b'\0' * 48, a='t', f=32).code, 'OK')
+        self.assertEqual(rgba_li(payload=b'R' * 12, c=1, s=2, v=2, f=24).code, 'OK')
+        frame_before_composition = rgba_grman.image_for_client_id(1)['extra_frames'][0]['data']
+        self.assertEqual(len(frame_before_composition), 48)
+        self.assertEqual(rgba_li(payload=b'', a='c', f=0, s=0, v=0, r=1, c=2, w=1, h=1, x=3, y=2).code, 'OK')
+        frame_after_composition = rgba_grman.image_for_client_id(1)['extra_frames'][0]['data']
+        self.assertEqual(frame_after_composition, frame_before_composition)
+
         # Test that compose commands with offset values that would overflow a 32-bit
         # unsigned integer are correctly rejected with EINVAL instead of crashing.
         # In the old code, UINT32_MAX + img->width wrapped around as uint32_t to a


### PR DESCRIPTION
Composing a frame stores fully coalesced pixel data, but left the frame's opacity and alignment metadata from the original delta. A later read could interpret RGBA data as RGB and truncate it.

Update the descriptor after caching the coalesced data and add a regression test for composing an RGB delta over an RGBA base.