### PR TITLE
Fix idle sync to monitor - primarily macOS.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -261,6 +261,9 @@ Detailed list of changes
 
 - dnd kitten: Add an option to use file copies instead of hard links for copy drops (:pull:`10412`)
 
+- Fix :opt:`sync_to_monitor` presenting new frames while idle even when the
+  screen has not changed
+
 - Fix a malformed CSI escape sequence such as ``\e[?:`` corrupting the parser state so that subsequent SGR color codes are ignored (:iss:`10434`)
 
 - Graphics protocol: Fix a regression in 0.45.0 that caused the overwrite

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -264,6 +264,9 @@ Detailed list of changes
 - Fix :opt:`sync_to_monitor` presenting new frames while idle even when the
   screen has not changed
 
+- Fix always-active custom shaders such as ``water`` stopping when the window is
+  idle
+
 - Fix a malformed CSI escape sequence such as ``\e[?:`` corrupting the parser state so that subsequent SGR color codes are ignored (:iss:`10434`)
 
 - Graphics protocol: Fix a regression in 0.45.0 that caused the overwrite

--- a/kitty/child-monitor.c
+++ b/kitty/child-monitor.c
@@ -1018,7 +1018,8 @@ render_prepared_os_window(
     color_type active_window_bg,
     unsigned int num_visible_windows,
     bool all_windows_have_same_bg,
-    monotonic_t now) {
+    monotonic_t now,
+    bool input_read) {
     Tab *tab = os_window->tabs + os_window->active_tab;
     setup_os_window_for_rendering(os_window, tab, NULL, true, now);
     BorderRects *br = &tab->border_rects;
@@ -1054,7 +1055,11 @@ render_prepared_os_window(
     os_window->last_active_window_id = active_window_id;
     os_window->focused_at_last_render = os_window->is_focused;
     if (os_window->redraw_count) os_window->redraw_count--;
-    if (USE_RENDER_FRAMES) request_frame_render(os_window);
+    if (USE_RENDER_FRAMES) {
+        // Keep a compositor frame outstanding only while the PTY is feeding.
+        if (input_read) request_frame_render(os_window);
+        else os_window->render_state = RENDER_FRAME_NOT_REQUESTED;
+    }
 #undef WD
 #undef TD
 }
@@ -1073,7 +1078,7 @@ no_render_frame_received_recently(OSWindow *w, monotonic_t now, monotonic_t max_
 }
 
 bool
-render_os_window(OSWindow *w, monotonic_t now, bool scan_for_animated_images) {
+render_os_window(OSWindow *w, monotonic_t now, bool scan_for_animated_images, bool input_read) {
     if (!w->num_tabs) return false;
     if (!should_os_window_be_rendered(w) && global_state.thumbnail_callback.os_window != w->id) {
         update_os_window_title(w);
@@ -1118,7 +1123,7 @@ render_os_window(OSWindow *w, monotonic_t now, bool scan_for_animated_images) {
         needs_render = true;
     if (w->last_active_window_id != active_window_id || w->last_active_tab != w->active_tab || w->focused_at_last_render != w->is_focused) needs_render = true;
     if (w->render_calls < 3 && background_image_for_os_window(w) != NULL) needs_render = true;
-    if (needs_render) render_prepared_os_window(w, active_window_id, active_window_bg, num_visible_windows, all_windows_have_same_bg, now);
+    if (needs_render) render_prepared_os_window(w, active_window_id, active_window_bg, num_visible_windows, all_windows_have_same_bg, now, input_read);
     if (w->is_focused) change_menubar_title(w->window_title);
     return needs_render;
 }
@@ -1143,7 +1148,7 @@ render(monotonic_t now, bool input_read) {
         // rendering is done in cocoa_os_window_resized()
         if (w->live_resize.in_progress) continue;
 #endif
-        if (!render_os_window(w, now, scan_for_animated_images)) {
+        if (!render_os_window(w, now, scan_for_animated_images, input_read)) {
             // since we didn't scan the window for animations, force a rescan on next wakeup/render frame
             if (scan_for_animated_images) global_state.check_for_active_animated_images = true;
         }

--- a/kitty/glfw.c
+++ b/kitty/glfw.c
@@ -373,7 +373,7 @@ cocoa_out_of_sequence_render(OSWindow *window) {
     if (window->fonts_data->sprite_map) {
         window->needs_render = true;
         window->render_state = RENDER_FRAME_READY;
-        rendered = render_os_window(window, monotonic(), true);
+        rendered = render_os_window(window, monotonic(), true, false);
     }
     if (!rendered) {
         debug_rendering("Cocoa out of sequence render did not happen\n");

--- a/kitty/shaders.c
+++ b/kitty/shaders.c
@@ -644,6 +644,7 @@ update_custom_shader_animations(unsigned event_mask, monotonic_t now, OSWindow *
             // Always-active, non-attached group — never enters the state machine.
             any_active = true;
             this_active = true;
+            min_step = MIN(min_step, cg->animation_step);
         } else {
             monotonic_t eff_dur = cg->animation_end_duration < 0 ? OPT(cursor_stop_blinking_after) : cg->animation_end_duration;
             if (cg->animation_start_events != 0) {

--- a/kitty/state.h
+++ b/kitty/state.h
@@ -762,7 +762,7 @@ void set_ignore_os_keyboard_processing(bool enabled);
 void push_modifier_remap_to_glfw(void);
 void update_menu_bar_title(PyObject *title UNUSED);
 void change_live_resize_state(OSWindow *, bool);
-bool render_os_window(OSWindow *w, monotonic_t now, bool scan_for_animated_images);
+bool render_os_window(OSWindow *w, monotonic_t now, bool scan_for_animated_images, bool input_read);
 void update_mouse_pointer_shape(void);
 void adjust_window_size_for_csd(OSWindow *w, int width, int height, int *adjusted_width, int *adjusted_height);
 void dispatch_buffered_keys(Window *w);


### PR DESCRIPTION
I noticed this while testing the shaped run cache. Idle windows were still redrawing at vsync on macOS. It was barely noticeable on Linux/Wayland but on macOS the updateLayer/Damage loop kept redrawing the window at vsync pace even when idle, Linux was just possibly one extra frame draw. This PR now gates, and only request a frame if the PTY has fed any input. (A smaller shader fix was also required, probably a long standing unnoticed bug as it relied on vsync timing, instead of an explicit timer).

With sync_to_monitor yes, kitty requested a frame after every present (Wayland 04fd058e0, macOS abd4de731). On macOS a present can also make AppKit call updateLayer, which GLFW reports as window damage, so the window kept redrawing. After a swap, request the next frame only while the PTY is feeding.

It does not regress the FPS performance issue addressed in 04fd058e0, as it will will still request a new frame event after the render if any PTY input is read.