### PR TITLE
Raise the maximum font size and fix the legacy zoom limit

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -202,6 +202,13 @@ Detailed list of changes
 
 - Support for :doc:`/custom-shaders` for adding various graphical effects (:iss:`10344`)
 
+- Allow zooming the font further in. The maximum size was ten times the
+  configured :opt:`font_size`, so a small configured font also meant a small
+  maximum zoom. It is now the larger of that multiple and an absolute 256pt
+
+- Fix :ac:`increase_font_size` stopping at five times the configured
+  :opt:`font_size` rather than the ten used by :ac:`change_font_size`
+
 - Various throughput performance improvements for a 15-35% real world improvement depending on workload
 
 - Add :opt:`window_border_radius` for rounded window borders (:pull:`10421`)

--- a/kitty/boss.py
+++ b/kitty/boss.py
@@ -140,7 +140,7 @@ from .keys import Mappings
 from .layout.base import set_layout_options
 from .notifications import NotificationManager
 from .options.types import Options, nullable_colors
-from .options.utils import MINIMUM_FONT_SIZE, KeyboardMode, KeyDefinition
+from .options.utils import KeyboardMode, KeyDefinition, clamp_font_size
 from .os_window_size import initial_window_size_func
 from .session import (
     Session,
@@ -1662,12 +1662,10 @@ class Boss:
             self.show_error(_('Unknown clear type'), _('The clear type: {} is unknown').format(action))
 
     def increase_font_size(self) -> None:  # legacy
-        cfs = global_font_size()
-        self.set_font_size(min(get_options().font_size * 5, cfs + 2.0))
+        self.set_font_size(global_font_size() + 2.0)
 
     def decrease_font_size(self) -> None:  # legacy
-        cfs = global_font_size()
-        self.set_font_size(max(MINIMUM_FONT_SIZE, cfs - 2.0))
+        self.set_font_size(global_font_size() - 2.0)
 
     def restore_font_size(self) -> None:  # legacy
         self.set_font_size(get_options().font_size)
@@ -1703,7 +1701,7 @@ class Boss:
                             pass  # no-op
                 else:
                     new_size = amt
-                new_size = max(MINIMUM_FONT_SIZE, min(new_size, get_options().font_size * 10))
+                new_size = clamp_font_size(new_size, get_options().font_size)
             return new_size
 
         if all_windows:

--- a/kitty/options/utils.py
+++ b/kitty/options/utils.py
@@ -49,6 +49,19 @@ KeyMap = dict[SingleKey, list['KeyDefinition']]
 MouseMap = dict[MouseEvent, str]
 KeySequence = tuple[SingleKey, ...]
 MINIMUM_FONT_SIZE = 4
+# Zooming is limited to a multiple of the configured font size, or to this
+# absolute size, whichever is larger. Without the absolute bound the largest
+# reachable size scales with the configured one, so a small configured font
+# also means a small maximum zoom.
+MAXIMUM_FONT_SIZE = 256.0
+FONT_SIZE_MULTIPLE = 10
+
+
+def clamp_font_size(new_size: float, configured_size: float) -> float:
+    upper = max(configured_size * FONT_SIZE_MULTIPLE, MAXIMUM_FONT_SIZE)
+    return max(MINIMUM_FONT_SIZE, min(new_size, upper))
+
+
 default_tab_separator = ' ┇'
 mod_map = {
     '⌃': 'CONTROL',

--- a/kitty_tests/options.py
+++ b/kitty_tests/options.py
@@ -35,6 +35,9 @@ class TestConfParsing(BaseTest):
     def test_cli_parsing(self):
         cli_parsing(self)
 
+    def test_font_size_clamping(self):
+        font_size_clamping(self)
+
     def test_session_discovery(self):
         from unittest.mock import patch
 
@@ -174,6 +177,32 @@ version
     t('-1 -v0', fails=True, version_called=True)
     t('-1 --version', fails=True, version_called=True)
     t('-f=3.142 --int 17', float=3.142, int=17)
+
+
+def font_size_clamping(self: 'BaseTest') -> None:
+    from kitty.options.utils import MAXIMUM_FONT_SIZE, MINIMUM_FONT_SIZE, clamp_font_size
+
+    # the floor applies whatever the configured size
+    self.ae(clamp_font_size(0, 11), MINIMUM_FONT_SIZE)
+    self.ae(clamp_font_size(-100, 11), MINIMUM_FONT_SIZE)
+
+    # sizes inside the range come back untouched
+    self.ae(clamp_font_size(11, 11), 11)
+    self.ae(clamp_font_size(64, 11), 64)
+
+    # the ceiling is the larger of the multiple and the absolute maximum, so a
+    # small configured size no longer implies a small maximum zoom
+    self.ae(clamp_font_size(1e6, 4), MAXIMUM_FONT_SIZE)
+    self.ae(clamp_font_size(1e6, 11), MAXIMUM_FONT_SIZE)
+    self.ae(clamp_font_size(200, 4), 200)
+
+    # a large configured size keeps its proportional ceiling
+    self.ae(clamp_font_size(1e6, 40), 400)
+    self.ae(clamp_font_size(1e6, 100), 1000)
+
+    # and the ceiling is never below the absolute maximum
+    for configured in (1, 4, 11, 25.6, 40, 100):
+        self.assertGreaterEqual(clamp_font_size(1e6, configured), MAXIMUM_FONT_SIZE)
 
 
 def launcher(self):


### PR DESCRIPTION
The zoom ceiling in `change_font_size` is `font_size * 10`, so the largest size
you can reach is a function of the size you configured:

| configured `font_size` | current max | with this change |
| --- | --- | --- |
| 4 | 40pt | 256pt |
| 6 | 60pt | 256pt |
| 11 (default) | 110pt | 256pt |
| 20 | 200pt | 256pt |
| 40 | 400pt | 400pt (unchanged) |

That seems backwards. Someone running a small font is if anything more likely
to want a large temporary zoom, not less, and at `font_size 4` zooming tops out
at 40pt.

This uses the larger of the existing multiple and an absolute 256pt, so no
existing setup loses range: the multiple still wins whenever it is the bigger
of the two. The two bounds and the clamp move into `options/utils.py` as
`clamp_font_size`, so the numbers live in one place and can be tested without
standing up a Boss.

The second commit-worthy thing turned up while reading that code.
`increase_font_size` carries its own cap of `font_size * 5`, which is the old
limit from before 25d8d9fe6 raised `change_font_size` to ten. Since the wrapper
clamps *before* delegating, the stale bound is the one that takes effect, so
`increase_font_size` has quietly been stopping at half the limit that
`change_font_size` uses. Both legacy wrappers can just drop their bounds
entirely rather than get new ones, because they call through
`change_font_size`, which already clamps.

I left `MINIMUM_FONT_SIZE` alone. Cell metrics degrade at very small sizes (the
font code already warns `Cell width too small`), so the 4pt floor looks
deliberate and it did not seem like something to change in passing.

Tested with `./test.py`: 265 tests and the same 8 worker errors on master and
on the branch on this machine, so nothing regressed. `test_font_size_clamping`
in `kitty_tests/options.py` covers the floor, the pass-through range, both
branches of the ceiling, and that the ceiling is never below the absolute
maximum. `ruff check` is clean on the touched files.