### PR TITLE
Require POSIX SHM names to be at most 30 characters plus leading slash

### DIFF
--- a/docs/graphics-protocol.rst
+++ b/docs/graphics-protocol.rst
@@ -347,7 +347,7 @@ Value of `t`          Meaning
 ``s``                 A *shared memory object*, which on POSIX systems is a
                       `POSIX shared memory object <https://pubs.opengroup.org/onlinepubs/9699919799/functions/shm_open.html>`_
                       and on Windows is a
-                      `Named shared memory object <https://docs.microsoft.com/en-us/windows/win32/memory/creating-named-shared-memory>`_. On POSIX shm names **must** start with a :file:`/` and be at most ``NAME_MAX`` characters none of which are slashes.
+                      `Named shared memory object <https://docs.microsoft.com/en-us/windows/win32/memory/creating-named-shared-memory>`_. On POSIX shm names **must** start with a :file:`/` and be limited to 30 ``min(SHM_NAME_MAX)`` characters plus the leading slash, with no other slashes.
                       The terminal emulator must read the data from the memory
                       object and then unlink and close it on POSIX and just
                       close it on Windows.


### PR DESCRIPTION
This makes the spec even stricter as macOS is a supported platform by Kitty, and macOS limits shm names to PSHMNAMLEN (31 including leading slash), and ignores NAME_MAX. macOS here is not in violation of the POSIX spec ``length limits for the name argument are implementation-defined and need not be the same as the pathname limits {PATH_MAX} and {NAME_MAX}.``. If the Kitty spec allows names longer than this, client implementations will be broken on macOS.

Require POSIX SHM names to be at most 30 min(SHM_NAME_MAX) (kitty/data-types.c) characters plus the leading slash.
