### PR TITLE
Pack shaped run cache arenas in 4 KiB blocks

### DIFF
--- a/kitty/shaped-run-cache.c
+++ b/kitty/shaped-run-cache.c
@@ -14,6 +14,7 @@
 #define SHAPED_RUN_MAX_ENTRIES 2048u
 #define SHAPED_RUN_MAX_BYTES (1024u * 1024u)
 #define SHAPED_RUN_MA_BLOCK_SIZE 16u
+#define SHAPED_RUN_SLAB 4096u
 
 typedef struct ShapedRunKey {
     uint32_t keysz_in_bytes;
@@ -56,11 +57,12 @@ static bool shaped_run_map_cmpr(KEY_TY a, KEY_TY b);
 #define MA_NAME Key
 #define MA_BLOCK_SIZE SHAPED_RUN_MA_BLOCK_SIZE
 static_assert(MA_BLOCK_SIZE > sizeof(ShapedRunKey), "increase arena block size");
-#define MA_ARENA_NUM_BLOCKS (2048u / MA_BLOCK_SIZE)
+static_assert(SHAPED_RUN_SLAB % MA_BLOCK_SIZE == 0, "slab must be a multiple of the block size");
+#define MA_ARENA_NUM_BLOCKS (SHAPED_RUN_SLAB / MA_BLOCK_SIZE)
 #include "arena.h"
 #define MA_NAME Val
 #define MA_BLOCK_SIZE SHAPED_RUN_MA_BLOCK_SIZE
-#define MA_ARENA_NUM_BLOCKS (2048u / MA_BLOCK_SIZE)
+#define MA_ARENA_NUM_BLOCKS (SHAPED_RUN_SLAB / MA_BLOCK_SIZE)
 #include "arena.h"
 
 #include "kitty-verstable.h"


### PR DESCRIPTION
I've been running with the shaped run cache and some extra logging, decided to bump to a 4KiB slab. The theoretical and actual waste do show up during use. My initial sizing was only a best guess based of glyph cache and a 32 cell run typically fitting just below a 2KiB slab.

Some stats from the logging.

- TUI/Editor/Shell use about 95%+ average hit rate; History - log file watching, git log, (longer more unique streams) still around 85%. It is nailing the goal of keeping harfbuzz shaping off active screens CPU profile.
- Everyday TUI/Editor/Shell, about 1800 live entries: 2 KiB sat at 14% waste (66 B/entry); 4 KiB was 7-10% (about 42 B/entry)
- History gather with many 17-18 cell runs: 2 KiB rose to 20% waste; 4 KiB history sessions stayed around 8%
- TUI/Editor/Shell typical run size 99% <= 16 cells, History ~90% <= 16 cells.
