### PR TITLE
Add configurable rounded window borders

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -200,6 +200,8 @@ Detailed list of changes
 0.49.0 [future]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+- Add :opt:`window_border_radius` for rounded window borders
+
 - Support for :doc:`/custom-shaders` for adding various graphical effects (:iss:`10344`)
 
 - Various throughput performance improvements for a 15-35% real world improvement depending on workload

--- a/kitty/borders.py
+++ b/kitty/borders.py
@@ -6,7 +6,7 @@ from enum import IntFlag
 from functools import partial
 from typing import NamedTuple
 
-from .fast_data_types import current_focused_os_window_id, get_options, set_borders_rects
+from .fast_data_types import current_focused_os_window_id, get_options, pt_to_px, set_borders_rects
 from .typing_compat import LayoutType
 from .utils import color_as_int
 from .window_list import WindowGroup, WindowList
@@ -25,19 +25,22 @@ class Border(NamedTuple):
     color: BorderColor
     border_type: int = 0
     horizontal: bool = False
+    render: bool = True
+    radius: int = 0
+    thickness: int = 0
 
 
-def vertical_edge(rects: list[Border], color: BorderColor, width: int, top: int, bottom: int, left: int, border_type: int) -> None:
+def vertical_edge(rects: list[Border], color: BorderColor, width: int, top: int, bottom: int, left: int, border_type: int, render: bool = True) -> None:
     if width > 0:
-        rects.append(Border(left, top, left + width, bottom, color, border_type, False))
+        rects.append(Border(left, top, left + width, bottom, color, border_type, False, render))
 
 
-def horizontal_edge(rects: list[Border], color: BorderColor, height: int, left: int, right: int, top: int, border_type: int) -> None:
+def horizontal_edge(rects: list[Border], color: BorderColor, height: int, left: int, right: int, top: int, border_type: int, render: bool = True) -> None:
     if height > 0:
-        rects.append(Border(left, top, right, top + height, color, border_type, True))
+        rects.append(Border(left, top, right, top + height, color, border_type, True, render))
 
 
-def add_borders(rects: list[Border], color: BorderColor, wg: WindowGroup) -> None:
+def add_borders(rects: list[Border], color: BorderColor, wg: WindowGroup, radius: int = 0) -> None:
     geometry = wg.geometry
     if geometry is None:
         return
@@ -60,10 +63,13 @@ def add_borders(rects: list[Border], color: BorderColor, wg: WindowGroup) -> Non
     bottom += width
     pl = pr = pb = pt = width
     wid = wg.active_window_id
-    h(pt, left, right, top, -wid)
-    h(pb, left, right, bt, wid)
-    v(pl, top, bottom, left, -wid)
-    v(pr, top, bottom, lr, wid)
+    render_edges = radius < 1
+    h(pt, left, right, top, -wid, render_edges)
+    h(pb, left, right, bt, wid, render_edges)
+    v(pl, top, bottom, left, -wid, render_edges)
+    v(pr, top, bottom, lr, wid, render_edges)
+    if radius > 0:
+        rects.append(Border(left, top, right, bottom, color, render=False, radius=radius, thickness=width))
 
 
 class Borders:
@@ -107,6 +113,12 @@ class Borders:
         if opts.draw_window_borders_for_single_window and num_visible_groups == 1:
             os_window_focused = current_focused_os_window_id() == self.os_window_id
 
+        radius, radius_unit = opts.window_border_radius
+        if radius_unit == 'pt':
+            radius = pt_to_px(radius, self.os_window_id)
+        else:
+            radius = round(radius)
+
         if draw_borders and not draw_minimal_borders:
             for i, wg in enumerate(groups):
                 window_bg = color_as_int(wg.default_bg)
@@ -116,7 +128,7 @@ class Borders:
                     color = BorderColor.active
                 else:
                     color = BorderColor.bell if wg.needs_attention else BorderColor.inactive
-                add_borders(rects, color, wg)
+                add_borders(rects, color, wg, int(radius))
 
         if draw_minimal_borders:
             for border_line in current_layout.get_minimal_borders(all_windows):

--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -1042,6 +1042,7 @@ render_prepared_os_window(
                 draw_cells(trd, os_window, i == tab->active_window, true, false, NULL, now);
         }
     }
+    draw_rounded_borders(br, active_window_bg, num_visible_windows, all_windows_have_same_bg, os_window);
     setup_os_window_for_rendering(os_window, tab, active_window, false, now);
     if (global_state.thumbnail_callback.os_window == os_window->id) {
         thumbnail_callback(os_window);

--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -1665,6 +1665,20 @@ drawn.
 )
 
 opt(
+    'window_border_radius',
+    '0',
+    option_type='window_border_width',
+    long_text="""
+The corner radius of window borders. Can be either in pixels (px) or pts (pt).
+Values in pts will be rounded to the nearest number of pixels based on screen
+resolution. If not specified, the unit is assumed to be pts. A value of zero
+disables rounded borders. This option applies only when full window borders are
+drawn; it has no effect with minimal borders. Rounded borders are drawn over
+corner cells, so use :opt:`window_padding_width` to keep text clear of them.
+""",
+)
+
+opt(
     'draw_window_borders_for_single_window',
     'no',
     option_type='to_bool',

--- a/kitty/options/parse.py
+++ b/kitty/options/parse.py
@@ -1530,6 +1530,9 @@ class Parser:
     def window_alert_on_bell(self, val: str, ans: dict[str, typing.Any]) -> None:
         ans['window_alert_on_bell'] = to_bool(val)
 
+    def window_border_radius(self, val: str, ans: dict[str, typing.Any]) -> None:
+        ans['window_border_radius'] = window_border_width(val)
+
     def window_border_width(self, val: str, ans: dict[str, typing.Any]) -> None:
         ans['window_border_width'] = window_border_width(val)
 

--- a/kitty/options/types.py
+++ b/kitty/options/types.py
@@ -506,6 +506,7 @@ option_names = (
     'wheel_scroll_min_lines',
     'wheel_scroll_multiplier',
     'window_alert_on_bell',
+    'window_border_radius',
     'window_border_width',
     'window_drag_tolerance',
     'window_logo_alpha',
@@ -719,6 +720,7 @@ class Options:
     wheel_scroll_min_lines: int = 1
     wheel_scroll_multiplier: float = 5.0
     window_alert_on_bell: bool = True
+    window_border_radius: tuple[float, str] = (0, 'pt')
     window_border_width: tuple[float, str] = (0.5, 'pt')
     window_drag_tolerance: float = 2.0
     window_logo_alpha: float = 0.5

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -349,15 +349,7 @@ thickness_as_float(const OSWindow *os_window, unsigned level) {
 
 static void
 draw_rounded_rect(
-    const OSWindow *os_window,
-    Viewport rect,
-    unsigned framebuffer_height,
-    unsigned thickness_level,
-    unsigned corner_radius_px,
-    color_type srgb_color,
-    color_type srgb_background,
-    float bg_alpha) {
-    float thickness = (float)thickness_as_float(os_window, thickness_level);
+    Viewport rect, unsigned framebuffer_height, float thickness, unsigned corner_radius_px, color_type srgb_color, color_type srgb_background, float bg_alpha) {
     bind_program(ROUNDED_RECT_PROGRAM);
     color_vec4(program_uniform_location(ROUNDED_RECT_PROGRAM, "color"), srgb_color, 1.f);
     color_vec4(program_uniform_location(ROUNDED_RECT_PROGRAM, "background_color"), srgb_background, bg_alpha);
@@ -1265,7 +1257,7 @@ render_a_bar(const UIRenderData *ui, WindowBarData *bar, PyObject *title, bool a
     restore_viewport();
     free_texture(&data.texture_id);
     // finally draw border with transparent bg
-    draw_rounded_rect(ui->os_window, border_rect, sh, 1, ui->cell_width, fg, bg, 0.f);
+    draw_rounded_rect(border_rect, sh, (float)thickness_as_float(ui->os_window, 1), ui->cell_width, fg, bg, 0.f);
     return border_rect.height;
 }
 
@@ -2071,6 +2063,19 @@ draw_cells(const WindowRenderData *srd, OSWindow *os_window, bool is_active_wind
 
 // Borders {{{
 
+static void
+populate_border_colors(GLuint colors[9], color_type active_window_bg, unsigned int num_visible_windows, bool all_windows_have_same_bg, const OSWindow *w) {
+    colors[0] = (num_visible_windows > 1 && !all_windows_have_same_bg) ? OPT(background) : active_window_bg;
+    colors[1] = OPT(active_border_color);
+    colors[2] = OPT(inactive_border_color);
+    colors[3] = 0;
+    colors[4] = OPT(bell_border_color);
+    colors[5] = OPT(tab_bar_background);
+    colors[6] = OPT(tab_bar_margin_color);
+    colors[7] = w->tab_bar_edge_color.left;
+    colors[8] = w->tab_bar_edge_color.right;
+}
+
 ssize_t
 create_border_vao(void) {
     ssize_t vao_idx = create_vao();
@@ -2118,17 +2123,8 @@ draw_borders(
         if (borders_buf_address) memcpy(borders_buf_address, rect_buf, sz);
         unmap_vao_buffer(vao_idx, 0);
     }
-    color_type default_bg = (num_visible_windows > 1 && !all_windows_have_same_bg) ? OPT(background) : active_window_bg;
-    GLuint colors[9] = {
-        default_bg,
-        OPT(active_border_color),
-        OPT(inactive_border_color),
-        0,
-        OPT(bell_border_color),
-        OPT(tab_bar_background),
-        OPT(tab_bar_margin_color),
-        w->tab_bar_edge_color.left,
-        w->tab_bar_edge_color.right};
+    GLuint colors[9];
+    populate_border_colors(colors, active_window_bg, num_visible_windows, all_windows_have_same_bg, w);
     void *colors_buf =
         map_vao_buffer_for_write_only(shader_globals_vao_idx, BORDER_COLORS_GLOBAL_BUFFER, 0, program_uniform_block(BORDERS_PROGRAM, "Colors").size);
     const ArrayInformation border_colors_array = program_uniform_array(BORDERS_PROGRAM, "colors");
@@ -2140,6 +2136,27 @@ draw_borders(
     if (!w->needs_layers) glDisable(GL_FRAMEBUFFER_SRGB);
     unbind_program();
     unbind_vertex_array();
+}
+
+void
+draw_rounded_borders(BorderRects *br, color_type active_window_bg, unsigned int num_visible_windows, bool all_windows_have_same_bg, OSWindow *w) {
+    if (!br->num_border_rects) return;
+    GLuint colors[9];
+    populate_border_colors(colors, active_window_bg, num_visible_windows, all_windows_have_same_bg, w);
+    bind_vertex_array(br->vao_idx);
+    if (!w->needs_layers) glEnable(GL_FRAMEBUFFER_SRGB);
+    for (unsigned i = 0; i < br->num_border_rects; i++) {
+        const BorderRect *r = br->rect_buf + i;
+        if (!r->radius || !r->thickness) continue;
+        Viewport rect = {.left = r->px.left, .top = r->px.top, .width = r->px.right - r->px.left, .height = r->px.bottom - r->px.top};
+        unsigned radius = MIN(r->radius, MIN(rect.width, rect.height) / 2);
+        unsigned color_index = r->color & 0xff;
+        color_type color = color_index == 3 ? r->color >> 8 : colors[MIN(color_index, 8u)];
+        draw_rounded_rect(rect, w->viewport_height, (float)r->thickness, radius, color, 0, 0.f);
+    }
+    if (!w->needs_layers) glDisable(GL_FRAMEBUFFER_SRGB);
+    unbind_program();
+    // Leave the VAO bound for the fullscreen blit in stop_os_window_rendering().
 }
 
 // }}}

--- a/kitty/state.c
+++ b/kitty/state.c
@@ -735,8 +735,10 @@ pyset_borders_rects(PyObject *self UNUSED, PyObject *args) {
         unsigned long color;
         long long border_type;
         BorderRect *r = br->rect_buf + i;
-        int horizontal;
-        if (!PyArg_ParseTuple(pr, "IIIIkLp", &r->px.left, &r->px.top, &r->px.right, &r->px.bottom, &color, &border_type, &horizontal)) return NULL;
+        int horizontal, render;
+        if (!PyArg_ParseTuple(
+                pr, "IIIIkLppII", &r->px.left, &r->px.top, &r->px.right, &r->px.bottom, &color, &border_type, &horizontal, &render, &r->radius, &r->thickness))
+            return NULL;
         r->left = gl_pos_x(r->px.left, osw->viewport_width);
         r->top = gl_pos_y(r->px.top, osw->viewport_height);
         r->right = r->left + gl_size(r->px.right - r->px.left, osw->viewport_width);
@@ -744,6 +746,7 @@ pyset_borders_rects(PyObject *self UNUSED, PyObject *args) {
         r->color = color;
         r->border_type = border_type;
         r->horizontal = horizontal;
+        if (!render) r->left = r->top = r->right = r->bottom = -2.f;
     }
     END_WITH_TAB
     Py_RETURN_NONE;

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -414,6 +414,7 @@ typedef struct BorderRect {
     uint32_t color;
     long long border_type;
     bool horizontal;
+    unsigned radius, thickness;
 } BorderRect;
 
 typedef struct BorderRects {
@@ -707,6 +708,7 @@ OSWindow *current_os_window(void);
 void os_window_regions(const OSWindow *, Region *main, Region *tab_bar);
 bool drag_scroll(Window *, OSWindow *);
 void draw_borders(ssize_t vao_idx, unsigned int num_border_rects, BorderRect *rect_buf, bool rect_data_is_dirty, color_type, unsigned int, bool, OSWindow *w);
+void draw_rounded_borders(BorderRects *, color_type, unsigned int, bool, OSWindow *);
 ssize_t create_cell_vao(void);
 ssize_t create_border_vao(void);
 void bind_shader_globals_to_current_context(void);

--- a/kitty_tests/layout.py
+++ b/kitty_tests/layout.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # License: GPL v3 Copyright: 2018, Kovid Goyal <kovid at kovidgoyal.net>
 
+from kitty.borders import Border, BorderColor, add_borders
 from kitty.config import defaults
 from kitty.fast_data_types import BOTTOM_EDGE, LEFT_EDGE, RIGHT_EDGE, TOP_EDGE, Region
 from kitty.layout.base import layout_dimension, lgd
@@ -101,6 +102,33 @@ class TestLayout(BaseTest):
     def setUp(self):
         super().setUp()
         self.set_options({'tab_bar_style': 'hidden'})
+
+    def test_window_border_radius_geometry(self):
+        q = create_layout(Splits)
+        windows = create_windows(q, 1)
+        windows.active_window.set_geometry(WindowGeometry(10, 20, 110, 120, 0, 0))
+        group = windows.active_group
+        color = BorderColor.active
+        straight = [
+            Border(8, 18, 112, 19, color, -1, True),
+            Border(8, 121, 112, 122, color, 1, True),
+            Border(8, 18, 9, 122, color, -1),
+            Border(111, 18, 112, 122, color, 1),
+        ]
+
+        rects = []
+        add_borders(rects, color, group)
+        self.ae(rects, straight)
+
+        rects = []
+        add_borders(rects, color, group, 12)
+        self.ae(
+            rects,
+            [
+                *(border._replace(render=False) for border in straight),
+                Border(8, 18, 112, 122, color, render=False, radius=12, thickness=1),
+            ],
+        )
 
     def do_ops_test(self, q):
         windows = create_windows(q)

--- a/kitty_tests/options.py
+++ b/kitty_tests/options.py
@@ -307,6 +307,10 @@ def conf_parsing(self):
 
     opts = p('font_size 11.37', 'clear_all_shortcuts y', 'color23 red')
     self.ae(opts.font_size, 11.37)
+    radius_opts = p('window_border_radius 7px')
+    self.ae(radius_opts.window_border_radius, (7.0, 'px'))
+    radius_opts = p('window_border_radius -2')
+    self.ae(radius_opts.window_border_radius, (0.0, 'pt'))
     self.ae(opts.mouse_hide_wait[0], 0 if is_macos else 3)
     self.ae(opts.mouse_hide_wait[1], 0)
     self.ae(opts.mouse_hide_wait[2], 40)


### PR DESCRIPTION
## Summary

- add `window_border_radius` with px/pt units and a zero default
- render full pane borders with the existing rounded-rectangle shader while preserving rectangular edge hit regions
- leave minimal borders unchanged and support transparent backgrounds

## Testing

- `ruff check --fix`
- `make debug`
- `./test.py --module layout window_border_radius_geometry`
- `./test.py conf_parsing`
- release `kitty.app` build
- macOS visual smoke with 0.75 opacity and a split created with Cmd+Enter; 20 captured frames remained stable
- full `./test.py`: 689/690 passed; `test_font_selection` requires Source Code Pro, which is not installed on this host

Refs #8617