### PR TITLE
Restore hints named-group program arguments

### DIFF
--- a/kittens/hints/main.py
+++ b/kittens/hints/main.py
@@ -427,8 +427,7 @@ def handle_result(args: list[str], data: dict[str, Any], target_window_id: int, 
                         w = boss.window_id_map.get(target_window_id)
                         boss.call_remote_control(self_window=w, args=tuple(launch_args + ([m] if isinstance(m, str) else m)))
                     else:
-                        if isinstance(m, str):
-                            boss.open_url(m, program, cwd=cwd)
+                        boss.open_url(m, program, cwd=cwd)
 
 
 if __name__ == '__main__':

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -2825,13 +2825,14 @@ class Boss:
         self.open_url(website_url())
 
     @ac('misc', 'Open the specified URL')
-    def open_url(self, url: str, program: str | list[str] | None = None, cwd: str | None = None) -> None:
+    def open_url(self, url: str | list[str], program: str | list[str] | None = None, cwd: str | None = None) -> None:
         if not url:
             return
         if isinstance(program, str):
             program = to_cmdline(program)
         found_action = False
         if program is None:
+            assert isinstance(url, str)
             from .open_actions import actions_for_url
 
             actions = list(actions_for_url(url))

--- a/kitty/utils.py
+++ b/kitty/utils.py
@@ -271,7 +271,7 @@ def open_cmd(
     )
 
 
-def open_url(url: str, program: str | list[str] = 'default', cwd: str | None = None, extra_env: dict[str, str] | None = None) -> 'PopenType[bytes]':
+def open_url(url: str | list[str], program: str | list[str] = 'default', cwd: str | None = None, extra_env: dict[str, str] | None = None) -> 'PopenType[bytes]':
     return open_cmd(command_for_open(program), url, cwd=cwd, extra_env=extra_env)
 
 

--- a/kitty_tests/hints.py
+++ b/kitty_tests/hints.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# License: GPL v3 Copyright: 2026, Kovid Goyal <kovid at kovidgoyal.net>
+
+from typing import Any
+from unittest.mock import Mock
+
+from kittens.hints.main import handle_result
+
+from .base import BaseTest
+
+
+class TestHints(BaseTest):
+    def test_named_groups_are_passed_to_program(self):
+        boss: Any = Mock()
+        boss.window_id_map = {}
+        handle_result(
+            [],
+            {
+                'customize_processing': '',
+                'type': 'regex',
+                'programs': ['echo'],
+                'match': ['ignored'],
+                'groupdicts': [{'name': 'value', 'empty': None}],
+                'multiple_joiner': '',
+                'cwd': '/tmp',
+            },
+            1,
+            boss,
+        )
+        boss.open_url.assert_called_once_with(['name=value', 'empty='], 'echo', cwd='/tmp')


### PR DESCRIPTION
Named regex groups were converted to key=value arguments but skipped before invoking non-launch programs.
Restore the typed argument path and add a regression test for named-group program execution.