### PR TITLE
Graphics protocol: Accept shm names without a leading slash

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -287,6 +287,9 @@ Detailed list of changes
   object at an offset (the ``O`` key) failing unless the offset happened to be
   a multiple of the system page size
 
+- Graphics protocol: Accept POSIX shared memory names that omit the leading
+  slash, so clients that encode the name without it still work on macOS
+
 - Clipboard protocol: Report an ``EFBIG`` error to programs that try to write
   more data to the clipboard than allowed by :opt:`clipboard_max_size`, instead
   of silently truncating their data. Also fix :opt:`clipboard_max_size` being

--- a/kitty/graphics.c
+++ b/kitty/graphics.c
@@ -696,6 +696,14 @@ load_image_data(
         case 's': // POSIX shared memory
             if (g->payload_sz > 2048) ABRT("EINVAL", "Filename too long");
             snprintf(fname, sizeof(fname) / sizeof(fname[0]), "%.*s", (int)g->payload_sz, payload);
+            if (transmission_type == 's' && fname[0] && fname[0] != '/') {
+                // POSIX shm names start with '/'. Darwin shm_open requires that form.
+                size_t n = strlen(fname);
+                if (n + 2 <= sizeof(fname)) {
+                    memmove(fname + 1, fname, n + 1);
+                    fname[0] = '/';
+                }
+            }
             if (transmission_type == 's') fd = safe_shm_open(fname, O_RDONLY, 0);
             else fd = safe_open(fname, O_CLOEXEC | O_RDONLY | O_NONBLOCK, 0); // O_NONBLOCK so that opening a FIFO pipe does not block
             if (fd == -1) ABRT("EBADF", "Failed to open file for graphics transmission with error: [%d] %s", errno, strerror(errno));

--- a/kitty_tests/graphics.py
+++ b/kitty_tests/graphics.py
@@ -502,6 +502,11 @@ class TestGraphics(BaseTest):
         shm_write(name, random_data)
         sl(name, s=1024, v=8, t='s', expecting_data=random_data)
         self.assertRaises(FileNotFoundError, shm_unlink, name)  # check that file was deleted
+        # Name without a leading slash. POSIX names start with '/'; Darwin requires it.
+        name = '/kitty-test-shm-noslash'
+        shm_write(name, random_data)
+        sl(name[1:], s=1024, v=8, t='s', expecting_data=random_data)
+        self.assertRaises(FileNotFoundError, shm_unlink, name)  # check that file was deleted
         s.reset()
         self.assertEqual(g.disk_cache.total_size, 0)
 


### PR DESCRIPTION
POSIX portable shm names start with '/'. Darwin shm_open requires that form, glibc accepts both, so clients that omit the slash fail on macOS.