### PR TITLE
Add directional window border resizing in split layout

### DIFF
--- a/docs/layouts.rst
+++ b/docs/layouts.rst
@@ -312,7 +312,17 @@ action, for example::
    map ctrl+right resize_window wider
    map ctrl+up resize_window taller
    map ctrl+down resize_window shorter 3
-   # reset all windows in the tab to default sizes
+
+In the :ref:`Splits layout <splits_layout>`, you can also move a window border in a fixed
+direction, for example::
+
+   map ctrl+alt+left resize_window towards_left
+   map ctrl+alt+right resize_window towards_right
+   map ctrl+alt+up resize_window towards_top
+   map ctrl+alt+down resize_window towards_bottom
+
+To reset all windows in the tab to default sizes, use::
+
    map ctrl+home resize_window reset
 
 The :ac:`resize_window` action has a second optional argument to control

--- a/kitty/layout/base.py
+++ b/kitty/layout/base.py
@@ -318,7 +318,9 @@ class Layout:
     def remove_all_biases(self) -> bool:
         return False
 
-    def modify_size_of_window(self, all_windows: WindowList, window_id: int, increment: float, is_horizontal: bool = True) -> bool:
+    def modify_size_of_window(self, all_windows: WindowList, window_id: int, increment: float, is_horizontal: bool = True, is_towards_edge: bool = False) -> bool:
+        if is_towards_edge:
+            return False
         idx = all_windows.group_idx_for_window(window_id)
         if idx is None or not increment:
             return False

--- a/kitty/layout/splits.py
+++ b/kitty/layout/splits.py
@@ -413,9 +413,9 @@ class Pair:
         b = max(0, min(bias, 100)) / 100
         self.bias = b if window_id == self.one else (1.0 - b)
 
-    def modify_size_of_child(self, which: int, increment: float, is_horizontal: bool, layout_object: 'Splits') -> bool:
+    def modify_size_of_child(self, which: int, increment: float, is_horizontal: bool, layout_object: 'Splits', is_towards_edge: bool = False) -> bool:
         if is_horizontal == self.horizontal and not self.is_redundant:
-            if which == 2:
+            if which == 2 and not is_towards_edge:
                 increment *= -1
             new_bias = max(0, min(self.bias + increment, 1))
             if new_bias != self.bias:
@@ -425,7 +425,7 @@ class Pair:
         parent = self.parent(layout_object.pairs_root)
         if parent is not None:
             which = 1 if parent.one is self else 2
-            return parent.modify_size_of_child(which, increment, is_horizontal, layout_object)
+            return parent.modify_size_of_child(which, increment, is_horizontal, layout_object, is_towards_edge)
         return False
 
     def neighbors_for_window(self, window_id: int, ans: NeighborsMap, layout_object: 'Splits', all_windows: WindowList) -> None:
@@ -653,7 +653,7 @@ class Splits(Layout):
         if bias is not None:
             p.bias = bias
 
-    def modify_size_of_window(self, all_windows: WindowList, window_id: int, increment: float, is_horizontal: bool = True) -> bool:
+    def modify_size_of_window(self, all_windows: WindowList, window_id: int, increment: float, is_horizontal: bool = True, is_towards_edge: bool = False) -> bool:
         grp = all_windows.group_for_window(window_id)
         if grp is None:
             return False
@@ -661,7 +661,7 @@ class Splits(Layout):
         if pair is None:
             return False
         which = 1 if pair.one == grp.id else 2
-        return pair.modify_size_of_child(which, increment, is_horizontal, self)
+        return pair.modify_size_of_child(which, increment, is_horizontal, self, is_towards_edge)
 
     def remove_all_biases(self) -> bool:
         for pair in self.pairs_root.self_and_descendants():

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -299,7 +299,7 @@ def resize_window(func: str, rest: str) -> FuncArgsType:
         args = ['wider', 1]
     else:
         quality = vals[0].lower()
-        if quality not in ('reset', 'taller', 'shorter', 'wider', 'narrower'):
+        if quality not in ('reset', 'taller', 'shorter', 'wider', 'narrower', 'towards_top', 'towards_bottom', 'towards_right', 'towards_left'):
             log_error(f'Invalid quality specification: {quality}')
             quality = 'wider'
         increment = 1

--- a/kitty/tabs.py
+++ b/kitty/tabs.py
@@ -668,9 +668,9 @@ class Tab:  # {{{
         else:
             self.goto_layout(layout_name)
 
-    def resize_window_by(self, window_id: int, increment: float, is_horizontal: bool) -> str | None:
+    def resize_window_by(self, window_id: int, increment: float, is_horizontal: bool, is_towards_edge: bool = False) -> str | None:
         increment_as_percent = self.current_layout.bias_increment_for_cell(self.windows, is_horizontal) * increment
-        if self.current_layout.modify_size_of_window(self.windows, window_id, increment_as_percent, is_horizontal):
+        if self.current_layout.modify_size_of_window(self.windows, window_id, increment_as_percent, is_horizontal, is_towards_edge):
             self.relayout()
             return None
         return 'Could not resize'
@@ -695,10 +695,11 @@ class Tab:  # {{{
             return
         if increment < 1:
             raise ValueError(increment)
-        is_horizontal = quality in ('wider', 'narrower')
-        increment *= 1 if quality in ('wider', 'taller') else -1
+        is_towards_edge = quality.startswith('towards_')
+        is_horizontal = quality in ('wider', 'narrower', 'towards_right', 'towards_left')
+        increment *= 1 if quality in ('wider', 'taller', 'towards_right', 'towards_bottom') else -1
         w = self.active_window
-        if w is not None and self.resize_window_by(w.id, increment, is_horizontal) is not None:
+        if w is not None and self.resize_window_by(w.id, increment, is_horizontal, is_towards_edge) is not None:
             if get_options().enable_audio_bell:
                 ring_bell(self.os_window_id)
 

--- a/kitty_tests/layout.py
+++ b/kitty_tests/layout.py
@@ -274,6 +274,47 @@ class TestLayout(BaseTest):
         self.ae(q.neighbors_for_window(windows[2], all_windows), {'left': [1], 'right': [4], 'top': [2]})
         self.ae(q.neighbors_for_window(windows[3], all_windows), {'left': [3], 'top': [2]})
 
+    def test_resize_window_towards_to(self):
+        # Ensure correct resizing direction
+        for location, is_horizontal in (('vsplit', True), ('hsplit', False)):
+            q = create_layout(Splits)
+            all_windows = create_windows(q, num=0)
+            q.add_window(all_windows, Window(1))
+            q.add_window(all_windows, Window(2), location=location)
+            pair = q.pairs_root.pair_for_window(1)
+            self.assertIsNotNone(pair)
+
+            for increment, expected_bias in ((-0.1, 0.4), (0.1, 0.6)):
+                pair.bias = 0.5
+                self.assertTrue(q.modify_size_of_window(all_windows, 1, increment, is_horizontal, is_towards_edge=True))
+                self.ae(pair.bias, expected_bias)
+                pair.bias = 0.5
+                self.assertTrue(q.modify_size_of_window(all_windows, 2, increment, is_horizontal, is_towards_edge=True))
+                self.ae(pair.bias, expected_bias)
+
+    def test_resize_window_towards_to_middle_window(self):
+        # Ensure resizing the middle window moves the correct window border in
+        # the correct direction
+        # Layout: w1 | w2 | w3, or the vertical equivalent. Window 2 has
+        # one border in the parent pair and another in its own pair with w3.
+        for location, is_horizontal in (('vsplit', True), ('hsplit', False)):
+            q = create_layout(Splits)
+            all_windows = create_windows(q, num=0)
+            q.add_window(all_windows, Window(1))
+            q.add_window(all_windows, Window(2), location=location)
+            q.add_window(all_windows, Window(3), location=location)
+            parent_pair = q.pairs_root.pair_for_window(1)
+            middle_pair = q.pairs_root.pair_for_window(2)
+            self.assertIsNotNone(parent_pair)
+            self.assertIsNotNone(middle_pair)
+            self.assertIsNot(parent_pair, middle_pair)
+
+            for increment, expected_bias in ((-0.1, 0.4), (0.1, 0.6)):
+                parent_pair.bias = middle_pair.bias = 0.5
+                self.assertTrue(q.modify_size_of_window(all_windows, 2, increment, is_horizontal, is_towards_edge=True))
+                self.ae(parent_pair.bias, 0.5)
+                self.ae(middle_pair.bias, expected_bias)
+
     def test_splits_unserialize_into_unused_layout(self):
         # Restoring the state of a layout that was not the active one when the session
         # was saved: its pairs tree is empty, and the window list must not be


### PR DESCRIPTION
Add four new values to 'resize_window' for moving a window border a fixed direction in the 'split' layout:
towards_left
towards_right
towards_top
towards_bottom.

I tried to keep the changes small and limited to the split layouts, because I'm not sure yet how the other layouts should behave with this action.

I've propagate additional boolean parameter to keep the implementation close to the existing code.

I've also added a documentation update and two tests

#10404