### PR TITLE
Treat empty display server envvars as unset

### DIFF
--- a/glfw/ibus_glfw.c
+++ b/glfw/ibus_glfw.c
@@ -286,7 +286,7 @@ get_ibus_address_file_name(void) {
     const char *host = "unix";
     // See https://github.com/ibus/ibus/commit/8ce25208c3f4adfd290a032c6aa739d2b7580eb1 for why we need this dance.
     const char *de = getenv("WAYLAND_DISPLAY");
-    if (de) {
+    if (de && de[0]) {
         disp_num = de;
     } else {
         const char *de = getenv("DISPLAY");

--- a/glfw/x11_init.c
+++ b/glfw/x11_init.c
@@ -708,7 +708,7 @@ _glfwPlatformInit(bool *supports_window_occlusion) {
     _glfw.x11.display = XOpenDisplay(NULL);
     if (!_glfw.x11.display) {
         const char *display = getenv("DISPLAY");
-        if (display) {
+        if (display && display[0]) {
             _glfwInputError(GLFW_PLATFORM_ERROR, "X11: Failed to open display %s", display);
         } else {
             _glfwInputError(GLFW_PLATFORM_ERROR, "X11: The DISPLAY environment variable is missing");

--- a/kitty/constants.py
+++ b/kitty/constants.py
@@ -220,9 +220,9 @@ def glfw_path(module: str) -> str:
 
 
 def detect_if_wayland_ok() -> bool:
-    if 'WAYLAND_DISPLAY' not in os.environ and 'WAYLAND_SOCKET' not in os.environ:
+    if not os.environ.get('WAYLAND_DISPLAY') and not os.environ.get('WAYLAND_SOCKET'):
         return False
-    if 'KITTY_DISABLE_WAYLAND' in os.environ:
+    if os.environ.get('KITTY_DISABLE_WAYLAND'):
         return False
     wayland = glfw_path('wayland')
     if not os.path.exists(wayland):


### PR DESCRIPTION
This makes the `DISPLAY`, `WAYLAND_DISPLAY`, `WAYLAND_SOCKET`, and
`KITTY_DISABLE_WAYLAND` envvars be treated as unset if they are the empty
string.  Therefore, users can simply do `WAYLAND_DISPLAY= kitty` as
opposed to the full incantation `env -u WAYLAND_DISPLAY kitty` (in this
case setting `KITTY_DISABLE_WAYLAND` would also work, but that wouldn't
propagate to any clients launched through kitty).  This matches the
behavior of many other programs.

No tests were added as I'm not sure how to test display server selection.
