### PR TITLE
Add AbsoluteTelnet/SSH to the SSH client list

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -66,6 +66,7 @@ Libraries:
 
 Other terminals that have implemented the graphics protocol:
 
+* `AbsoluteTelnet/SSH <https://www.celestialsoftware.net/kitty-graphics-protocol>`_
 * `Ghostty <https://ghostty.org>`_
 * `Konsole <https://invent.kde.org/utilities/konsole/-/merge_requests/594>`_
 * `Mobile SSH <https://mobile-ssh.github.io/docs/terminal/>`_


### PR DESCRIPTION
Add AbsoluteTelnet/SSH to the list of clients that support the kitty graphics protocol.  See [https://www.celestialsoftware.net/kitty-graphics-protocol](https://www.celestialsoftware.net/kitty-graphics-protocol) For examples