### PR TITLE
Fix session discovery with goto_session options

### DIFF
--- a/kitty/session.py
+++ b/kitty/session.py
@@ -450,12 +450,19 @@ def get_all_known_sessions() -> dict[str, str]:
             for kd in kdefs:
                 for key_action in opts.alias_map.resolve_aliases(kd.definition, 'map'):
                     if key_action.func == 'goto_session':
-                        path = ''
-                        for x in key_action.args:
-                            if isinstance(x, str) and not x.startswith('-'):
-                                path = x
-                                break
-                        if path:
+                        cmdline: list[str] = []
+                        for arg in key_action.args:
+                            assert isinstance(arg, str)
+                            cmdline.append(arg)
+                        try:
+                            _, args = parse_goto_session_cmdline(cmdline)
+                        except ValueError:
+                            continue
+                        if args and (path := args[0]):
+                            if len(args) == 1:
+                                with suppress(ValueError):
+                                    if int(path) < 0:
+                                        continue
                             path, session_name = resolve_session_path_and_name(path)
                             if session_name not in all_known_sessions:
                                 all_known_sessions[session_name] = path

--- a/kitty_tests/options.py
+++ b/kitty_tests/options.py
@@ -35,6 +35,58 @@ class TestConfParsing(BaseTest):
     def test_cli_parsing(self):
         cli_parsing(self)
 
+    def test_session_discovery(self):
+        from unittest.mock import patch
+
+        from kitty.config import load_config
+        from kitty.constants import config_dir
+        from kitty.fast_data_types import set_options
+        from kitty.session import get_all_known_sessions, seen_session_paths
+
+        def discover(*lines):
+            bad_lines = []
+            opts = load_config(overrides=('clear_all_shortcuts yes', *lines), accumulate_bad_lines=bad_lines)
+            self.assertFalse(bad_lines)
+            set_options(opts)
+            return get_all_known_sessions()
+
+        with patch.dict(seen_session_paths, {}, clear=True):
+            for args, name in (
+                ('work.kitty-session', 'work'),
+                ('--sort-by alphabetical work.kitty-session', 'work'),
+                ('--sort-by=alphabetical work.kitty-session', 'work'),
+                ('--active-only=no --sort-by recent work.kitty-session', 'work'),
+                ('work.kitty-session --sort-by alphabetical', 'work'),
+                ('-- "-work project.kitty-session"', '-work project'),
+                ('-- -0', '-0'),
+                ('', ''),
+                ('--sort-by alphabetical', ''),
+                ('--sort-by=alphabetical', ''),
+                ('--active-only', ''),
+                ('-1', ''),
+                ('-- -1', ''),
+                ('--sort-by alphabetical -- -2', ''),
+                ('--sort-by', ''),
+                ('--sort-by invalid work.kitty-session', ''),
+                ('--unknown work.kitty-session', ''),
+                ('--active-only=invalid work.kitty-session', ''),
+            ):
+                with self.subTest(args=args):
+                    filename = f'{name}.kitty-session' if name != '-0' else name
+                    expected = {name: os.path.join(config_dir, filename)} if name else {}
+                    self.ae(discover(f'map f7 goto_session {args}'), expected)
+
+            seen_path = os.path.join(self.tdir, 'work.kitty-session')
+            seen_session_paths['work'] = seen_path
+            self.ae(
+                discover(
+                    'action_alias project goto_session --sort-by alphabetical',
+                    'map f7 project work.kitty-session',
+                    'map f8 combine : goto_session --sort-by : project other.kitty-session',
+                ),
+                {'work': seen_path, 'other': os.path.join(config_dir, 'other.kitty-session')},
+            )
+
 
 def cli_parsing(self):
     from kitty.cli import CLIOptions, Options, parse_cmdline, parse_option_spec


### PR DESCRIPTION
Session discovery treats the value in --sort-by alphabetical as a filename. Use the existing goto_session parser so the actual session is listed and history shortcuts stay excluded.

Includes regression tests for option forms, aliases and invalid bindings. Full test suite passes.